### PR TITLE
Cherry-pick: Fix Kotlin single-version build when the best candidate has trailing version info

### DIFF
--- a/java/kotlin-extractor/kotlin_plugin_versions.py
+++ b/java/kotlin-extractor/kotlin_plugin_versions.py
@@ -15,11 +15,11 @@ def is_windows():
     return False
 
 def version_tuple_to_string(version):
-    return f'{version[0]}.{version[1]}.{version[2]}'
+    return f'{version[0]}.{version[1]}.{version[2]}{version[3]}'
 
 def version_string_to_tuple(version):
-    m = re.match(r'([0-9]+)\.([0-9]+)\.([0-9]+)', version)
-    return tuple([int(m.group(i)) for i in range(1, 4)])
+    m = re.match(r'([0-9]+)\.([0-9]+)\.([0-9]+)(.*)', version)
+    return tuple([int(m.group(i)) for i in range(1, 4)] + [m.group(4)])
 
 many_versions = [ '1.4.32', '1.5.0', '1.5.10', '1.5.21', '1.5.31', '1.6.10', '1.7.0-RC', '1.6.20' ]
 


### PR DESCRIPTION
For example, 1.7.0-RC would previously be truncated to 1.7.0 resulting in failure to build the single-version distro as all candidate alternate-version kotlin files would be ignored.

Cherry-picks https://github.com/github/codeql/pull/9580 onto rc/3.6