### PR TITLE
Swift: Fix 'toString' on 'OtherConstructorDeclRefExpr'

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/expr/OtherConstructorDeclRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/OtherConstructorDeclRefExpr.qll
@@ -1,7 +1,5 @@
 private import codeql.swift.generated.expr.OtherConstructorDeclRefExpr
 
 class OtherConstructorDeclRefExpr extends OtherConstructorDeclRefExprBase {
-  override string toString() {
-    result = "call to ..." // TODO: We can make this better once we extract the constructor call
-  }
+  override string toString() { result = this.getConstructorDecl().toString() }
 }

--- a/swift/ql/test/extractor-tests/expressions/all.expected
+++ b/swift/ql/test/extractor-tests/expressions/all.expected
@@ -160,7 +160,7 @@
 | expressions.swift:79:5:79:11 | call to ... |
 | expressions.swift:79:5:79:21 | call to ... |
 | expressions.swift:79:5:79:21 | self = ... |
-| expressions.swift:79:11:79:11 | call to ... |
+| expressions.swift:79:11:79:11 | init |
 | expressions.swift:79:19:79:19 | 22 |
 | expressions.swift:83:15:83:15 | Derived.Type |
 | expressions.swift:83:15:83:15 | call to ... |

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -4895,7 +4895,7 @@ cfg.swift:
 #-----|  -> exit init
 
 #  378| init
-#-----|  -> call to ...
+#-----|  -> init
 
 #  379| super
 #-----|  -> call to ...
@@ -4909,7 +4909,7 @@ cfg.swift:
 #  379| self = ...
 #-----|  -> return
 
-#  379| call to ...
+#  379| init
 #-----|  -> super
 
 #  379| 0

--- a/swift/ql/test/library-tests/parent/parent.expected
+++ b/swift/ql/test/library-tests/parent/parent.expected
@@ -567,7 +567,7 @@
 | expressions.swift:78:3:80:3 | init | ConstructorDecl | expressions.swift:78:10:80:3 | { ... } | BraceStmt |
 | expressions.swift:78:10:80:3 | { ... } | BraceStmt | expressions.swift:79:5:79:21 | self = ... | RebindSelfInConstructorExpr |
 | expressions.swift:78:10:80:3 | { ... } | BraceStmt | expressions.swift:80:3:80:3 | return | ReturnStmt |
-| expressions.swift:79:5:79:11 | call to ... | DotSyntaxCallExpr | expressions.swift:79:11:79:11 | call to ... | OtherConstructorDeclRefExpr |
+| expressions.swift:79:5:79:11 | call to ... | DotSyntaxCallExpr | expressions.swift:79:11:79:11 | init | OtherConstructorDeclRefExpr |
 | expressions.swift:79:5:79:21 | call to ... | CallExpr | expressions.swift:79:5:79:11 | call to ... | DotSyntaxCallExpr |
 | expressions.swift:79:5:79:21 | self = ... | RebindSelfInConstructorExpr | expressions.swift:78:3:78:3 | self | ParamDecl |
 | expressions.swift:79:5:79:21 | self = ... | RebindSelfInConstructorExpr | expressions.swift:79:5:79:21 | call to ... | CallExpr |


### PR DESCRIPTION
I had incorrectly concluded that `OtherConstructorDeclRefExpr` was also modeling the _call_ to the constructor, but it's really just the _reference_ to the constructor declarations.