### PR TITLE
Swift: remove check for inout params in SSA gen

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/SsaImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/SsaImplSpecific.qll
@@ -32,7 +32,6 @@ predicate variableWrite(BasicBlock bb, int i, SourceVariable v, boolean certain)
   exists(CallExpr call, Argument arg |
     arg.getExpr().(InOutExpr).getSubExpr() = v.getAnAccess() and
     call.getAnArgument() = arg and
-    call.getStaticTarget().getParam(arg.getIndex()).isInout() and
     bb.getNode(i).getNode().asAstNode() = call and
     certain = false
   )


### PR DESCRIPTION
This check is unnecessary since it's enforced by the compiler, and is causing a bad join order.