### PR TITLE
Fix `codeql/suite-helpers` dependency for Go

### DIFF
--- a/go/ql/src/qlpack.yml
+++ b/go/ql/src/qlpack.yml
@@ -8,4 +8,4 @@ extractor: go
 defaultSuiteFile: codeql-suites/go-code-scanning.qls
 dependencies:
   codeql/go-all: "*"
-  codeql/suite-helpers: ~0.0.2
+  codeql/suite-helpers: "*"


### PR DESCRIPTION
Now that Go is in the same repo as the `codeql/suite-helpers` pack, we always pick up the repo version of that dependency. Thus, we should use an unrestricted version range, like we do for other intra-repo dependencies.

Targeting `rc/3.6` since this is affecting @rvermeulen and his attempts at package customization.