### PR TITLE
Kotlin: Put overloads together

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/ExternalDeclExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/ExternalDeclExtractor.kt
@@ -19,6 +19,9 @@ class ExternalDeclExtractor(val logger: FileLogger, val invocationTrapFile: Stri
     val externalDeclsDone = HashSet<IrDeclaration>()
     val externalDeclWorkList = ArrayList<Pair<IrDeclaration, String>>()
 
+    val propertySignature = ";property"
+    val fieldSignature = ";field"
+
     fun extractLater(d: IrDeclaration, signature: String): Boolean {
         if (d !is IrClass && !isExternalFileClassMember(d)) {
             logger.errorElement("External declaration is neither a class, nor a top-level declaration", d)
@@ -28,13 +31,8 @@ class ExternalDeclExtractor(val logger: FileLogger, val invocationTrapFile: Stri
         if (ret) externalDeclWorkList.add(Pair(d, signature))
         return ret
     }
-
-    val propertySignature = ";property"
-    val fieldSignature = ";field"
-
     fun extractLater(p: IrProperty) = extractLater(p, propertySignature)
     fun extractLater(f: IrField) = extractLater(f, fieldSignature)
-
     fun extractLater(c: IrClass) = extractLater(c, "")
 
     fun extractExternalClasses() {

--- a/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
+++ b/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
@@ -277,12 +277,6 @@ open class FileTrapWriter (
         return getLocation(e.startOffset, e.endOffset)
     }
     /**
-     * Gets a label for the location representing the whole of this file.
-     */
-    fun getWholeFileLocation(): Label<DbLocation> {
-        return getWholeFileLocation(fileId)
-    }
-    /**
      * Gets a label for the location corresponding to `startOffset` and
      * `endOffset` within this file.
      */
@@ -302,6 +296,12 @@ open class FileTrapWriter (
         // where we have actually determined the start/end lines/columns
         // to be 0.
         return "file://$filePath"
+    }
+    /**
+     * Gets a label for the location representing the whole of this file.
+     */
+    fun getWholeFileLocation(): Label<DbLocation> {
+        return getWholeFileLocation(fileId)
     }
 }
 


### PR DESCRIPTION
Makes it easier when reading the code.

The substituteTypeArguments functions aren't actually overloads, but I think the same applies.