### PR TITLE
Swift: Mark closures as callables in the CFG library

### DIFF
--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowElements.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowElements.qll
@@ -4,6 +4,7 @@ cached
 newtype TControlFlowElement =
   TAstElement(AstNode n) or
   TFuncDeclElement(AbstractFunctionDecl func) { func.hasBody() } or
+  TClosureElement(ClosureExpr clos) or
   TPropertyGetterElement(Decl accessor, Expr ref) { isPropertyGetterElement(accessor, ref) } or
   TPropertySetterElement(AccessorDecl accessor, AssignExpr assign) {
     isPropertySetterElement(accessor, assign)
@@ -184,6 +185,18 @@ class KeyPathElement extends ControlFlowElement, TKeyPathElement {
   override Location getLocation() { result = expr.getLocation() }
 
   KeyPathExpr getAst() { result = expr }
+
+  override string toString() { result = expr.toString() }
+}
+
+class ClosureElement extends ControlFlowElement, TClosureElement {
+  ClosureExpr expr;
+
+  ClosureElement() { this = TClosureElement(expr) }
+
+  override Location getLocation() { result = expr.getLocation() }
+
+  ClosureExpr getAst() { result = expr }
 
   override string toString() { result = expr.toString() }
 }

--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
@@ -65,6 +65,16 @@ module CfgScope {
 
     final override predicate exit(ControlFlowElement last, Completion c) { last(tree, last, c) }
   }
+
+  private class ClosureExprScope extends Range_ instanceof ClosureExpr {
+    Exprs::ClosureExprTree tree;
+
+    ClosureExprScope() { tree.getAst() = this }
+
+    final override predicate entry(ControlFlowElement first) { first(tree, first) }
+
+    final override predicate exit(ControlFlowElement last, Completion c) { last(tree, last, c) }
+  }
 }
 
 /** Holds if `first` is first executed when entering `scope`. */
@@ -1043,6 +1053,21 @@ module Exprs {
       }
 
       final override predicate isSet(ControlFlowElement node) { node.asAstNode() = ast }
+    }
+  }
+
+  class ClosureExprTree extends StandardPreOrderTree, TClosureElement {
+    ClosureExpr expr;
+
+    ClosureExprTree() { this = TClosureElement(expr) }
+
+    ClosureExpr getAst() { result = expr }
+
+    final override ControlFlowElement getChildElement(int i) {
+      result.asAstNode() = expr.getParam(i)
+      or
+      result.asAstNode() = expr.getBody() and
+      i = expr.getNumberOfParams()
     }
   }
 

--- a/swift/ql/lib/codeql/swift/controlflow/internal/Scope.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/Scope.qll
@@ -2,7 +2,7 @@ private import swift
 private import codeql.swift.generated.GetImmediateParent
 
 module CallableBase {
-  class TypeRange = @abstract_function_decl or @key_path_expr;
+  class TypeRange = @abstract_function_decl or @key_path_expr or @closure_expr;
 
   class Range extends Scope::Range, TypeRange { }
 }

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -373,8 +373,40 @@ cfg.swift:
 #   46| return ...
 #-----| return -> exit createClosure1 (normal)
 
+#   46| enter { ... }
+#-----|  -> { ... }
+
+#   46| exit { ... }
+
+#   46| exit { ... } (normal)
+#-----|  -> exit { ... }
+
 #   46| { ... }
 #-----|  -> return ...
+
+#   46| { ... }
+#-----|  -> +
+
+#   47| return ...
+#-----| return -> exit { ... } (normal)
+
+#   47| s
+#-----|  -> 
+
+#   47| ... call to + ...
+#-----|  -> return ...
+
+#   47| +
+#-----|  -> String.Type
+
+#   47| String.Type
+#-----|  -> call to +
+
+#   47| call to +
+#-----|  -> s
+
+#   47| 
+#-----|  -> ... call to + ...
 
 #   51| createClosure2
 #-----|  -> x
@@ -436,8 +468,43 @@ cfg.swift:
 #   59| return ...
 #-----| return -> exit createClosure3 (normal)
 
+#   59| enter { ... }
+#-----|  -> { ... }
+
+#   59| exit { ... }
+
+#   59| exit { ... } (normal)
+#-----|  -> exit { ... }
+
 #   59| { ... }
 #-----|  -> return ...
+
+#   59| { ... }
+#-----|  -> y
+
+#   60| y
+#-----|  -> +
+
+#   60| x
+#-----|  -> y
+
+#   60| ... call to + ...
+#-----|  -> return ...
+
+#   60| return ...
+#-----| return -> exit { ... } (normal)
+
+#   60| +
+#-----|  -> Int.Type
+
+#   60| Int.Type
+#-----|  -> call to +
+
+#   60| call to +
+#-----|  -> x
+
+#   60| y
+#-----|  -> ... call to + ...
 
 #   64| callClosures
 #-----|  -> x1
@@ -4633,11 +4700,22 @@ cfg.swift:
 #  368| return ...
 #-----| return -> exit testCapture (normal)
 
+#  368| enter { ... }
+#-----|  -> { ... }
+
+#  368| exit { ... }
+
+#  368| exit { ... } (normal)
+#-----|  -> exit { ... }
+
 #  368| { ... }
 #-----|  -> return ...
 
 #  368| { ... }
 #-----|  -> { ... }
+
+#  368| { ... }
+#-----|  -> z
 
 #  368| z
 #-----| match -> +
@@ -4671,6 +4749,12 @@ cfg.swift:
 
 #  368| literal
 #-----|  -> var ... = ...
+
+#  369| return ...
+#-----| return -> exit { ... } (normal)
+
+#  369| z
+#-----|  -> return ...
 
 #  373| enter testTupleElement
 #-----|  -> testTupleElement


### PR DESCRIPTION
This implements the necessary changes to address https://github.com/github/codeql/pull/9555/files/0b85bc66d178813f6b8413bdcb617da8c1836f20#r897092930.