### PR TITLE
Kotlin: Introduce / restore implied wildcard types

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -497,7 +497,9 @@ open class KotlinFileExtractor(
                 else
                     null
             } ?: vp.type
-            val substitutedType = typeSubstitution?.let { it(maybeErasedType, TypeContext.OTHER, pluginContext) } ?: maybeErasedType
+            val typeWithWildcards = addJavaLoweringWildcards(maybeErasedType, true)
+            val substitutedType = typeSubstitution?.let { it(typeWithWildcards, TypeContext.OTHER, pluginContext) } ?: typeWithWildcards
+
             val id = useValueParameter(vp, parent)
             if (extractTypeAccess) {
                 extractTypeAccessRecursive(substitutedType, location, id, -1)
@@ -704,7 +706,7 @@ open class KotlinFileExtractor(
 
                 val paramsSignature = allParamTypes.joinToString(separator = ",", prefix = "(", postfix = ")") { it.javaResult.signature!! }
 
-                val adjustedReturnType = getAdjustedReturnType(f)
+                val adjustedReturnType = addJavaLoweringWildcards(getAdjustedReturnType(f), false)
                 val substReturnType = typeSubstitution?.let { it(adjustedReturnType, TypeContext.RETURN, pluginContext) } ?: adjustedReturnType
 
                 val locId = locOverride ?: getLocation(f, classTypeArgsIncludingOuterClasses)

--- a/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
@@ -237,9 +237,10 @@ delegatedProperties.kt:
 #   18|       3: [TypeAccess] Unit
 #-----|       4: (Parameters)
 #   18|         0: [Parameter] map
-#   18|           0: [TypeAccess] Map<String,Object>
+#   18|           0: [TypeAccess] Map<String,? extends Object>
 #   18|             0: [TypeAccess] String
-#   18|             1: [TypeAccess] Object
+#   18|             1: [WildcardTypeAccess] ? ...
+#   18|               0: [TypeAccess] Object
 #   18|       5: [BlockStmt] { ... }
 #   19|         0: [BlockStmt] { ... }
 #   19|           0: [LocalVariableDeclStmt] var ...;
@@ -425,6 +426,7 @@ delegatedProperties.kt:
 #   27|                                 0: [TypeAccess] Object
 #   27|                               1: [Parameter] property
 #   27|                                 0: [TypeAccess] KProperty<?>
+#   27|                                   0: [WildcardTypeAccess] ? ...
 #   27|                             5: [BlockStmt] { ... }
 #   27|                               0: [ReturnStmt] return ...
 #   27|                                 0: [MethodAccess] getCurValue(...)
@@ -436,6 +438,7 @@ delegatedProperties.kt:
 #   28|                                 0: [TypeAccess] Object
 #   28|                               1: [Parameter] property
 #   28|                                 0: [TypeAccess] KProperty<?>
+#   28|                                   0: [WildcardTypeAccess] ? ...
 #   28|                               2: [Parameter] value
 #   28|                                 0: [TypeAccess] int
 #   28|                             5: [BlockStmt] { ... }
@@ -734,6 +737,7 @@ delegatedProperties.kt:
 #   46|           0: [TypeAccess] Owner
 #   46|         1: [Parameter] property
 #   46|           0: [TypeAccess] KProperty<?>
+#   46|             0: [WildcardTypeAccess] ? ...
 #   46|       5: [BlockStmt] { ... }
 #   47|         0: [ReturnStmt] return ...
 #   47|           0: [IntegerLiteral] 1
@@ -744,6 +748,7 @@ delegatedProperties.kt:
 #   49|           0: [TypeAccess] Owner
 #   49|         1: [Parameter] property
 #   49|           0: [TypeAccess] KProperty<?>
+#   49|             0: [WildcardTypeAccess] ? ...
 #   49|         2: [Parameter] value
 #   49|           0: [TypeAccess] Integer
 #   49|       5: [BlockStmt] { ... }
@@ -759,6 +764,7 @@ delegatedProperties.kt:
 #   54|           0: [TypeAccess] Owner
 #   54|         1: [Parameter] prop
 #   54|           0: [TypeAccess] KProperty<?>
+#   54|             0: [WildcardTypeAccess] ? ...
 #   54|       5: [BlockStmt] { ... }
 #   56|         0: [ReturnStmt] return ...
 #   56|           0: [ClassInstanceExpr] new ResourceDelegate(...)
@@ -3081,8 +3087,9 @@ funcExprs.kt:
 #    2|       3: [TypeAccess] Unit
 #-----|       4: (Parameters)
 #    2|         0: [Parameter] f
-#    2|           0: [TypeAccess] Function0<Object>
-#    2|             0: [TypeAccess] Object
+#    2|           0: [TypeAccess] Function0<? extends Object>
+#    2|             0: [WildcardTypeAccess] ? ...
+#    2|               0: [TypeAccess] Object
 #    2|       5: [BlockStmt] { ... }
 #    2|         0: [ExprStmt] <Expr>;
 #    2|           0: [ImplicitCoercionToUnitExpr] <implicit coercion to unit>
@@ -3093,8 +3100,9 @@ funcExprs.kt:
 #    3|       3: [TypeAccess] Unit
 #-----|       4: (Parameters)
 #    3|         0: [Parameter] f
-#    3|           0: [TypeAccess] Function0<Object>
-#    3|             0: [TypeAccess] Object
+#    3|           0: [TypeAccess] Function0<? extends Object>
+#    3|             0: [WildcardTypeAccess] ? ...
+#    3|               0: [TypeAccess] Object
 #    3|       5: [BlockStmt] { ... }
 #    3|         0: [ExprStmt] <Expr>;
 #    3|           0: [ImplicitCoercionToUnitExpr] <implicit coercion to unit>
@@ -3107,8 +3115,9 @@ funcExprs.kt:
 #    4|         0: [Parameter] x
 #    4|           0: [TypeAccess] int
 #    4|         1: [Parameter] f
-#    4|           0: [TypeAccess] Function1<Integer,Integer>
-#    4|             0: [TypeAccess] Integer
+#    4|           0: [TypeAccess] Function1<? super Integer,Integer>
+#    4|             0: [WildcardTypeAccess] ? ...
+#    4|               1: [TypeAccess] Integer
 #    4|             1: [TypeAccess] Integer
 #    4|       5: [BlockStmt] { ... }
 #    4|         0: [ExprStmt] <Expr>;
@@ -3123,9 +3132,10 @@ funcExprs.kt:
 #    5|         0: [Parameter] x
 #    5|           0: [TypeAccess] int
 #    5|         1: [Parameter] f
-#    5|           0: [TypeAccess] Function1<Object,Object>
+#    5|           0: [TypeAccess] Function1<Object,? extends Object>
 #    5|             0: [TypeAccess] Object
-#    5|             1: [TypeAccess] Object
+#    5|             1: [WildcardTypeAccess] ? ...
+#    5|               0: [TypeAccess] Object
 #    5|       5: [BlockStmt] { ... }
 #    5|         0: [ExprStmt] <Expr>;
 #    5|           0: [ImplicitCoercionToUnitExpr] <implicit coercion to unit>
@@ -3139,9 +3149,11 @@ funcExprs.kt:
 #    6|         0: [Parameter] x
 #    6|           0: [TypeAccess] int
 #    6|         1: [Parameter] f
-#    6|           0: [TypeAccess] Function2<FuncRef,Integer,Integer>
-#    6|             0: [TypeAccess] FuncRef
-#    6|             1: [TypeAccess] Integer
+#    6|           0: [TypeAccess] Function2<? super FuncRef,? super Integer,Integer>
+#    6|             0: [WildcardTypeAccess] ? ...
+#    6|               1: [TypeAccess] FuncRef
+#    6|             1: [WildcardTypeAccess] ? ...
+#    6|               1: [TypeAccess] Integer
 #    6|             2: [TypeAccess] Integer
 #    6|       5: [BlockStmt] { ... }
 #    6|         0: [ExprStmt] <Expr>;
@@ -3158,9 +3170,11 @@ funcExprs.kt:
 #    7|         0: [Parameter] x
 #    7|           0: [TypeAccess] int
 #    7|         1: [Parameter] f
-#    7|           0: [TypeAccess] Function2<Integer,Integer,Integer>
-#    7|             0: [TypeAccess] Integer
-#    7|             1: [TypeAccess] Integer
+#    7|           0: [TypeAccess] Function2<? super Integer,? super Integer,Integer>
+#    7|             0: [WildcardTypeAccess] ? ...
+#    7|               1: [TypeAccess] Integer
+#    7|             1: [WildcardTypeAccess] ? ...
+#    7|               1: [TypeAccess] Integer
 #    7|             2: [TypeAccess] Integer
 #    7|       5: [BlockStmt] { ... }
 #    7|         0: [ExprStmt] <Expr>;
@@ -3176,9 +3190,11 @@ funcExprs.kt:
 #    8|         0: [Parameter] x
 #    8|           0: [TypeAccess] int
 #    8|         1: [Parameter] f
-#    8|           0: [TypeAccess] Function2<Integer,Integer,Integer>
-#    8|             0: [TypeAccess] Integer
-#    8|             1: [TypeAccess] Integer
+#    8|           0: [TypeAccess] Function2<? super Integer,? super Integer,Integer>
+#    8|             0: [WildcardTypeAccess] ? ...
+#    8|               1: [TypeAccess] Integer
+#    8|             1: [WildcardTypeAccess] ? ...
+#    8|               1: [TypeAccess] Integer
 #    8|             2: [TypeAccess] Integer
 #    8|       5: [BlockStmt] { ... }
 #    8|         0: [ExprStmt] <Expr>;
@@ -3194,11 +3210,14 @@ funcExprs.kt:
 #    9|         0: [Parameter] x
 #    9|           0: [TypeAccess] int
 #    9|         1: [Parameter] f
-#    9|           0: [TypeAccess] Function1<Integer,Function1<Integer,Double>>
-#    9|             0: [TypeAccess] Integer
-#    9|             1: [TypeAccess] Function1<Integer,Double>
-#    9|               0: [TypeAccess] Integer
-#    9|               1: [TypeAccess] Double
+#    9|           0: [TypeAccess] Function1<? super Integer,? extends Function1<? super Integer,Double>>
+#    9|             0: [WildcardTypeAccess] ? ...
+#    9|               1: [TypeAccess] Integer
+#    9|             1: [WildcardTypeAccess] ? ...
+#    9|               0: [TypeAccess] Function1<? super Integer,Double>
+#    9|                 0: [WildcardTypeAccess] ? ...
+#    9|                   1: [TypeAccess] Integer
+#    9|                 1: [TypeAccess] Double
 #    9|       5: [BlockStmt] { ... }
 #    9|         0: [ExprStmt] <Expr>;
 #    9|           0: [ImplicitCoercionToUnitExpr] <implicit coercion to unit>
@@ -3214,29 +3233,51 @@ funcExprs.kt:
 #   11|         0: [Parameter] x
 #   11|           0: [TypeAccess] int
 #   11|         1: [Parameter] f
-#   11|           0: [TypeAccess] Function22<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Unit>
-#   11|             0: [TypeAccess] Integer
-#   11|             1: [TypeAccess] Integer
-#   11|             2: [TypeAccess] Integer
-#   11|             3: [TypeAccess] Integer
-#   11|             4: [TypeAccess] Integer
-#   11|             5: [TypeAccess] Integer
-#   11|             6: [TypeAccess] Integer
-#   11|             7: [TypeAccess] Integer
-#   11|             8: [TypeAccess] Integer
-#   11|             9: [TypeAccess] Integer
-#   11|             10: [TypeAccess] Integer
-#   11|             11: [TypeAccess] Integer
-#   11|             12: [TypeAccess] Integer
-#   11|             13: [TypeAccess] Integer
-#   11|             14: [TypeAccess] Integer
-#   11|             15: [TypeAccess] Integer
-#   11|             16: [TypeAccess] Integer
-#   11|             17: [TypeAccess] Integer
-#   11|             18: [TypeAccess] Integer
-#   11|             19: [TypeAccess] Integer
-#   11|             20: [TypeAccess] Integer
-#   11|             21: [TypeAccess] Integer
+#   11|           0: [TypeAccess] Function22<? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,Unit>
+#   11|             0: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             1: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             2: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             3: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             4: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             5: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             6: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             7: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             8: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             9: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             10: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             11: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             12: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             13: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             14: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             15: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             16: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             17: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             18: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             19: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             20: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
+#   11|             21: [WildcardTypeAccess] ? ...
+#   11|               1: [TypeAccess] Integer
 #   11|             22: [TypeAccess] Unit
 #   11|       5: [BlockStmt] { ... }
 #   12|         0: [ExprStmt] <Expr>;
@@ -3271,29 +3312,52 @@ funcExprs.kt:
 #   14|           0: [TypeAccess] int
 #   14|         1: [Parameter] f
 #   14|           0: [TypeAccess] FunctionN<String>
-#   14|             0: [TypeAccess] Integer
-#   14|             1: [TypeAccess] Integer
-#   14|             2: [TypeAccess] Integer
-#   14|             3: [TypeAccess] Integer
-#   14|             4: [TypeAccess] Integer
-#   14|             5: [TypeAccess] Integer
-#   14|             6: [TypeAccess] Integer
-#   14|             7: [TypeAccess] Integer
-#   14|             8: [TypeAccess] Integer
-#   14|             9: [TypeAccess] Integer
-#   14|             10: [TypeAccess] Integer
-#   14|             11: [TypeAccess] Integer
-#   14|             12: [TypeAccess] Integer
-#   14|             13: [TypeAccess] Integer
-#   14|             14: [TypeAccess] Integer
-#   14|             15: [TypeAccess] Integer
-#   14|             16: [TypeAccess] Integer
-#   14|             17: [TypeAccess] Integer
-#   14|             18: [TypeAccess] Integer
-#   14|             19: [TypeAccess] Integer
-#   14|             20: [TypeAccess] Integer
-#   14|             21: [TypeAccess] Integer
-#   14|             22: [TypeAccess] Integer
+#   14|             0: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             1: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             2: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             3: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             4: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             5: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             6: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             7: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             8: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             9: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             10: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             11: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             12: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             13: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             14: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             15: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             16: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             17: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             18: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             19: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             20: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             21: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
+#   14|             22: [WildcardTypeAccess] ? ...
+#   14|               1: [TypeAccess] Integer
 #   14|             23: [TypeAccess] String
 #   14|       5: [BlockStmt] { ... }
 #   15|         0: [ExprStmt] <Expr>;
@@ -3335,30 +3399,54 @@ funcExprs.kt:
 #   17|           0: [TypeAccess] int
 #   17|         1: [Parameter] f
 #   17|           0: [TypeAccess] FunctionN<String>
-#   17|             0: [TypeAccess] FuncRef
-#   17|             1: [TypeAccess] Integer
-#   17|             2: [TypeAccess] Integer
-#   17|             3: [TypeAccess] Integer
-#   17|             4: [TypeAccess] Integer
-#   17|             5: [TypeAccess] Integer
-#   17|             6: [TypeAccess] Integer
-#   17|             7: [TypeAccess] Integer
-#   17|             8: [TypeAccess] Integer
-#   17|             9: [TypeAccess] Integer
-#   17|             10: [TypeAccess] Integer
-#   17|             11: [TypeAccess] Integer
-#   17|             12: [TypeAccess] Integer
-#   17|             13: [TypeAccess] Integer
-#   17|             14: [TypeAccess] Integer
-#   17|             15: [TypeAccess] Integer
-#   17|             16: [TypeAccess] Integer
-#   17|             17: [TypeAccess] Integer
-#   17|             18: [TypeAccess] Integer
-#   17|             19: [TypeAccess] Integer
-#   17|             20: [TypeAccess] Integer
-#   17|             21: [TypeAccess] Integer
-#   17|             22: [TypeAccess] Integer
-#   17|             23: [TypeAccess] Integer
+#   17|             0: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] FuncRef
+#   17|             1: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             2: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             3: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             4: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             5: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             6: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             7: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             8: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             9: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             10: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             11: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             12: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             13: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             14: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             15: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             16: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             17: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             18: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             19: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             20: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             21: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             22: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
+#   17|             23: [WildcardTypeAccess] ? ...
+#   17|               1: [TypeAccess] Integer
 #   17|             24: [TypeAccess] String
 #   17|       5: [BlockStmt] { ... }
 #   18|         0: [ExprStmt] <Expr>;
@@ -4496,8 +4584,9 @@ funcExprs.kt:
 #   58|       3: [TypeAccess] Unit
 #-----|       4: (Parameters)
 #   58|         0: [Parameter] l
-#   58|           0: [TypeAccess] Function0<T>
-#   58|             0: [TypeAccess] T
+#   58|           0: [TypeAccess] Function0<? extends T>
+#   58|             0: [WildcardTypeAccess] ? ...
+#   58|               0: [TypeAccess] T
 #   58|       5: [BlockStmt] { ... }
 #   59|     15: [ExtensionMethod] f3
 #   59|       3: [TypeAccess] int
@@ -4685,10 +4774,11 @@ funcExprs.kt:
 #   77|       3: [TypeAccess] Unit
 #-----|       4: (Parameters)
 #   77|         0: [Parameter] f
-#   77|           0: [TypeAccess] Function1<Generic<Generic<Integer>>,String>
-#   77|             0: [TypeAccess] Generic<Generic<Integer>>
-#   77|               0: [TypeAccess] Generic<Integer>
-#   77|                 0: [TypeAccess] Integer
+#   77|           0: [TypeAccess] Function1<? super Generic<Generic<Integer>>,String>
+#   77|             0: [WildcardTypeAccess] ? ...
+#   77|               1: [TypeAccess] Generic<Generic<Integer>>
+#   77|                 0: [TypeAccess] Generic<Integer>
+#   77|                   0: [TypeAccess] Integer
 #   77|             1: [TypeAccess] String
 #   77|       5: [BlockStmt] { ... }
 #   79|     6: [Class,GenericType,ParameterizedType] Generic

--- a/java/ql/test/kotlin/library-tests/exprs/exprs.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/exprs.expected
@@ -64,7 +64,8 @@
 | delegatedProperties.kt:11:17:11:21 | Object | delegatedProperties.kt:5:5:12:5 | fn | TypeAccess |
 | delegatedProperties.kt:11:17:11:21 | new (...) | delegatedProperties.kt:5:5:12:5 | fn | ClassInstanceExpr |
 | delegatedProperties.kt:18:5:40:5 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| delegatedProperties.kt:18:12:18:33 | Map<String,Object> | file://:0:0:0:0 | <none> | TypeAccess |
+| delegatedProperties.kt:18:12:18:33 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| delegatedProperties.kt:18:12:18:33 | Map<String,? extends Object> | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:18:12:18:33 | Object | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:18:12:18:33 | String | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:19:31:19:51 | ...::... | delegatedProperties.kt:19:31:19:51 | <get-varResource1> | PropertyRefExpr |
@@ -148,11 +149,13 @@
 | delegatedProperties.kt:26:28:26:28 | 0 | delegatedProperties.kt:25:64:31:9 |  | IntegerLiteral |
 | delegatedProperties.kt:27:22:27:88 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:27:35:27:47 | Object | file://:0:0:0:0 | <none> | TypeAccess |
+| delegatedProperties.kt:27:50:27:71 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | delegatedProperties.kt:27:50:27:71 | KProperty<?> | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:27:81:27:88 | getCurValue(...) | delegatedProperties.kt:27:22:27:88 | getValue | MethodAccess |
 | delegatedProperties.kt:27:81:27:88 | this | delegatedProperties.kt:27:22:27:88 | getValue | ThisAccess |
 | delegatedProperties.kt:28:22:30:13 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:28:35:28:47 | Object | file://:0:0:0:0 | <none> | TypeAccess |
+| delegatedProperties.kt:28:50:28:71 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | delegatedProperties.kt:28:50:28:71 | KProperty<?> | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:28:74:28:83 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:29:17:29:24 | setCurValue(...) | delegatedProperties.kt:28:22:30:13 | setValue | MethodAccess |
@@ -280,14 +283,17 @@
 | delegatedProperties.kt:42:30:42:47 | setValue(...) | delegatedProperties.kt:42:27:42:47 | setVarResource0 | MethodAccess |
 | delegatedProperties.kt:46:14:48:5 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:46:27:46:41 | Owner | file://:0:0:0:0 | <none> | TypeAccess |
+| delegatedProperties.kt:46:44:46:65 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | delegatedProperties.kt:46:44:46:65 | KProperty<?> | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:47:16:47:16 | 1 | delegatedProperties.kt:46:14:48:5 | getValue | IntegerLiteral |
 | delegatedProperties.kt:49:14:50:5 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:49:27:49:41 | Owner | file://:0:0:0:0 | <none> | TypeAccess |
+| delegatedProperties.kt:49:44:49:65 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | delegatedProperties.kt:49:44:49:65 | KProperty<?> | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:49:68:49:78 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:54:14:57:5 | ResourceDelegate | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:54:34:54:48 | Owner | file://:0:0:0:0 | <none> | TypeAccess |
+| delegatedProperties.kt:54:51:54:68 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | delegatedProperties.kt:54:51:54:68 | KProperty<?> | file://:0:0:0:0 | <none> | TypeAccess |
 | delegatedProperties.kt:56:16:56:33 | ResourceDelegate | delegatedProperties.kt:54:14:57:5 | provideDelegate | TypeAccess |
 | delegatedProperties.kt:56:16:56:33 | new ResourceDelegate(...) | delegatedProperties.kt:54:14:57:5 | provideDelegate | ClassInstanceExpr |
@@ -1725,14 +1731,16 @@
 | funcExprs.kt:1:42:1:44 | Unit | funcExprs.kt:1:1:1:46 | functionExpression0a | TypeAccess |
 | funcExprs.kt:1:42:1:44 | invoke(...) | funcExprs.kt:1:1:1:46 | functionExpression0a | MethodAccess |
 | funcExprs.kt:2:1:2:47 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:2:26:2:38 | Function0<Object> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:2:26:2:38 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:2:26:2:38 | Function0<? extends Object> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:2:26:2:38 | Object | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:2:43:2:43 | f | funcExprs.kt:2:1:2:47 | functionExpression0b | VarAccess |
 | funcExprs.kt:2:43:2:45 | <implicit coercion to unit> | funcExprs.kt:2:1:2:47 | functionExpression0b | ImplicitCoercionToUnitExpr |
 | funcExprs.kt:2:43:2:45 | Unit | funcExprs.kt:2:1:2:47 | functionExpression0b | TypeAccess |
 | funcExprs.kt:2:43:2:45 | invoke(...) | funcExprs.kt:2:1:2:47 | functionExpression0b | MethodAccess |
 | funcExprs.kt:3:1:3:46 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:3:26:3:37 | Function0<Object> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:3:26:3:37 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:3:26:3:37 | Function0<? extends Object> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:3:26:3:37 | Object | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:3:42:3:42 | f | funcExprs.kt:3:1:3:46 | functionExpression0c | VarAccess |
 | funcExprs.kt:3:42:3:44 | <implicit coercion to unit> | funcExprs.kt:3:1:3:46 | functionExpression0c | ImplicitCoercionToUnitExpr |
@@ -1740,7 +1748,8 @@
 | funcExprs.kt:3:42:3:44 | invoke(...) | funcExprs.kt:3:1:3:46 | functionExpression0c | MethodAccess |
 | funcExprs.kt:4:1:4:58 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:4:26:4:31 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:4:34:4:48 | Function1<Integer,Integer> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:4:34:4:48 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:4:34:4:48 | Function1<? super Integer,Integer> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:4:34:4:48 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:4:34:4:48 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:4:53:4:53 | f | funcExprs.kt:4:1:4:58 | functionExpression1a | VarAccess |
@@ -1750,7 +1759,8 @@
 | funcExprs.kt:4:55:4:55 | x | funcExprs.kt:4:1:4:58 | functionExpression1a | VarAccess |
 | funcExprs.kt:5:1:5:60 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:5:26:5:31 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:5:34:5:50 | Function1<Object,Object> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:5:34:5:50 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:5:34:5:50 | Function1<Object,? extends Object> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:5:34:5:50 | Object | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:5:34:5:50 | Object | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:5:55:5:55 | f | funcExprs.kt:5:1:5:60 | functionExpression1b | VarAccess |
@@ -1760,8 +1770,10 @@
 | funcExprs.kt:5:57:5:57 | x | funcExprs.kt:5:1:5:60 | functionExpression1b | VarAccess |
 | funcExprs.kt:6:1:6:78 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:6:26:6:31 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:6:34:6:57 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:6:34:6:57 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | funcExprs.kt:6:34:6:57 | FuncRef | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:6:34:6:57 | Function2<FuncRef,Integer,Integer> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:6:34:6:57 | Function2<? super FuncRef,? super Integer,Integer> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:6:34:6:57 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:6:34:6:57 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:6:62:6:62 | f | funcExprs.kt:6:1:6:78 | functionExpression1c | VarAccess |
@@ -1773,7 +1785,9 @@
 | funcExprs.kt:6:75:6:75 | x | funcExprs.kt:6:1:6:78 | functionExpression1c | VarAccess |
 | funcExprs.kt:7:1:7:65 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:7:25:7:30 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:7:33:7:52 | Function2<Integer,Integer,Integer> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:7:33:7:52 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:7:33:7:52 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:7:33:7:52 | Function2<? super Integer,? super Integer,Integer> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:7:33:7:52 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:7:33:7:52 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:7:33:7:52 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
@@ -1785,7 +1799,9 @@
 | funcExprs.kt:7:62:7:62 | x | funcExprs.kt:7:1:7:65 | functionExpression2 | VarAccess |
 | funcExprs.kt:8:1:8:63 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:8:25:8:30 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:8:33:8:51 | Function2<Integer,Integer,Integer> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:8:33:8:51 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:8:33:8:51 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:8:33:8:51 | Function2<? super Integer,? super Integer,Integer> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:8:33:8:51 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:8:33:8:51 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:8:33:8:51 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
@@ -1797,9 +1813,12 @@
 | funcExprs.kt:8:60:8:60 | x | funcExprs.kt:8:1:8:63 | functionExpression3 | VarAccess |
 | funcExprs.kt:9:1:9:74 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:9:25:9:30 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:9:33:9:61 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:9:33:9:61 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:9:33:9:61 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | funcExprs.kt:9:33:9:61 | Double | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:9:33:9:61 | Function1<Integer,Double> | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:9:33:9:61 | Function1<Integer,Function1<Integer,Double>> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:9:33:9:61 | Function1<? super Integer,? extends Function1<? super Integer,Double>> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:9:33:9:61 | Function1<? super Integer,Double> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:9:33:9:61 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:9:33:9:61 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:9:66:9:66 | f | funcExprs.kt:9:1:9:74 | functionExpression4 | VarAccess |
@@ -1811,7 +1830,29 @@
 | funcExprs.kt:9:71:9:71 | x | funcExprs.kt:9:1:9:74 | functionExpression4 | VarAccess |
 | funcExprs.kt:11:1:13:1 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:11:26:11:31 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:11:34:11:154 | Function22<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Unit> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:11:34:11:154 | Function22<? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,? super Integer,Unit> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:11:34:11:154 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:11:34:11:154 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:11:34:11:154 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
@@ -1861,6 +1902,29 @@
 | funcExprs.kt:12:49:12:49 | x | funcExprs.kt:11:1:13:1 | functionExpression22 | VarAccess |
 | funcExprs.kt:14:1:16:1 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:14:26:14:31 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:14:34:14:161 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | funcExprs.kt:14:34:14:161 | FunctionN<String> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:14:34:14:161 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:14:34:14:161 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
@@ -1919,6 +1983,30 @@
 | funcExprs.kt:15:51:15:51 | x | funcExprs.kt:14:1:16:1 | functionExpression23 | VarAccess |
 | funcExprs.kt:17:1:19:1 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:17:27:17:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:17:35:17:171 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
 | funcExprs.kt:17:35:17:171 | FuncRef | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:17:35:17:171 | FunctionN<String> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:17:35:17:171 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
@@ -2733,7 +2821,8 @@
 | funcExprs.kt:55:34:55:39 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:55:49:55:49 | 5 | funcExprs.kt:55:23:55:49 | invoke | IntegerLiteral |
 | funcExprs.kt:58:1:58:25 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:58:12:58:21 | Function0<T> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:58:12:58:21 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:58:12:58:21 | Function0<? extends T> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:58:12:58:21 | T | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:59:1:59:22 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:59:5:59:7 | int | file://:0:0:0:0 | <none> | TypeAccess |
@@ -2809,7 +2898,8 @@
 | funcExprs.kt:75:14:75:14 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:75:20:75:20 | a | funcExprs.kt:75:12:75:22 | invoke | StringLiteral |
 | funcExprs.kt:77:13:77:60 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| funcExprs.kt:77:20:77:55 | Function1<Generic<Generic<Integer>>,String> | file://:0:0:0:0 | <none> | TypeAccess |
+| funcExprs.kt:77:20:77:55 | ? ... | file://:0:0:0:0 | <none> | WildcardTypeAccess |
+| funcExprs.kt:77:20:77:55 | Function1<? super Generic<Generic<Integer>>,String> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:77:20:77:55 | Generic<Generic<Integer>> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:77:20:77:55 | Generic<Integer> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:77:20:77:55 | Integer | file://:0:0:0:0 | <none> | TypeAccess |

--- a/java/ql/test/kotlin/library-tests/function-n/test.expected
+++ b/java/ql/test/kotlin/library-tests/function-n/test.expected
@@ -1,3 +1,3 @@
 | test.kt:4:5:4:138 | f1 | FunctionN<String> | String |
-| test.kt:5:5:5:134 | f2 | FunctionN<T1> | T1 |
-| test.kt:6:5:6:110 | f3 | FunctionN<T3> | T3 |
+| test.kt:5:5:5:134 | f2 | FunctionN<? extends T1> | ? extends T1 |
+| test.kt:6:5:6:110 | f3 | FunctionN<? extends T3> | ? extends T3 |

--- a/java/ql/test/kotlin/library-tests/java-kotlin-collection-type-generic-methods/test.expected
+++ b/java/ql/test/kotlin/library-tests/java-kotlin-collection-type-generic-methods/test.expected
@@ -372,7 +372,7 @@ methodWithDuplicate
 | Map<String,String> | replace | String |
 | Map<String,String> | replaceAll | BiFunction<? super String,? super String,? extends String> |
 | MutableCollection | add | E |
-| MutableCollection | addAll | Collection |
+| MutableCollection | addAll | Collection<? extends E> |
 | MutableCollection | remove | Object |
 | MutableCollection | removeAll | Collection<?> |
 | MutableCollection | removeIf | Predicate<? super E> |
@@ -380,7 +380,6 @@ methodWithDuplicate
 | MutableList | add | E |
 | MutableList | add | int |
 | MutableList | addAll | Collection<? extends E> |
-| MutableList | addAll | Collection<E> |
 | MutableList | addAll | int |
 | MutableList | listIterator | int |
 | MutableList | remove | Object |
@@ -403,7 +402,7 @@ methodWithDuplicate
 | MutableMap | merge | V |
 | MutableMap | put | K |
 | MutableMap | put | V |
-| MutableMap | putAll | Map<? extends K,V> |
+| MutableMap | putAll | Map<? extends K,? extends V> |
 | MutableMap | putIfAbsent | K |
 | MutableMap | putIfAbsent | V |
 | MutableMap | remove | Object |

--- a/java/ql/test/kotlin/library-tests/multiple_extensions/calls.expected
+++ b/java/ql/test/kotlin/library-tests/multiple_extensions/calls.expected
@@ -1,4 +1,4 @@
-| PropertyReferenceDelegatesKt | getValue(KProperty0<V>, Object, KProperty<?>) |
-| PropertyReferenceDelegatesKt | getValue(KProperty1<T,V>, T, KProperty<?>) |
+| PropertyReferenceDelegatesKt | getValue(KProperty0<? extends V>, Object, KProperty<?>) |
+| PropertyReferenceDelegatesKt | getValue(KProperty1<T,? extends V>, T, KProperty<?>) |
 | StringsKt | removePrefix(String, CharSequence) |
 | StringsKt | startsWith(String, String, boolean) |

--- a/java/ql/test/kotlin/library-tests/reflection/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/reflection/PrintAst.expected
@@ -211,9 +211,11 @@ reflection.kt:
 #  102|         0: [Parameter] l
 #  102|           0: [TypeAccess] T
 #  102|         1: [Parameter] transform
-#  102|           0: [TypeAccess] Function1<T,R>
-#  102|             0: [TypeAccess] T
-#  102|             1: [TypeAccess] R
+#  102|           0: [TypeAccess] Function1<? super T,? extends R>
+#  102|             0: [WildcardTypeAccess] ? ...
+#  102|               1: [TypeAccess] T
+#  102|             1: [WildcardTypeAccess] ? ...
+#  102|               0: [TypeAccess] R
 #  102|       5: [BlockStmt] { ... }
 #  103|     8: [Method] fn12
 #-----|       2: (Generic Parameters)
@@ -224,9 +226,11 @@ reflection.kt:
 #  103|         0: [Parameter] l
 #  103|           0: [TypeAccess] T1
 #  103|         1: [Parameter] l2
-#  103|           0: [TypeAccess] Function1<T1,R>
-#  103|             0: [TypeAccess] T1
-#  103|             1: [TypeAccess] R
+#  103|           0: [TypeAccess] Function1<? super T1,? extends R>
+#  103|             0: [WildcardTypeAccess] ? ...
+#  103|               1: [TypeAccess] T1
+#  103|             1: [WildcardTypeAccess] ? ...
+#  103|               0: [TypeAccess] R
 #  103|       5: [BlockStmt] { ... }
 #  121|     9: [Method] fn1
 #  121|       3: [TypeAccess] int
@@ -557,6 +561,7 @@ reflection.kt:
 #-----|                       4: (Parameters)
 #   24|                         0: [Parameter] it
 #   24|                           0: [TypeAccess] KCallable<?>
+#   24|                             0: [WildcardTypeAccess] ? ...
 #   24|                       5: [BlockStmt] { ... }
 #   24|                         0: [ReturnStmt] return ...
 #   24|                           0: [ValueEQExpr] ... (value equals) ...


### PR DESCRIPTION
For Kotlin code, introduce wildcards where the compiler would introduce them when lowering to bytecode (when a type parameter has declaration-site variance, by default only in parameter context, special-casing types that can't be extended / with no supertypes, and obeying the `@JvmWildcard` and `@JvmSuppressWildcards` annotations.

For Java code, use the original Java type to suppress wildcard introduction if the Java type didn't use a wildcard even though it would have been appropriate (for example, Java can ask for exactly `Comparable<String>` even though it would lose nothing to permit `Comparable<? super String>`)