### PR TITLE
QL: Add parser support for parameterised modules

### DIFF
--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=a8e519e676ff6e7aa9c1d0a8a329edefcaac69ae#a8e519e676ff6e7aa9c1d0a8a329edefcaac69ae"
+source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=91cdab850c2b6d97d1211da0423adb53c67fef3e#91cdab850c2b6d97d1211da0423adb53c67fef3e"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=725395405e65814f10095a451404b0ced5dc6289#725395405e65814f10095a451404b0ced5dc6289"
+source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=4239ed505a53e9f5340e03725de76911d17387b1#4239ed505a53e9f5340e03725de76911d17387b1"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=4239ed505a53e9f5340e03725de76911d17387b1#4239ed505a53e9f5340e03725de76911d17387b1"
+source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=7928a971a9a408f7ad59876c2ecda4a5329a6795#7928a971a9a408f7ad59876c2ecda4a5329a6795"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=f073fca8875e9320142c171caa722544cd531b9d#f073fca8875e9320142c171caa722544cd531b9d"
+source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=99f3bc30fa772b07ad19a23799fe7433dc15f765#99f3bc30fa772b07ad19a23799fe7433dc15f765"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=67f75344593b90c40201c6f895207fe9ddb4442b#67f75344593b90c40201c6f895207fe9ddb4442b"
+source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=f073fca8875e9320142c171caa722544cd531b9d#f073fca8875e9320142c171caa722544cd531b9d"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=91cdab850c2b6d97d1211da0423adb53c67fef3e#91cdab850c2b6d97d1211da0423adb53c67fef3e"
+source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=67f75344593b90c40201c6f895207fe9ddb4442b#67f75344593b90c40201c6f895207fe9ddb4442b"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=7928a971a9a408f7ad59876c2ecda4a5329a6795#7928a971a9a408f7ad59876c2ecda4a5329a6795"
+source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=a8e519e676ff6e7aa9c1d0a8a329edefcaac69ae#a8e519e676ff6e7aa9c1d0a8a329edefcaac69ae"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "f073fca8875e9320142c171caa722544cd531b9d" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "99f3bc30fa772b07ad19a23799fe7433dc15f765" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "725395405e65814f10095a451404b0ced5dc6289" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "4239ed505a53e9f5340e03725de76911d17387b1" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "7928a971a9a408f7ad59876c2ecda4a5329a6795" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "a8e519e676ff6e7aa9c1d0a8a329edefcaac69ae" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "67f75344593b90c40201c6f895207fe9ddb4442b" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "f073fca8875e9320142c171caa722544cd531b9d" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "4239ed505a53e9f5340e03725de76911d17387b1" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "7928a971a9a408f7ad59876c2ecda4a5329a6795" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "91cdab850c2b6d97d1211da0423adb53c67fef3e" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "67f75344593b90c40201c6f895207fe9ddb4442b" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "a8e519e676ff6e7aa9c1d0a8a329edefcaac69ae" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "91cdab850c2b6d97d1211da0423adb53c67fef3e" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "7928a971a9a408f7ad59876c2ecda4a5329a6795" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "a8e519e676ff6e7aa9c1d0a8a329edefcaac69ae" }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "a8e519e676ff6e7aa9c1d0a8a329edefcaac69ae" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "91cdab850c2b6d97d1211da0423adb53c67fef3e" }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "f073fca8875e9320142c171caa722544cd531b9d" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "99f3bc30fa772b07ad19a23799fe7433dc15f765" }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "4239ed505a53e9f5340e03725de76911d17387b1" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "7928a971a9a408f7ad59876c2ecda4a5329a6795" }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "67f75344593b90c40201c6f895207fe9ddb4442b" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "f073fca8875e9320142c171caa722544cd531b9d" }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "725395405e65814f10095a451404b0ced5dc6289" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "4239ed505a53e9f5340e03725de76911d17387b1" }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "91cdab850c2b6d97d1211da0423adb53c67fef3e" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "67f75344593b90c40201c6f895207fe9ddb4442b" }

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -673,7 +673,7 @@ class TypeExpr extends TType, AstNode {
    * Gets the module of the type, if it exists.
    * E.g. `DataFlow` in `DataFlow::Node`.
    */
-  ModuleExpr getModule() { toQL(result) = type.getChild() }
+  ModuleExpr getModule() { toQL(result) = type.getQualifier() }
 
   /**
    * Gets the type that this type reference refers to.

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -977,18 +977,6 @@ module QL {
     final override AstNode getAFieldOrChild() { ql_module_alias_body_def(this, result) }
   }
 
-  /** A class representing `moduleApplication` nodes. */
-  class ModuleApplication extends @ql_module_application, AstNode {
-    /** Gets the name of the primary QL class for this element. */
-    final override string getAPrimaryQlClass() { result = "ModuleApplication" }
-
-    /** Gets the `i`th child of this node. */
-    final SignatureExpr getChild(int i) { ql_module_application_child(this, i, result) }
-
-    /** Gets a field or child node of this node. */
-    final override AstNode getAFieldOrChild() { ql_module_application_child(this, _, result) }
-  }
-
   /** A class representing `moduleExpr` nodes. */
   class ModuleExpr extends @ql_module_expr, AstNode {
     /** Gets the name of the primary QL class for this element. */
@@ -1004,6 +992,18 @@ module QL {
     final override AstNode getAFieldOrChild() {
       ql_module_expr_name(this, result) or ql_module_expr_def(this, result)
     }
+  }
+
+  /** A class representing `moduleInstantiation` nodes. */
+  class ModuleInstantiation extends @ql_module_instantiation, AstNode {
+    /** Gets the name of the primary QL class for this element. */
+    final override string getAPrimaryQlClass() { result = "ModuleInstantiation" }
+
+    /** Gets the `i`th child of this node. */
+    final SignatureExpr getChild(int i) { ql_module_instantiation_child(this, i, result) }
+
+    /** Gets a field or child node of this node. */
+    final override AstNode getAFieldOrChild() { ql_module_instantiation_child(this, _, result) }
   }
 
   /** A class representing `moduleMember` nodes. */

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -1320,15 +1320,20 @@ module QL {
     /** Gets the name of the primary QL class for this element. */
     final override string getAPrimaryQlClass() { result = "SignatureExpr" }
 
+    /** Gets the node corresponding to the field `arity`. */
+    final Integer getArity() { ql_signature_expr_arity(this, result) }
+
     /** Gets the node corresponding to the field `name`. */
     final SimpleId getName() { ql_signature_expr_def(this, result) }
 
-    /** Gets the `i`th child of this node. */
-    final AstNode getChild(int i) { ql_signature_expr_child(this, i, result) }
+    /** Gets the node corresponding to the field `qualifier`. */
+    final ModuleExpr getQualifier() { ql_signature_expr_qualifier(this, result) }
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() {
-      ql_signature_expr_def(this, result) or ql_signature_expr_child(this, _, result)
+      ql_signature_expr_arity(this, result) or
+      ql_signature_expr_def(this, result) or
+      ql_signature_expr_qualifier(this, result)
     }
   }
 

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -944,15 +944,24 @@ module QL {
     /** Gets the name of the primary QL class for this element. */
     final override string getAPrimaryQlClass() { result = "Module" }
 
+    /** Gets the node corresponding to the field `implements`. */
+    final AstNode getImplements(int i) { ql_module_implements(this, i, result) }
+
     /** Gets the node corresponding to the field `name`. */
     final ModuleName getName() { ql_module_def(this, result) }
+
+    /** Gets the node corresponding to the field `parameter`. */
+    final AstNode getParameter(int i) { ql_module_parameter(this, i, result) }
 
     /** Gets the `i`th child of this node. */
     final AstNode getChild(int i) { ql_module_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() {
-      ql_module_def(this, result) or ql_module_child(this, _, result)
+      ql_module_implements(this, _, result) or
+      ql_module_def(this, result) or
+      ql_module_parameter(this, _, result) or
+      ql_module_child(this, _, result)
     }
   }
 
@@ -966,6 +975,18 @@ module QL {
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() { ql_module_alias_body_def(this, result) }
+  }
+
+  /** A class representing `moduleApplication` nodes. */
+  class ModuleApplication extends @ql_module_application, AstNode {
+    /** Gets the name of the primary QL class for this element. */
+    final override string getAPrimaryQlClass() { result = "ModuleApplication" }
+
+    /** Gets the `i`th child of this node. */
+    final SignatureExpr getChild(int i) { ql_module_application_child(this, i, result) }
+
+    /** Gets a field or child node of this node. */
+    final override AstNode getAFieldOrChild() { ql_module_application_child(this, _, result) }
   }
 
   /** A class representing `moduleExpr` nodes. */
@@ -1007,6 +1028,18 @@ module QL {
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() { ql_module_name_def(this, result) }
+  }
+
+  /** A class representing `moduleParam` nodes. */
+  class ModuleParam extends @ql_module_param, AstNode {
+    /** Gets the name of the primary QL class for this element. */
+    final override string getAPrimaryQlClass() { result = "ModuleParam" }
+
+    /** Gets the `i`th child of this node. */
+    final AstNode getChild(int i) { ql_module_param_child(this, i, result) }
+
+    /** Gets a field or child node of this node. */
+    final override AstNode getAFieldOrChild() { ql_module_param_child(this, _, result) }
   }
 
   /** A class representing `mul_expr` nodes. */
@@ -1275,6 +1308,23 @@ module QL {
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() { ql_set_literal_child(this, _, result) }
+  }
+
+  /** A class representing `signatureExpr` nodes. */
+  class SignatureExpr extends @ql_signature_expr, AstNode {
+    /** Gets the name of the primary QL class for this element. */
+    final override string getAPrimaryQlClass() { result = "SignatureExpr" }
+
+    /** Gets the node corresponding to the field `name`. */
+    final SimpleId getName() { ql_signature_expr_def(this, result) }
+
+    /** Gets the `i`th child of this node. */
+    final AstNode getChild(int i) { ql_signature_expr_child(this, i, result) }
+
+    /** Gets a field or child node of this node. */
+    final override AstNode getAFieldOrChild() {
+      ql_signature_expr_def(this, result) or ql_signature_expr_child(this, _, result)
+    }
   }
 
   /** A class representing `simpleId` tokens. */

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -1035,11 +1035,16 @@ module QL {
     /** Gets the name of the primary QL class for this element. */
     final override string getAPrimaryQlClass() { result = "ModuleParam" }
 
-    /** Gets the `i`th child of this node. */
-    final AstNode getChild(int i) { ql_module_param_child(this, i, result) }
+    /** Gets the node corresponding to the field `parameter`. */
+    final SimpleId getParameter() { ql_module_param_def(this, result, _) }
+
+    /** Gets the node corresponding to the field `signature`. */
+    final SignatureExpr getSignature() { ql_module_param_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    final override AstNode getAFieldOrChild() { ql_module_param_child(this, _, result) }
+    final override AstNode getAFieldOrChild() {
+      ql_module_param_def(this, result, _) or ql_module_param_def(this, _, result)
+    }
   }
 
   /** A class representing `mul_expr` nodes. */

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -951,7 +951,7 @@ module QL {
     final ModuleName getName() { ql_module_def(this, result) }
 
     /** Gets the node corresponding to the field `parameter`. */
-    final AstNode getParameter(int i) { ql_module_parameter(this, i, result) }
+    final ModuleParam getParameter(int i) { ql_module_parameter(this, i, result) }
 
     /** Gets the `i`th child of this node. */
     final AstNode getChild(int i) { ql_module_child(this, i, result) }

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -137,13 +137,13 @@ module QL {
     /** Gets the node corresponding to the field `name`. */
     final LiteralId getName() { ql_arityless_predicate_expr_def(this, result) }
 
-    /** Gets the child of this node. */
-    final ModuleExpr getChild() { ql_arityless_predicate_expr_child(this, result) }
+    /** Gets the node corresponding to the field `qualifier`. */
+    final ModuleExpr getQualifier() { ql_arityless_predicate_expr_qualifier(this, result) }
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() {
       ql_arityless_predicate_expr_def(this, result) or
-      ql_arityless_predicate_expr_child(this, result)
+      ql_arityless_predicate_expr_qualifier(this, result)
     }
   }
 
@@ -1320,20 +1320,15 @@ module QL {
     /** Gets the name of the primary QL class for this element. */
     final override string getAPrimaryQlClass() { result = "SignatureExpr" }
 
-    /** Gets the node corresponding to the field `arity`. */
-    final Integer getArity() { ql_signature_expr_arity(this, result) }
+    /** Gets the node corresponding to the field `predicate`. */
+    final PredicateExpr getPredicate() { ql_signature_expr_predicate(this, result) }
 
-    /** Gets the node corresponding to the field `name`. */
-    final SimpleId getName() { ql_signature_expr_def(this, result) }
-
-    /** Gets the node corresponding to the field `qualifier`. */
-    final ModuleExpr getQualifier() { ql_signature_expr_qualifier(this, result) }
+    /** Gets the node corresponding to the field `type_expr`. */
+    final TypeExpr getTypeExpr() { ql_signature_expr_type_expr(this, result) }
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() {
-      ql_signature_expr_arity(this, result) or
-      ql_signature_expr_def(this, result) or
-      ql_signature_expr_qualifier(this, result)
+      ql_signature_expr_predicate(this, result) or ql_signature_expr_type_expr(this, result)
     }
   }
 
@@ -1417,12 +1412,17 @@ module QL {
     /** Gets the node corresponding to the field `name`. */
     final ClassName getName() { ql_type_expr_name(this, result) }
 
+    /** Gets the node corresponding to the field `qualifier`. */
+    final ModuleExpr getQualifier() { ql_type_expr_qualifier(this, result) }
+
     /** Gets the child of this node. */
     final AstNode getChild() { ql_type_expr_child(this, result) }
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() {
-      ql_type_expr_name(this, result) or ql_type_expr_child(this, result)
+      ql_type_expr_name(this, result) or
+      ql_type_expr_qualifier(this, result) or
+      ql_type_expr_child(this, result)
     }
   }
 

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -945,7 +945,7 @@ module QL {
     final override string getAPrimaryQlClass() { result = "Module" }
 
     /** Gets the node corresponding to the field `implements`. */
-    final AstNode getImplements(int i) { ql_module_implements(this, i, result) }
+    final SignatureExpr getImplements(int i) { ql_module_implements(this, i, result) }
 
     /** Gets the node corresponding to the field `name`. */
     final ModuleName getName() { ql_module_def(this, result) }

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -95,9 +95,9 @@ ql_annotation_def(
   int name: @ql_token_annot_name ref
 );
 
-ql_arityless_predicate_expr_child(
+ql_arityless_predicate_expr_qualifier(
   unique int ql_arityless_predicate_expr: @ql_arityless_predicate_expr ref,
-  unique int child: @ql_module_expr ref
+  unique int qualifier: @ql_module_expr ref
 );
 
 ql_arityless_predicate_expr_def(
@@ -886,19 +886,18 @@ ql_set_literal_def(
   unique int id: @ql_set_literal
 );
 
-ql_signature_expr_arity(
+ql_signature_expr_predicate(
   unique int ql_signature_expr: @ql_signature_expr ref,
-  unique int arity: @ql_token_integer ref
+  unique int predicate: @ql_predicate_expr ref
 );
 
-ql_signature_expr_qualifier(
+ql_signature_expr_type_expr(
   unique int ql_signature_expr: @ql_signature_expr ref,
-  unique int qualifier: @ql_module_expr ref
+  unique int type_expr: @ql_type_expr ref
 );
 
 ql_signature_expr_def(
-  unique int id: @ql_signature_expr,
-  int name: @ql_token_simple_id ref
+  unique int id: @ql_signature_expr
 );
 
 ql_special_call_def(
@@ -929,7 +928,12 @@ ql_type_expr_name(
   unique int name: @ql_token_class_name ref
 );
 
-@ql_typeExpr_child_type = @ql_module_expr | @ql_token_dbtype | @ql_token_primitive_type
+ql_type_expr_qualifier(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+@ql_typeExpr_child_type = @ql_token_dbtype | @ql_token_primitive_type
 
 ql_type_expr_child(
   unique int ql_type_expr: @ql_type_expr ref,

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -610,13 +610,11 @@ ql_module_implements(
   unique int implements: @ql_module_implements_type ref
 );
 
-@ql_module_parameter_type = @ql_module_param | @ql_reserved_word
-
 #keyset[ql_module, index]
 ql_module_parameter(
   int ql_module: @ql_module ref,
   int index: int ref,
-  unique int parameter: @ql_module_parameter_type ref
+  unique int parameter: @ql_module_param ref
 );
 
 @ql_module_child_type = @ql_module_alias_body | @ql_module_member

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -601,13 +601,11 @@ ql_member_predicate_def(
   int return_type: @ql_memberPredicate_returnType_type ref
 );
 
-@ql_module_implements_type = @ql_reserved_word | @ql_signature_expr
-
 #keyset[ql_module, index]
 ql_module_implements(
   int ql_module: @ql_module ref,
   int index: int ref,
-  unique int implements: @ql_module_implements_type ref
+  unique int implements: @ql_signature_expr ref
 );
 
 #keyset[ql_module, index]

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -601,6 +601,24 @@ ql_member_predicate_def(
   int return_type: @ql_memberPredicate_returnType_type ref
 );
 
+@ql_module_implements_type = @ql_reserved_word | @ql_signature_expr
+
+#keyset[ql_module, index]
+ql_module_implements(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int implements: @ql_module_implements_type ref
+);
+
+@ql_module_parameter_type = @ql_module_param | @ql_reserved_word
+
+#keyset[ql_module, index]
+ql_module_parameter(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int parameter: @ql_module_parameter_type ref
+);
+
 @ql_module_child_type = @ql_module_alias_body | @ql_module_member
 
 #keyset[ql_module, index]
@@ -620,12 +638,23 @@ ql_module_alias_body_def(
   int child: @ql_module_expr ref
 );
 
+#keyset[ql_module_application, index]
+ql_module_application_child(
+  int ql_module_application: @ql_module_application ref,
+  int index: int ref,
+  unique int child: @ql_signature_expr ref
+);
+
+ql_module_application_def(
+  unique int id: @ql_module_application
+);
+
 ql_module_expr_name(
   unique int ql_module_expr: @ql_module_expr ref,
   unique int name: @ql_token_simple_id ref
 );
 
-@ql_moduleExpr_child_type = @ql_module_expr | @ql_token_simple_id
+@ql_moduleExpr_child_type = @ql_module_application | @ql_module_expr | @ql_token_simple_id
 
 ql_module_expr_def(
   unique int id: @ql_module_expr,
@@ -648,6 +677,19 @@ ql_module_member_def(
 ql_module_name_def(
   unique int id: @ql_module_name,
   int child: @ql_token_simple_id ref
+);
+
+@ql_moduleParam_child_type = @ql_signature_expr | @ql_token_simple_id
+
+#keyset[ql_module_param, index]
+ql_module_param_child(
+  int ql_module_param: @ql_module_param ref,
+  int index: int ref,
+  unique int child: @ql_moduleParam_child_type ref
+);
+
+ql_module_param_def(
+  unique int id: @ql_module_param
 );
 
 @ql_mul_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
@@ -855,6 +897,20 @@ ql_set_literal_def(
   unique int id: @ql_set_literal
 );
 
+@ql_signatureExpr_child_type = @ql_module_expr | @ql_token_integer
+
+#keyset[ql_signature_expr, index]
+ql_signature_expr_child(
+  int ql_signature_expr: @ql_signature_expr ref,
+  int index: int ref,
+  unique int child: @ql_signatureExpr_child_type ref
+);
+
+ql_signature_expr_def(
+  unique int id: @ql_signature_expr,
+  int name: @ql_token_simple_id ref
+);
+
 ql_special_call_def(
   unique int id: @ql_special_call,
   int child: @ql_token_special_id ref
@@ -1057,7 +1113,7 @@ case @ql_token.kind of
 ;
 
 
-@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_db_annotation | @ql_db_args_annotation | @ql_db_branch | @ql_db_case_decl | @ql_db_col_type | @ql_db_column | @ql_db_entry | @ql_db_repr_type | @ql_db_table | @ql_db_table_name | @ql_db_union_decl | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_member | @ql_module_name | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qual_module_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable | @ql_yaml_comment | @ql_yaml_entry | @ql_yaml_key | @ql_yaml_keyvaluepair | @ql_yaml_listitem
+@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_db_annotation | @ql_db_args_annotation | @ql_db_branch | @ql_db_case_decl | @ql_db_col_type | @ql_db_column | @ql_db_entry | @ql_db_repr_type | @ql_db_table | @ql_db_table_name | @ql_db_union_decl | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_application | @ql_module_expr | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qual_module_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable | @ql_yaml_comment | @ql_yaml_entry | @ql_yaml_key | @ql_yaml_keyvaluepair | @ql_yaml_listitem
 
 @ql_ast_node_parent = @file | @ql_ast_node
 

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -890,13 +890,14 @@ ql_set_literal_def(
   unique int id: @ql_set_literal
 );
 
-@ql_signatureExpr_child_type = @ql_module_expr | @ql_token_integer
+ql_signature_expr_arity(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int arity: @ql_token_integer ref
+);
 
-#keyset[ql_signature_expr, index]
-ql_signature_expr_child(
-  int ql_signature_expr: @ql_signature_expr ref,
-  int index: int ref,
-  unique int child: @ql_signatureExpr_child_type ref
+ql_signature_expr_qualifier(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int qualifier: @ql_module_expr ref
 );
 
 ql_signature_expr_def(

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -679,17 +679,10 @@ ql_module_name_def(
   int child: @ql_token_simple_id ref
 );
 
-@ql_moduleParam_child_type = @ql_signature_expr | @ql_token_simple_id
-
-#keyset[ql_module_param, index]
-ql_module_param_child(
-  int ql_module_param: @ql_module_param ref,
-  int index: int ref,
-  unique int child: @ql_moduleParam_child_type ref
-);
-
 ql_module_param_def(
-  unique int id: @ql_module_param
+  unique int id: @ql_module_param,
+  int parameter: @ql_token_simple_id ref,
+  int signature: @ql_signature_expr ref
 );
 
 @ql_mul_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -638,27 +638,27 @@ ql_module_alias_body_def(
   int child: @ql_module_expr ref
 );
 
-#keyset[ql_module_application, index]
-ql_module_application_child(
-  int ql_module_application: @ql_module_application ref,
-  int index: int ref,
-  unique int child: @ql_signature_expr ref
-);
-
-ql_module_application_def(
-  unique int id: @ql_module_application
-);
-
 ql_module_expr_name(
   unique int ql_module_expr: @ql_module_expr ref,
   unique int name: @ql_token_simple_id ref
 );
 
-@ql_moduleExpr_child_type = @ql_module_application | @ql_module_expr | @ql_token_simple_id
+@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_simple_id
 
 ql_module_expr_def(
   unique int id: @ql_module_expr,
   int child: @ql_moduleExpr_child_type ref
+);
+
+#keyset[ql_module_instantiation, index]
+ql_module_instantiation_child(
+  int ql_module_instantiation: @ql_module_instantiation ref,
+  int index: int ref,
+  unique int child: @ql_signature_expr ref
+);
+
+ql_module_instantiation_def(
+  unique int id: @ql_module_instantiation
 );
 
 @ql_moduleMember_child_type = @ql_annotation | @ql_classless_predicate | @ql_dataclass | @ql_datatype | @ql_import_directive | @ql_module | @ql_select | @ql_token_qldoc
@@ -1113,7 +1113,7 @@ case @ql_token.kind of
 ;
 
 
-@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_db_annotation | @ql_db_args_annotation | @ql_db_branch | @ql_db_case_decl | @ql_db_col_type | @ql_db_column | @ql_db_entry | @ql_db_repr_type | @ql_db_table | @ql_db_table_name | @ql_db_union_decl | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_application | @ql_module_expr | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qual_module_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable | @ql_yaml_comment | @ql_yaml_entry | @ql_yaml_key | @ql_yaml_keyvaluepair | @ql_yaml_listitem
+@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_db_annotation | @ql_db_args_annotation | @ql_db_branch | @ql_db_case_decl | @ql_db_col_type | @ql_db_column | @ql_db_entry | @ql_db_repr_type | @ql_db_table | @ql_db_table_name | @ql_db_union_decl | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qual_module_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable | @ql_yaml_comment | @ql_yaml_entry | @ql_yaml_key | @ql_yaml_keyvaluepair | @ql_yaml_listitem
 
 @ql_ast_node_parent = @file | @ql_ast_node
 


### PR DESCRIPTION
See https://github.com/tausbn/tree-sitter-ql/compare/725395405e65814f10095a451404b0ced5dc6289...tausbn:various-fixes for the actual changes to the grammar (and tests thereof).

---

A brief summary of the various nodes is perhaps in order.

- `ModuleApplication` represents the "instantiation" of a parameterised module (e.g. `Foo<...>`. Such applications may have children, each of which will be a...
- ... `SignatureExpr`, which corresponds to a predicate `bar::foo/1` or a class `Cls`. Both the `::` prefix and the arity are optional (and if the latter is absent, it's a class).
- `ModuleParam`, which represents a parameter of a parameterised module declaration. Each of these consists of two parts, a `SignatureExpr` and an identifier (representing the "type" and "variable" respectively).