### PR TITLE
C++: Add test for Dereferenced.qll.

### DIFF
--- a/cpp/ql/test/library-tests/controlflow/dereferenced/dereferenced.cpp
+++ b/cpp/ql/test/library-tests/controlflow/dereferenced/dereferenced.cpp
@@ -16,7 +16,7 @@ void test1(int *ptr, int &ref)
 	ptr[0] = 0; // `ptr` dereferenced
 	ptr = 0;
 
-	(*ptr)++; // `ptr` dereferenced
+	(*ptr)++; // `ptr`, `*ptr` dereferenced
 	*(ptr++); // `ptr++` dereferenced
 	ptr++;
 

--- a/cpp/ql/test/library-tests/controlflow/dereferenced/dereferenced.cpp
+++ b/cpp/ql/test/library-tests/controlflow/dereferenced/dereferenced.cpp
@@ -1,0 +1,49 @@
+
+int *global_ptr;
+const char *global_string = "hello, world";
+
+void test1(int *ptr, int &ref)
+{
+	const char *str;
+	int v, *p;
+	char c;
+
+	v = *ptr; // `ptr` dereferenced
+	v = ptr[0]; // `ptr` dereferenced
+	p = ptr;
+
+	*ptr = 0; // `ptr` dereferenced
+	ptr[0] = 0; // `ptr` dereferenced
+	ptr = 0;
+
+	(*ptr)++; // `ptr` dereferenced
+	*(ptr++); // `ptr++` dereferenced
+	ptr++;
+
+	v = ref; // (`ref` implicitly dereferenced, not detected)
+	p = &ref;
+	ref = 0; // (`ref` implicitly dereferenced, not detected)
+	ref++; // (`ref` implicitly dereferenced, not detected)
+
+	*global_ptr; // `global_ptr` dereferenced
+	str = global_string;
+	c = global_string[5]; // `global_string` dereferenced
+}
+
+struct myStruct
+{
+	int x;
+	void f() {};
+	void (*g)();
+};
+
+void test1(myStruct *ms)
+{
+	void (*h)();
+
+	ms;
+	ms->x; // `ms` dereferenced
+	ms->f(); // `ms` dereferenced
+	ms->g(); // `ms` dereferenced
+	h = ms->g; // `ms` dereferenced
+}

--- a/cpp/ql/test/library-tests/controlflow/dereferenced/dereferenced.expected
+++ b/cpp/ql/test/library-tests/controlflow/dereferenced/dereferenced.expected
@@ -1,0 +1,13 @@
+| dereferenced.cpp:11:6:11:9 | * ... | dereferenced.cpp:11:7:11:9 | ptr |
+| dereferenced.cpp:12:6:12:11 | access to array | dereferenced.cpp:12:6:12:8 | ptr |
+| dereferenced.cpp:15:2:15:5 | * ... | dereferenced.cpp:15:3:15:5 | ptr |
+| dereferenced.cpp:16:2:16:7 | access to array | dereferenced.cpp:16:2:16:4 | ptr |
+| dereferenced.cpp:19:3:19:6 | * ... | dereferenced.cpp:19:4:19:6 | ptr |
+| dereferenced.cpp:19:4:19:6 | ptr | dereferenced.cpp:19:3:19:6 | * ... |
+| dereferenced.cpp:20:2:20:9 | * ... | dereferenced.cpp:20:4:20:8 | ... ++ |
+| dereferenced.cpp:28:2:28:12 | * ... | dereferenced.cpp:28:3:28:12 | global_ptr |
+| dereferenced.cpp:30:6:30:21 | access to array | dereferenced.cpp:30:6:30:18 | global_string |
+| dereferenced.cpp:45:6:45:6 | x | dereferenced.cpp:45:2:45:3 | ms |
+| dereferenced.cpp:46:6:46:6 | call to f | dereferenced.cpp:46:2:46:3 | ms |
+| dereferenced.cpp:47:6:47:6 | g | dereferenced.cpp:47:2:47:3 | ms |
+| dereferenced.cpp:48:10:48:10 | g | dereferenced.cpp:48:6:48:7 | ms |

--- a/cpp/ql/test/library-tests/controlflow/dereferenced/dereferenced.ql
+++ b/cpp/ql/test/library-tests/controlflow/dereferenced/dereferenced.ql
@@ -1,0 +1,6 @@
+import cpp
+import semmle.code.cpp.controlflow.Dereferenced
+
+from Expr op, Expr e
+where dereferencedByOperation(op, e) // => dereferenced(e)
+select op, e


### PR DESCRIPTION
Add test for `Dereferenced.qll`.  I was investigating an issue this morning that turned out to be nothing (I think I was reading a result incorrectly).  But it seems good to have a permanent test for this.