### PR TITLE
QL: Allow module applications to the right of `::`

### DIFF
--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=99f3bc30fa772b07ad19a23799fe7433dc15f765#99f3bc30fa772b07ad19a23799fe7433dc15f765"
+source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=c3d626a77cf5acc5d8c11aaf91c12348880c8eca#c3d626a77cf5acc5d8c11aaf91c12348880c8eca"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "99f3bc30fa772b07ad19a23799fe7433dc15f765" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "c3d626a77cf5acc5d8c11aaf91c12348880c8eca" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "99f3bc30fa772b07ad19a23799fe7433dc15f765" }
+tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "c3d626a77cf5acc5d8c11aaf91c12348880c8eca" }

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2187,7 +2187,7 @@ class ModuleExpr extends TModuleExpr, ModuleRef {
    * is `Bar`.
    */
   string getName() {
-    result = me.getName().getValue()
+    result = me.getName().(QL::SimpleId).getValue()
     or
     not exists(me.getName()) and result = me.getChild().(QL::SimpleId).getValue()
   }

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -983,7 +983,7 @@ module QL {
     final override string getAPrimaryQlClass() { result = "ModuleExpr" }
 
     /** Gets the node corresponding to the field `name`. */
-    final SimpleId getName() { ql_module_expr_name(this, result) }
+    final AstNode getName() { ql_module_expr_name(this, result) }
 
     /** Gets the child of this node. */
     final AstNode getChild() { ql_module_expr_def(this, result) }

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -634,9 +634,11 @@ ql_module_alias_body_def(
   int child: @ql_module_expr ref
 );
 
+@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_simple_id
+
 ql_module_expr_name(
   unique int ql_module_expr: @ql_module_expr ref,
-  unique int name: @ql_token_simple_id ref
+  unique int name: @ql_moduleExpr_name_type ref
 );
 
 @ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_simple_id


### PR DESCRIPTION
At this point, `getName` is not really a good name for this member predicate, but I'll leave that bit of cleanup for later.