### PR TITLE
Swift: Make sure property setters and getters also have `ExprNodes`

### DIFF
--- a/swift/ql/lib/codeql/swift/controlflow/BasicBlocks.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/BasicBlocks.qll
@@ -214,15 +214,15 @@ private module JoinBlockPredecessors {
   }
 
   int getId(JoinBlockPredecessor jbp) {
-    idOf(projctToAst(jbp.getFirstNode().(AstCfgNode).getNode()), result)
+    idOf(projctToAst(jbp.getFirstNode().(CfgNode).getNode()), result)
     or
     idOf(jbp.(EntryBasicBlock).getScope(), result)
   }
 
   string getSplitString(JoinBlockPredecessor jbp) {
-    result = jbp.getFirstNode().(AstCfgNode).getSplitsString()
+    result = jbp.getFirstNode().(CfgNode).getSplitsString()
     or
-    not exists(jbp.getFirstNode().(AstCfgNode).getSplitsString()) and
+    not exists(jbp.getFirstNode().(CfgNode).getSplitsString()) and
     result = ""
   }
 }

--- a/swift/ql/lib/codeql/swift/controlflow/CfgNodes.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/CfgNodes.qll
@@ -61,15 +61,15 @@ class ExitNode extends ControlFlowNode, TExitNode {
 /**
  * A node for an AST node.
  *
- * Each AST node maps to zero or more `AstCfgNode`s: zero when the node is unreachable
+ * Each AST node maps to zero or more `CfgNode`s: zero when the node is unreachable
  * (dead) code or not important for control flow, and multiple when there are different
  * splits for the AST node.
  */
-class AstCfgNode extends ControlFlowNode, TElementNode {
+class CfgNode extends ControlFlowNode, TElementNode {
   private Splits splits;
-  private ControlFlowElement n;
+  ControlFlowElement n;
 
-  AstCfgNode() { this = TElementNode(_, n, splits) }
+  CfgNode() { this = TElementNode(_, n, splits) }
 
   final override ControlFlowElement getNode() { result = n }
 
@@ -94,13 +94,27 @@ class AstCfgNode extends ControlFlowNode, TElementNode {
 }
 
 /** A control-flow node that wraps an AST expression. */
-class ExprCfgNode extends AstCfgNode {
+class ExprCfgNode extends CfgNode {
   Expr e;
 
   ExprCfgNode() { e = this.getNode().asAstNode() }
 
   /** Gets the underlying expression. */
   Expr getExpr() { result = e }
+}
+
+/** A control-flow node that wraps a property getter. */
+class PropertyGetterCfgNode extends CfgNode {
+  override PropertyGetterElement n;
+
+  Expr getRef() { result = n.getRef() }
+}
+
+/** A control-flow node that wraps a property setter. */
+class PropertySetterCfgNode extends CfgNode {
+  override PropertySetterElement n;
+
+  AssignExpr getAssignExpr() { result = n.getAssignExpr() }
 }
 
 class ApplyExprCfgNode extends ExprCfgNode {

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -37,7 +37,7 @@ private class ExprNodeImpl extends ExprNode, NodeImpl {
 
   override string toStringImpl() { result = expr.toString() }
 
-  override DataFlowCallable getEnclosingCallable() { result = TDataFlowFunc(expr.getScope()) }
+  override DataFlowCallable getEnclosingCallable() { result = TDataFlowFunc(n.getScope()) }
 }
 
 private class SsaDefinitionNodeImpl extends SsaDefinitionNode, NodeImpl {
@@ -62,7 +62,7 @@ cached
 private module Cached {
   cached
   newtype TNode =
-    TExprNode(ExprCfgNode e) or
+    TExprNode(CfgNode n, Expr e) { hasExprNode(n, e) } or
     TSsaDefinitionNode(Ssa::Definition def) or
     TInoutReturnNode(ParamDecl param) { param.isInout() } or
     TInOutUpdateNode(ParamDecl param, CallExpr call) {
@@ -70,6 +70,14 @@ private module Cached {
       call.getStaticTarget() = param.getDeclaringFunction()
     } or
     TSummaryNode(FlowSummary::SummarizedCallable c, FlowSummaryImpl::Private::SummaryNodeState state)
+
+  private predicate hasExprNode(CfgNode n, Expr e) {
+    n.(ExprCfgNode).getExpr() = e
+    or
+    n.(PropertyGetterCfgNode).getRef() = e
+    or
+    n.(PropertySetterCfgNode).getAssignExpr() = e
+  }
 
   private predicate localSsaFlowStepUseUse(Ssa::Definition def, Node nodeFrom, Node nodeTo) {
     def.adjacentReadPair(nodeFrom.getCfgNode(), nodeTo.getCfgNode()) and

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
@@ -56,13 +56,14 @@ class Node extends TNode {
  * `ControlFlow::Node`s.
  */
 class ExprNode extends Node, TExprNode {
-  ExprCfgNode expr;
+  CfgNode n;
+  Expr expr;
 
-  ExprNode() { this = TExprNode(expr) }
+  ExprNode() { this = TExprNode(n, expr) }
 
-  override Expr asExpr() { result = expr.getNode().asAstNode() }
+  override Expr asExpr() { result = expr }
 
-  override ControlFlowNode getCfgNode() { result = expr }
+  override ControlFlowNode getCfgNode() { result = n }
 }
 
 /**


### PR DESCRIPTION
This should fix a problem @geoffw0 has been having with `MemberRefExpr`s not having an `ExprNode`. The problem is that the CFG library maps these to `PropertyGetterElement`s to model them as calls to the (sometimes compiler-generated) functions. The same applies to `PropertySetterElement`.

There might be an issue where we now have several `ExprNodes` mapping to the same `Expr`, but I think we can fix that later by restricting which nodes will have an `AstNode` in the CFG library (in particular, the nodes for which there exists a `PropertyGetterElement` or `PropertySetterElement` shouldn't have an `AstNode`).

What do you think about this solution, @rdmarsh2?