### PR TITLE
Go: Properly escape dash in tracing-config.lua

### DIFF
--- a/go/codeql-tools/tracing-config.lua
+++ b/go/codeql-tools/tracing-config.lua
@@ -1,7 +1,7 @@
 function RegisterExtractorPack()
     local goExtractor = GetPlatformToolsDirectory() .. 'go-extractor'
     local patterns = {
-        CreatePatternMatcher({'^go-autobuilder$'}, MatchCompilerName, nil,
+        CreatePatternMatcher({'^go%-autobuilder$'}, MatchCompilerName, nil,
                              {trace = false}),
         CreatePatternMatcher({'^go$'}, MatchCompilerName, goExtractor, {
             prepend = {'--mimic', '${compiler}'},
@@ -12,7 +12,7 @@ function RegisterExtractorPack()
     if OperatingSystem == 'windows' then
         goExtractor = goExtractor .. 'go-extractor.exe'
         patterns = {
-            CreatePatternMatcher({'^go-autobuilder%.exe$'}, MatchCompilerName,
+            CreatePatternMatcher({'^go%-autobuilder%.exe$'}, MatchCompilerName,
                                  nil, {trace = false}),
             CreatePatternMatcher({'^go%.exe$'}, MatchCompilerName, goExtractor,
                                  {


### PR DESCRIPTION
Previously, the pattern didn't match what it was intended to match.