### PR TITLE
JS: Add meta query for measuring library inputs

### DIFF
--- a/javascript/ql/src/meta/alerts/LibraryInputs.ql
+++ b/javascript/ql/src/meta/alerts/LibraryInputs.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Library inputs
+ * @description An input coming from the client of a library
+ * @kind problem
+ * @problem.severity recommendation
+ * @id js/meta/alerts/library-inputs
+ * @tags meta
+ * @precision very-low
+ */
+
+import javascript
+import semmle.javascript.PackageExports
+
+select getALibraryInputParameter(), "Library input"


### PR DESCRIPTION
Adds a meta query for flagging changes to what nodes are considered library inputs.

I almost introduced a bug which was only caught because an alert happened to be affected by a lost library input, but it's much more reliable to track the library inputs themselves.