### PR TITLE
QL: support for parameterized modules

### DIFF
--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/erik-krogh/tree-sitter-ql.git?rev=d8da4b8190a3c1f3fab293016bbbb60469e56ea3#d8da4b8190a3c1f3fab293016bbbb60469e56ea3"
+source = "git+https://github.com/erik-krogh/tree-sitter-ql.git?rev=343cc5873e20510586ade803659ef8ce153bd603#343cc5873e20510586ade803659ef8ce153bd603"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tausbn/tree-sitter-ql.git?rev=c3d626a77cf5acc5d8c11aaf91c12348880c8eca#c3d626a77cf5acc5d8c11aaf91c12348880c8eca"
+source = "git+https://github.com/erik-krogh/tree-sitter-ql.git?rev=d8da4b8190a3c1f3fab293016bbbb60469e56ea3#d8da4b8190a3c1f3fab293016bbbb60469e56ea3"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "c3d626a77cf5acc5d8c11aaf91c12348880c8eca" }
+tree-sitter-ql = { git = "https://github.com/erik-krogh/tree-sitter-ql.git", rev = "d8da4b8190a3c1f3fab293016bbbb60469e56ea3" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
-tree-sitter-ql = { git = "https://github.com/erik-krogh/tree-sitter-ql.git", rev = "d8da4b8190a3c1f3fab293016bbbb60469e56ea3" }
+tree-sitter-ql = { git = "https://github.com/erik-krogh/tree-sitter-ql.git", rev = "343cc5873e20510586ade803659ef8ce153bd603" }
 clap = "2.33"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/erik-krogh/tree-sitter-ql.git", rev = "d8da4b8190a3c1f3fab293016bbbb60469e56ea3" }
+tree-sitter-ql = { git = "https://github.com/erik-krogh/tree-sitter-ql.git", rev = "343cc5873e20510586ade803659ef8ce153bd603" }

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,4 +11,4 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tausbn/tree-sitter-ql.git", rev = "c3d626a77cf5acc5d8c11aaf91c12348880c8eca" }
+tree-sitter-ql = { git = "https://github.com/erik-krogh/tree-sitter-ql.git", rev = "d8da4b8190a3c1f3fab293016bbbb60469e56ea3" }

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -726,11 +726,9 @@ class Module extends TModule, ModuleDeclaration {
   /** Holds if the `i`th parameter of this module has `name` and type `sig`. */
   predicate hasParameter(int i, string name, SignatureExpr sig) {
     exists(QL::ModuleParam param |
-      param = mod.getParameter(i) and name = param.getParameter().getValue()
-    |
-      toQL(sig) = param.getSignature().getPredicate()
-      or
-      toQL(sig) = param.getSignature().getTypeExpr()
+      param = mod.getParameter(i) and
+      name = param.getParameter().getValue() and
+      sig.toQL() = param.getSignature()
     )
   }
 }
@@ -2240,15 +2238,24 @@ class ModuleExpr extends TModuleExpr, ModuleRef {
    */
   SignatureExpr getArgument(int i) {
     exists(QL::ModuleInstantiation instantiation | instantiation.getParent() = me |
-      toQL(result) = instantiation.getChild(i).getPredicate()
-      or
-      toQL(result) = instantiation.getChild(i).getTypeExpr()
+      result.toQL() = instantiation.getChild(i)
     )
   }
 }
 
 /** A signature expression, either a `PredicateExpr` or a `TypeExpr`. */
-class SignatureExpr extends TSignatureExpr, AstNode { }
+class SignatureExpr extends TSignatureExpr, AstNode {
+  QL::SignatureExpr sig;
+
+  SignatureExpr() {
+    toQL(this) = sig.getPredicate()
+    or
+    toQL(this) = sig.getTypeExpr()
+  }
+
+  /** Gets the generated AST node that contains this signature expression. */
+  QL::SignatureExpr toQL() { result = sig }
+}
 
 /** An argument to an annotation. */
 private class AnnotationArg extends TAnnotationArg, AstNode {

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -722,7 +722,7 @@ class Module extends TModule, ModuleDeclaration {
     or
     pred = directMember("getAMember") and result = this.getAMember()
     or
-    exists(int i | pred = indexedMember("hasParameter", i) and hasParameter(i, _, result))
+    exists(int i | pred = indexedMember("hasParameter", i) and this.hasParameter(i, _, result))
   }
 
   /** Holds if the `i`th parameter of this module has `name` and type `sig`. */

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -162,6 +162,8 @@ class QLDoc extends TQLDoc, AstNode {
   string getContents() { result = qldoc.getValue() }
 
   override string getAPrimaryQlClass() { result = "QLDoc" }
+
+  override AstNode getParent() { result.getQLDoc() = this }
 }
 
 class BlockComment extends TBlockComment, AstNode {
@@ -2313,7 +2315,7 @@ class Annotation extends TAnnotation, AstNode {
   /** Gets the node corresponding to the field `name`. */
   string getName() { result = annot.getName().getValue() }
 
-  override AstNode getParent() { result = AstNode.super.getParent() }
+  override AstNode getParent() { result.getAnAnnotation() = this }
 
   override AstNode getAChild(string pred) {
     result = super.getAChild(pred)

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -697,7 +697,7 @@ class Module extends TModule, ModuleDeclaration {
 
   override string getAPrimaryQlClass() { result = "Module" }
 
-  override string getName() { result = mod.getName().getChild().getValue() }
+  override string getName() { result = mod.getName().getValue() }
 
   /**
    * Gets a member of the module.
@@ -1116,7 +1116,7 @@ class Import extends TImport, ModuleMember, ModuleRef {
    * import semmle.javascript.dataflow.Configuration as Flow
    * ```
    */
-  string importedAs() { result = imp.getChild(1).(QL::ModuleName).getChild().getValue() }
+  string importedAs() { result = imp.getChild(1).(QL::ModuleName).getValue() }
 
   /**
    * Gets the `i`th selected name from the imported module.
@@ -2187,9 +2187,13 @@ class ModuleExpr extends TModuleExpr, ModuleRef {
    * is `Bar`.
    */
   string getName() {
-    result = me.getName().(QL::SimpleId).getValue()
+    result = me.getName().(QL::ModuleName).getValue()
     or
-    not exists(me.getName()) and result = me.getChild().(QL::SimpleId).getValue()
+    not exists(me.getName()) and result = me.getChild().(QL::ModuleName).getValue()
+    or
+    exists(QL::ModuleInstantiation instantiation | instantiation.getParent() = me |
+      result = instantiation.getName().getValue()
+    )
   }
 
   /**

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2217,6 +2217,20 @@ class ModuleExpr extends TModuleExpr, ModuleRef {
     result = super.getAChild(pred)
     or
     pred = directMember("getQualifier") and result = this.getQualifier()
+    or
+    exists(int i | pred = indexedMember("getArgument", i) and result = this.getArgument(i))
+  }
+
+  /**
+   * Gets the `i`th type argument if this module is a module instantiation.
+   * The result is either a `PredicateExpr` or a `TypeExpr`.
+   */
+  AstNode getArgument(int i) {
+    exists(QL::ModuleInstantiation instantiation | instantiation.getParent() = me |
+      toQL(result) = instantiation.getChild(i).getPredicate()
+      or
+      toQL(result) = instantiation.getChild(i).getTypeExpr()
+    )
   }
 }
 

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -719,6 +719,19 @@ class Module extends TModule, ModuleDeclaration {
     pred = directMember("getAlias") and result = this.getAlias()
     or
     pred = directMember("getAMember") and result = this.getAMember()
+    or
+    exists(int i | pred = indexedMember("hasParameter", i) and hasParameter(i, _, result))
+  }
+
+  /** Holds if the `i`th parameter of this module has `name` and type `sig`. */
+  predicate hasParameter(int i, string name, SignatureExpr sig) {
+    exists(QL::ModuleParam param |
+      param = mod.getParameter(i) and name = param.getParameter().getValue()
+    |
+      toQL(sig) = param.getSignature().getPredicate()
+      or
+      toQL(sig) = param.getSignature().getTypeExpr()
+    )
   }
 }
 
@@ -2225,7 +2238,7 @@ class ModuleExpr extends TModuleExpr, ModuleRef {
    * Gets the `i`th type argument if this module is a module instantiation.
    * The result is either a `PredicateExpr` or a `TypeExpr`.
    */
-  AstNode getArgument(int i) {
+  SignatureExpr getArgument(int i) {
     exists(QL::ModuleInstantiation instantiation | instantiation.getParent() = me |
       toQL(result) = instantiation.getChild(i).getPredicate()
       or
@@ -2233,6 +2246,9 @@ class ModuleExpr extends TModuleExpr, ModuleRef {
     )
   }
 }
+
+/** A signature expression, either a `PredicateExpr` or a `TypeExpr`. */
+class SignatureExpr extends TSignatureExpr, AstNode { }
 
 /** An argument to an annotation. */
 private class AnnotationArg extends TAnnotationArg, AstNode {

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2257,6 +2257,12 @@ class SignatureExpr extends TSignatureExpr, AstNode {
 
   /** Gets the generated AST node that contains this signature expression. */
   QL::SignatureExpr toQL() { result = sig }
+
+  /** Gets this signature expression if it represents a predicate expression. */
+  PredicateExpr asPredicate() { result = this }
+
+  /** Gets this signature expression if it represents a type expression. */
+  TypeExpr asType() { result = this }
 }
 
 /** An argument to an annotation. */

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -699,7 +699,7 @@ class Module extends TModule, ModuleDeclaration {
 
   override string getAPrimaryQlClass() { result = "Module" }
 
-  override string getName() { result = mod.getName().getValue() }
+  override string getName() { result = mod.getName().getChild().getValue() }
 
   /**
    * Gets a member of the module.
@@ -1129,7 +1129,7 @@ class Import extends TImport, ModuleMember, ModuleRef {
    * import semmle.javascript.dataflow.Configuration as Flow
    * ```
    */
-  string importedAs() { result = imp.getChild(1).(QL::ModuleName).getValue() }
+  string importedAs() { result = imp.getChild(1).(QL::ModuleName).getChild().getValue() }
 
   /**
    * Gets the `i`th selected name from the imported module.
@@ -2200,12 +2200,12 @@ class ModuleExpr extends TModuleExpr, ModuleRef {
    * is `Bar`.
    */
   string getName() {
-    result = me.getName().(QL::ModuleName).getValue()
+    result = me.getName().(QL::SimpleId).getValue()
     or
-    not exists(me.getName()) and result = me.getChild().(QL::ModuleName).getValue()
+    not exists(me.getName()) and result = me.getChild().(QL::SimpleId).getValue()
     or
     exists(QL::ModuleInstantiation instantiation | instantiation.getParent() = me |
-      result = instantiation.getName().getValue()
+      result = instantiation.getName().getChild().getValue()
     )
   }
 

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
@@ -231,4 +231,6 @@ module AstConsistency {
     not node instanceof YAML::YAMLNode and // parents for YAML doens't work
     not (node instanceof QLDoc and node.getLocation().getFile().getExtension() = "dbscheme") // qldoc in dbschemes are not hooked up
   }
+
+  query predicate nonUniqueParent(AstNode node) { count(node.getParent()) >= 2 }
 }

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
@@ -83,7 +83,7 @@ class TExpr =
 
 class TCall = TPredicateCall or TMemberCall or TNoneCall or TAnyCall;
 
-class TModuleRef = TImport or TModuleExpr or TType;
+class TTypeRef = TImport or TModuleExpr or TType;
 
 class TYamlNode = TYamlCommemt or TYamlEntry or TYamlKey or TYamlListitem or TYamlValue;
 

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
@@ -87,6 +87,8 @@ class TModuleRef = TImport or TModuleExpr;
 
 class TYamlNode = TYamlCommemt or TYamlEntry or TYamlKey or TYamlListitem or TYamlValue;
 
+class TSignatureExpr = TPredicateExpr or TType;
+
 /** DEPRECATED: Alias for TYamlNode */
 deprecated class TYAMLNode = TYamlNode;
 

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
@@ -19,7 +19,11 @@ newtype TAstNode =
   TNewType(QL::Datatype dt) or
   TNewTypeBranch(QL::DatatypeBranch branch) or
   TImport(QL::ImportDirective imp) or
-  TType(QL::TypeExpr type) or
+  // splitting up the TypeExpr based on whether they are a reference to a type or to a module, with some duplicates. 
+  TType(QL::TypeExpr type) { not isDefinitelyModuleParameter(type) } or
+  TModuleParameterRef(QL::TypeExpr type) {
+    isDefinitelyModuleParameter(type) or mightBeModuleParameter(type)
+  } or
   TDisjunction(QL::Disjunction disj) or
   TConjunction(QL::Conjunction conj) or
   TComparisonFormula(QL::CompTerm comp) or
@@ -83,11 +87,43 @@ class TExpr =
 
 class TCall = TPredicateCall or TMemberCall or TNoneCall or TAnyCall;
 
-class TModuleRef = TImport or TModuleExpr;
+class TModuleRef = TImport or TModuleExpr or TModuleParameterRef;
 
 class TYamlNode = TYamlCommemt or TYamlEntry or TYamlKey or TYamlListitem or TYamlValue;
 
-class TSignatureExpr = TPredicateExpr or TType;
+class TSignatureExpr = TPredicateExpr or TType or TModuleParameterRef;
+
+private predicate isDefinitelyModuleParameter(QL::TypeExpr type) {
+  // the signature of a parameterized module
+  exists(QL::SignatureExpr expr, QL::Module m, QL::ModuleParam param, string name |
+    param = m.getParameter(_) and
+    name = param.getParameter().getValue() and
+    expr = param.getSignature() and
+    type = expr.getTypeExpr() and
+    // we have a ref to it, to confirm that it's actually a module.
+    exists(QL::ModuleExpr ref | getNameForModuleExpr(ref) = name | ref.getParent+() = m)
+  )
+  or
+  // the implements clause of a module.
+  exists(QL::Module qlmod | qlmod.getImplements(_).getTypeExpr() = type)
+}
+
+private predicate mightBeModuleParameter(QL::TypeExpr type) {
+  // or it's in an instantiation. The only way to know for sure if it's a module ref or not is to try, so we just have duplicates in the AST.
+  // we spuriously have both TypeExpr and ModuleParameterRef for the same thing.
+  exists(QL::ModuleInstantiation inst | type = inst.getChild(_).getTypeExpr())
+}
+
+// ensuring non-monotonic recursion by outlining predicate out of `ModuleExpr`
+string getNameForModuleExpr(QL::ModuleExpr me) {
+  result = me.getName().(QL::SimpleId).getValue()
+  or
+  not exists(me.getName()) and result = me.getChild().(QL::SimpleId).getValue()
+  or
+  exists(QL::ModuleInstantiation instantiation | instantiation.getParent() = me |
+    result = instantiation.getName().getChild().getValue()
+  )
+}
 
 /** DEPRECATED: Alias for TYamlNode */
 deprecated class TYAMLNode = TYamlNode;
@@ -175,6 +211,8 @@ QL::AstNode toQL(AST::AstNode n) {
   n = TNewType(result)
   or
   n = TNewTypeBranch(result)
+  or
+  n = TModuleParameterRef(result)
   or
   n = TImport(result)
   or

--- a/ql/ql/src/codeql_ql/ast/internal/Module.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Module.qll
@@ -326,11 +326,14 @@ module ModConsistency {
         .regexpMatch(".*/(test|examples|ql-training|recorded-call-graph-metrics)/.*")
   }
 
-  query predicate multipleResolveModuleRef(ModuleExpr me, int c, ContainerOrModule m) {
-    c = strictcount(ContainerOrModule m0 | resolveModuleRef(me, m0)) and
-    c > 1 and
-    resolveModuleRef(me, m)
-  }
+  // This can happen with parameterized modules.
+  /*
+   * query predicate multipleResolveModuleRef(ModuleExpr me, int c, ContainerOrModule m) {
+   *    c = strictcount(ContainerOrModule m0 | resolveModuleRef(me, m0)) and
+   *    c > 1 and
+   *    resolveModuleRef(me, m)
+   *  }
+   */
 
   query predicate noName(Module mod) { not exists(mod.getName()) }
 

--- a/ql/ql/src/codeql_ql/ast/internal/Module.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Module.qll
@@ -311,4 +311,8 @@ module ModConsistency {
     c > 1 and
     resolveModuleExpr(me, m)
   }
+
+  query predicate noName(Module mod) { not exists(mod.getName()) }
+
+  query predicate nonUniqueName(Module mod) { count(mod.getName()) >= 2 }
 }

--- a/ql/ql/src/codeql_ql/ast/internal/Module.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Module.qll
@@ -114,7 +114,6 @@ class Module_ extends FileOrModule, TModule {
   }
 }
 
-// class ModuleRef = AstNodes::TModuleExpr or AstNodes::TType;
 private predicate resolveQualifiedName(Import imp, ContainerOrModule m, int i) {
   not m = TFile(any(File f | f.getExtension() = "ql")) and
   exists(string q | q = imp.getQualifiedName(i) |
@@ -264,8 +263,10 @@ private predicate definesModule(
     public = false and
     ty = sig.asModuleRef()
   |
+    // resolve to the signature module
     m = ty.getResolvedModule()
     or
+    // resolve to the arguments of the instantiated module
     exists(ModuleExpr inst | inst.getResolvedModule().asModule() = mod |
       m = inst.getArgument(i).asModuleRef().getResolvedModule()
     )

--- a/ql/ql/src/codeql_ql/ast/internal/Module.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Module.qll
@@ -24,11 +24,11 @@ private class ContainerOrModule extends TContainerOrModule {
     this = TFolder(_) and result = "folder"
   }
 
-    /** Gets the module for this imported module. */
-    Module asModule() { this = TModule(result) }
+  /** Gets the module for this imported module. */
+  Module asModule() { this = TModule(result) }
 
-    /** Gets the file for this file. */
-    File asFile() { this = TFile(result) }
+  /** Gets the file for this file. */
+  File asFile() { this = TFile(result) }
 }
 
 private class TFileOrModule = TFile or TModule;
@@ -115,7 +115,6 @@ class Module_ extends FileOrModule, TModule {
 }
 
 // class ModuleRef = AstNodes::TModuleExpr or AstNodes::TType;
-
 private predicate resolveQualifiedName(Import imp, ContainerOrModule m, int i) {
   not m = TFile(any(File f | f.getExtension() = "ql")) and
   exists(string q | q = imp.getQualifiedName(i) |
@@ -209,7 +208,7 @@ private module Cached {
 
   /** Holds if module expression `me` resolves to `m`. */
   cached
-  predicate resolveModuleRef(ModuleRef me, FileOrModule m) { // TODO: name.
+  predicate resolveModuleRef(ModuleRef me, FileOrModule m) {
     not m = TFile(any(File f | f.getExtension() = "ql")) and
     not exists(me.(ModuleExpr).getQualifier()) and
     exists(ContainerOrModule enclosing, string name | resolveModuleRefHelper(me, enclosing, name) |
@@ -257,17 +256,17 @@ private predicate definesModule(
     or
     m = TModule(any(Module mod | public = getPublicBool(mod)))
   )
-   or
+  or
   // signature module in a paramertized module
-  exists(Module mod, SignatureExpr sig, ModuleParameterRef ty, int i | 
+  exists(Module mod, SignatureExpr sig, ModuleParameterRef ty, int i |
     mod = container.asModule() and
     mod.hasParameter(i, name, sig) and
     public = false and
-    ty = sig.asModuleRef() 
-    |
+    ty = sig.asModuleRef()
+  |
     m = ty.getResolvedModule()
     or
-    exists(ModuleExpr inst | inst.getResolvedModule().asModule() = mod | 
+    exists(ModuleExpr inst | inst.getResolvedModule().asModule() = mod |
       m = inst.getArgument(i).asModuleRef().getResolvedModule()
     )
   )
@@ -307,12 +306,14 @@ module ModConsistency {
         .regexpMatch(".*/(test|examples|ql-training|recorded-call-graph-metrics)/.*")
   }
 
-  query predicate noResolveModuleRef(ModuleRef me) { // TODO: name?
+  query predicate noResolveModuleRef(ModuleRef me) {
     not exists(me.getResolvedModule()) and
     not me.getLocation()
         .getFile()
         .getAbsolutePath()
-        .regexpMatch(".*/(test|examples|ql-training|recorded-call-graph-metrics)/.*")
+        .regexpMatch(".*/(test|examples|ql-training|recorded-call-graph-metrics)/.*") and
+    // this ModuleRef might really be a type.
+    not exists(me.(TypeExpr).getResolvedType())
   }
 
   query predicate multipleResolve(Import imp, int c, ContainerOrModule m) {

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -70,10 +70,16 @@ private module Cached {
       definesPredicate(m, pc.getPredicateName(), pc.getNumberOfArguments(), p, public)
     )
     or
-    exists(Module mod, PredicateExpr sig |
-      mod.hasParameter(_, pc.getPredicateName(), sig) and
-      p = sig.getResolvedPredicate() and // <- this is a `signature predicate`, but that's fine.
-      sig.getArity() = pc.getNumberOfArguments() // TODO: resolve all instantiations?
+    exists(Module mod, PredicateExpr sig, int i |
+      mod.hasParameter(i, pc.getPredicateName(), sig) and
+      sig.getArity() = pc.getNumberOfArguments()
+    |
+      p = sig.getResolvedPredicate() // <- this is a `signature predicate`, but that's fine.
+      or
+      exists(ModuleExpr inst, SignatureExpr arg | inst.getResolvedModule().asModule() = mod |
+        arg = inst.getArgument(i) and
+        p = arg.asPredicate().getResolvedPredicate()
+      )
     )
   }
 

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -73,7 +73,7 @@ private module Cached {
     exists(Module mod, PredicateExpr sig |
       mod.hasParameter(_, pc.getPredicateName(), sig) and
       p = sig.getResolvedPredicate() and // <- this is a `signature predicate`, but that's fine.
-      sig.getArity() = pc.getNumberOfArguments()
+      sig.getArity() = pc.getNumberOfArguments() // TODO: resolve all instantiations?
     )
   }
 

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -69,6 +69,12 @@ private module Cached {
     |
       definesPredicate(m, pc.getPredicateName(), pc.getNumberOfArguments(), p, public)
     )
+    or
+    exists(Module mod, PredicateExpr sig |
+      mod.hasParameter(_, pc.getPredicateName(), sig) and
+      p = sig.getResolvedPredicate() and // <- this is a `signature predicate`, but that's fine.
+      sig.getArity() = pc.getNumberOfArguments()
+    )
   }
 
   private predicate resolveMemberCall(MemberCall mc, PredicateOrBuiltin p) {

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -74,8 +74,10 @@ private module Cached {
       mod.hasParameter(i, pc.getPredicateName(), sig) and
       sig.getArity() = pc.getNumberOfArguments()
     |
+      // resolve to the signature predicate
       p = sig.getResolvedPredicate() // <- this is a `signature predicate`, but that's fine.
       or
+      // resolve to the instantiations
       exists(ModuleExpr inst, SignatureExpr arg | inst.getResolvedModule().asModule() = mod |
         arg = inst.getArgument(i) and
         p = arg.asPredicate().getResolvedPredicate()

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -174,17 +174,20 @@ module PredConsistency {
     c > 1 and
     resolvePredicateExpr(pe, p)
   }
+  // This can happen with parametarized modules
+  /*
+   * query predicate multipleResolveCall(Call call, int c, PredicateOrBuiltin p) {
+   *    c =
+   *      strictcount(PredicateOrBuiltin p0 |
+   *        resolveCall(call, p0) and
+   *        // aliases are expected to resolve to multiple.
+   *        not exists(p0.(ClasslessPredicate).getAlias()) and
+   *        // overridden predicates may have multiple targets
+   *        not p0.(ClassPredicate).isOverride()
+   *      ) and
+   *    c > 1 and
+   *    resolveCall(call, p)
+   *  }
+   */
 
-  query predicate multipleResolveCall(Call call, int c, PredicateOrBuiltin p) {
-    c =
-      strictcount(PredicateOrBuiltin p0 |
-        resolveCall(call, p0) and
-        // aliases are expected to resolve to multiple.
-        not exists(p0.(ClasslessPredicate).getAlias()) and
-        // overridden predicates may have multiple targets
-        not p0.(ClassPredicate).isOverride()
-      ) and
-    c > 1 and
-    resolveCall(call, p)
   }
-}

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -999,11 +999,16 @@ module QL {
     /** Gets the name of the primary QL class for this element. */
     final override string getAPrimaryQlClass() { result = "ModuleInstantiation" }
 
+    /** Gets the node corresponding to the field `name`. */
+    final ModuleName getName() { ql_module_instantiation_def(this, result) }
+
     /** Gets the `i`th child of this node. */
     final SignatureExpr getChild(int i) { ql_module_instantiation_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    final override AstNode getAFieldOrChild() { ql_module_instantiation_child(this, _, result) }
+    final override AstNode getAFieldOrChild() {
+      ql_module_instantiation_def(this, result) or ql_module_instantiation_child(this, _, result)
+    }
   }
 
   /** A class representing `moduleMember` nodes. */
@@ -1018,16 +1023,10 @@ module QL {
     final override AstNode getAFieldOrChild() { ql_module_member_child(this, _, result) }
   }
 
-  /** A class representing `moduleName` nodes. */
-  class ModuleName extends @ql_module_name, AstNode {
+  /** A class representing `moduleName` tokens. */
+  class ModuleName extends @ql_token_module_name, Token {
     /** Gets the name of the primary QL class for this element. */
     final override string getAPrimaryQlClass() { result = "ModuleName" }
-
-    /** Gets the child of this node. */
-    final SimpleId getChild() { ql_module_name_def(this, result) }
-
-    /** Gets a field or child node of this node. */
-    final override AstNode getAFieldOrChild() { ql_module_name_def(this, result) }
   }
 
   /** A class representing `moduleParam` nodes. */

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -1023,10 +1023,16 @@ module QL {
     final override AstNode getAFieldOrChild() { ql_module_member_child(this, _, result) }
   }
 
-  /** A class representing `moduleName` tokens. */
-  class ModuleName extends @ql_token_module_name, Token {
+  /** A class representing `moduleName` nodes. */
+  class ModuleName extends @ql_module_name, AstNode {
     /** Gets the name of the primary QL class for this element. */
     final override string getAPrimaryQlClass() { result = "ModuleName" }
+
+    /** Gets the child of this node. */
+    final SimpleId getChild() { ql_module_name_def(this, result) }
+
+    /** Gets a field or child node of this node. */
+    final override AstNode getAFieldOrChild() { ql_module_name_def(this, result) }
   }
 
   /** A class representing `moduleParam` nodes. */

--- a/ql/ql/src/codeql_ql/ast/internal/Type.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Type.qll
@@ -348,7 +348,12 @@ module TyConsistency {
     not te.getLocation()
         .getFile()
         .getAbsolutePath()
-        .regexpMatch(".*/(test|examples|ql-training|recorded-call-graph-metrics)/.*")
+        .regexpMatch(".*/(test|examples|ql-training|recorded-call-graph-metrics)/.*") and
+    // we have some duplicate with moduleRef, so that might be resolved correctly.
+    // TODO: Collapse both ModuleRef and TypeExpr into one class?
+    not exists(ModuleRef ref | AstNodes::toQL(te) = AstNodes::toQL(ref) |
+      exists(ref.getResolvedModule())
+    )
   }
 
   query predicate multipleResolve(TypeExpr te, int c, Type t) {

--- a/ql/ql/src/codeql_ql/ast/internal/Type.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Type.qll
@@ -350,7 +350,6 @@ module TyConsistency {
         .getAbsolutePath()
         .regexpMatch(".*/(test|examples|ql-training|recorded-call-graph-metrics)/.*") and
     // we have some duplicate with moduleRef, so that might be resolved correctly.
-    // TODO: Collapse both ModuleRef and TypeExpr into one class?
     not exists(ModuleRef ref | AstNodes::toQL(te) = AstNodes::toQL(ref) |
       exists(ref.getResolvedModule())
     )

--- a/ql/ql/src/codeql_ql/ast/internal/Type.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Type.qll
@@ -355,11 +355,14 @@ module TyConsistency {
     )
   }
 
-  query predicate multipleResolve(TypeExpr te, int c, Type t) {
-    c = strictcount(Type t0 | resolveTypeExpr(te, t0)) and
-    c > 1 and
-    resolveTypeExpr(te, t)
-  }
+  // This can happen with parameterized modules.
+  /*
+   * query predicate multipleResolve(TypeExpr te, int c, Type t) {
+   *    c = strictcount(Type t0 | resolveTypeExpr(te, t0)) and
+   *    c > 1 and
+   *    resolveTypeExpr(te, t)
+   *  }
+   */
 
   query predicate multiplePrimitives(TypeExpr te, int c, PrimitiveType t) {
     c = strictcount(PrimitiveType t0 | resolveTypeExpr(te, t0)) and

--- a/ql/ql/src/codeql_ql/ast/internal/Type.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Type.qll
@@ -330,10 +330,10 @@ private predicate defines(FileOrModule m, string name, Type t, boolean public) {
     mod.hasParameter(i, name, param) and
     public = true
   |
-    // we resolve it both to the signature type
+    // resolve to the signature class
     t = param.asType().getResolvedType()
     or
-    // or any instantiated type
+    // resolve to the instantiations
     exists(ModuleExpr inst, SignatureExpr arg |
       inst.getArgument(i) = arg and
       inst.getResolvedModule() = m and

--- a/ql/ql/src/codeql_ql/ast/internal/Type.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Type.qll
@@ -323,6 +323,23 @@ private predicate defines(FileOrModule m, string name, Type t, boolean public) {
     public = getPublicBool(im) and
     defines(im.getResolvedModule(), name, t, true)
   )
+  or
+  // classes in parameterized modules.
+  exists(Module mod, SignatureExpr param, int i |
+    m.asModule() = mod and
+    mod.hasParameter(i, name, param) and
+    public = true
+  |
+    // we resolve it both to the signature type
+    t = param.asType().getResolvedType()
+    or
+    // or any instantiated type
+    exists(ModuleExpr inst, SignatureExpr arg |
+      inst.getArgument(i) = arg and
+      inst.getResolvedModule() = m and
+      t = arg.asType().getResolvedType()
+    )
+  )
 }
 
 module TyConsistency {

--- a/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
+++ b/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
@@ -164,6 +164,9 @@ private AstNode aliveStep(AstNode prev) {
   result = prev.(Annotation).getAChild()
   or
   result = prev.(Predicate).getReturnType().getDeclaration()
+  or
+  // a module parameter is alive is the module is alive
+  prev.(Module).hasParameter(_, _, result)
 }
 
 private AstNode deprecated() {

--- a/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
+++ b/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
@@ -167,6 +167,9 @@ private AstNode aliveStep(AstNode prev) {
   or
   // a module parameter is alive is the module is alive
   prev.(Module).hasParameter(_, _, result)
+  or
+  // the implements of a module
+  result = prev.(Module).getImplements(_)
 }
 
 private AstNode deprecated() {

--- a/ql/ql/src/ide-contextual-queries/Definitions.qll
+++ b/ql/ql/src/ide-contextual-queries/Definitions.qll
@@ -28,14 +28,15 @@ class Loc extends TLoc {
   }
 }
 
-private predicate resolveModule(ModuleRef ref, FileOrModule target, string kind) {
+private predicate resolveModule(TypeRef ref, FileOrModule target, string kind) {
   target = ref.getResolvedModule() and
   kind = "module"
 }
 
 private predicate resolveType(TypeExpr ref, AstNode target, string kind) {
   target = ref.getResolvedType().getDeclaration() and
-  kind = "type"
+  kind = "type" and
+  not resolveModule(ref, _, _) // modules are types, so we exclude them here.
 }
 
 private predicate resolvePredicate(PredicateExpr ref, Predicate target, string kind) {

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -529,7 +529,7 @@ ql_implication_def(
   int right: @ql_implication_right_type ref
 );
 
-@ql_importDirective_child_type = @ql_import_module_expr | @ql_token_module_name
+@ql_importDirective_child_type = @ql_import_module_expr | @ql_module_name
 
 #keyset[ql_import_directive, index]
 ql_import_directive_child(
@@ -626,7 +626,7 @@ ql_module_child(
 
 ql_module_def(
   unique int id: @ql_module,
-  int name: @ql_token_module_name ref
+  int name: @ql_module_name ref
 );
 
 ql_module_alias_body_def(
@@ -634,14 +634,14 @@ ql_module_alias_body_def(
   int child: @ql_module_expr ref
 );
 
-@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_module_name
+@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_simple_id
 
 ql_module_expr_name(
   unique int ql_module_expr: @ql_module_expr ref,
   unique int name: @ql_moduleExpr_name_type ref
 );
 
-@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_module_name
+@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_simple_id
 
 ql_module_expr_def(
   unique int id: @ql_module_expr,
@@ -657,7 +657,7 @@ ql_module_instantiation_child(
 
 ql_module_instantiation_def(
   unique int id: @ql_module_instantiation,
-  int name: @ql_token_module_name ref
+  int name: @ql_module_name ref
 );
 
 @ql_moduleMember_child_type = @ql_annotation | @ql_classless_predicate | @ql_dataclass | @ql_datatype | @ql_import_directive | @ql_module | @ql_select | @ql_token_qldoc
@@ -671,6 +671,11 @@ ql_module_member_child(
 
 ql_module_member_def(
   unique int id: @ql_module_member
+);
+
+ql_module_name_def(
+  unique int id: @ql_module_name,
+  int child: @ql_token_simple_id ref
 );
 
 ql_module_param_def(
@@ -1086,27 +1091,26 @@ case @ql_token.kind of
 | 22 = @ql_token_integer
 | 23 = @ql_token_line_comment
 | 24 = @ql_token_literal_id
-| 25 = @ql_token_module_name
-| 26 = @ql_token_mulop
-| 27 = @ql_token_predicate
-| 28 = @ql_token_predicate_name
-| 29 = @ql_token_primitive_type
-| 30 = @ql_token_qldoc
-| 31 = @ql_token_quantifier
-| 32 = @ql_token_result
-| 33 = @ql_token_simple_id
-| 34 = @ql_token_special_id
-| 35 = @ql_token_string
-| 36 = @ql_token_super
-| 37 = @ql_token_this
-| 38 = @ql_token_true
-| 39 = @ql_token_underscore
-| 40 = @ql_token_unop
-| 41 = @ql_token_yaml_value
+| 25 = @ql_token_mulop
+| 26 = @ql_token_predicate
+| 27 = @ql_token_predicate_name
+| 28 = @ql_token_primitive_type
+| 29 = @ql_token_qldoc
+| 30 = @ql_token_quantifier
+| 31 = @ql_token_result
+| 32 = @ql_token_simple_id
+| 33 = @ql_token_special_id
+| 34 = @ql_token_string
+| 35 = @ql_token_super
+| 36 = @ql_token_this
+| 37 = @ql_token_true
+| 38 = @ql_token_underscore
+| 39 = @ql_token_unop
+| 40 = @ql_token_yaml_value
 ;
 
 
-@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_db_annotation | @ql_db_args_annotation | @ql_db_branch | @ql_db_case_decl | @ql_db_col_type | @ql_db_column | @ql_db_entry | @ql_db_repr_type | @ql_db_table | @ql_db_table_name | @ql_db_union_decl | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qual_module_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable | @ql_yaml_comment | @ql_yaml_entry | @ql_yaml_key | @ql_yaml_keyvaluepair | @ql_yaml_listitem
+@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_db_annotation | @ql_db_args_annotation | @ql_db_branch | @ql_db_case_decl | @ql_db_col_type | @ql_db_column | @ql_db_entry | @ql_db_repr_type | @ql_db_table | @ql_db_table_name | @ql_db_union_decl | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qual_module_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable | @ql_yaml_comment | @ql_yaml_entry | @ql_yaml_key | @ql_yaml_keyvaluepair | @ql_yaml_listitem
 
 @ql_ast_node_parent = @file | @ql_ast_node
 

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -529,7 +529,7 @@ ql_implication_def(
   int right: @ql_implication_right_type ref
 );
 
-@ql_importDirective_child_type = @ql_import_module_expr | @ql_module_name
+@ql_importDirective_child_type = @ql_import_module_expr | @ql_token_module_name
 
 #keyset[ql_import_directive, index]
 ql_import_directive_child(
@@ -626,7 +626,7 @@ ql_module_child(
 
 ql_module_def(
   unique int id: @ql_module,
-  int name: @ql_module_name ref
+  int name: @ql_token_module_name ref
 );
 
 ql_module_alias_body_def(
@@ -634,14 +634,14 @@ ql_module_alias_body_def(
   int child: @ql_module_expr ref
 );
 
-@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_simple_id
+@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_module_name
 
 ql_module_expr_name(
   unique int ql_module_expr: @ql_module_expr ref,
   unique int name: @ql_moduleExpr_name_type ref
 );
 
-@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_simple_id
+@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_module_name
 
 ql_module_expr_def(
   unique int id: @ql_module_expr,
@@ -656,7 +656,8 @@ ql_module_instantiation_child(
 );
 
 ql_module_instantiation_def(
-  unique int id: @ql_module_instantiation
+  unique int id: @ql_module_instantiation,
+  int name: @ql_token_module_name ref
 );
 
 @ql_moduleMember_child_type = @ql_annotation | @ql_classless_predicate | @ql_dataclass | @ql_datatype | @ql_import_directive | @ql_module | @ql_select | @ql_token_qldoc
@@ -670,11 +671,6 @@ ql_module_member_child(
 
 ql_module_member_def(
   unique int id: @ql_module_member
-);
-
-ql_module_name_def(
-  unique int id: @ql_module_name,
-  int child: @ql_token_simple_id ref
 );
 
 ql_module_param_def(
@@ -1090,26 +1086,27 @@ case @ql_token.kind of
 | 22 = @ql_token_integer
 | 23 = @ql_token_line_comment
 | 24 = @ql_token_literal_id
-| 25 = @ql_token_mulop
-| 26 = @ql_token_predicate
-| 27 = @ql_token_predicate_name
-| 28 = @ql_token_primitive_type
-| 29 = @ql_token_qldoc
-| 30 = @ql_token_quantifier
-| 31 = @ql_token_result
-| 32 = @ql_token_simple_id
-| 33 = @ql_token_special_id
-| 34 = @ql_token_string
-| 35 = @ql_token_super
-| 36 = @ql_token_this
-| 37 = @ql_token_true
-| 38 = @ql_token_underscore
-| 39 = @ql_token_unop
-| 40 = @ql_token_yaml_value
+| 25 = @ql_token_module_name
+| 26 = @ql_token_mulop
+| 27 = @ql_token_predicate
+| 28 = @ql_token_predicate_name
+| 29 = @ql_token_primitive_type
+| 30 = @ql_token_qldoc
+| 31 = @ql_token_quantifier
+| 32 = @ql_token_result
+| 33 = @ql_token_simple_id
+| 34 = @ql_token_special_id
+| 35 = @ql_token_string
+| 36 = @ql_token_super
+| 37 = @ql_token_this
+| 38 = @ql_token_true
+| 39 = @ql_token_underscore
+| 40 = @ql_token_unop
+| 41 = @ql_token_yaml_value
 ;
 
 
-@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_db_annotation | @ql_db_args_annotation | @ql_db_branch | @ql_db_case_decl | @ql_db_col_type | @ql_db_column | @ql_db_entry | @ql_db_repr_type | @ql_db_table | @ql_db_table_name | @ql_db_union_decl | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qual_module_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable | @ql_yaml_comment | @ql_yaml_entry | @ql_yaml_key | @ql_yaml_keyvaluepair | @ql_yaml_listitem
+@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_db_annotation | @ql_db_args_annotation | @ql_db_branch | @ql_db_case_decl | @ql_db_col_type | @ql_db_column | @ql_db_entry | @ql_db_repr_type | @ql_db_table | @ql_db_table_name | @ql_db_union_decl | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qual_module_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable | @ql_yaml_comment | @ql_yaml_entry | @ql_yaml_key | @ql_yaml_keyvaluepair | @ql_yaml_listitem
 
 @ql_ast_node_parent = @file | @ql_ast_node
 

--- a/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
+++ b/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
@@ -39,8 +39,6 @@ where
   or
   ModConsistency::noResolve(node) and msg = "ModConsistency::noResolve"
   or
-  ModConsistency::noResolveModuleRef(node) and msg = "ModConsistency::noResolveModuleRef"
-  or
   ModConsistency::noName(node) and msg = "ModConsistency::noName"
   or
   ModConsistency::nonUniqueName(node) and msg = "ModConsistency::nonUniqueName"

--- a/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
+++ b/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
@@ -31,7 +31,7 @@ where
   TypeConsistency::multiplePrimitivesExpr(node, _, _) and
   msg = "TypeConsistency::multiplePrimitivesExpr"
   or
-  AstConsistency::nonTotalGetParent(node) and msg = "AstConsistency::nonTotalGetParent"
+  AstConsistency::nonTotalGetParent(node) and msg = "AstConsistency::nonTotalGetParent" // TODO: unique parent
   or
   TypeConsistency::noResolve(node) and msg = "TypeConsistency::noResolve"
   or
@@ -39,15 +39,12 @@ where
   or
   ModConsistency::noResolveModuleExpr(node) and msg = "ModConsistency::noResolveModuleExpr"
   or
+  ModConsistency::noName(node) and msg = "ModConsistency::noName"
+  or
+  ModConsistency::nonUniqueName(node) and msg = "ModConsistency::nonUniqueName"
+  or
   VarConsistency::noFieldDef(node) and msg = "VarConsistency::noFieldDef"
   or
   VarConsistency::noVarDef(node) and msg = "VarConsistency::noVarDef"
-  or
-  node instanceof ModuleExpr and
-  not exists(node.(ModuleExpr).getName()) and
-  msg = "exists(ModuleExpr::getName)"
-  or
-  node instanceof ModuleExpr and
-  count(node.(ModuleExpr).getName()) >= 2 and
-  msg = "unique(ModuleExpr::getName)"
 select node, msg
+// TODO: vardef consistency.

--- a/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
+++ b/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
@@ -31,7 +31,9 @@ where
   TypeConsistency::multiplePrimitivesExpr(node, _, _) and
   msg = "TypeConsistency::multiplePrimitivesExpr"
   or
-  AstConsistency::nonTotalGetParent(node) and msg = "AstConsistency::nonTotalGetParent" // TODO: unique parent
+  AstConsistency::nonTotalGetParent(node) and msg = "AstConsistency::nonTotalGetParent"
+  or
+  AstConsistency::nonUniqueParent(node) and msg = "AstConsistency::nonUniqueParent"
   or
   TypeConsistency::noResolve(node) and msg = "TypeConsistency::noResolve"
   or
@@ -47,4 +49,3 @@ where
   or
   VarConsistency::noVarDef(node) and msg = "VarConsistency::noVarDef"
 select node, msg
-// TODO: vardef consistency.

--- a/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
+++ b/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
@@ -39,7 +39,7 @@ where
   or
   ModConsistency::noResolve(node) and msg = "ModConsistency::noResolve"
   or
-  ModConsistency::noResolveModuleExpr(node) and msg = "ModConsistency::noResolveModuleExpr"
+  ModConsistency::noResolveModuleRef(node) and msg = "ModConsistency::noResolveModuleRef"
   or
   ModConsistency::noName(node) and msg = "ModConsistency::noName"
   or

--- a/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
+++ b/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
@@ -42,4 +42,12 @@ where
   VarConsistency::noFieldDef(node) and msg = "VarConsistency::noFieldDef"
   or
   VarConsistency::noVarDef(node) and msg = "VarConsistency::noVarDef"
+  or
+  node instanceof ModuleExpr and
+  not exists(node.(ModuleExpr).getName()) and
+  msg = "exists(ModuleExpr::getName)"
+  or
+  node instanceof ModuleExpr and
+  count(node.(ModuleExpr).getName()) >= 2 and
+  msg = "unique(ModuleExpr::getName)"
 select node, msg

--- a/ql/ql/test/callgraph/ParamModules.qll
+++ b/ql/ql/test/callgraph/ParamModules.qll
@@ -1,0 +1,19 @@
+module PredicateSig {
+  signature predicate fooSig(int i);
+
+  module UsesFoo<fooSig/1 fooImpl> {
+    predicate bar(int i) { fooImpl(i + 1) }
+  }
+
+  predicate myFoo(int i) { i = 42 }
+
+  predicate use(int i) { UsesFoo<myFoo/1>::bar(i) }
+}
+
+module ClassSig {
+  // TODO:
+}
+
+module ModuleSig {
+  // TODO:
+}

--- a/ql/ql/test/callgraph/ParamModules.qll
+++ b/ql/ql/test/callgraph/ParamModules.qll
@@ -27,5 +27,37 @@ module ClassSig {
 }
 
 module ModuleSig {
-  // TODO:
+  signature module FooSig {
+    class A;
+
+    A getThing();
+  }
+
+  module UsesFoo<FooSig FooImpl> {
+    B getThing() { result = FooImpl::getThing() }
+
+    class B = FooImpl::A;
+  }
+
+  module MyFoo implements FooSig {
+    class C extends int {
+      C() { this = [0 .. 10] }
+
+      string myFoo() { result = "myFoo" }
+    }
+
+    class A = C;
+
+    C getThing() { any() }
+  }
+
+  module ImplStuff {
+    module Inst = UsesFoo<MyFoo>;
+
+    class D = Inst::B;
+
+    string use1() { result = Inst::getThing().myFoo() }
+
+    string use2(Inst::B b) { result = b.myFoo() }
+  }
 }

--- a/ql/ql/test/callgraph/ParamModules.qll
+++ b/ql/ql/test/callgraph/ParamModules.qll
@@ -11,7 +11,19 @@ module PredicateSig {
 }
 
 module ClassSig {
-  // TODO:
+  signature class FooSig extends int;
+
+  module UsesFoo<FooSig FooImpl> {
+    FooImpl getAnEven() { result % 2 = 0 }
+  }
+
+  class MyFoo extends int {
+    MyFoo() { this = [0 .. 10] }
+
+    string myFoo() { result = "myFoo" }
+  }
+
+  string use() { result = UsesFoo<MyFoo>::getAnEven().myFoo() }
 }
 
 module ModuleSig {

--- a/ql/ql/test/callgraph/callgraph.expected
+++ b/ql/ql/test/callgraph/callgraph.expected
@@ -25,6 +25,11 @@ getTarget
 | ParamModules.qll:10:26:10:49 | PredicateCall | ParamModules.qll:5:5:5:43 | ClasslessPredicate bar |
 | ParamModules.qll:26:27:26:53 | PredicateCall | ParamModules.qll:17:5:17:42 | ClasslessPredicate getAnEven |
 | ParamModules.qll:26:27:26:61 | MemberCall | ParamModules.qll:23:5:23:39 | ClassPredicate myFoo |
+| ParamModules.qll:37:29:37:47 | PredicateCall | ParamModules.qll:33:5:33:17 | ClasslessPredicate getThing |
+| ParamModules.qll:37:29:37:47 | PredicateCall | ParamModules.qll:51:5:51:26 | ClasslessPredicate getThing |
+| ParamModules.qll:59:30:59:45 | PredicateCall | ParamModules.qll:37:5:37:49 | ClasslessPredicate getThing |
+| ParamModules.qll:59:30:59:53 | MemberCall | ParamModules.qll:46:7:46:41 | ClassPredicate myFoo |
+| ParamModules.qll:61:39:61:47 | MemberCall | ParamModules.qll:46:7:46:41 | ClassPredicate myFoo |
 | packs/other/OtherThing.qll:5:3:5:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:1:1:30 | ClasslessPredicate foo |
 | packs/other/OtherThing.qll:6:3:6:8 | PredicateCall | packs/src/SrcThing.qll:8:1:8:30 | ClasslessPredicate bar |
 | packs/src/SrcThing.qll:4:3:4:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:1:1:30 | ClasslessPredicate foo |

--- a/ql/ql/test/callgraph/callgraph.expected
+++ b/ql/ql/test/callgraph/callgraph.expected
@@ -21,6 +21,8 @@ getTarget
 | Overrides.qll:24:39:24:48 | MemberCall | Overrides.qll:22:12:22:44 | ClassPredicate bar |
 | Overrides.qll:28:3:28:9 | MemberCall | Overrides.qll:6:3:6:29 | ClassPredicate bar |
 | Overrides.qll:29:3:29:10 | MemberCall | Overrides.qll:8:3:8:41 | ClassPredicate baz |
+| ParamModules.qll:5:28:5:41 | PredicateCall | ParamModules.qll:2:13:2:36 | ClasslessPredicate fooSig |
+| ParamModules.qll:10:26:10:49 | PredicateCall | ParamModules.qll:5:5:5:43 | ClasslessPredicate bar |
 | packs/other/OtherThing.qll:5:3:5:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:1:1:30 | ClasslessPredicate foo |
 | packs/other/OtherThing.qll:6:3:6:8 | PredicateCall | packs/src/SrcThing.qll:8:1:8:30 | ClasslessPredicate bar |
 | packs/src/SrcThing.qll:4:3:4:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:1:1:30 | ClasslessPredicate foo |
@@ -33,3 +35,5 @@ exprPredicate
 | Foo.qll:26:22:26:31 | predicate | Foo.qll:20:3:20:54 | ClasslessPredicate myThing2 |
 | Foo.qll:47:55:47:62 | predicate | Foo.qll:42:20:42:27 | NewTypeBranch MkRoot |
 | Foo.qll:47:65:47:70 | predicate | Foo.qll:44:9:44:56 | ClasslessPredicate edge |
+| ParamModules.qll:4:18:4:25 | predicate | ParamModules.qll:2:13:2:36 | ClasslessPredicate fooSig |
+| ParamModules.qll:10:34:10:40 | predicate | ParamModules.qll:8:3:8:35 | ClasslessPredicate myFoo |

--- a/ql/ql/test/callgraph/callgraph.expected
+++ b/ql/ql/test/callgraph/callgraph.expected
@@ -23,6 +23,8 @@ getTarget
 | Overrides.qll:29:3:29:10 | MemberCall | Overrides.qll:8:3:8:41 | ClassPredicate baz |
 | ParamModules.qll:5:28:5:41 | PredicateCall | ParamModules.qll:2:13:2:36 | ClasslessPredicate fooSig |
 | ParamModules.qll:10:26:10:49 | PredicateCall | ParamModules.qll:5:5:5:43 | ClasslessPredicate bar |
+| ParamModules.qll:26:27:26:53 | PredicateCall | ParamModules.qll:17:5:17:42 | ClasslessPredicate getAnEven |
+| ParamModules.qll:26:27:26:61 | MemberCall | ParamModules.qll:23:5:23:39 | ClassPredicate myFoo |
 | packs/other/OtherThing.qll:5:3:5:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:1:1:30 | ClasslessPredicate foo |
 | packs/other/OtherThing.qll:6:3:6:8 | PredicateCall | packs/src/SrcThing.qll:8:1:8:30 | ClasslessPredicate bar |
 | packs/src/SrcThing.qll:4:3:4:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:1:1:30 | ClasslessPredicate foo |

--- a/ql/ql/test/callgraph/callgraph.expected
+++ b/ql/ql/test/callgraph/callgraph.expected
@@ -22,6 +22,7 @@ getTarget
 | Overrides.qll:28:3:28:9 | MemberCall | Overrides.qll:6:3:6:29 | ClassPredicate bar |
 | Overrides.qll:29:3:29:10 | MemberCall | Overrides.qll:8:3:8:41 | ClassPredicate baz |
 | ParamModules.qll:5:28:5:41 | PredicateCall | ParamModules.qll:2:13:2:36 | ClasslessPredicate fooSig |
+| ParamModules.qll:5:28:5:41 | PredicateCall | ParamModules.qll:8:3:8:35 | ClasslessPredicate myFoo |
 | ParamModules.qll:10:26:10:49 | PredicateCall | ParamModules.qll:5:5:5:43 | ClasslessPredicate bar |
 | ParamModules.qll:26:27:26:53 | PredicateCall | ParamModules.qll:17:5:17:42 | ClasslessPredicate getAnEven |
 | ParamModules.qll:26:27:26:61 | MemberCall | ParamModules.qll:23:5:23:39 | ClassPredicate myFoo |


### PR DESCRIPTION
Supports all the features currently used in `main` (empty consistency predicates and no parse errors :tada:). 

~~But doesn't support the features that will (hopefully) be used soon.   
I'm going to work on that next.~~  
All current features should be supported!   

Commit-by-commit review partially recommended.   
The commit history is the raw history of how I implemented this (e.g. the initial parser changes were wrong).  

![image](https://user-images.githubusercontent.com/54990334/174029676-3c87fff2-777d-432a-949a-2fde11e55c2b.png)
