### PR TITLE
Go autobuilder: don't attempt a go mod tidy when there's a vendor directory present

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -291,7 +291,7 @@ func main() {
 	}
 
 	// Go 1.16 and later won't automatically attempt to update go.mod / go.sum during package loading, so try to update them here:
-	if depMode == GoGetWithModules && semver.Compare(getEnvGoSemVer(), "1.16") >= 0 {
+	if modMode != ModVendor && depMode == GoGetWithModules && semver.Compare(getEnvGoSemVer(), "1.16") >= 0 {
 		// stat go.mod and go.sum
 		beforeGoModFileInfo, beforeGoModErr := os.Stat("go.mod")
 		if beforeGoModErr != nil {


### PR DESCRIPTION
This is likely to spuriously remove dependencies leading to a later build failure due to missing requirements.