### PR TITLE
Go: Sync InlineExpectationsTest

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -390,7 +390,8 @@
     "java/ql/test/TestUtilities/InlineExpectationsTest.qll",
     "python/ql/test/TestUtilities/InlineExpectationsTest.qll",
     "ruby/ql/test/TestUtilities/InlineExpectationsTest.qll",
-    "ql/ql/test/TestUtilities/InlineExpectationsTest.qll"
+    "ql/ql/test/TestUtilities/InlineExpectationsTest.qll",
+    "go/ql/test/TestUtilities/InlineExpectationsTest.qll"
   ],
   "C++ ExternalAPIs": [
     "cpp/ql/src/Security/CWE/CWE-020/ExternalAPIs.qll",

--- a/go/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/go/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -93,7 +93,7 @@
 private import InlineExpectationsTestPrivate
 
 /**
- * Base class for tests with inline expectations. The test extends this class to provide the actual
+ * The base class for tests with inline expectations. The test extends this class to provide the actual
  * results of the query, which are then compared with the expected results in comments to produce a
  * list of failure messages that point out where the actual results differ from the expected
  * results.
@@ -121,11 +121,17 @@ abstract class InlineExpectationsTest extends string {
    * - `value` - The value of the result, which will be matched against the value associated with
    *   `tag` in any expected result comment on that line.
    */
-  abstract predicate hasActualResult(string file, int line, string element, string tag, string value);
+  abstract predicate hasActualResult(Location location, string element, string tag, string value);
 
-  predicate hasActualResult(Location location, string element, string tag, string value) {
-    this.hasActualResult(location.getFile().getAbsolutePath(), location.getStartLine(), element,
-      tag, value)
+  /**
+   * Holds if there is an optional result on the specified location.
+   *
+   * This is similar to `hasActualResult`, but returns results that do not require a matching annotation.
+   * A failure will still arise if there is an annotation that does not match any results, but not vice versa.
+   * Override this predicate to specify optional results.
+   */
+  predicate hasOptionalResult(Location location, string element, string tag, string value) {
+    none()
   }
 
   final predicate hasFailureMessage(FailureLocatable element, string message) {
@@ -139,13 +145,14 @@ abstract class InlineExpectationsTest extends string {
         )
         or
         not exists(ValidExpectation expectation | expectation.matchesActualResult(actualResult)) and
-        message = "Unexpected result: " + actualResult.getExpectationText()
+        message = "Unexpected result: " + actualResult.getExpectationText() and
+        not actualResult.isOptional()
       )
     )
     or
     exists(ValidExpectation expectation |
       not exists(ActualResult actualResult | expectation.matchesActualResult(actualResult)) and
-      expectation.getTag() = this.getARelevantTag() and
+      expectation.getTag() = getARelevantTag() and
       element = expectation and
       (
         expectation instanceof GoodExpectation and
@@ -174,7 +181,7 @@ private string expectationCommentPattern() { result = "\\s*\\$((?:[^/]|/[^/])*)(
 /**
  * The possible columns in an expectation comment. The `TDefaultColumn` branch represents the first
  * column in a comment. This column is not precedeeded by a name. `TNamedColumn(name)` represents a
- * column containing expected results preceeded by the string `name:`.
+ * column containing expected results preceded by the string `name:`.
  */
 private newtype TColumn =
   TDefaultColumn() or
@@ -248,9 +255,13 @@ private string expectationPattern() {
 
 private newtype TFailureLocatable =
   TActualResult(
-    InlineExpectationsTest test, Location location, string element, string tag, string value
+    InlineExpectationsTest test, Location location, string element, string tag, string value,
+    boolean optional
   ) {
-    test.hasActualResult(location, element, tag, value)
+    test.hasActualResult(location, element, tag, value) and
+    optional = false
+    or
+    test.hasOptionalResult(location, element, tag, value) and optional = true
   } or
   TValidExpectation(ExpectationComment comment, string tag, string value, string knownFailure) {
     exists(TColumn column, string tags |
@@ -269,7 +280,7 @@ class FailureLocatable extends TFailureLocatable {
 
   Location getLocation() { none() }
 
-  final string getExpectationText() { result = this.getTag() + "=" + this.getValue() }
+  final string getExpectationText() { result = getTag() + "=" + getValue() }
 
   string getTag() { none() }
 
@@ -282,8 +293,9 @@ class ActualResult extends FailureLocatable, TActualResult {
   string element;
   string tag;
   string value;
+  boolean optional;
 
-  ActualResult() { this = TActualResult(test, location, element, tag, value) }
+  ActualResult() { this = TActualResult(test, location, element, tag, value, optional) }
 
   override string toString() { result = element }
 
@@ -294,6 +306,8 @@ class ActualResult extends FailureLocatable, TActualResult {
   override string getTag() { result = tag }
 
   override string getValue() { result = value }
+
+  predicate isOptional() { optional = true }
 }
 
 abstract private class Expectation extends FailureLocatable {
@@ -318,24 +332,24 @@ private class ValidExpectation extends Expectation, TValidExpectation {
   string getKnownFailure() { result = knownFailure }
 
   predicate matchesActualResult(ActualResult actualResult) {
-    this.getLocation().getStartLine() = actualResult.getLocation().getStartLine() and
-    this.getLocation().getFile() = actualResult.getLocation().getFile() and
-    this.getTag() = actualResult.getTag() and
-    this.getValue() = actualResult.getValue()
+    getLocation().getStartLine() = actualResult.getLocation().getStartLine() and
+    getLocation().getFile() = actualResult.getLocation().getFile() and
+    getTag() = actualResult.getTag() and
+    getValue() = actualResult.getValue()
   }
 }
 
 /* Note: These next three classes correspond to all the possible values of type `TColumn`. */
 class GoodExpectation extends ValidExpectation {
-  GoodExpectation() { this.getKnownFailure() = "" }
+  GoodExpectation() { getKnownFailure() = "" }
 }
 
 class FalsePositiveExpectation extends ValidExpectation {
-  FalsePositiveExpectation() { this.getKnownFailure() = "SPURIOUS" }
+  FalsePositiveExpectation() { getKnownFailure() = "SPURIOUS" }
 }
 
 class FalseNegativeExpectation extends ValidExpectation {
-  FalseNegativeExpectation() { this.getKnownFailure() = "MISSING" }
+  FalseNegativeExpectation() { getKnownFailure() = "MISSING" }
 }
 
 class InvalidExpectation extends Expectation, TInvalidExpectation {

--- a/go/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/go/ql/test/TestUtilities/InlineFlowTest.qll
@@ -79,7 +79,7 @@ class InlineFlowTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasValueFlow" and
     exists(DataFlow::Node src, DataFlow::Node sink | getValueFlowConfig().hasFlow(src, sink) |
-      sink.hasLocationInfo(file, line, _, _, _) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "\"" + sink.toString() + "\""
     )
@@ -88,7 +88,7 @@ class InlineFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node src, DataFlow::Node sink |
       getTaintFlowConfig().hasFlow(src, sink) and not getValueFlowConfig().hasFlow(src, sink)
     |
-      sink.hasLocationInfo(file, line, _, _, _) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "\"" + sink.toString() + "\""
     )

--- a/go/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/go/ql/test/TestUtilities/InlineFlowTest.qll
@@ -76,7 +76,7 @@ class InlineFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasValueFlow" and
     exists(DataFlow::Node src, DataFlow::Node sink | getValueFlowConfig().hasFlow(src, sink) |
       sink.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/go/ql/test/TestUtilities/InlineFlowTest.qll
@@ -79,7 +79,8 @@ class InlineFlowTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasValueFlow" and
     exists(DataFlow::Node src, DataFlow::Node sink | getValueFlowConfig().hasFlow(src, sink) |
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "\"" + sink.toString() + "\""
     )
@@ -88,7 +89,8 @@ class InlineFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node src, DataFlow::Node sink |
       getTaintFlowConfig().hasFlow(src, sink) and not getValueFlowConfig().hasFlow(src, sink)
     |
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "\"" + sink.toString() + "\""
     )

--- a/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.ql
@@ -12,7 +12,8 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     // Dynamic key-value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getName().toString() and
         value = hw.getName().toString() and
@@ -26,7 +27,8 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     or
     // Static key, dynamic value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getHeaderName().toString() and
         value = hw.getHeaderName() and
@@ -40,7 +42,8 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     or
     // Static key, static value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getHeaderName().toString() and
         value = hw.getHeaderName() and

--- a/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.ql
@@ -12,7 +12,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     // Dynamic key-value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(file, line, _, _, _) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getName().toString() and
         value = hw.getName().toString() and
@@ -26,7 +26,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     or
     // Static key, dynamic value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(file, line, _, _, _) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getHeaderName().toString() and
         value = hw.getHeaderName() and
@@ -40,7 +40,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     or
     // Static key, static value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(file, line, _, _, _) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getHeaderName().toString() and
         value = hw.getHeaderName() and

--- a/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.ql
@@ -9,7 +9,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     result = ["headerKeyNode", "headerValNode", "headerKey", "headerVal"]
   }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     // Dynamic key-value header:
     exists(HTTP::HeaderWrite hw |
       hw.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.ql
@@ -7,7 +7,7 @@ class HttpRedirectTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "redirectUrl" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "redirectUrl" and
     exists(HTTP::Redirect rd |
       rd.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.ql
@@ -10,7 +10,7 @@ class HttpRedirectTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "redirectUrl" and
     exists(HTTP::Redirect rd |
-      rd.hasLocationInfo(file, line, _, _, _) and
+      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rd.getUrl().toString() and
       value = rd.getUrl().toString()
     )

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.ql
@@ -10,7 +10,8 @@ class HttpRedirectTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "redirectUrl" and
     exists(HTTP::Redirect rd |
-      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rd.getUrl().toString() and
       value = rd.getUrl().toString()
     )

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.ql
@@ -9,7 +9,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(HTTP::ResponseBody rd |
-      rd.hasLocationInfo(file, line, _, _, _) and
+      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = rd.getAContentType().toString() and
         value = rd.getAContentType().toString() and

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.ql
@@ -7,7 +7,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = ["contentType", "responseBody"] }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(HTTP::ResponseBody rd |
       rd.hasLocationInfo(file, line, _, _, _) and
       (

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.ql
@@ -9,7 +9,8 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(HTTP::ResponseBody rd |
-      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = rd.getAContentType().toString() and
         value = rd.getAContentType().toString() and

--- a/go/ql/test/experimental/frameworks/CleverGo/TaintTracking.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/TaintTracking.ql
@@ -24,7 +24,8 @@ class TaintTrackingTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/experimental/frameworks/CleverGo/TaintTracking.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/TaintTracking.ql
@@ -19,7 +19,7 @@ class TaintTrackingTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "taintSink" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "taintSink" and
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/experimental/frameworks/CleverGo/TaintTracking.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/TaintTracking.ql
@@ -24,7 +24,7 @@ class TaintTrackingTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/experimental/frameworks/CleverGo/UntrustedSources.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/UntrustedSources.ql
@@ -7,7 +7,7 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "untrustedFlowSource" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "untrustedFlowSource" and
     exists(DataFlow::CallNode sinkCall, DataFlow::ArgumentNode arg |
       sinkCall.getCalleeName() = "sink" and

--- a/go/ql/test/experimental/frameworks/CleverGo/UntrustedSources.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/UntrustedSources.ql
@@ -16,7 +16,8 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
     |
       element = arg.toString() and
       value = "" and
-      arg.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      arg.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/experimental/frameworks/CleverGo/UntrustedSources.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/UntrustedSources.ql
@@ -16,7 +16,7 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
     |
       element = arg.toString() and
       value = "" and
-      arg.hasLocationInfo(file, line, _, _, _)
+      arg.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.ql
@@ -12,7 +12,8 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     // Dynamic key-value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getName().toString() and
         value = hw.getName().toString() and
@@ -26,7 +27,8 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     or
     // Static key, dynamic value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getHeaderName().toString() and
         value = hw.getHeaderName() and
@@ -40,7 +42,8 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     or
     // Static key, static value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getHeaderName().toString() and
         value = hw.getHeaderName() and

--- a/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.ql
@@ -12,7 +12,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     // Dynamic key-value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(file, line, _, _, _) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getName().toString() and
         value = hw.getName().toString() and
@@ -26,7 +26,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     or
     // Static key, dynamic value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(file, line, _, _, _) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getHeaderName().toString() and
         value = hw.getHeaderName() and
@@ -40,7 +40,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     or
     // Static key, static value header:
     exists(HTTP::HeaderWrite hw |
-      hw.hasLocationInfo(file, line, _, _, _) and
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = hw.getHeaderName().toString() and
         value = hw.getHeaderName() and

--- a/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.ql
@@ -9,7 +9,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     result = ["headerKeyNode", "headerValNode", "headerKey", "headerVal"]
   }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     // Dynamic key-value header:
     exists(HTTP::HeaderWrite hw |
       hw.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/experimental/frameworks/Fiber/Redirect.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/Redirect.ql
@@ -7,7 +7,7 @@ class HttpRedirectTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "redirectUrl" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "redirectUrl" and
     exists(HTTP::Redirect rd |
       rd.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/experimental/frameworks/Fiber/Redirect.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/Redirect.ql
@@ -10,7 +10,7 @@ class HttpRedirectTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "redirectUrl" and
     exists(HTTP::Redirect rd |
-      rd.hasLocationInfo(file, line, _, _, _) and
+      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rd.getUrl().toString() and
       value = rd.getUrl().toString()
     )

--- a/go/ql/test/experimental/frameworks/Fiber/Redirect.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/Redirect.ql
@@ -10,7 +10,8 @@ class HttpRedirectTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "redirectUrl" and
     exists(HTTP::Redirect rd |
-      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rd.getUrl().toString() and
       value = rd.getUrl().toString()
     )

--- a/go/ql/test/experimental/frameworks/Fiber/ResponseBody.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/ResponseBody.ql
@@ -9,7 +9,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(HTTP::ResponseBody rd |
-      rd.hasLocationInfo(file, line, _, _, _) and
+      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = rd.getAContentType().toString() and
         value = rd.getAContentType().toString() and

--- a/go/ql/test/experimental/frameworks/Fiber/ResponseBody.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/ResponseBody.ql
@@ -7,7 +7,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = ["contentType", "responseBody"] }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(HTTP::ResponseBody rd |
       rd.hasLocationInfo(file, line, _, _, _) and
       (

--- a/go/ql/test/experimental/frameworks/Fiber/ResponseBody.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/ResponseBody.ql
@@ -9,7 +9,8 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(HTTP::ResponseBody rd |
-      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
         element = rd.getAContentType().toString() and
         value = rd.getAContentType().toString() and

--- a/go/ql/test/experimental/frameworks/Fiber/TaintTracking.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/TaintTracking.ql
@@ -24,7 +24,8 @@ class TaintTrackingTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/experimental/frameworks/Fiber/TaintTracking.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/TaintTracking.ql
@@ -19,7 +19,7 @@ class TaintTrackingTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "taintSink" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "taintSink" and
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/experimental/frameworks/Fiber/TaintTracking.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/TaintTracking.ql
@@ -24,7 +24,7 @@ class TaintTrackingTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/experimental/frameworks/Fiber/UntrustedFlowSources.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/UntrustedFlowSources.ql
@@ -7,7 +7,7 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "untrustedFlowSource" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "untrustedFlowSource" and
     exists(DataFlow::CallNode sinkCall, DataFlow::ArgumentNode arg |
       sinkCall.getCalleeName() = "sink" and

--- a/go/ql/test/experimental/frameworks/Fiber/UntrustedFlowSources.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/UntrustedFlowSources.ql
@@ -16,7 +16,8 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
     |
       element = arg.toString() and
       value = "" and
-      arg.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      arg.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/experimental/frameworks/Fiber/UntrustedFlowSources.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/UntrustedFlowSources.ql
@@ -16,7 +16,7 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
     |
       element = arg.toString() and
       value = "" and
-      arg.hasLocationInfo(file, line, _, _, _)
+      arg.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/Function/isVariadic.ql
+++ b/go/ql/test/library-tests/semmle/go/Function/isVariadic.ql
@@ -9,7 +9,8 @@ class FunctionIsVariadicTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(CallExpr ce |
       ce.getTarget().isVariadic() and
-      ce.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      ce.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = ce.toString() and
       value = "" and
       tag = "isVariadic"

--- a/go/ql/test/library-tests/semmle/go/Function/isVariadic.ql
+++ b/go/ql/test/library-tests/semmle/go/Function/isVariadic.ql
@@ -9,7 +9,7 @@ class FunctionIsVariadicTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(CallExpr ce |
       ce.getTarget().isVariadic() and
-      ce.hasLocationInfo(file, line, _, _, _) and
+      ce.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = ce.toString() and
       value = "" and
       tag = "isVariadic"

--- a/go/ql/test/library-tests/semmle/go/Function/isVariadic.ql
+++ b/go/ql/test/library-tests/semmle/go/Function/isVariadic.ql
@@ -6,7 +6,7 @@ class FunctionIsVariadicTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "isVariadic" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(CallExpr ce |
       ce.getTarget().isVariadic() and
       ce.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/library-tests/semmle/go/Types/ImplementsComparable.ql
+++ b/go/ql/test/library-tests/semmle/go/Types/ImplementsComparable.ql
@@ -13,7 +13,7 @@ class ImplementsComparableTest extends InlineExpectationsTest {
       ts.getName().matches("testComparable%") and
       ts.getATypeParameterDecl().getTypeConstraint().implementsComparable()
     |
-      ts.hasLocationInfo(file, line, _, _, _) and
+      ts.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = ts.getName() and
       value = ""
     )

--- a/go/ql/test/library-tests/semmle/go/Types/ImplementsComparable.ql
+++ b/go/ql/test/library-tests/semmle/go/Types/ImplementsComparable.ql
@@ -6,7 +6,7 @@ class ImplementsComparableTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "implementsComparable" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     // file = "interface.go" and
     tag = "implementsComparable" and
     exists(TypeSpec ts |

--- a/go/ql/test/library-tests/semmle/go/Types/ImplementsComparable.ql
+++ b/go/ql/test/library-tests/semmle/go/Types/ImplementsComparable.ql
@@ -13,7 +13,8 @@ class ImplementsComparableTest extends InlineExpectationsTest {
       ts.getName().matches("testComparable%") and
       ts.getATypeParameterDecl().getTypeConstraint().implementsComparable()
     |
-      ts.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      ts.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = ts.getName() and
       value = ""
     )

--- a/go/ql/test/library-tests/semmle/go/Types/SignatureType_isVariadic.ql
+++ b/go/ql/test/library-tests/semmle/go/Types/SignatureType_isVariadic.ql
@@ -6,7 +6,7 @@ class SignatureTypeIsVariadicTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "isVariadic" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(FuncDef fd |
       fd.isVariadic() and
       fd.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/library-tests/semmle/go/Types/SignatureType_isVariadic.ql
+++ b/go/ql/test/library-tests/semmle/go/Types/SignatureType_isVariadic.ql
@@ -9,7 +9,7 @@ class SignatureTypeIsVariadicTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(FuncDef fd |
       fd.isVariadic() and
-      fd.hasLocationInfo(file, line, _, _, _) and
+      fd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = fd.toString() and
       value = "" and
       tag = "isVariadic"

--- a/go/ql/test/library-tests/semmle/go/Types/SignatureType_isVariadic.ql
+++ b/go/ql/test/library-tests/semmle/go/Types/SignatureType_isVariadic.ql
@@ -9,7 +9,8 @@ class SignatureTypeIsVariadicTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(FuncDef fd |
       fd.isVariadic() and
-      fd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      fd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = fd.toString() and
       value = "" and
       tag = "isVariadic"

--- a/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.ql
@@ -11,7 +11,7 @@ class HttpHandler extends InlineExpectationsTest {
     exists(HTTP::RequestHandler h, DataFlow::Node check |
       element = h.toString() and value = check.toString()
     |
-      h.hasLocationInfo(file, line, _, _, _) and
+      h.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       h.guardedBy(check)
     )
   }

--- a/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.ql
@@ -6,7 +6,7 @@ class HttpHandler extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "handler" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "handler" and
     exists(HTTP::RequestHandler h, DataFlow::Node check |
       element = h.toString() and value = check.toString()

--- a/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.ql
@@ -11,7 +11,8 @@ class HttpHandler extends InlineExpectationsTest {
     exists(HTTP::RequestHandler h, DataFlow::Node check |
       element = h.toString() and value = check.toString()
     |
-      h.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      h.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       h.guardedBy(check)
     )
   }

--- a/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/LoggerCall.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/LoggerCall.ql
@@ -6,7 +6,7 @@ class LoggerTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "logger" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(LoggerCall log |
       log.hasLocationInfo(file, line, _, _, _) and
       element = log.toString() and

--- a/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/LoggerCall.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/LoggerCall.ql
@@ -8,7 +8,8 @@ class LoggerTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(LoggerCall log |
-      log.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      log.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = log.toString() and
       value = log.getAMessageComponent().toString() and
       tag = "logger"

--- a/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/LoggerCall.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/LoggerCall.ql
@@ -8,7 +8,7 @@ class LoggerTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(LoggerCall log |
-      log.hasLocationInfo(file, line, _, _, _) and
+      log.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = log.toString() and
       value = log.getAMessageComponent().toString() and
       tag = "logger"

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowVarArgs/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowVarArgs/Flows.ql
@@ -39,7 +39,8 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -66,7 +67,8 @@ class TaintFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowVarArgs/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowVarArgs/Flows.ql
@@ -34,7 +34,7 @@ class DataFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "dataflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "dataflow" and
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
@@ -61,7 +61,7 @@ class TaintFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "taintflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "taintflow" and
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowVarArgs/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowVarArgs/Flows.ql
@@ -39,7 +39,7 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -66,7 +66,7 @@ class TaintFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/GuardingFunctions/test.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/GuardingFunctions/test.ql
@@ -33,7 +33,7 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and
       value = sink.toString() and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/GuardingFunctions/test.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/GuardingFunctions/test.ql
@@ -28,7 +28,7 @@ class DataFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "dataflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "dataflow" and
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/dataflow/GuardingFunctions/test.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/GuardingFunctions/test.ql
@@ -33,7 +33,8 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and
       value = sink.toString() and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/ListOfConstantsSanitizerGuards/test.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ListOfConstantsSanitizerGuards/test.ql
@@ -23,7 +23,7 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and
       value = sink.toString() and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/ListOfConstantsSanitizerGuards/test.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ListOfConstantsSanitizerGuards/test.ql
@@ -18,7 +18,7 @@ class DataFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "dataflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "dataflow" and
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/dataflow/ListOfConstantsSanitizerGuards/test.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ListOfConstantsSanitizerGuards/test.ql
@@ -23,7 +23,8 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and
       value = sink.toString() and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/PromotedFields/DataFlowConfig.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/PromotedFields/DataFlowConfig.ql
@@ -29,7 +29,8 @@ class PromotedFieldsTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "" and
       tag = "promotedfields"

--- a/go/ql/test/library-tests/semmle/go/dataflow/PromotedFields/DataFlowConfig.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/PromotedFields/DataFlowConfig.ql
@@ -29,7 +29,7 @@ class PromotedFieldsTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
-      sink.hasLocationInfo(file, line, _, _, _) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "" and
       tag = "promotedfields"

--- a/go/ql/test/library-tests/semmle/go/dataflow/PromotedFields/DataFlowConfig.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/PromotedFields/DataFlowConfig.ql
@@ -26,7 +26,7 @@ class PromotedFieldsTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "promotedfields" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
       sink.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.ql
@@ -30,7 +30,8 @@ class PromotedMethodsTest extends InlineExpectationsTest {
     exists(TestConfig config, DataFlow::Node source, DataFlow::Node sink |
       config.hasFlow(source, sink)
     |
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = source.getEnclosingCallable().getName() and
       tag = "promotedmethods"

--- a/go/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.ql
@@ -30,7 +30,7 @@ class PromotedMethodsTest extends InlineExpectationsTest {
     exists(TestConfig config, DataFlow::Node source, DataFlow::Node sink |
       config.hasFlow(source, sink)
     |
-      sink.hasLocationInfo(file, line, _, _, _) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = source.getEnclosingCallable().getName() and
       tag = "promotedmethods"

--- a/go/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.ql
@@ -26,7 +26,7 @@ class PromotedMethodsTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "promotedmethods" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::Node source, DataFlow::Node sink |
       config.hasFlow(source, sink)
     |

--- a/go/ql/test/library-tests/semmle/go/dataflow/TypeAssertions/DataFlow.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/TypeAssertions/DataFlow.ql
@@ -23,7 +23,8 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = sink.toString() and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/TypeAssertions/DataFlow.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/TypeAssertions/DataFlow.ql
@@ -23,7 +23,7 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = sink.toString() and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/TypeAssertions/DataFlow.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/TypeAssertions/DataFlow.ql
@@ -18,7 +18,7 @@ class DataFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "dataflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "dataflow" and
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/dataflow/VarArgs/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/VarArgs/Flows.ql
@@ -23,7 +23,8 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -50,7 +51,8 @@ class TaintFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/VarArgs/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/VarArgs/Flows.ql
@@ -18,7 +18,7 @@ class DataFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "dataflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "dataflow" and
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
@@ -45,7 +45,7 @@ class TaintFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "taintflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "taintflow" and
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/dataflow/VarArgs/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/VarArgs/Flows.ql
@@ -23,7 +23,7 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -50,7 +50,7 @@ class TaintFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/VarArgsWithFunctionModels/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/VarArgsWithFunctionModels/Flows.ql
@@ -50,7 +50,7 @@ class DataFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "dataflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "dataflow" and
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
@@ -79,7 +79,7 @@ class TaintFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "taintflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "taintflow" and
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/dataflow/VarArgsWithFunctionModels/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/VarArgsWithFunctionModels/Flows.ql
@@ -55,7 +55,7 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -84,7 +84,7 @@ class TaintFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/VarArgsWithFunctionModels/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/VarArgsWithFunctionModels/Flows.ql
@@ -55,7 +55,8 @@ class DataFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(DataConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -84,7 +85,8 @@ class TaintFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TaintConfiguration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/frameworks/CouchbaseV1/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/CouchbaseV1/test.ql
@@ -12,7 +12,8 @@ class SqlInjectionTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(SqlInjection::Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = sink.toString() and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/frameworks/CouchbaseV1/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/CouchbaseV1/test.ql
@@ -7,7 +7,7 @@ class SqlInjectionTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "sqlinjection" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "sqlinjection" and
     exists(DataFlow::Node sink | any(SqlInjection::Configuration c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/frameworks/CouchbaseV1/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/CouchbaseV1/test.ql
@@ -12,7 +12,7 @@ class SqlInjectionTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(SqlInjection::Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = sink.toString() and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.ql
@@ -10,7 +10,8 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
     tag = "untrustedflowsource" and
     value = element and
     exists(UntrustedFlowSource src | value = "\"" + src.toString() + "\"" |
-      src.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      src.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -25,7 +26,8 @@ class HeaderWriteTest extends InlineExpectationsTest {
     exists(HTTP::HeaderWrite hw, string name, string val | element = hw.toString() |
       hw.definesHeader(name, val) and
       value = name + ":" + val and
-      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -37,7 +39,8 @@ class LoggerTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(LoggerCall log |
-      log.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      log.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = log.toString() and
       value = log.getAMessageComponent().toString() and
       tag = "logger"

--- a/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.ql
@@ -10,7 +10,7 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
     tag = "untrustedflowsource" and
     value = element and
     exists(UntrustedFlowSource src | value = "\"" + src.toString() + "\"" |
-      src.hasLocationInfo(file, line, _, _, _)
+      src.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -25,7 +25,7 @@ class HeaderWriteTest extends InlineExpectationsTest {
     exists(HTTP::HeaderWrite hw, string name, string val | element = hw.toString() |
       hw.definesHeader(name, val) and
       value = name + ":" + val and
-      hw.hasLocationInfo(file, line, _, _, _)
+      hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }
@@ -37,7 +37,7 @@ class LoggerTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(LoggerCall log |
-      log.hasLocationInfo(file, line, _, _, _) and
+      log.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = log.toString() and
       value = log.getAMessageComponent().toString() and
       tag = "logger"

--- a/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.ql
@@ -6,7 +6,7 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "untrustedflowsource" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "untrustedflowsource" and
     value = element and
     exists(UntrustedFlowSource src | value = "\"" + src.toString() + "\"" |
@@ -20,7 +20,7 @@ class HeaderWriteTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "headerwrite" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "headerwrite" and
     exists(HTTP::HeaderWrite hw, string name, string val | element = hw.toString() |
       hw.definesHeader(name, val) and
@@ -35,7 +35,7 @@ class LoggerTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "logger" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(LoggerCall log |
       log.hasLocationInfo(file, line, _, _, _) and
       element = log.toString() and

--- a/go/ql/test/library-tests/semmle/go/frameworks/EvanphxJsonPatch/TaintFlows.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/EvanphxJsonPatch/TaintFlows.ql
@@ -21,7 +21,7 @@ class TaintFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "taintflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "taintflow" and
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/frameworks/EvanphxJsonPatch/TaintFlows.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/EvanphxJsonPatch/TaintFlows.ql
@@ -26,7 +26,8 @@ class TaintFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/frameworks/EvanphxJsonPatch/TaintFlows.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/EvanphxJsonPatch/TaintFlows.ql
@@ -26,7 +26,7 @@ class TaintFlowTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(Configuration c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/frameworks/GoKit/untrustedflowsource.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/GoKit/untrustedflowsource.ql
@@ -7,7 +7,7 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "source" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(UntrustedFlowSource source |
       source.hasLocationInfo(file, line, _, _, _) and
       element = source.toString() and

--- a/go/ql/test/library-tests/semmle/go/frameworks/GoKit/untrustedflowsource.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/GoKit/untrustedflowsource.ql
@@ -9,7 +9,9 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(UntrustedFlowSource source |
-      source.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      source
+          .hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+            location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = source.toString() and
       value = "\"" + source.toString() + "\"" and
       tag = "source"

--- a/go/ql/test/library-tests/semmle/go/frameworks/GoKit/untrustedflowsource.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/GoKit/untrustedflowsource.ql
@@ -9,7 +9,7 @@ class UntrustedFlowSourceTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(UntrustedFlowSource source |
-      source.hasLocationInfo(file, line, _, _, _) and
+      source.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = source.toString() and
       value = "\"" + source.toString() + "\"" and
       tag = "source"

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApiCoreV1/TaintFlowsInline.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApiCoreV1/TaintFlowsInline.ql
@@ -26,7 +26,7 @@ class K8sIoApiCoreV1Test extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "KsIoApiCoreV" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
       sink.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApiCoreV1/TaintFlowsInline.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApiCoreV1/TaintFlowsInline.ql
@@ -29,7 +29,7 @@ class K8sIoApiCoreV1Test extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
-      sink.hasLocationInfo(file, line, _, _, _) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "" and
       tag = "KsIoApiCoreV"

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApiCoreV1/TaintFlowsInline.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApiCoreV1/TaintFlowsInline.ql
@@ -29,7 +29,8 @@ class K8sIoApiCoreV1Test extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "" and
       tag = "KsIoApiCoreV"

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApimachineryPkgRuntime/TaintFlowsInline.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApimachineryPkgRuntime/TaintFlowsInline.ql
@@ -29,7 +29,8 @@ class K8sIoApimachineryPkgRuntimeTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "" and
       tag = "KsIoApimachineryPkgRuntime"

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApimachineryPkgRuntime/TaintFlowsInline.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApimachineryPkgRuntime/TaintFlowsInline.ql
@@ -29,7 +29,7 @@ class K8sIoApimachineryPkgRuntimeTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
-      sink.hasLocationInfo(file, line, _, _, _) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString() and
       value = "" and
       tag = "KsIoApimachineryPkgRuntime"

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApimachineryPkgRuntime/TaintFlowsInline.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoApimachineryPkgRuntime/TaintFlowsInline.ql
@@ -26,7 +26,7 @@ class K8sIoApimachineryPkgRuntimeTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "KsIoApimachineryPkgRuntime" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TestConfig config, DataFlow::PathNode source, DataFlow::PathNode sink |
       config.hasFlowPath(source, sink) and
       sink.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoClientGo/SecretInterfaceSource.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoClientGo/SecretInterfaceSource.ql
@@ -8,7 +8,9 @@ class K8sIoApimachineryPkgRuntimeTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(K8sIoClientGo::SecretInterfaceSource source |
-      source.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      source
+          .hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+            location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = source.toString() and
       value = "" and
       tag = "KsIoClientGo"

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoClientGo/SecretInterfaceSource.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoClientGo/SecretInterfaceSource.ql
@@ -8,7 +8,7 @@ class K8sIoApimachineryPkgRuntimeTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(K8sIoClientGo::SecretInterfaceSource source |
-      source.hasLocationInfo(file, line, _, _, _) and
+      source.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = source.toString() and
       value = "" and
       tag = "KsIoClientGo"

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoClientGo/SecretInterfaceSource.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoClientGo/SecretInterfaceSource.ql
@@ -6,7 +6,7 @@ class K8sIoApimachineryPkgRuntimeTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "KsIoClientGo" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(K8sIoClientGo::SecretInterfaceSource source |
       source.hasLocationInfo(file, line, _, _, _) and
       element = source.toString() and

--- a/go/ql/test/library-tests/semmle/go/frameworks/NoSQL/Query.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/NoSQL/Query.ql
@@ -8,7 +8,7 @@ class NoSQLQueryTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(NoSQL::Query q |
-      q.hasLocationInfo(file, line, _, _, _) and
+      q.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = q.toString() and
       value = q.toString() and
       tag = "nosqlquery"

--- a/go/ql/test/library-tests/semmle/go/frameworks/NoSQL/Query.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/NoSQL/Query.ql
@@ -8,7 +8,8 @@ class NoSQLQueryTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(NoSQL::Query q |
-      q.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      q.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = q.toString() and
       value = q.toString() and
       tag = "nosqlquery"

--- a/go/ql/test/library-tests/semmle/go/frameworks/NoSQL/Query.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/NoSQL/Query.ql
@@ -6,7 +6,7 @@ class NoSQLQueryTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "nosqlquery" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(NoSQL::Query q |
       q.hasLocationInfo(file, line, _, _, _) and
       element = q.toString() and

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.ql
@@ -25,7 +25,8 @@ class MissingDataFlowTest extends InlineExpectationsTest {
     value = "" and
     exists(Sink sink |
       not any(TestConfig c).hasFlow(_, sink) and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString()
     )
   }
@@ -39,7 +40,8 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "responsebody" and
     exists(HTTP::ResponseBody rb |
-      rb.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      rb.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rb.toString() and
       value = "'" + rb.toString() + "'"
     )

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.ql
@@ -25,7 +25,7 @@ class MissingDataFlowTest extends InlineExpectationsTest {
     value = "" and
     exists(Sink sink |
       not any(TestConfig c).hasFlow(_, sink) and
-      sink.hasLocationInfo(file, line, _, _, _) and
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = sink.toString()
     )
   }
@@ -39,7 +39,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "responsebody" and
     exists(HTTP::ResponseBody rb |
-      rb.hasLocationInfo(file, line, _, _, _) and
+      rb.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rb.toString() and
       value = "'" + rb.toString() + "'"
     )

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.ql
@@ -20,7 +20,7 @@ class MissingDataFlowTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "noflow" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "noflow" and
     value = "" and
     exists(Sink sink |
@@ -36,7 +36,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "responsebody" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "responsebody" and
     exists(HTTP::ResponseBody rb |
       rb.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/QueryString.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/QueryString.ql
@@ -9,7 +9,7 @@ class SQLTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "query" and
     exists(SQL::Query q, SQL::QueryString qs, string qsFile, int qsLine | qs = q.getAQueryString() |
-      q.hasLocationInfo(file, line, _, _, _) and
+      q.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       qs.hasLocationInfo(qsFile, qsLine, _, _, _) and
       element = q.toString() and
       value = qs.toString()
@@ -26,7 +26,7 @@ class QueryString extends InlineExpectationsTest {
     tag = "querystring" and
     element = "" and
     exists(SQL::QueryString qs | not exists(SQL::Query q | qs = q.getAQueryString()) |
-      qs.hasLocationInfo(file, line, _, _, _) and
+      qs.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       value = qs.toString()
     )
   }

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/QueryString.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/QueryString.ql
@@ -9,7 +9,8 @@ class SQLTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "query" and
     exists(SQL::Query q, SQL::QueryString qs, string qsFile, int qsLine | qs = q.getAQueryString() |
-      q.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      q.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       qs.hasLocationInfo(qsFile, qsLine, _, _, _) and
       element = q.toString() and
       value = qs.toString()
@@ -26,7 +27,8 @@ class QueryString extends InlineExpectationsTest {
     tag = "querystring" and
     element = "" and
     exists(SQL::QueryString qs | not exists(SQL::Query q | qs = q.getAQueryString()) |
-      qs.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      qs.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       value = qs.toString()
     )
   }

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/QueryString.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/QueryString.ql
@@ -6,7 +6,7 @@ class SQLTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "query" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "query" and
     exists(SQL::Query q, SQL::QueryString qs, string qsFile, int qsLine | qs = q.getAQueryString() |
       q.hasLocationInfo(file, line, _, _, _) and
@@ -22,7 +22,7 @@ class QueryString extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "querystring" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "querystring" and
     element = "" and
     exists(SQL::QueryString qs | not exists(SQL::Query q | qs = q.getAQueryString()) |

--- a/go/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/test.ql
@@ -6,7 +6,7 @@ class FileSystemAccessTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "fsaccess" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(FileSystemAccess f |
       f.hasLocationInfo(file, line, _, _, _) and
       element = f.toString() and

--- a/go/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/test.ql
@@ -8,7 +8,8 @@ class FileSystemAccessTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(FileSystemAccess f |
-      f.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      f.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = f.toString() and
       value = f.getAPathArgument().toString() and
       tag = "fsaccess"

--- a/go/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/test.ql
@@ -8,7 +8,7 @@ class FileSystemAccessTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(FileSystemAccess f |
-      f.hasLocationInfo(file, line, _, _, _) and
+      f.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = f.toString() and
       value = f.getAPathArgument().toString() and
       tag = "fsaccess"

--- a/go/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.ql
@@ -6,7 +6,7 @@ class TaintFunctionModelTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "ttfnmodelstep" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "ttfnmodelstep" and
     exists(TaintTracking::FunctionModel model, DataFlow::CallNode call | call = model.getACall() |
       call.hasLocationInfo(file, line, _, _, _) and
@@ -21,7 +21,7 @@ class MarshalerTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "marshaler" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "marshaler" and
     exists(MarshalingFunction m, DataFlow::CallNode call | call = m.getACall() |
       call.hasLocationInfo(file, line, _, _, _) and
@@ -38,7 +38,7 @@ class UnmarshalerTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "unmarshaler" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "unmarshaler" and
     exists(UnmarshalingFunction m, DataFlow::CallNode call | call = m.getACall() |
       call.hasLocationInfo(file, line, _, _, _) and

--- a/go/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.ql
@@ -9,7 +9,7 @@ class TaintFunctionModelTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "ttfnmodelstep" and
     exists(TaintTracking::FunctionModel model, DataFlow::CallNode call | call = model.getACall() |
-      call.hasLocationInfo(file, line, _, _, _) and
+      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = call.toString() and
       value = "\"" + model.getAnInputNode(call) + " -> " + model.getAnOutputNode(call) + "\""
     )
@@ -24,7 +24,7 @@ class MarshalerTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "marshaler" and
     exists(MarshalingFunction m, DataFlow::CallNode call | call = m.getACall() |
-      call.hasLocationInfo(file, line, _, _, _) and
+      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = call.toString() and
       value =
         "\"" + m.getFormat() + ": " + m.getAnInput().getNode(call) + " -> " +
@@ -41,7 +41,7 @@ class UnmarshalerTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "unmarshaler" and
     exists(UnmarshalingFunction m, DataFlow::CallNode call | call = m.getACall() |
-      call.hasLocationInfo(file, line, _, _, _) and
+      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = call.toString() and
       value =
         "\"" + m.getFormat() + ": " + m.getAnInput().getNode(call) + " -> " +

--- a/go/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.ql
@@ -9,7 +9,8 @@ class TaintFunctionModelTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "ttfnmodelstep" and
     exists(TaintTracking::FunctionModel model, DataFlow::CallNode call | call = model.getACall() |
-      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = call.toString() and
       value = "\"" + model.getAnInputNode(call) + " -> " + model.getAnOutputNode(call) + "\""
     )
@@ -24,7 +25,8 @@ class MarshalerTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "marshaler" and
     exists(MarshalingFunction m, DataFlow::CallNode call | call = m.getACall() |
-      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = call.toString() and
       value =
         "\"" + m.getFormat() + ": " + m.getAnInput().getNode(call) + " -> " +
@@ -41,7 +43,8 @@ class UnmarshalerTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "unmarshaler" and
     exists(UnmarshalingFunction m, DataFlow::CallNode call | call = m.getACall() |
-      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+      call.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = call.toString() and
       value =
         "\"" + m.getFormat() + ": " + m.getAnInput().getNode(call) + " -> " +

--- a/go/ql/test/library-tests/semmle/go/frameworks/Zap/TaintFlows.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Zap/TaintFlows.ql
@@ -18,7 +18,7 @@ class ZapTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "zap" }
 
-  override predicate hasActualResult(string file, int line, string element, string tag, string value) {
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "zap" and
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and

--- a/go/ql/test/library-tests/semmle/go/frameworks/Zap/TaintFlows.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Zap/TaintFlows.ql
@@ -23,7 +23,7 @@ class ZapTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "\"" + sink.toString() + "\"" and
-      sink.hasLocationInfo(file, line, _, _, _)
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }

--- a/go/ql/test/library-tests/semmle/go/frameworks/Zap/TaintFlows.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Zap/TaintFlows.ql
@@ -23,7 +23,8 @@ class ZapTest extends InlineExpectationsTest {
     exists(DataFlow::Node sink | any(TestConfig c).hasFlow(_, sink) |
       element = sink.toString() and
       value = "\"" + sink.toString() + "\"" and
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(), location.getStartColumn(), location.getEndLine(), location.getEndColumn())
+      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+        location.getStartColumn(), location.getEndLine(), location.getEndColumn())
     )
   }
 }


### PR DESCRIPTION
This came up since I wanted to make a change to the shared library, and realized it didn't get synced to Go :scream: 