### PR TITLE
C++: Two small QL fixes

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/internal/QualifiedName.qll
+++ b/cpp/ql/lib/semmle/code/cpp/internal/QualifiedName.qll
@@ -4,11 +4,7 @@
  * qualified.
  *
  * This file contains classes that mirror the standard AST classes for C++, but
- * these classes are only concerned with naming. The other difference is that
- * these classes don't use the `ResolveClass.qll` mechanisms like
- * `unresolveElement` because these classes should eventually be part of the
- * implementation of `ResolveClass.qll`, allowing it to match up classes when
- * their qualified names and parameters match.
+ * these classes are only concerned with naming.
  */
 
 private import semmle.code.cpp.Declaration as D

--- a/cpp/ql/lib/semmle/code/cpp/internal/ResolveClass.qll
+++ b/cpp/ql/lib/semmle/code/cpp/internal/ResolveClass.qll
@@ -115,15 +115,13 @@ private module Cached {
    */
   cached
   predicate isClass(@usertype t) {
-    (
-      usertypes(t, _, 1) or
-      usertypes(t, _, 2) or
-      usertypes(t, _, 3) or
-      usertypes(t, _, 6) or
-      usertypes(t, _, 10) or
-      usertypes(t, _, 11) or
-      usertypes(t, _, 12)
-    )
+    usertypes(t, _, 1) or
+    usertypes(t, _, 2) or
+    usertypes(t, _, 3) or
+    usertypes(t, _, 6) or
+    usertypes(t, _, 10) or
+    usertypes(t, _, 11) or
+    usertypes(t, _, 12)
   }
 
   cached


### PR DESCRIPTION
* Remove a comment that no longer applies, as we switched to mangled names in `ResolveClass.qll`
* Remove redundant parentheses
