### PR TITLE
Revert "C++: Fix test failures where location of reference dereference in lambda changed"

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -218,10 +218,10 @@ postWithInFlow
 | lambdas.cpp:20:11:20:11 | FieldAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:20:11:20:11 | FieldAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:20:11:20:11 | FieldAddress [post update] | PostUpdateNode should not be the target of local flow. |
+| lambdas.cpp:23:3:23:3 | (reference dereference) [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:23:3:23:14 | FieldAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:23:3:23:14 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:23:3:23:14 | v [post update] | PostUpdateNode should not be the target of local flow. |
-| lambdas.cpp:23:15:23:15 | (reference dereference) [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:28:7:28:7 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:28:10:31:2 | FieldAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:28:10:31:2 | FieldAddress [post update] | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/ir/ir/operand_locations.expected
+++ b/cpp/ql/test/library-tests/ir/ir/operand_locations.expected
@@ -4833,6 +4833,9 @@
 | ir.cpp:1043:24:1043:24 | SideEffect | ~m1043_20 |
 | ir.cpp:1043:31:1043:31 | Address | &:r1043_9 |
 | ir.cpp:1043:36:1043:55 | Address | &:r1043_11 |
+| ir.cpp:1043:43:1043:43 | Address | &:r1043_16 |
+| ir.cpp:1043:43:1043:43 | Arg(this) | this:r1043_16 |
+| ir.cpp:1043:43:1043:43 | SideEffect | ~m1043_20 |
 | ir.cpp:1043:43:1043:54 | Address | &:r1043_22 |
 | ir.cpp:1043:43:1043:54 | Address | &:r1043_24 |
 | ir.cpp:1043:43:1043:54 | Address | &:r1043_25 |
@@ -4853,11 +4856,8 @@
 | ir.cpp:1043:45:1043:49 | SideEffect | ~m1043_4 |
 | ir.cpp:1043:45:1043:49 | Unary | r1043_13 |
 | ir.cpp:1043:45:1043:49 | Unary | r1043_15 |
-| ir.cpp:1043:52:1043:52 | Address | &:r1043_16 |
-| ir.cpp:1043:52:1043:52 | Arg(this) | this:r1043_16 |
-| ir.cpp:1043:52:1043:52 | SideEffect | ~m1043_20 |
-| ir.cpp:1043:54:1043:54 | Load | ~m1043_20 |
-| ir.cpp:1043:54:1043:54 | Right | r1043_26 |
+| ir.cpp:1043:53:1043:53 | Load | ~m1043_20 |
+| ir.cpp:1043:53:1043:53 | Right | r1043_26 |
 | ir.cpp:1043:58:1043:58 | ChiPartial | partial:m1043_9 |
 | ir.cpp:1043:58:1043:58 | ChiTotal | total:m1043_3 |
 | ir.cpp:1043:58:1043:58 | StoreValue | r1043_8 |
@@ -4972,6 +4972,9 @@
 | ir.cpp:1047:34:1047:34 | SideEffect | ~m1047_20 |
 | ir.cpp:1047:41:1047:41 | Address | &:r1047_9 |
 | ir.cpp:1047:46:1047:65 | Address | &:r1047_11 |
+| ir.cpp:1047:53:1047:53 | Address | &:r1047_16 |
+| ir.cpp:1047:53:1047:53 | Arg(this) | this:r1047_16 |
+| ir.cpp:1047:53:1047:53 | SideEffect | ~m1047_20 |
 | ir.cpp:1047:53:1047:64 | Address | &:r1047_23 |
 | ir.cpp:1047:53:1047:64 | Load | ~m1047_20 |
 | ir.cpp:1047:53:1047:64 | StoreValue | r1047_24 |
@@ -4986,9 +4989,6 @@
 | ir.cpp:1047:55:1047:59 | SideEffect | ~m1047_4 |
 | ir.cpp:1047:55:1047:59 | Unary | r1047_13 |
 | ir.cpp:1047:55:1047:59 | Unary | r1047_15 |
-| ir.cpp:1047:62:1047:62 | Address | &:r1047_16 |
-| ir.cpp:1047:62:1047:62 | Arg(this) | this:r1047_16 |
-| ir.cpp:1047:62:1047:62 | SideEffect | ~m1047_20 |
 | ir.cpp:1047:63:1047:63 | Right | r1047_22 |
 | ir.cpp:1047:68:1047:68 | StoreValue | r1047_8 |
 | ir.cpp:1047:68:1047:68 | Unary | r1047_7 |
@@ -5097,6 +5097,9 @@
 | ir.cpp:1051:39:1051:39 | SideEffect | ~m1051_20 |
 | ir.cpp:1051:46:1051:46 | Address | &:r1051_9 |
 | ir.cpp:1051:51:1051:70 | Address | &:r1051_11 |
+| ir.cpp:1051:58:1051:58 | Address | &:r1051_16 |
+| ir.cpp:1051:58:1051:58 | Arg(this) | this:r1051_16 |
+| ir.cpp:1051:58:1051:58 | SideEffect | ~m1051_20 |
 | ir.cpp:1051:58:1051:69 | Address | &:r1051_22 |
 | ir.cpp:1051:58:1051:69 | Address | &:r1051_24 |
 | ir.cpp:1051:58:1051:69 | Address | &:r1051_26 |
@@ -5117,9 +5120,6 @@
 | ir.cpp:1051:60:1051:64 | SideEffect | ~m1051_4 |
 | ir.cpp:1051:60:1051:64 | Unary | r1051_13 |
 | ir.cpp:1051:60:1051:64 | Unary | r1051_15 |
-| ir.cpp:1051:67:1051:67 | Address | &:r1051_16 |
-| ir.cpp:1051:67:1051:67 | Arg(this) | this:r1051_16 |
-| ir.cpp:1051:67:1051:67 | SideEffect | ~m1051_20 |
 | ir.cpp:1051:73:1051:73 | ChiPartial | partial:m1051_9 |
 | ir.cpp:1051:73:1051:73 | ChiTotal | total:m1051_3 |
 | ir.cpp:1051:73:1051:73 | StoreValue | r1051_8 |
@@ -5184,6 +5184,9 @@
 | ir.cpp:1054:49:1054:49 | SideEffect | ~m1054_20 |
 | ir.cpp:1054:56:1054:56 | Address | &:r1054_9 |
 | ir.cpp:1054:61:1054:88 | Address | &:r1054_11 |
+| ir.cpp:1054:68:1054:68 | Address | &:r1054_16 |
+| ir.cpp:1054:68:1054:68 | Arg(this) | this:r1054_16 |
+| ir.cpp:1054:68:1054:68 | SideEffect | ~m1054_20 |
 | ir.cpp:1054:68:1054:87 | Address | &:r1054_37 |
 | ir.cpp:1054:68:1054:87 | Load | ~m1054_20 |
 | ir.cpp:1054:68:1054:87 | StoreValue | r1054_38 |
@@ -5198,9 +5201,6 @@
 | ir.cpp:1054:70:1054:74 | SideEffect | ~m1054_4 |
 | ir.cpp:1054:70:1054:74 | Unary | r1054_13 |
 | ir.cpp:1054:70:1054:74 | Unary | r1054_15 |
-| ir.cpp:1054:77:1054:77 | Address | &:r1054_16 |
-| ir.cpp:1054:77:1054:77 | Arg(this) | this:r1054_16 |
-| ir.cpp:1054:77:1054:77 | SideEffect | ~m1054_20 |
 | ir.cpp:1054:78:1054:82 | Address | &:r1054_22 |
 | ir.cpp:1054:78:1054:82 | Address | &:r1054_24 |
 | ir.cpp:1054:78:1054:82 | Left | r1054_25 |

--- a/cpp/ql/test/library-tests/lambdas/captures/elements.expected
+++ b/cpp/ql/test/library-tests/lambdas/captures/elements.expected
@@ -156,10 +156,10 @@
 | captures.cpp:23:12:23:16 | x |
 | captures.cpp:23:12:23:16 | y |
 | captures.cpp:23:12:23:20 | ... + ... |
+| captures.cpp:23:16:23:16 | (reference dereference) |
 | captures.cpp:23:16:23:16 | definition of y |
 | captures.cpp:23:16:23:16 | y |
 | captures.cpp:23:16:23:16 | y |
-| captures.cpp:23:18:23:18 | (reference dereference) |
 | captures.cpp:23:20:23:20 | z |
 | captures.cpp:26:3:26:24 | return ... |
 | captures.cpp:26:10:26:17 | (const lambda [] type at line 22, col. 19)... |


### PR DESCRIPTION
This reverts commit 8e7066600a20f87baae93c6b8a7cd1600b7ec89b.

The frontend issue that made this change necessary was fixed.