### PR TITLE
Swift: Add `nomagic` to `getLocation`

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/Locatable.qll
+++ b/swift/ql/lib/codeql/swift/elements/Locatable.qll
@@ -1,6 +1,7 @@
 private import codeql.swift.generated.Locatable
 
 class Locatable extends LocatableBase {
+  pragma[nomagic]
   override Location getLocation() {
     result = LocatableBase.super.getLocation()
     or


### PR DESCRIPTION
Fixes a bad join I was getting due to some horrible magic:
```
Tuple counts for Locatable::Locatable::getLocation#dispred#f0820431#fb@5a4d3akt:
            16500   ~0%    {2} r1 = JOIN @locatable#f WITH Locatable::LocatableBase::getLocation#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0
            16000   ~0%    {2} r2 = JOIN r1 WITH m#ControlFlowGraph::ControlFlowNode::getLocation#dispred#f0820431#fb ON FIRST 1 OUTPUT Lhs.1, Lhs.0
                       
            34500   ~0%    {1} r3 = @locatable#f AND NOT Locatable::LocatableBase::getLocation#f0820431#ff_0#antijoin_rhs(Lhs.0)
        251908500   ~0%    {7} r4 = JOIN r3 WITH m#ControlFlowGraph::ControlFlowNode::getLocation#dispred#f0820431#fb CARTESIAN PRODUCT OUTPUT Rhs.0, "", 0, 0, 0, 0, Lhs.0
            34000   ~0%    {2} r5 = JOIN r4 WITH Location::Location::hasLocationInfo#dispred#f0820431#ffffff ON FIRST 6 OUTPUT Lhs.6, Lhs.0
                       
            50000   ~0%    {2} r6 = r2 UNION r5
                           return r6
```