### PR TITLE
Swift: Add a placeholder query

### DIFF
--- a/swift/ql/src/queries/placeholder.ql
+++ b/swift/ql/src/queries/placeholder.ql
@@ -1,0 +1,9 @@
+/**
+ * @kind problem
+ * @id swift/placeholder
+ */
+
+import swift
+
+from IntegerLiteralExpr lit
+select lit, "A literal"


### PR DESCRIPTION
Currently, DCA assumes a non-empty set of queries exists for a language when running experiments. So for Swift DCA support, we need to add a placeholder query until we have a property query to run.

We can delete this placeholder query as soon as we have a _real_ query.