### PR TITLE
Swift: tag -> pragma in codegen

### DIFF
--- a/swift/codegen/generators/qlgen.py
+++ b/swift/codegen/generators/qlgen.py
@@ -19,7 +19,7 @@ class FormatError(Exception):
 def get_ql_property(cls: schema.Class, prop: schema.Property):
     common_args = dict(
         type=prop.type if not prop.is_predicate else "predicate",
-        skip_qltest="no_qltest" in prop.tags,
+        skip_qltest="skip_qltest" in prop.pragmas,
         is_child=prop.is_child,
         is_optional=prop.is_optional,
         is_predicate=prop.is_predicate,
@@ -64,7 +64,7 @@ def get_ql_class(cls: schema.Class):
         final=not cls.derived,
         properties=[get_ql_property(cls, p) for p in cls.properties],
         dir=cls.dir,
-        skip_qltest="no_qltest" in cls.tags,
+        skip_qltest="skip_qltest" in cls.pragmas,
     )
 
 

--- a/swift/codegen/schema.yml
+++ b/swift/codegen/schema.yml
@@ -14,14 +14,14 @@ _directories:
 
 Element:
   is_unknown: predicate
-  _tags: [ no_qltest ]
+  _pragma: skip_qltest
 
 File:
   name: string
 
 Locatable:
   location: Location?
-  _tags: [ no_qltest ]
+  _pragma: skip_qltest
 
 Location:
   file: File
@@ -29,7 +29,7 @@ Location:
   start_column: int
   end_line: int
   end_column: int
-  _tags: [ no_qltest ]
+  _pragma: skip_qltest
 
 Type:
   diagnostics_name: string
@@ -385,7 +385,7 @@ EnumIsCaseExpr:
 
 ErrorExpr:
   _extends: Expr
-  _tags: [ no_qltest ]  # unexpected emission
+  _pragma: skip_qltest  # unexpected emission
 
 ExplicitCastExpr:
   _extends: Expr
@@ -460,7 +460,7 @@ ObjCSelectorExpr:
   _children:
     sub_expr: Expr
   method: AbstractFunctionDecl
-  _tags: [ no_qltest ]  # to be tested in integration tests
+  _pragma: skip_qltest  # to be tested in integration tests
 
 OneWayExpr:
   _extends: Expr
@@ -502,7 +502,7 @@ SequenceExpr:
   _extends: Expr
   _children:
     elements: Expr*
-  _tags: [ no_qltest ]  # we should really never extract these, as these should be resolved to trees of operations
+  _pragma: skip_qltest  # we should really never extract these, as these should be resolved to trees of operations
 
 SuperRefExpr:
   _extends: Expr
@@ -534,7 +534,7 @@ TypeExpr:
 UnresolvedDeclRefExpr:
   _extends: Expr
   name: string?
-  _tags: [ no_qltest ]  # we should really never extract these
+  _pragma: skip_qltest  # we should really never extract these
 
 UnresolvedDotExpr:
   _extends: Expr
@@ -545,15 +545,15 @@ UnresolvedDotExpr:
 UnresolvedMemberExpr:
   _extends: Expr
   name: string
-  _tags: [ no_qltest ]  # we should really never extract these
+  _pragma: skip_qltest  # we should really never extract these
 
 UnresolvedPatternExpr:
   _extends: Expr
-  _tags: [ no_qltest ]  # we should really never extract these
+  _pragma: skip_qltest  # we should really never extract these
 
 UnresolvedSpecializeExpr:
   _extends: Expr
-  _tags: [ no_qltest ]  # we should really never extract these
+  _pragma: skip_qltest  # we should really never extract these
 
 VarargExpansionExpr:
   _extends: Expr
@@ -821,11 +821,11 @@ ArrayToPointerExpr:
 
 BridgeFromObjCExpr:
   _extends: ImplicitConversionExpr
-  _tags: [ no_qltest ]  # to be tested in integration tests
+  _pragma: skip_qltest  # to be tested in integration tests
 
 BridgeToObjCExpr:
   _extends: ImplicitConversionExpr
-  _tags: [ no_qltest ]  # to be tested in integration tests
+  _pragma: skip_qltest  # to be tested in integration tests
 
 ClassMetatypeToObjectExpr:
   _extends: ImplicitConversionExpr
@@ -835,7 +835,7 @@ CollectionUpcastConversionExpr:
 
 ConditionalBridgeFromObjCExpr:
   _extends: ImplicitConversionExpr
-  _tags: [ no_qltest ]  # to be tested in integration tests
+  _pragma: skip_qltest  # to be tested in integration tests
 
 CovariantFunctionConversionExpr:
   _extends: ImplicitConversionExpr

--- a/swift/codegen/test/test_qlgen.py
+++ b/swift/codegen/test/test_qlgen.py
@@ -458,13 +458,13 @@ def test_test_properties_skipped(opts, generate_tests):
     write(opts.ql_test_output / "Derived" / "test.swift")
     assert generate_tests([
         schema.Class("Base", derived={"Derived"}, properties=[
-            schema.SingleProperty("x", "string", tags=["no_qltest", "foo"]),
-            schema.RepeatedProperty("y", "int", tags=["bar", "no_qltest"]),
+            schema.SingleProperty("x", "string", pragmas=["skip_qltest", "foo"]),
+            schema.RepeatedProperty("y", "int", pragmas=["bar", "skip_qltest"]),
         ]),
         schema.Class("Derived", bases={"Base"}, properties=[
-            schema.PredicateProperty("a", tags=["no_qltest"]),
+            schema.PredicateProperty("a", pragmas=["skip_qltest"]),
             schema.OptionalProperty(
-                "b", "int", tags=["bar", "no_qltest", "baz"]),
+                "b", "int", pragmas=["bar", "skip_qltest", "baz"]),
         ]),
     ]) == {
                "Derived/Derived.ql": ql.ClassTester(class_name="Derived"),
@@ -474,7 +474,7 @@ def test_test_properties_skipped(opts, generate_tests):
 def test_test_base_class_skipped(opts, generate_tests):
     write(opts.ql_test_output / "Derived" / "test.swift")
     assert generate_tests([
-        schema.Class("Base", derived={"Derived"}, tags=["no_qltest", "foo"], properties=[
+        schema.Class("Base", derived={"Derived"}, pragmas=["skip_qltest", "foo"], properties=[
             schema.SingleProperty("x", "string"),
             schema.RepeatedProperty("y", "int"),
         ]),
@@ -488,7 +488,7 @@ def test_test_final_class_skipped(opts, generate_tests):
     write(opts.ql_test_output / "Derived" / "test.swift")
     assert generate_tests([
         schema.Class("Base", derived={"Derived"}),
-        schema.Class("Derived", bases={"Base"}, tags=["no_qltest", "foo"], properties=[
+        schema.Class("Derived", bases={"Base"}, pragmas=["skip_qltest", "foo"], properties=[
             schema.SingleProperty("x", "string"),
             schema.RepeatedProperty("y", "int"),
         ]),

--- a/swift/codegen/test/test_schema.py
+++ b/swift/codegen/test/test_schema.py
@@ -217,32 +217,81 @@ A:
     ]
 
 
-def test_property_with_explicit_type_and_tags(load):
+def test_property_with_explicit_type_and_pragmas(load):
     ret = load("""
 A:
     x: 
       type: string*
-      _tags: [foo, bar]
+      _pragma: [foo, bar]
 """)
     assert ret.classes == [
         schema.Class(root_name, derived={'A'}),
         schema.Class('A', bases={root_name}, properties=[
-            schema.RepeatedProperty('x', 'string', tags=["foo", "bar"]),
+            schema.RepeatedProperty('x', 'string', pragmas=["foo", "bar"]),
         ]),
     ]
 
 
-def test_class_with_tags(load):
+def test_property_with_explicit_type_and_one_pragma(load):
+    ret = load("""
+A:
+    x: 
+      type: string*
+      _pragma: foo
+""")
+    assert ret.classes == [
+        schema.Class(root_name, derived={'A'}),
+        schema.Class('A', bases={root_name}, properties=[
+            schema.RepeatedProperty('x', 'string', pragmas=["foo"]),
+        ]),
+    ]
+
+
+def test_property_with_explicit_type_and_unknown_metadata(load):
+    with pytest.raises(schema.Error):
+        load("""
+A:
+    x: 
+      type: string*
+      _what_is_this: [foo, bar]
+""")
+
+
+def test_property_with_dict_without_explicit_type(load):
+    with pytest.raises(schema.Error):
+        load("""
+A:
+    x: 
+      typo: string*
+""")
+
+
+
+def test_class_with_pragmas(load):
     ret = load("""
 A:
     x: string*
-    _tags: [foo, bar]
+    _pragma: [foo, bar]
 """)
     assert ret.classes == [
         schema.Class(root_name, derived={'A'}),
         schema.Class('A', bases={root_name}, properties=[
             schema.RepeatedProperty('x', 'string'),
-        ], tags=["foo", "bar"]),
+        ], pragmas=["foo", "bar"]),
+    ]
+
+
+def test_class_with_one_pragma(load):
+    ret = load("""
+A:
+    x: string*
+    _pragma: foo
+""")
+    assert ret.classes == [
+        schema.Class(root_name, derived={'A'}),
+        schema.Class('A', bases={root_name}, properties=[
+            schema.RepeatedProperty('x', 'string'),
+        ], pragmas=["foo"]),
     ]
 
 


### PR DESCRIPTION
For the use the former tags are meant for, pragma is a more
meaningful name. It now also accepts both strings and lists of strings.