### PR TITLE
JS: add heuristic taint-step for potentially unmodelled libraries

### DIFF
--- a/javascript/ql/lib/semmle/javascript/heuristics/AdditionalTaintSteps.qll
+++ b/javascript/ql/lib/semmle/javascript/heuristics/AdditionalTaintSteps.qll
@@ -17,3 +17,15 @@ private class HeuristicStringManipulationTaintStep extends TaintTracking::Shared
     )
   }
 }
+
+/** Any call to a library component where we assume taint from any argument to the result */
+private class HeuristicLibraryCallTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(API::CallNode call |
+      pred = call.getAnArgument() or // the plain argument
+      pred = call.getAnArgument().(DataFlow::SourceNode).getAPropertyWrite().getRhs() // one property down
+    |
+      succ = call
+    )
+  }
+}

--- a/javascript/ql/src/meta/analysis-quality/UnmodelledSteps.ql
+++ b/javascript/ql/src/meta/analysis-quality/UnmodelledSteps.ql
@@ -1,0 +1,42 @@
+/**
+ * @name Unmodeled step
+ * @description A potential step from an argument to a return that has no data/taint step.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/unmodeled-step
+ */
+
+import javascript
+import meta.MetaMetrics
+private import Expressions.ExprHasNoEffect
+import meta.internal.TaintMetrics
+
+predicate unmodeled(API::Node callee, API::CallNode call, DataFlow::Node pred, DataFlow::Node succ) {
+  callee.getACall() = call and
+  pred = call.getAnArgument() and
+  succ = call and
+  not inVoidContext(succ.asExpr()) and // void calls are irrelevant
+  not call.getAnArgument() = relevantTaintSink() and // calls with sinks are considered modeled
+  // we assume taint to the return value means the call is modeled
+  not (
+    TaintTracking::sharedTaintStep(_, succ)
+    or
+    DataFlow::SharedFlowStep::step(_, succ)
+    or
+    DataFlow::SharedFlowStep::step(_, succ, _, _)
+    or
+    DataFlow::SharedFlowStep::loadStep(_, succ, _)
+    or
+    DataFlow::SharedFlowStep::storeStep(_, succ, _)
+    or
+    DataFlow::SharedFlowStep::loadStoreStep(_, succ, _, _)
+    or
+    DataFlow::SharedFlowStep::loadStoreStep(_, succ, _)
+  ) and
+  not pred.getFile() instanceof IgnoredFile and
+  not succ.getFile() instanceof IgnoredFile
+}
+
+select projectRoot(), count(DataFlow::Node pred, DataFlow::Node succ | unmodeled(_, _, pred, succ))


### PR DESCRIPTION
For a call to a library function we add a taint-step from the arguments to the return value.   
Might be helpful for quickly debugging some missing taint flows.   

Also adds a meta query for counting potential unmodelled steps

(See thread on #codeql-dynamic from Jun 8th). 

I've tried to enable these steps on a few queries on `microsoft/vscode`.   
The analysis still terminated, so it seems to scale.  