### PR TITLE
Swift: add empty implementation of `defaultImplicitTaintRead`

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPublic.qll
@@ -20,3 +20,10 @@ predicate localExprTaint(DataFlowExpr e1, DataFlowExpr e2) {
 }
 
 predicate localTaintStep = localTaintStepCached/2;
+
+/**
+ * Holds if default `TaintTracking::Configuration`s should allow implicit reads
+ * of `c` at sinks and inputs to additional taint steps.
+ */
+bindingset[node]
+predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::Content c) { none() }


### PR DESCRIPTION
[This call](https://github.com/github/codeql/blob/7c5a83833b974ee40be5d76faed3cdd1b5066708/swift/ql/lib/codeql/swift/dataflow/internal/tainttracking1/TaintTrackingImpl.qll#L166) had no targets, because there was no implementation of `defaultImplicitTaintRead` in the Swift implementation.    
So I added an empty implementation.  

I found it because it was the only consistency error reported by QL-for-QL (after #9575). 