### PR TITLE
Swift: add devcontainer setup

### DIFF
--- a/.devcontainer/swift/Dockerfile
+++ b/.devcontainer/swift/Dockerfile
@@ -1,0 +1,11 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/cpp/.devcontainer/base.Dockerfile
+
+# [Choice] Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/22.04 on local arm64/Apple Silicon): debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT="bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+
+ARG BAZELISK_VERSION=v1.10.1
+ARG BAZELISK_DOWNLOAD_SHA=dev-mode
+USER root
+ADD root.sh /tmp/root.sh
+RUN bash /tmp/root.sh && rm /tmp/root.sh

--- a/.devcontainer/swift/Dockerfile
+++ b/.devcontainer/swift/Dockerfile
@@ -5,4 +5,5 @@ FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-ubuntu-22.04
 
 USER root
 ADD root.sh /tmp/root.sh
+ADD update-codeql.sh /usr/local/bin/update-codeql
 RUN bash /tmp/root.sh && rm /tmp/root.sh

--- a/.devcontainer/swift/Dockerfile
+++ b/.devcontainer/swift/Dockerfile
@@ -1,11 +1,8 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/cpp/.devcontainer/base.Dockerfile
 
 # [Choice] Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/22.04 on local arm64/Apple Silicon): debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
-ARG VARIANT="bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-ubuntu-22.04
 
-ARG BAZELISK_VERSION=v1.10.1
-ARG BAZELISK_DOWNLOAD_SHA=dev-mode
 USER root
 ADD root.sh /tmp/root.sh
 RUN bash /tmp/root.sh && rm /tmp/root.sh

--- a/.devcontainer/swift/devcontainer.json
+++ b/.devcontainer/swift/devcontainer.json
@@ -14,9 +14,6 @@
 	},
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": {
-			"VARIANT": "ubuntu-20.04"
-		}
 	},
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",

--- a/.devcontainer/swift/devcontainer.json
+++ b/.devcontainer/swift/devcontainer.json
@@ -1,0 +1,28 @@
+{
+	"extensions": [
+		"github.vscode-codeql",
+		"hbenl.vscode-test-explorer",
+		"ms-vscode.test-adapter-converter",
+		"slevesque.vscode-zipexplorer",
+		"ms-vscode.cpptools"
+	],
+	"settings": {
+		"files.watcherExclude": {
+			"**/target/**": true
+		},
+		"codeQL.runningQueries.memory": 2048
+	},
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "ubuntu-20.04"
+		}
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	"remoteUser": "vscode",
+	"onCreateCommand": ".devcontainer/swift/user.sh"
+}

--- a/.devcontainer/swift/root.sh
+++ b/.devcontainer/swift/root.sh
@@ -17,3 +17,6 @@ curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/rel
 echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check -
 chmod 0755 /usr/local/bin/bazelisk
 ln -s bazelisk /usr/local/bin/bazel
+
+# install latest codeql
+update-codeql

--- a/.devcontainer/swift/root.sh
+++ b/.devcontainer/swift/root.sh
@@ -1,15 +1,19 @@
 set -xe
 
+BAZELISK_VERSION=v1.12.0
+BAZELISK_DOWNLOAD_SHA=6b0bcb2ea15bca16fffabe6fda75803440375354c085480fe361d2cbf32501db
+
 apt-get update
 export DEBIAN_FRONTEND=noninteractive
 apt-get -y install --no-install-recommends \
     zlib1g-dev \
     uuid-dev \
     python3-distutils \
-    python3-pip
+    python3-pip \
+    bash-completion
 
 # Install Bazel
 curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64
-([ "${BAZELISK_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check - )
+echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check -
 chmod 0755 /usr/local/bin/bazelisk
 ln -s bazelisk /usr/local/bin/bazel

--- a/.devcontainer/swift/root.sh
+++ b/.devcontainer/swift/root.sh
@@ -5,7 +5,8 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get -y install --no-install-recommends \
     zlib1g-dev \
     uuid-dev \
-    python3-distutils
+    python3-distutils \
+    python3-pip
 
 # Install Bazel
 curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64

--- a/.devcontainer/swift/root.sh
+++ b/.devcontainer/swift/root.sh
@@ -1,0 +1,14 @@
+set -xe
+
+apt-get update
+export DEBIAN_FRONTEND=noninteractive
+apt-get -y install --no-install-recommends \
+    zlib1g-dev \
+    uuid-dev \
+    python3-distutils
+
+# Install Bazel
+curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64
+([ "${BAZELISK_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check - )
+chmod 0755 /usr/local/bin/bazelisk
+ln -s bazelisk /usr/local/bin/bazel

--- a/.devcontainer/swift/update-codeql.sh
+++ b/.devcontainer/swift/update-codeql.sh
@@ -4,9 +4,15 @@ URL=https://github.com/github/codeql-cli-binaries/releases
 LATEST_VERSION=$(curl -L -s -H 'Accept: application/json' $URL/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 CURRENT_VERSION=v$(codeql version 2>/dev/null | sed -ne 's/.*release \([0-9.]*\)\./\1/p')
 if [[ $CURRENT_VERSION != $LATEST_VERSION ]]; then
-  curl -fSqL -o /tmp/codeql.zip $URL/download/$LATEST_VERSION/codeql-linux64.zip
-  unzip /tmp/codeql.zip -qd /opt
-  rm /tmp/codeql.zip
+  if [[ $UID != 0 ]]; then
+    echo "update required, please run this script with sudo:"
+    echo "  sudo $0"
+    exit 1
+  fi
+  ZIP=$(mktemp codeql.XXXX.zip)
+  curl -fSqL -o $ZIP $URL/download/$LATEST_VERSION/codeql-linux64.zip
+  unzip -q $ZIP -d /opt
+  rm $ZIP
   ln -sf /opt/codeql/codeql /usr/local/bin/codeql
   echo installed version $LATEST_VERSION
 else

--- a/.devcontainer/swift/update-codeql.sh
+++ b/.devcontainer/swift/update-codeql.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+URL=https://github.com/github/codeql-cli-binaries/releases
+LATEST_VERSION=$(curl -L -s -H 'Accept: application/json' $URL/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+CURRENT_VERSION=v$(codeql version 2>/dev/null | sed -ne 's/.*release \([0-9.]*\)\./\1/p')
+if [[ $CURRENT_VERSION != $LATEST_VERSION ]]; then
+  curl -fSqL -o /tmp/codeql.zip $URL/download/$LATEST_VERSION/codeql-linux64.zip
+  unzip /tmp/codeql.zip -qd /opt
+  rm /tmp/codeql.zip
+  ln -sf /opt/codeql/codeql /usr/local/bin/codeql
+  echo installed version $LATEST_VERSION
+else
+  echo current version $CURRENT_VERSION is up-to-date
+fi

--- a/.devcontainer/swift/user.sh
+++ b/.devcontainer/swift/user.sh
@@ -9,8 +9,8 @@ cd /workspaces/codeql
 bazel run swift/create-extractor-pack
 
 #install and set up pre-commit
-python3 -m pip install pre-commit
-pre-commit install
+python3 -m pip install pre-commit --no-warn-script-location
+$HOME/.local/bin/pre-commit install
 
 cat >> $HOME/.bashrc << EOF
 

--- a/.devcontainer/swift/user.sh
+++ b/.devcontainer/swift/user.sh
@@ -8,6 +8,10 @@ echo "--search-path /workspaces/codeql" > /home/vscode/.config/codeql/config
 cd /workspaces/codeql
 bazel run swift/create-extractor-pack
 
+#install and set up pre-commit
+python3 -m pip install pre-commit
+pre-commit install
+
 cat >> $HOME/.bashrc << EOF
 
 # have the codeql binary installed by vscode automatically in PATH

--- a/.devcontainer/swift/user.sh
+++ b/.devcontainer/swift/user.sh
@@ -1,0 +1,18 @@
+set -xe
+
+# add the workspace to the codeql search path
+mkdir -p /home/vscode/.config/codeql
+echo "--search-path /workspaces/codeql" > /home/vscode/.config/codeql/config
+
+# create a swift extractor pack with the current state
+cd /workspaces/codeql
+bazel run swift/create-extractor-pack
+
+cat >> $HOME/.bashrc << EOF
+
+# have the codeql binary installed by vscode automatically in PATH
+bin=\$(ls \$HOME/.vscode-remote/data/User/globalStorage/github.vscode-codeql/*/codeql/codeql -t 2>/dev/null | head -1)
+if [[ -n \$bin ]]; then
+  export PATH=\$PATH:$(dirname "\$bin")
+fi
+EOF

--- a/.devcontainer/swift/user.sh
+++ b/.devcontainer/swift/user.sh
@@ -12,11 +12,4 @@ bazel run swift/create-extractor-pack
 python3 -m pip install pre-commit --no-warn-script-location
 $HOME/.local/bin/pre-commit install
 
-cat >> $HOME/.bashrc << EOF
-
-# have the codeql binary installed by vscode automatically in PATH
-bin=\$(ls \$HOME/.vscode-remote/data/User/globalStorage/github.vscode-codeql/*/codeql/codeql -t 2>/dev/null | head -1)
-if [[ -n \$bin ]]; then
-  export PATH=\$PATH:$(dirname "\$bin")
-fi
-EOF
+cat $(dirname $0)/user_bashrc.sh >> $HOME/.bashrc

--- a/.devcontainer/swift/user.sh
+++ b/.devcontainer/swift/user.sh
@@ -11,5 +11,3 @@ bazel run swift/create-extractor-pack
 #install and set up pre-commit
 python3 -m pip install pre-commit --no-warn-script-location
 $HOME/.local/bin/pre-commit install
-
-cat $(dirname $0)/user_bashrc.sh >> $HOME/.bashrc

--- a/.devcontainer/swift/user_bashrc.sh
+++ b/.devcontainer/swift/user_bashrc.sh
@@ -1,5 +1,0 @@
-# have the codeql binary installed by vscode automatically in PATH
-bin=$(ls $HOME/.vscode-remote/data/User/globalStorage/github.vscode-codeql/*/codeql/codeql -t 2>/dev/null | head -1)
-if [[ -n $bin ]]; then
-  export PATH=$PATH:$(dirname "$bin")
-fi

--- a/.devcontainer/swift/user_bashrc.sh
+++ b/.devcontainer/swift/user_bashrc.sh
@@ -1,0 +1,5 @@
+# have the codeql binary installed by vscode automatically in PATH
+bin=$(ls $HOME/.vscode-remote/data/User/globalStorage/github.vscode-codeql/*/codeql/codeql -t 2>/dev/null | head -1)
+if [[ -n $bin ]]; then
+  export PATH=$PATH:$(dirname "$bin")
+fi


### PR DESCRIPTION
This adds a specific devcontainer setup to spin up a codespace ready for use for swift development.

The configuration is selectable from the `Configure and create codespace` subcommand (selectable by clicking the down arrow next to the default `Create codespace on main` button), and on codespace creation it will:

* install required dependencies to build the swift extractor
* install bazelisk and make it callable via `bazel`
* install the latest version of codeql (can be updated with `update-codeql` at a later stage)
* create a swift extractor pack with the current version of the checked-out code
* create a codeql config file setting up `--search-path` so that the extractor pack is picked up
* set up `pre-commit`

One still needs to update the codeql CLI via the vscode command. After that, swift QL tests will be runnable immediately without any further steps or command line flags.

The initial devcontainer setup was taken from the default C++ one. I'm not entirely sure whether we need the `runArgs` that were taken from there.