### PR TITLE
Misc: query-list should run on `codeql-cli/*` tags

### DIFF
--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -5,6 +5,8 @@ on:
     branches:
      - main
      - 'rc/**'
+    tags:
+     - 'codeql-cli/*'
   pull_request:
     paths:
       - '.github/workflows/query-list.yml'


### PR DESCRIPTION
Since go doesn't need to be cloned with the same tag, that makes this change much easier to implement in practice :muscle: