### PR TITLE
Python/JS/Ruby: Ignore common words (like certain) as sensitive data source

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
+++ b/javascript/ql/lib/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
@@ -50,7 +50,7 @@ module HeuristicNames {
    * Gets a regular expression that identifies strings that may indicate the presence of secret
    * or trusted data.
    */
-  string maybeSecret() { result = "(?is).*((?<!is)secret|(?<!un|is)trusted).*" }
+  string maybeSecret() { result = "(?is).*((?<!is|is_)secret|(?<!un|un_|is|is_)trusted).*" }
 
   /**
    * Gets a regular expression that identifies strings that may indicate the presence of
@@ -96,10 +96,14 @@ module HeuristicNames {
    * Gets a regular expression that identifies strings that may indicate the presence of data
    * that is hashed or encrypted, and hence rendered non-sensitive, or contains special characters
    * suggesting nouns within the string do not represent the meaning of the whole string (e.g. a URL or a SQL query).
+   *
+   * We also filter out common words like `certain` and `concert`, since otherwise these could
+   * be matched by the certificate regular expressions. Same for `accountable` (account), or
+   * `secretarial` (secret).
    */
   string notSensitiveRegexp() {
     result =
-      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)).*"
+      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)|certain|concert|secretar|accountant|accountab).*"
   }
 
   /**

--- a/python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll
+++ b/python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll
@@ -96,10 +96,14 @@ module HeuristicNames {
    * Gets a regular expression that identifies strings that may indicate the presence of data
    * that is hashed or encrypted, and hence rendered non-sensitive, or contains special characters
    * suggesting nouns within the string do not represent the meaning of the whole string (e.g. a URL or a SQL query).
+   *
+   * We also filter out common words like `certain` and `concert`, since otherwise these could
+   * be matched by the certificate regular expressions. Same for `accountable` (account), or
+   * `secretarial` (secret).
    */
   string notSensitiveRegexp() {
     result =
-      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)).*"
+      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)|certain|concert|secretar|accountant|accountab).*"
   }
 
   /**

--- a/python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll
+++ b/python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll
@@ -50,7 +50,7 @@ module HeuristicNames {
    * Gets a regular expression that identifies strings that may indicate the presence of secret
    * or trusted data.
    */
-  string maybeSecret() { result = "(?is).*((?<!is)secret|(?<!un|is)trusted).*" }
+  string maybeSecret() { result = "(?is).*((?<!is|is_)secret|(?<!un|un_|is|is_)trusted).*" }
 
   /**
    * Gets a regular expression that identifies strings that may indicate the presence of

--- a/python/ql/test/experimental/dataflow/sensitive-data/test.py
+++ b/python/ql/test/experimental/dataflow/sensitive-data/test.py
@@ -37,6 +37,10 @@ f = not_found.get_passwd # $ SensitiveDataSource=password
 x = f()
 print(x) # $ SensitiveUse=password
 
+# some prefixes makes us ignore it as a source
+not_found.isSecret
+not_found.is_secret # $ SPURIOUS: SensitiveDataSource=secret
+
 def my_func(non_sensitive_name):
     x = non_sensitive_name()
     print(x) # $ SensitiveUse=password

--- a/python/ql/test/experimental/dataflow/sensitive-data/test.py
+++ b/python/ql/test/experimental/dataflow/sensitive-data/test.py
@@ -56,6 +56,11 @@ getattr(foo, x) # $ SensitiveDataSource=password
 def my_func(password): # $ SensitiveDataSource=password
     print(password) # $ SensitiveUse=password
 
+# FP where the `cert` in `uncertainty` makes us treat it like a certificate
+# https://github.com/github/codeql/issues/9632
+def my_other_func(uncertainty): # $ SPURIOUS: SensitiveDataSource=certificate
+    print(uncertainty) # $ SPURIOUS: SensitiveUse=certificate
+
 password = some_function() # $ SensitiveDataSource=password
 print(password) # $ SensitiveUse=password
 

--- a/python/ql/test/experimental/dataflow/sensitive-data/test.py
+++ b/python/ql/test/experimental/dataflow/sensitive-data/test.py
@@ -58,8 +58,8 @@ def my_func(password): # $ SensitiveDataSource=password
 
 # FP where the `cert` in `uncertainty` makes us treat it like a certificate
 # https://github.com/github/codeql/issues/9632
-def my_other_func(uncertainty): # $ SPURIOUS: SensitiveDataSource=certificate
-    print(uncertainty) # $ SPURIOUS: SensitiveUse=certificate
+def my_other_func(uncertainty):
+    print(uncertainty)
 
 password = some_function() # $ SensitiveDataSource=password
 print(password) # $ SensitiveUse=password

--- a/python/ql/test/experimental/dataflow/sensitive-data/test.py
+++ b/python/ql/test/experimental/dataflow/sensitive-data/test.py
@@ -39,7 +39,7 @@ print(x) # $ SensitiveUse=password
 
 # some prefixes makes us ignore it as a source
 not_found.isSecret
-not_found.is_secret # $ SPURIOUS: SensitiveDataSource=secret
+not_found.is_secret
 
 def my_func(non_sensitive_name):
     x = non_sensitive_name()

--- a/ruby/ql/lib/codeql/ruby/security/internal/SensitiveDataHeuristics.qll
+++ b/ruby/ql/lib/codeql/ruby/security/internal/SensitiveDataHeuristics.qll
@@ -50,7 +50,7 @@ module HeuristicNames {
    * Gets a regular expression that identifies strings that may indicate the presence of secret
    * or trusted data.
    */
-  string maybeSecret() { result = "(?is).*((?<!is)secret|(?<!un|is)trusted).*" }
+  string maybeSecret() { result = "(?is).*((?<!is|is_)secret|(?<!un|un_|is|is_)trusted).*" }
 
   /**
    * Gets a regular expression that identifies strings that may indicate the presence of
@@ -96,10 +96,14 @@ module HeuristicNames {
    * Gets a regular expression that identifies strings that may indicate the presence of data
    * that is hashed or encrypted, and hence rendered non-sensitive, or contains special characters
    * suggesting nouns within the string do not represent the meaning of the whole string (e.g. a URL or a SQL query).
+   *
+   * We also filter out common words like `certain` and `concert`, since otherwise these could
+   * be matched by the certificate regular expressions. Same for `accountable` (account), or
+   * `secretarial` (secret).
    */
   string notSensitiveRegexp() {
     result =
-      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)).*"
+      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)|certain|concert|secretar|accountant|accountab).*"
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/9632

I tested our old regexes against `/usr/share/dict/words`, and we had quite a few matches that were nonsens, like `concert` for a certificate, or `secretary` as a secret :grimacing:

The change from the few allow-list words I've added can be seen below.

(also introduced a small fix for snake_case support)

If you review commit by commit, you can see the fixes being applied to the tests. 

```diff
-Secretariat
-Secretary
 account
-accountability
-accountable
 accountancy
-accountant
-accountants
 accounted
 accounting
 accounts
-ascertain
-ascertainable
-ascertained
-ascertaining
-ascertains
-certain
-certainly
-certainties
-certainty
 certifiable
 certificate
 certificated
 certificates
 certificating
 certification
 certifications
 certified
 certifies
 certify
 certifying
 certitude
-concert
-concerted
-concerti
-concertina
-concertinaed
-concertinaing
-concertinas
-concerting
-concertmaster
-concertmasters
-concerto
-concertos
-concerts
-disconcert
-disconcerted
-disconcerting
-disconcerts
 entrusted
 intrusted
 password
 passwords
 secret
-secretarial
-secretariat
-secretariats
-secretaries
-secretary
 secrete
 secreted
 secretes
 secreting
 secretion
 secretions
 secretive
 secretively
 secretiveness
 secretly
 secrets
 trusted
-unaccountable
-unaccountably
-uncertain
-uncertainly
-uncertainties
-uncertainty
-undersecretaries
-undersecretary
 username
 usernames
```