### PR TITLE
JS: Downgrade ast_node_symbol relation

### DIFF
--- a/javascript/downgrades/c0664d5721c90dd32a5b167efea24f9cc6f57cfb/ast_node_symbol.ql
+++ b/javascript/downgrades/c0664d5721c90dd32a5b167efea24f9cc6f57cfb/ast_node_symbol.ql
@@ -1,0 +1,11 @@
+class AstNodeWithSymbol extends @ast_node_with_symbol {
+  string toString() { none() }
+}
+
+class Symbol extends @symbol {
+  string toString() { none() }
+}
+
+from AstNodeWithSymbol node, Symbol symbol
+where ast_node_symbol(node, symbol) and not node instanceof @external_module_declaration
+select node, symbol

--- a/javascript/downgrades/c0664d5721c90dd32a5b167efea24f9cc6f57cfb/upgrade.properties
+++ b/javascript/downgrades/c0664d5721c90dd32a5b167efea24f9cc6f57cfb/upgrade.properties
@@ -1,2 +1,4 @@
 description: Associate symbols with external module declarations
 compatibility: backwards
+
+ast_node_symbol.rel: run ast_node_symbol.qlo


### PR DESCRIPTION
Avoids introducing a DB inconsistency when downgrading