### PR TITLE
Swift: String length conflation query

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/type/Type.qll
+++ b/swift/ql/lib/codeql/swift/elements/type/Type.qll
@@ -2,4 +2,6 @@ private import codeql.swift.generated.type.Type
 
 class Type extends TypeBase {
   override string toString() { result = this.getDiagnosticsName() }
+
+  string getName() { result = this.getDiagnosticsName() }
 }

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.qhelp
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.qhelp
@@ -1,0 +1,34 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Using a length value from an <code>NSString</code> in a <code>String</code>, or a count from a <code>String</code> in an <code>NSString</code>, may cause unexpected behavior. This is because certain unicode sequences are represented as one character in a <code>String</code> but as a sequence of multiple characters in an <code>NSString</code>. For example, a 'thumbs up' emoji with a skin tone modifier (&#x1F44D;&#x1F3FF;) is represented as U+1F44D (&#x1F44D;) then the modifier U+1F3FF.</p>
+
+</overview>
+<recommendation>
+
+<p>Use <code>String.count</code> when working with a <code>String</code>. Use <code>NSString.length</code> when working with an <code>NSString</code>. Do not mix values for lengths and offsets between the two types as they are not compatible measures.</p>
+
+<p>If you need to convert between <code>Range</code> and <code>NSRange</code>, do so directly using the appropriate constructor. Do not attempt to use incompatible length and offset values to accomplish conversion.</p>
+
+</recommendation>
+<example>
+
+<p>In the following example, a <code>String</code> is converted to <code>NSString</code>, but a range is created from the <code>String</code> to do some processing on it.</p>
+
+<sample src="StringLengthConflationBad.swift" />
+
+<p>This is dangerous because, if the input contains certain characters, the range computed on the <code>String</code> will be wrong for the <code>NSString</code>.  This will lead to incorrect behaviour in the string processing that follows. To fix the problem, we can use <code>NSString.length</code> to create the <code>NSRange</code> instead, as follows:</p>
+
+<sample src="StringLengthConflationGood.swift" />
+
+</example>
+<references>
+
+<li>
+  <a href="https://talk.objc.io/episodes/S01E80-swift-string-vs-nsstring">Swift String vs. NSString</a>
+</li>
+
+</references>
+</qhelp>

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.qhelp
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.qhelp
@@ -3,7 +3,7 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Using a length value from an <code>NSString</code> in a <code>String</code>, or a count from a <code>String</code> in an <code>NSString</code>, may cause unexpected behavior. This is because certain unicode sequences are represented as one character in a <code>String</code> but as a sequence of multiple characters in an <code>NSString</code>. For example, a 'thumbs up' emoji with a skin tone modifier (&#x1F44D;&#x1F3FF;) is represented as U+1F44D (&#x1F44D;) then the modifier U+1F3FF.</p>
+<p>Using a length value from an <code>NSString</code> in a <code>String</code>, or a count from a <code>String</code> in an <code>NSString</code>, may cause unexpected behavior including (in some cases) buffer overwrites. This is because certain unicode sequences are represented as one character in a <code>String</code> but as a sequence of multiple characters in an <code>NSString</code>. For example, a 'thumbs up' emoji with a skin tone modifier (&#x1F44D;&#x1F3FF;) is represented as U+1F44D (&#x1F44D;) then the modifier U+1F3FF.</p>
 
 </overview>
 <recommendation>

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -20,7 +20,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
   override predicate isSource(DataFlow::Node node, string flowstate) {
     // result of a call to to `String.count`
     exists(MemberRefExpr member |
-      member.getBaseExpr().getType().toString() = "String" and // TODO: use of toString
+      member.getBaseExpr().getType().getName() = "String" and
       member.getMember().toString() = "count" and // TODO: use of toString
       node.asExpr() = member and
       flowstate = "String"

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -58,14 +58,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
       c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
       call.getFunction().(ApplyExpr).getFunction().(DeclRefExpr).getDecl() = f and
       call.getFunction().(ApplyExpr).getFunction().toString() = methodName and // TODO: use of toString
-      call.getFunction()
-          .(ApplyExpr)
-          .getFunction()
-          .(DeclRefExpr)
-          .getDecl()
-          .(AbstractFunctionDecl)
-          .getParam(arg)
-          .getName() = argName and
+      f.getParam(arg).getName() = argName and
       call.getArgument(arg).getExpr() = node.asExpr() and
       flowstate = "String" // `String` length flowing into `NSString`
     )
@@ -73,9 +66,9 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
     // arguments to function calls...
     exists(string funcName, string argName, CallExpr call, int arg |
       // `NSMakeRange`
-      funcName = "NSMakeRange" and
+      funcName = "NSMakeRange(_:_:)" and
       argName = ["loc", "len"] and
-      call.getStaticTarget().getName().matches(funcName + "%") and
+      call.getStaticTarget().getName() = funcName and
       call.getStaticTarget().getParam(arg).getName() = argName and
       call.getArgument(arg).getExpr() = node.asExpr() and
       flowstate = "String" // `String` length flowing into `NSString`
@@ -85,4 +78,4 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
 
 from StringLengthConflationConfiguration config, DataFlow::PathNode source, DataFlow::PathNode sink
 where config.hasFlowPath(source, sink)
-select sink, source, sink, "RESULT"
+select sink.getNode(), source, sink, "RESULT"

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -1,6 +1,6 @@
 /**
  * @name String length conflation
- * @description TODO
+ * @description Using a length value from an `NSString` in a `String`, or a `count` from a `String` in an `NSString`, may cause unexpected behavior.
  * @kind problem
  * @problem.severity TODO
  * @security-severity TODO

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -62,7 +62,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
       c.getName() = className and
       c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
       call.getFunction().(ApplyExpr).getStaticTarget() = f and
-      f.(AbstractFunctionDecl).getName() = methodName and
+      f.getName() = methodName and
       f.getParam(arg).getName() = paramName and
       call.getArgument(arg).getExpr() = node.asExpr() and
       flowstate = "String" // `String` length flowing into `NSString`

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -1,6 +1,6 @@
 /**
  * @name String length conflation
- * @description Using a length value from an `NSString` in a `String`, or a `count` from a `String` in an `NSString`, may cause unexpected behavior.
+ * @description Using a length value from an `NSString` in a `String`, or a count from a `String` in an `NSString`, may cause unexpected behavior.
  * @kind problem
  * @problem.severity TODO
  * @security-severity TODO

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -2,8 +2,8 @@
  * @name String length conflation
  * @description Using a length value from an `NSString` in a `String`, or a count from a `String` in an `NSString`, may cause unexpected behavior.
  * @kind problem
- * @problem.severity TODO
- * @security-severity TODO
+ * @problem.severity error
+ * @security-severity 7.8
  * @precision TODO
  * @id swift/string-length-conflation
  * @tags security

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -71,7 +71,7 @@ predicate isSink0(Expr e) {
     // `NSMakeRange`
     funcName = "NSMakeRange" and
     argName = ["loc", "len"] and
-    call.getStaticTarget().getName() = funcName and
+    call.getStaticTarget().getName().matches(funcName + "%") and
     call.getStaticTarget().getParam(arg).getName() = argName and
     call.getArgument(arg).getExpr() = e
   )

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -61,14 +61,8 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
       ) and
       c.getName() = className and
       c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
-      call.getFunction().(ApplyExpr).getFunction().(DeclRefExpr).getDecl() = f and
-      call.getFunction()
-          .(ApplyExpr)
-          .getFunction()
-          .(DeclRefExpr)
-          .getDecl()
-          .(AbstractFunctionDecl)
-          .getName() = methodName and
+      call.getFunction().(ApplyExpr).getStaticTarget() = f and
+      f.(AbstractFunctionDecl).getName() = methodName and
       f.getParam(arg).getName() = paramName and
       call.getArgument(arg).getExpr() = node.asExpr() and
       flowstate = "String" // `String` length flowing into `NSString`

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -14,78 +14,72 @@ import swift
 import codeql.swift.dataflow.DataFlow
 import DataFlow::PathGraph
 
-predicate isSource0(Expr e) {
-  // result of a call to to `String.count`
-  exists(MemberRefExpr member |
-    member.getBaseExpr().getType().toString() = "String" and // TODO: use of toString
-    member.getMember().toString() = "count" and // TODO: use of toString
-    e = member
-  )
-  // TODO: other sources such as NSString.length, with different set of sinks
-}
-
-predicate isSink0(Expr e) {
-  // arguments to method calls...
-  exists(
-    string className, string methodName, string argName, ClassDecl c, AbstractFunctionDecl f,
-    CallExpr call, int arg
-  |
-    (
-      // `NSRange.init`
-      className = "NSRange" and
-      methodName = "init" and
-      argName = ["location", "length"]
-      or
-      // `NSString.character`
-      className = ["NSString", "NSMutableString"] and
-      methodName = "character" and
-      argName = "at"
-      or
-      // `NSString.character`
-      className = ["NSString", "NSMutableString"] and
-      methodName = "substring" and
-      argName = ["from", "to"]
-      or
-      // `NSMutableString.insert`
-      className = "NSMutableString" and
-      methodName = "insert" and
-      argName = "at"
-    ) and
-    c.toString() = className and // TODO: use of toString
-    c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
-    call.getFunction().(ApplyExpr).getFunction().(DeclRefExpr).getDecl() = f and
-    call.getFunction().(ApplyExpr).getFunction().toString() = methodName and // TODO: use of toString
-    call.getFunction()
-        .(ApplyExpr)
-        .getFunction()
-        .(DeclRefExpr)
-        .getDecl()
-        .(AbstractFunctionDecl)
-        .getParam(arg)
-        .getName() = argName and
-    call.getArgument(arg).getExpr() = e
-  )
-  or
-  // arguments to function calls...
-  exists(string funcName, string argName, CallExpr call, int arg |
-    // `NSMakeRange`
-    funcName = "NSMakeRange" and
-    argName = ["loc", "len"] and
-    call.getStaticTarget().getName().matches(funcName + "%") and
-    call.getStaticTarget().getParam(arg).getName() = argName and
-    call.getArgument(arg).getExpr() = e
-  )
-}
-
 class StringLengthConflationConfiguration extends DataFlow::Configuration {
   StringLengthConflationConfiguration() { this = "StringLengthConflationConfiguration" }
 
   override predicate isSource(DataFlow::Node node, string flowstate) {
-    isSource0(node.asExpr()) and flowstate = "String"
+    // result of a call to to `String.count`
+    exists(MemberRefExpr member |
+      member.getBaseExpr().getType().toString() = "String" and // TODO: use of toString
+      member.getMember().toString() = "count" and // TODO: use of toString
+      node.asExpr() = member and
+      flowstate = "String"
+    )
   }
 
   override predicate isSink(DataFlow::Node node, string flowstate) {
-    isSink0(node.asExpr()) and flowstate = "String"
+    // arguments to method calls...
+    exists(
+      string className, string methodName, string argName, ClassDecl c, AbstractFunctionDecl f,
+      CallExpr call, int arg
+    |
+      (
+        // `NSRange.init`
+        className = "NSRange" and
+        methodName = "init" and
+        argName = ["location", "length"]
+        or
+        // `NSString.character`
+        className = ["NSString", "NSMutableString"] and
+        methodName = "character" and
+        argName = "at"
+        or
+        // `NSString.character`
+        className = ["NSString", "NSMutableString"] and
+        methodName = "substring" and
+        argName = ["from", "to"]
+        or
+        // `NSMutableString.insert`
+        className = "NSMutableString" and
+        methodName = "insert" and
+        argName = "at"
+      ) and
+      c.toString() = className and // TODO: use of toString
+      c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
+      call.getFunction().(ApplyExpr).getFunction().(DeclRefExpr).getDecl() = f and
+      call.getFunction().(ApplyExpr).getFunction().toString() = methodName and // TODO: use of toString
+      call.getFunction()
+          .(ApplyExpr)
+          .getFunction()
+          .(DeclRefExpr)
+          .getDecl()
+          .(AbstractFunctionDecl)
+          .getParam(arg)
+          .getName() = argName and
+      call.getArgument(arg).getExpr() = node.asExpr() and
+      flowstate = "String" // `String` length flowing into `NSString`
+    )
+    or
+    // arguments to function calls...
+    exists(string funcName, string argName, CallExpr call, int arg |
+      // `NSMakeRange`
+      funcName = "NSMakeRange" and
+      argName = ["loc", "len"] and
+      call.getStaticTarget().getName().matches(funcName + "%") and
+      call.getStaticTarget().getParam(arg).getName() = argName and
+      call.getArgument(arg).getExpr() = node.asExpr() and
+      flowstate = "String" // `String` length flowing into `NSString`
+    )
   }
 }
 

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -30,46 +30,46 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
   override predicate isSink(DataFlow::Node node, string flowstate) {
     // arguments to method calls...
     exists(
-      string className, string methodName, string argName, ClassDecl c, AbstractFunctionDecl f,
+      string className, string methodName, string paramName, ClassDecl c, AbstractFunctionDecl f,
       CallExpr call, int arg
     |
       (
         // `NSRange.init`
         className = "NSRange" and
         methodName = "init" and
-        argName = ["location", "length"]
+        paramName = ["location", "length"]
         or
         // `NSString.character`
         className = ["NSString", "NSMutableString"] and
         methodName = "character" and
-        argName = "at"
+        paramName = "at"
         or
         // `NSString.character`
         className = ["NSString", "NSMutableString"] and
         methodName = "substring" and
-        argName = ["from", "to"]
+        paramName = ["from", "to"]
         or
         // `NSMutableString.insert`
         className = "NSMutableString" and
         methodName = "insert" and
-        argName = "at"
+        paramName = "at"
       ) and
       c.toString() = className and // TODO: use of toString
       c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
       call.getFunction().(ApplyExpr).getFunction().(DeclRefExpr).getDecl() = f and
       call.getFunction().(ApplyExpr).getFunction().toString() = methodName and // TODO: use of toString
-      f.getParam(arg).getName() = argName and
+      f.getParam(arg).getName() = paramName and
       call.getArgument(arg).getExpr() = node.asExpr() and
       flowstate = "String" // `String` length flowing into `NSString`
     )
     or
     // arguments to function calls...
-    exists(string funcName, string argName, CallExpr call, int arg |
+    exists(string funcName, string paramName, CallExpr call, int arg |
       // `NSMakeRange`
       funcName = "NSMakeRange(_:_:)" and
-      argName = ["loc", "len"] and
+      paramName = ["loc", "len"] and
       call.getStaticTarget().getName() = funcName and
-      call.getStaticTarget().getParam(arg).getName() = argName and
+      call.getStaticTarget().getParam(arg).getName() = paramName and
       call.getArgument(arg).getExpr() = node.asExpr() and
       flowstate = "String" // `String` length flowing into `NSString`
     )

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -81,6 +81,17 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
   }
 }
 
-from StringLengthConflationConfiguration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
-select sink.getNode(), source, sink, "RESULT"
+from
+  StringLengthConflationConfiguration config, DataFlow::PathNode source, DataFlow::PathNode sink,
+  string flowstate, string message
+where
+  config.hasFlowPath(source, sink) and
+  config.isSink(sink.getNode(), flowstate) and
+  (
+    flowstate = "String" and
+    message = "This String length is used in an NSString, but it may not be equivalent."
+    or
+    flowstate = "NSString" and
+    message = "This NSString length is used in a String, but it may not be equivalent."
+  )
+select sink.getNode(), source, sink, message

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflationBad.swift
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflationBad.swift
@@ -1,0 +1,7 @@
+
+func myFunction(s: String) {
+	let ns = NSString(string: s)
+	let nsrange = NSMakeRange(0, s.count) // BAD: String length used in NSMakeRange
+
+	// ... use nsrange to process ns
+}

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflationGood.swift
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflationGood.swift
@@ -1,0 +1,7 @@
+
+func myFunction(s: String) {
+	let ns = NSString(string: s)
+	let nsrange = NSMakeRange(0, ns.length) // Fixed: NSString length used in NSMakeRange
+
+	// ... use nsrange to process ns
+}

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,45 +1,6 @@
-| StringLengthConflation.swift:10:37:10:44 | Location | StringLengthConflation.swift:10:37:10:44 | .count | isSource |
-| StringLengthConflation.swift:21:37:21:44 | Location | StringLengthConflation.swift:21:37:21:44 | .count | isSource |
-| StringLengthConflation.swift:38:80:38:80 | Location | StringLengthConflation.swift:38:80:38:80 | loc | isSink |
-| StringLengthConflation.swift:38:93:38:93 | Location | StringLengthConflation.swift:38:93:38:93 | len | isSink |
-| StringLengthConflation.swift:47:20:47:22 | Location | StringLengthConflation.swift:47:20:47:22 | .count | isSource |
-| StringLengthConflation.swift:52:43:52:45 | Location | StringLengthConflation.swift:52:43:52:45 | .count | isSource |
-| StringLengthConflation.swift:59:47:59:49 | Location | StringLengthConflation.swift:59:47:59:49 | .count | isSource |
-| StringLengthConflation.swift:64:33:64:35 | Location | StringLengthConflation.swift:64:33:64:35 | .count | isSource |
-| StringLengthConflation.swift:71:30:71:30 | Location | StringLengthConflation.swift:71:30:71:30 | 0 | isSink |
-| StringLengthConflation.swift:71:33:71:36 | Location | StringLengthConflation.swift:71:33:71:36 | .length | isSink |
-| StringLengthConflation.swift:72:30:72:30 | Location | StringLengthConflation.swift:72:30:72:30 | 0 | isSink |
-| StringLengthConflation.swift:72:33:72:35 | Location | StringLengthConflation.swift:72:33:72:35 | .count | ***RESULT***, isSink, isSource |
-| StringLengthConflation.swift:73:30:73:30 | Location | StringLengthConflation.swift:73:30:73:30 | 0 | isSink |
-| StringLengthConflation.swift:73:33:73:46 | Location | StringLengthConflation.swift:73:33:73:46 | .count | isSink |
-| StringLengthConflation.swift:74:30:74:30 | Location | StringLengthConflation.swift:74:30:74:30 | 0 | isSink |
-| StringLengthConflation.swift:74:33:74:78 | Location | StringLengthConflation.swift:74:33:74:78 | call to ... | isSink |
-| StringLengthConflation.swift:77:36:77:36 | Location | StringLengthConflation.swift:77:36:77:36 | 0 | isSink |
-| StringLengthConflation.swift:77:47:77:50 | Location | StringLengthConflation.swift:77:47:77:50 | .length | isSink |
-| StringLengthConflation.swift:78:36:78:36 | Location | StringLengthConflation.swift:78:36:78:36 | 0 | isSink |
-| StringLengthConflation.swift:78:47:78:49 | Location | StringLengthConflation.swift:78:47:78:49 | .count | ***RESULT***, isSink, isSource |
-| StringLengthConflation.swift:83:28:83:30 | Location | StringLengthConflation.swift:83:28:83:30 | .count | isSource |
-| StringLengthConflation.swift:87:27:87:29 | Location | StringLengthConflation.swift:87:27:87:29 | .count | isSource |
-| StringLengthConflation.swift:91:25:91:27 | Location | StringLengthConflation.swift:91:25:91:27 | .count | isSource |
-| StringLengthConflation.swift:95:25:95:27 | Location | StringLengthConflation.swift:95:25:95:27 | .count | isSource |
-| StringLengthConflation.swift:99:34:99:46 | Location | StringLengthConflation.swift:99:34:99:46 | ... call to - ... | isSink |
-| StringLengthConflation.swift:100:36:100:49 | Location | StringLengthConflation.swift:100:36:100:49 | ... call to - ... | isSink |
-| StringLengthConflation.swift:101:34:101:36 | Location | StringLengthConflation.swift:101:34:101:36 | .count | isSource |
-| StringLengthConflation.swift:101:34:101:44 | Location | StringLengthConflation.swift:101:34:101:44 | ... call to - ... | isSink |
-| StringLengthConflation.swift:102:36:102:38 | Location | StringLengthConflation.swift:102:36:102:38 | .count | isSource |
-| StringLengthConflation.swift:102:36:102:46 | Location | StringLengthConflation.swift:102:36:102:46 | ... call to - ... | isSink |
-| StringLengthConflation.swift:105:36:105:48 | Location | StringLengthConflation.swift:105:36:105:48 | ... call to - ... | isSink |
-| StringLengthConflation.swift:106:38:106:51 | Location | StringLengthConflation.swift:106:38:106:51 | ... call to - ... | isSink |
-| StringLengthConflation.swift:107:36:107:38 | Location | StringLengthConflation.swift:107:36:107:38 | .count | isSource |
-| StringLengthConflation.swift:107:36:107:46 | Location | StringLengthConflation.swift:107:36:107:46 | ... call to - ... | isSink |
-| StringLengthConflation.swift:108:38:108:40 | Location | StringLengthConflation.swift:108:38:108:40 | .count | isSource |
-| StringLengthConflation.swift:108:38:108:48 | Location | StringLengthConflation.swift:108:38:108:48 | ... call to - ... | isSink |
-| StringLengthConflation.swift:111:34:111:46 | Location | StringLengthConflation.swift:111:34:111:46 | ... call to - ... | isSink |
-| StringLengthConflation.swift:112:36:112:49 | Location | StringLengthConflation.swift:112:36:112:49 | ... call to - ... | isSink |
-| StringLengthConflation.swift:113:34:113:36 | Location | StringLengthConflation.swift:113:34:113:36 | .count | isSource |
-| StringLengthConflation.swift:113:34:113:44 | Location | StringLengthConflation.swift:113:34:113:44 | ... call to - ... | isSink |
-| StringLengthConflation.swift:114:36:114:38 | Location | StringLengthConflation.swift:114:36:114:38 | .count | isSource |
-| StringLengthConflation.swift:114:36:114:46 | Location | StringLengthConflation.swift:114:36:114:46 | ... call to - ... | isSink |
-| StringLengthConflation.swift:118:28:118:41 | Location | StringLengthConflation.swift:118:28:118:41 | ... call to - ... | isSink |
-| StringLengthConflation.swift:120:28:120:30 | Location | StringLengthConflation.swift:120:28:120:30 | .count | isSource |
-| StringLengthConflation.swift:120:28:120:38 | Location | StringLengthConflation.swift:120:28:120:38 | ... call to - ... | isSink |
+edges
+nodes
+| StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
+subpaths
+#select
+| StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | RESULT |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,6 +1,8 @@
 edges
 nodes
+| StringLengthConflation.swift:72:33:72:35 | .count | semmle.label | .count |
 | StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
 subpaths
 #select
+| StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | RESULT |
 | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | RESULT |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -4,5 +4,5 @@ nodes
 | StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
 subpaths
 #select
-| StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | RESULT |
-| StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | RESULT |
+| StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | This String length is used in an NSString, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,1 +1,45 @@
-| TODO |
+| StringLengthConflation.swift:10:37:10:44 | Location | StringLengthConflation.swift:10:37:10:44 | .count | isSource |
+| StringLengthConflation.swift:21:37:21:44 | Location | StringLengthConflation.swift:21:37:21:44 | .count | isSource |
+| StringLengthConflation.swift:38:80:38:80 | Location | StringLengthConflation.swift:38:80:38:80 | loc | isSink |
+| StringLengthConflation.swift:38:93:38:93 | Location | StringLengthConflation.swift:38:93:38:93 | len | isSink |
+| StringLengthConflation.swift:47:20:47:22 | Location | StringLengthConflation.swift:47:20:47:22 | .count | isSource |
+| StringLengthConflation.swift:52:43:52:45 | Location | StringLengthConflation.swift:52:43:52:45 | .count | isSource |
+| StringLengthConflation.swift:59:47:59:49 | Location | StringLengthConflation.swift:59:47:59:49 | .count | isSource |
+| StringLengthConflation.swift:64:33:64:35 | Location | StringLengthConflation.swift:64:33:64:35 | .count | isSource |
+| StringLengthConflation.swift:71:30:71:30 | Location | StringLengthConflation.swift:71:30:71:30 | 0 | isSink |
+| StringLengthConflation.swift:71:33:71:36 | Location | StringLengthConflation.swift:71:33:71:36 | .length | isSink |
+| StringLengthConflation.swift:72:30:72:30 | Location | StringLengthConflation.swift:72:30:72:30 | 0 | isSink |
+| StringLengthConflation.swift:72:33:72:35 | Location | StringLengthConflation.swift:72:33:72:35 | .count | ***RESULT***, isSink, isSource |
+| StringLengthConflation.swift:73:30:73:30 | Location | StringLengthConflation.swift:73:30:73:30 | 0 | isSink |
+| StringLengthConflation.swift:73:33:73:46 | Location | StringLengthConflation.swift:73:33:73:46 | .count | isSink |
+| StringLengthConflation.swift:74:30:74:30 | Location | StringLengthConflation.swift:74:30:74:30 | 0 | isSink |
+| StringLengthConflation.swift:74:33:74:78 | Location | StringLengthConflation.swift:74:33:74:78 | call to ... | isSink |
+| StringLengthConflation.swift:77:36:77:36 | Location | StringLengthConflation.swift:77:36:77:36 | 0 | isSink |
+| StringLengthConflation.swift:77:47:77:50 | Location | StringLengthConflation.swift:77:47:77:50 | .length | isSink |
+| StringLengthConflation.swift:78:36:78:36 | Location | StringLengthConflation.swift:78:36:78:36 | 0 | isSink |
+| StringLengthConflation.swift:78:47:78:49 | Location | StringLengthConflation.swift:78:47:78:49 | .count | ***RESULT***, isSink, isSource |
+| StringLengthConflation.swift:83:28:83:30 | Location | StringLengthConflation.swift:83:28:83:30 | .count | isSource |
+| StringLengthConflation.swift:87:27:87:29 | Location | StringLengthConflation.swift:87:27:87:29 | .count | isSource |
+| StringLengthConflation.swift:91:25:91:27 | Location | StringLengthConflation.swift:91:25:91:27 | .count | isSource |
+| StringLengthConflation.swift:95:25:95:27 | Location | StringLengthConflation.swift:95:25:95:27 | .count | isSource |
+| StringLengthConflation.swift:99:34:99:46 | Location | StringLengthConflation.swift:99:34:99:46 | ... call to - ... | isSink |
+| StringLengthConflation.swift:100:36:100:49 | Location | StringLengthConflation.swift:100:36:100:49 | ... call to - ... | isSink |
+| StringLengthConflation.swift:101:34:101:36 | Location | StringLengthConflation.swift:101:34:101:36 | .count | isSource |
+| StringLengthConflation.swift:101:34:101:44 | Location | StringLengthConflation.swift:101:34:101:44 | ... call to - ... | isSink |
+| StringLengthConflation.swift:102:36:102:38 | Location | StringLengthConflation.swift:102:36:102:38 | .count | isSource |
+| StringLengthConflation.swift:102:36:102:46 | Location | StringLengthConflation.swift:102:36:102:46 | ... call to - ... | isSink |
+| StringLengthConflation.swift:105:36:105:48 | Location | StringLengthConflation.swift:105:36:105:48 | ... call to - ... | isSink |
+| StringLengthConflation.swift:106:38:106:51 | Location | StringLengthConflation.swift:106:38:106:51 | ... call to - ... | isSink |
+| StringLengthConflation.swift:107:36:107:38 | Location | StringLengthConflation.swift:107:36:107:38 | .count | isSource |
+| StringLengthConflation.swift:107:36:107:46 | Location | StringLengthConflation.swift:107:36:107:46 | ... call to - ... | isSink |
+| StringLengthConflation.swift:108:38:108:40 | Location | StringLengthConflation.swift:108:38:108:40 | .count | isSource |
+| StringLengthConflation.swift:108:38:108:48 | Location | StringLengthConflation.swift:108:38:108:48 | ... call to - ... | isSink |
+| StringLengthConflation.swift:111:34:111:46 | Location | StringLengthConflation.swift:111:34:111:46 | ... call to - ... | isSink |
+| StringLengthConflation.swift:112:36:112:49 | Location | StringLengthConflation.swift:112:36:112:49 | ... call to - ... | isSink |
+| StringLengthConflation.swift:113:34:113:36 | Location | StringLengthConflation.swift:113:34:113:36 | .count | isSource |
+| StringLengthConflation.swift:113:34:113:44 | Location | StringLengthConflation.swift:113:34:113:44 | ... call to - ... | isSink |
+| StringLengthConflation.swift:114:36:114:38 | Location | StringLengthConflation.swift:114:36:114:38 | .count | isSource |
+| StringLengthConflation.swift:114:36:114:46 | Location | StringLengthConflation.swift:114:36:114:46 | ... call to - ... | isSink |
+| StringLengthConflation.swift:118:28:118:41 | Location | StringLengthConflation.swift:118:28:118:41 | ... call to - ... | isSink |
+| StringLengthConflation.swift:120:28:120:30 | Location | StringLengthConflation.swift:120:28:120:30 | .count | isSource |
+| StringLengthConflation.swift:120:28:120:38 | Location | StringLengthConflation.swift:120:28:120:38 | ... call to - ... | isSink |


### PR DESCRIPTION
String length conflation query, i.e. query for [CVE-2022-23625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23625) ([patch](https://github.com/wireapp/wire-ios-transport/commit/02e90aa45edaf7eb2d8b97fa2377cd8104274170)) / [CWE-135](https://cwe.mitre.org/data/definitions/135.html).

~This is a draft PR because there are a bunch of things I need to clean up that I'm looking for advice on - see the `TODO` comments in the code.  Many of these will involve small additions in the libraries and I'm seeking discussion of the design of these improvements.~

~The query is also missing qldoc, qhelp, Swift example code, query metadata, a proper violation message, change note ... and results in the `NSString` -> `Swift.String` direction.  I don't anticipate any problems in these areas.~  UPDATE: the rest of this will be addressed in a follow-up PR.