### PR TITLE
C++: Add global variable tests

### DIFF
--- a/cpp/ql/test/library-tests/variables/global/b.c
+++ b/cpp/ql/test/library-tests/variables/global/b.c
@@ -1,3 +1,4 @@
 
 #include "a.h"
 
+#include "c.h"

--- a/cpp/ql/test/library-tests/variables/global/c.c
+++ b/cpp/ql/test/library-tests/variables/global/c.c
@@ -1,0 +1,12 @@
+
+int js[] = { 1, 2, 3, 4 };
+
+int ks[4] = { 1, 2, 3, 4 };
+
+int ls[4] = { 1, 2, 3, 4 };
+
+int iss[4][2] = { { 1, 2 }, { 3, 4 }, { 1, 2 }, { 3, 4 } };
+
+typedef int int_alias;
+
+int_alias i;

--- a/cpp/ql/test/library-tests/variables/global/c.h
+++ b/cpp/ql/test/library-tests/variables/global/c.h
@@ -1,0 +1,10 @@
+
+extern int js[];
+
+extern int ks[];
+
+extern int ls[4];
+
+extern int iss[][2];
+
+extern int i;

--- a/cpp/ql/test/library-tests/variables/global/vardecl.expected
+++ b/cpp/ql/test/library-tests/variables/global/vardecl.expected
@@ -1,5 +1,15 @@
 | a.c:4:5:4:6 | definition of is | array of {int} | 1 |
 | a.h:2:12:2:13 | declaration of is | array of 4 {int} | 1 |
+| c.c:2:5:2:6 | definition of js | array of {int} | 1 |
+| c.c:4:5:4:6 | definition of ks | array of 4 {int} | 1 |
+| c.c:6:5:6:6 | definition of ls | array of 4 {int} | 1 |
+| c.c:8:5:8:7 | definition of iss | array of 4 {array of 2 {int}} | 1 |
+| c.c:12:11:12:11 | definition of i | typedef {int} as "int_alias" | 1 |
+| c.h:2:12:2:13 | declaration of js | array of {int} | 1 |
+| c.h:4:12:4:13 | declaration of ks | array of {int} | 1 |
+| c.h:6:12:6:13 | declaration of ls | array of 4 {int} | 1 |
+| c.h:8:12:8:14 | declaration of iss | array of {array of 2 {int}} | 1 |
+| c.h:10:12:10:12 | declaration of i | int | 1 |
 | file://:0:0:0:0 | definition of fp_offset | unsigned int | 1 |
 | file://:0:0:0:0 | definition of gp_offset | unsigned int | 1 |
 | file://:0:0:0:0 | definition of overflow_arg_area | pointer to {void} | 1 |

--- a/cpp/ql/test/library-tests/variables/global/variables.expected
+++ b/cpp/ql/test/library-tests/variables/global/variables.expected
@@ -1,4 +1,12 @@
 | a.c:4:5:4:6 | is | array of {int} | 1 |
+| c.c:2:5:2:6 | js | array of {int} | 1 |
+| c.c:4:5:4:6 | ks | array of 4 {int} | 1 |
+| c.c:6:5:6:6 | ls | array of 4 {int} | 1 |
+| c.c:8:5:8:7 | iss | array of 4 {array of 2 {int}} | 1 |
+| c.c:12:11:12:11 | i | typedef {int} as "int_alias" | 1 |
+| c.h:4:12:4:13 | ks | array of {int} | 1 |
+| c.h:8:12:8:14 | iss | array of {array of 2 {int}} | 1 |
+| c.h:10:12:10:12 | i | int | 1 |
 | file://:0:0:0:0 | fp_offset | unsigned int | 1 |
 | file://:0:0:0:0 | gp_offset | unsigned int | 1 |
 | file://:0:0:0:0 | overflow_arg_area | pointer to {void} | 1 |


### PR DESCRIPTION
These expose an issue in the extractor (note the duplication of variables between `c.h` and `c.c` in `variables.expected`). I'd like to have these in whether or not I manage to fix the extractor issue.