### PR TITLE
Experimental manually check request verb query

### DIFF
--- a/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
+++ b/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
@@ -1,6 +1,6 @@
 /**
  * @name Manually checking http verb instead of using built in rails routes and protections
- * @description Manually checking HTTP verbs is an indication that multiple requests are routed to the same controller action. This could lead to bypassing necessary authorization methods and other protections, like CSRF protection. Prefer using different controller actions for each HTTP method and relying Rails routing to handle mappting resources and verbs to specific methods. 
+ * @description Manually checking HTTP verbs is an indication that multiple requests are routed to the same controller action. This could lead to bypassing necessary authorization methods and other protections, like CSRF protection. Prefer using different controller actions for each HTTP method and relying Rails routing to handle mappting resources and verbs to specific methods.
  * @kind problem
  * @problem.severity error
  * @security-severity 7.0
@@ -20,59 +20,63 @@ class ManuallyCheckHttpVerb extends DataFlow::CallNode {
     this instanceof CheckPostRequest or
     this instanceof CheckDeleteRequest or
     this instanceof CheckHeadRequest or
-    this.asExpr().getExpr() instanceof CheckRequestMethodFromEnv
+    this instanceof CheckRequestMethodFromEnv
   }
 }
 
-class CheckRequestMethodFromEnv extends ComparisonOperation {
+class CheckRequestMethodFromEnv extends DataFlow::CallNode {
   CheckRequestMethodFromEnv() {
-    this.getAnOperand() instanceof GetRequestMethodFromEnv
+    // is this node an instance of `env["REQUEST_METHOD"]
+    this.getExprNode().getNode() instanceof GetRequestMethodFromEnv and
+    (
+      // and is this node a param of a call to `.include?`
+      exists(MethodCall call | call.getAnArgument() = this.getExprNode().getNode() |
+        call.getMethodName() = "include?"
+      )
+      or
+      exists(DataFlow::Node node |
+        node.asExpr().getExpr().(MethodCall).getMethodName() = "include?"
+      |
+        node.getALocalSource() = this
+      )
+      or
+      // or is this node on either size of an equality comparison
+      exists(EqualityOperation eq | eq.getAChild() = this.getExprNode().getNode())
+    )
   }
 }
 
 class GetRequestMethodFromEnv extends ElementReference {
   GetRequestMethodFromEnv() {
-    this.getAChild+().toString() = "REQUEST_METHOD" // and
-    // this.getReceiver().toString() = "env"
+    this.getAChild+().toString() = "REQUEST_METHOD" and
+    this.getAChild+().toString() = "env"
   }
 }
 
 class CheckGetRequest extends DataFlow::CallNode {
-  CheckGetRequest() {
-  this.getMethodName() = "get?"
-  }
+  CheckGetRequest() { this.getMethodName() = "get?" }
 }
 
 class CheckPostRequest extends DataFlow::CallNode {
-  CheckPostRequest() {
-    this.getMethodName() = "post?"
-  }
+  CheckPostRequest() { this.getMethodName() = "post?" }
 }
 
 class CheckPutRequest extends DataFlow::CallNode {
-  CheckPutRequest() {
-    this.getMethodName() = "put?"
-  }
+  CheckPutRequest() { this.getMethodName() = "put?" }
 }
 
 class CheckPatchRequest extends DataFlow::CallNode {
-  CheckPatchRequest() {
-    this.getMethodName() = "patch?"
-  }
+  CheckPatchRequest() { this.getMethodName() = "patch?" }
 }
 
 class CheckDeleteRequest extends DataFlow::CallNode {
-  CheckDeleteRequest() {
-    this.getMethodName() = "delete?"
-  }
+  CheckDeleteRequest() { this.getMethodName() = "delete?" }
 }
 
 class CheckHeadRequest extends DataFlow::CallNode {
-  CheckHeadRequest() {
-    this.getMethodName() = "head?"
-  }
+  CheckHeadRequest() { this.getMethodName() = "head?" }
 }
 
 from ManuallyCheckHttpVerb check
-where check.asExpr().getExpr().getAControlFlowNode().isCondition()
-select check, "Manually checking HTTP verbs is an indication that multiple requests are routed to the same controller action. This could lead to bypassing necessary authorization methods and other protections, like CSRF protection. Prefer using different controller actions for each HTTP method and relying Rails routing to handle mappting resources and verbs to specific methods."
+select check,
+  "Manually checking HTTP verbs is an indication that multiple requests are routed to the same controller action. This could lead to bypassing necessary authorization methods and other protections, like CSRF protection. Prefer using different controller actions for each HTTP method and relying Rails routing to handle mappting resources and verbs to specific methods."

--- a/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
+++ b/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
@@ -1,0 +1,78 @@
+/**
+ * @name Manually checking http verb instead of using built in rails routes and protections
+ * @description Manually checking HTTP verbs is an indication that multiple requests are routed to the same controller action. This could lead to bypassing necessary authorization methods and other protections, like CSRF protection. Prefer using different controller actions for each HTTP method and relying Rails routing to handle mappting resources and verbs to specific methods. 
+ * @kind problem
+ * @problem.severity error
+ * @security-severity 7.0
+ * @precision medium
+ * @id rb/manually-checking-http-verb
+ * @tags security
+ */
+
+import ruby
+import codeql.ruby.DataFlow
+
+class ManuallyCheckHttpVerb extends DataFlow::CallNode {
+  ManuallyCheckHttpVerb() {
+    this instanceof CheckGetRequest or
+    this instanceof CheckPostRequest or
+    this instanceof CheckPatchRequest or
+    this instanceof CheckPostRequest or
+    this instanceof CheckDeleteRequest or
+    this instanceof CheckHeadRequest or
+    this.asExpr().getExpr() instanceof CheckRequestMethodFromEnv
+  }
+}
+
+class CheckRequestMethodFromEnv extends ComparisonOperation {
+  CheckRequestMethodFromEnv() {
+    this.getAnOperand() instanceof GetRequestMethodFromEnv
+  }
+}
+
+class GetRequestMethodFromEnv extends ElementReference {
+  GetRequestMethodFromEnv() {
+    this.getAChild+().toString() = "REQUEST_METHOD" // and
+    // this.getReceiver().toString() = "env"
+  }
+}
+
+class CheckGetRequest extends DataFlow::CallNode {
+  CheckGetRequest() {
+  this.getMethodName() = "get?"
+  }
+}
+
+class CheckPostRequest extends DataFlow::CallNode {
+  CheckPostRequest() {
+    this.getMethodName() = "post?"
+  }
+}
+
+class CheckPutRequest extends DataFlow::CallNode {
+  CheckPutRequest() {
+    this.getMethodName() = "put?"
+  }
+}
+
+class CheckPatchRequest extends DataFlow::CallNode {
+  CheckPatchRequest() {
+    this.getMethodName() = "patch?"
+  }
+}
+
+class CheckDeleteRequest extends DataFlow::CallNode {
+  CheckDeleteRequest() {
+    this.getMethodName() = "delete?"
+  }
+}
+
+class CheckHeadRequest extends DataFlow::CallNode {
+  CheckHeadRequest() {
+    this.getMethodName() = "head?"
+  }
+}
+
+from ManuallyCheckHttpVerb check
+where check.asExpr().getExpr().getAControlFlowNode().isCondition()
+select check, "Manually checking HTTP verbs is an indication that multiple requests are routed to the same controller action. This could lead to bypassing necessary authorization methods and other protections, like CSRF protection. Prefer using different controller actions for each HTTP method and relying Rails routing to handle mappting resources and verbs to specific methods."

--- a/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
+++ b/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
@@ -12,15 +12,14 @@
 import ruby
 import codeql.ruby.DataFlow
 
-class ManuallyCheckHttpVerb extends DataFlow::CallNode {
-  ManuallyCheckHttpVerb() {
+class HttpVerbMethod extends MethodCall {
+  HttpVerbMethod() {
     this instanceof CheckGetRequest or
     this instanceof CheckPostRequest or
     this instanceof CheckPatchRequest or
     this instanceof CheckPostRequest or
     this instanceof CheckDeleteRequest or
-    this instanceof CheckHeadRequest or
-    this instanceof CheckRequestMethodFromEnv
+    this instanceof CheckHeadRequest
   }
 }
 
@@ -53,30 +52,33 @@ class GetRequestMethodFromEnv extends ElementReference {
   }
 }
 
-class CheckGetRequest extends DataFlow::CallNode {
+class CheckGetRequest extends MethodCall {
   CheckGetRequest() { this.getMethodName() = "get?" }
 }
 
-class CheckPostRequest extends DataFlow::CallNode {
+class CheckPostRequest extends MethodCall {
   CheckPostRequest() { this.getMethodName() = "post?" }
 }
 
-class CheckPutRequest extends DataFlow::CallNode {
+class CheckPutRequest extends MethodCall {
   CheckPutRequest() { this.getMethodName() = "put?" }
 }
 
-class CheckPatchRequest extends DataFlow::CallNode {
+class CheckPatchRequest extends MethodCall {
   CheckPatchRequest() { this.getMethodName() = "patch?" }
 }
 
-class CheckDeleteRequest extends DataFlow::CallNode {
+class CheckDeleteRequest extends MethodCall {
   CheckDeleteRequest() { this.getMethodName() = "delete?" }
 }
 
-class CheckHeadRequest extends DataFlow::CallNode {
+class CheckHeadRequest extends MethodCall {
   CheckHeadRequest() { this.getMethodName() = "head?" }
 }
 
-from ManuallyCheckHttpVerb check
-select check,
+from CheckRequestMethodFromEnv env, AstNode node
+where
+  node instanceof HttpVerbMethod or
+  node = env.asExpr().getExpr()
+select node,
   "Manually checking HTTP verbs is an indication that multiple requests are routed to the same controller action. This could lead to bypassing necessary authorization methods and other protections, like CSRF protection. Prefer using different controller actions for each HTTP method and relying Rails routing to handle mappting resources and verbs to specific methods."

--- a/ruby/ql/test/query-tests/security/manually-check-http-verb/ExampleController.rb
+++ b/ruby/ql/test/query-tests/security/manually-check-http-verb/ExampleController.rb
@@ -18,8 +18,16 @@ class ExampleController < ActionController::Base
   end
 end
 
+class OtherController < ActionController::Base
+  def other_action
+    if env['REQUEST_METHOD'] == "GET"
+      Other.find(params[:id])
+    end
+  end
+end
+
 class ResourceController < ActionController::Base
-    # This method should have 1 vulnerable line
+    # This method should have 1 vulnerable line, but is currently failing because it's not a comparison node
     def resource_action
       case env['REQUEST_METHOD']
       when "GET"

--- a/ruby/ql/test/query-tests/security/manually-check-http-verb/ExampleController.rb
+++ b/ruby/ql/test/query-tests/security/manually-check-http-verb/ExampleController.rb
@@ -1,0 +1,51 @@
+class ExampleController < ActionController::Base
+  # This function should have 6 vulnerable lines
+  def example_action
+    if request.get?
+      Example.find(params[:example_id])
+    elsif request.post?
+      Example.new(params[:example_name], params[:example_details])
+    elsif request.delete?
+      example = Example.find(params[:example_id])
+      example.delete
+    elsif request.put?
+      Example.upsert(params[:example_name], params[:example_details])
+    elsif request.path?
+      Example.update(params[:example_name], params[:example_details])
+    elsif request.head?
+      "This is the endpoint for the Example resource."
+    end
+  end
+end
+
+class ResourceController < ActionController::Base
+    # This method should have 1 vulnerable line
+    def resource_action
+      case env['REQUEST_METHOD']
+      when "GET"
+        Resource.find(params[:id])
+      when "POST"
+        Resource.new(params[:id], params[:details])
+      end
+    end
+end
+
+class SafeController < ActionController::Base
+  # this method should have no hits because controllers rely on conventional Rails routes
+  def index
+    Safe.find(params[:id])
+  end
+
+  def create
+    Safe.new(params[:id], params[:details])
+  end
+
+  def update
+    Safe.update(params[:id], params[:details])
+  end
+
+  def delete
+    s = Safe.find(params[:id])
+    s.delete
+  end
+end

--- a/ruby/ql/test/query-tests/security/manually-check-http-verb/ManuallyCheckHttpVerb.qlref
+++ b/ruby/ql/test/query-tests/security/manually-check-http-verb/ManuallyCheckHttpVerb.qlref
@@ -1,0 +1,1 @@
+experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql

--- a/ruby/ql/test/query-tests/security/manually-check-http-verb/NotController.rb
+++ b/ruby/ql/test/query-tests/security/manually-check-http-verb/NotController.rb
@@ -1,0 +1,28 @@
+# There should be no hits from this class because it does not inherit from ActionController
+class NotAController
+  def example_action
+    if request.get?
+      Example.find(params[:example_id])
+    elsif request.post?
+      Example.new(params[:example_name], params[:example_details])
+    elsif request.delete?
+      example = Example.find(params[:example_id])
+      example.delete
+    elsif request.put?
+      Example.upsert(params[:example_name], params[:example_details])
+    elsif request.path?
+      Example.update(params[:example_name], params[:example_details])
+    elsif request.head?
+      "This is the endpoint for the Example resource."
+    end
+  end
+
+  def resource_action
+    case env['REQUEST_METHOD']
+    when "GET"
+      Resource.find(params[:id])
+    when "POST"
+      Resource.new(params[:id], params[:details])
+    end
+  end
+end


### PR DESCRIPTION
The aim of this query is to find all calls to `.get?`, `.post?`, `.patch?`, `.put?`, `.delete?`, and `.head?`, as well as element references to `env["REQUEST_METHOD"]` that are used in control flow expressions. The general idea is that if controller action methods are manually checking http methods as part of control flow, they might be unintentionally bypassing security measures that are intended to run before the controller method runs. For example, this could include authorization checks, CSRF token checks, etc.

There are a few areas where I'd like to refine this query:
- If possible, I'd like to limit findings to just those found in subclasses of `ActionController`. The idea here is that while some of the underlying scaffolding of a Rails app may need to use these checks in legitimate ways, it's probably not a good idea to do this in your standard controller classes. One thought I had was maybe checking the filepath of the file in question, but that seems a bit naive even though standard Rails convention would have the controllers in the `app/controllers` directory.
- Another feature I'd like to add is to check instances where `env["REQUEST_METHOD"]` references isn't directly used in a conditional statement or passed into `include?`, but is instead assigned to a variable who's value then flows into this check. I've tried to add this as part of `CheckRequestMethodFromEnv` but it doesn't seem to be working as expected.
- While my query does seem to be returning results from an existing application database, I don't seem to be getting any hits for my test classes. I need to figure out what I'm missing here.