### PR TITLE
C#: Fix global statement extraction

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/ImplicitMainMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/ImplicitMainMethod.cs
@@ -1,0 +1,36 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.CSharp.Entities.Statements;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Semmle.Extraction.CSharp.Entities
+{
+    internal class ImplicitMainMethod : OrdinaryMethod
+    {
+        private readonly List<GlobalStatementSyntax> globalStatements;
+
+        public ImplicitMainMethod(Context cx, IMethodSymbol symbol, List<GlobalStatementSyntax> globalStatements)
+            : base(cx, symbol)
+        {
+            this.globalStatements = globalStatements;
+        }
+
+        protected override void PopulateMethodBody(TextWriter trapFile)
+        {
+            GlobalStatementsBlock.Create(Context, this, globalStatements);
+        }
+
+        public static ImplicitMainMethod Create(Context cx, IMethodSymbol method, List<GlobalStatementSyntax> globalStatements)
+        {
+            return ImplicitMainMethodFactory.Instance.CreateEntity(cx, method, (method, globalStatements));
+        }
+
+        private class ImplicitMainMethodFactory : CachedEntityFactory<(IMethodSymbol, List<GlobalStatementSyntax>), ImplicitMainMethod>
+        {
+            public static ImplicitMainMethodFactory Instance { get; } = new ImplicitMainMethodFactory();
+
+            public override ImplicitMainMethod Create(Context cx, (IMethodSymbol, List<GlobalStatementSyntax>) init) => new ImplicitMainMethod(cx, init.Item1, init.Item2);
+        }
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -46,7 +46,7 @@ namespace Semmle.Extraction.CSharp.Entities
             // so there's nothing to extract.
         }
 
-        private void PopulateMethodBody(TextWriter trapFile)
+        protected virtual void PopulateMethodBody(TextWriter trapFile)
         {
             if (!IsSourceDeclaration)
                 return;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
@@ -8,7 +8,7 @@ namespace Semmle.Extraction.CSharp.Entities
 {
     internal class OrdinaryMethod : Method
     {
-        private OrdinaryMethod(Context cx, IMethodSymbol init)
+        protected OrdinaryMethod(Context cx, IMethodSymbol init)
             : base(cx, init) { }
 
         public override string Name => Symbol.GetName();

--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/CompilationUnitVisitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/CompilationUnitVisitor.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Util.Logging;
 using Semmle.Extraction.CSharp.Entities;
-using Semmle.Extraction.CSharp.Entities.Statements;
 using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Populators
@@ -60,23 +59,14 @@ namespace Semmle.Extraction.CSharp.Populators
             }
 
             var entryPoint = Cx.Compilation.GetEntryPoint(System.Threading.CancellationToken.None);
-            var entryMethod = Method.Create(Cx, entryPoint);
-            if (entryMethod is null)
+            if (entryPoint is null)
             {
                 Cx.ExtractionError("No entry method found. Skipping the extraction of global statements.",
                     null, Cx.CreateLocation(globalStatements[0].GetLocation()), null, Severity.Info);
                 return;
             }
 
-            var block = GlobalStatementsBlock.Create(Cx, entryMethod);
-
-            for (var i = 0; i < globalStatements.Count; i++)
-            {
-                if (globalStatements[i].Statement is not null)
-                {
-                    Statement.Create(Cx, globalStatements[i].Statement, block, i);
-                }
-            }
+            ImplicitMainMethod.Create(Cx, entryPoint, globalStatements);
         }
     }
 }

--- a/csharp/ql/test/library-tests/csharp9-standalone/ExtractorError.expected
+++ b/csharp/ql/test/library-tests/csharp9-standalone/ExtractorError.expected
@@ -1,0 +1,1 @@
+| GlobalStmt.cs:13:6:13:6 | TagStack unexpectedly empty | Unexpected C# extractor error: TagStack unexpectedly empty\n |

--- a/csharp/ql/test/library-tests/csharp9-standalone/ExtractorError.expected
+++ b/csharp/ql/test/library-tests/csharp9-standalone/ExtractorError.expected
@@ -1,1 +1,0 @@
-| GlobalStmt.cs:13:6:13:6 | TagStack unexpectedly empty | Unexpected C# extractor error: TagStack unexpectedly empty\n |

--- a/csharp/ql/test/library-tests/csharp9-standalone/ExtractorError.ql
+++ b/csharp/ql/test/library-tests/csharp9-standalone/ExtractorError.ql
@@ -1,0 +1,7 @@
+import csharp
+import semmle.code.csharp.commons.Diagnostics
+
+from ExtractorError error
+where not exists(CompilerError ce | ce.getLocation().getFile() = error.getLocation().getFile())
+select error,
+  "Unexpected " + error.getOrigin() + " error: " + error.getText() + "\n" + error.getStackTrace()


### PR DESCRIPTION
This PR fixes global statement extraction. Previously the implicit main method was extracted first, and then its body and statements were extracted independently. However, the statement extraction requires to be run in a method extraction context because it expects the tag stack to contain the current method. This PR fixes this by extracting the global statements as if they appeared inside the implicit main method.

The first commit in this PR shows that there was an extraction error before the fix in the second commit is applied. 

This issue was reported recently in https://github.com/github/codeql/issues/9536.