### PR TITLE
JS: Add withoutPropStep and model raw 'await' step with it

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/StepSummary.qll
@@ -45,7 +45,8 @@ private module Cached {
       CopyStep(PropertyName prop) or
       LoadStoreStep(PropertyName fromProp, PropertyName toProp) {
         SharedTypeTrackingStep::loadStoreStep(_, _, fromProp, toProp)
-      }
+      } or
+      WithoutPropStep(PropertySet props) { SharedTypeTrackingStep::withoutPropStep(_, _, props) }
   }
 
   /**
@@ -108,6 +109,11 @@ private module Cached {
       or
       SharedTypeTrackingStep::loadStoreStep(pred, succ, prop) and
       summary = CopyStep(prop)
+    )
+    or
+    exists(PropertySet props |
+      SharedTypeTrackingStep::withoutPropStep(pred, succ, props) and
+      summary = WithoutPropStep(props)
     )
     or
     exists(string fromProp, string toProp |
@@ -193,6 +199,8 @@ class StepSummary extends TStepSummary {
     exists(string prop | this = LoadStep(prop) | result = "load " + prop)
     or
     exists(string prop | this = CopyStep(prop) | result = "copy " + prop)
+    or
+    exists(string prop | this = WithoutPropStep(prop) | result = "without " + prop)
     or
     exists(string fromProp, string toProp | this = LoadStoreStep(fromProp, toProp) |
       result = "load " + fromProp + " and store to " + toProp

--- a/javascript/ql/test/library-tests/TypeTracking/TypeTracking.ql
+++ b/javascript/ql/test/library-tests/TypeTracking/TypeTracking.ql
@@ -34,6 +34,7 @@ from Locatable loc, File f, int l, string name, string msg
 where
   expected(loc, f, l, name) and
   not actual(_, f, l, name) and
+  name != "none" and
   msg = "Failed to track " + name + " here."
   or
   actual(loc, f, l, name) and

--- a/javascript/ql/test/library-tests/TypeTracking/raw-await.js
+++ b/javascript/ql/test/library-tests/TypeTracking/raw-await.js
@@ -1,0 +1,32 @@
+const lib = require('testlib');
+
+function foo() {
+    return lib.foo(); // name: raw-await-source
+}
+
+async function test() {
+  const x = await foo();
+  const y = await x;
+  const z = await y;
+  z; // track: raw-await-source
+}
+
+async function exceptionThrower() {
+    throw {}; // name: raw-await-err
+}
+
+async function exceptionReThrower() {
+    const x = await exceptionThrower();
+    const y = x.catch(err => {
+        err; // track: none
+    });
+    return y;
+}
+
+async function exceptionCatcher() {
+    try {
+        await exceptionThrower();
+    } catch (err) {
+        err; // track: raw-await-err
+    }
+}


### PR DESCRIPTION
Doing `await x` on non-promise value just returns `x` itself, but our type-tracking steps didn't take this into account, leading to missed flow.

This PR adds support for this by adding `PropertySet` and `withoutPropStep(Node pred, Node succ, PropertySet props)`. This steps allows flow from `pred -> succ` but without the properties in `props` (see qldoc in PR).

This new step is deliberately similar to the `WithoutElement` step that @hvitved added in https://github.com/github/codeql/pull/8938. (The `WithElement` step is called a `loadStoreStep` in JS)

[Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/without-prop-st__default__code-scanning/reports) was quiet