### PR TITLE
Swift: fix stub revert prevention

### DIFF
--- a/swift/codegen/generators/qlgen.py
+++ b/swift/codegen/generators/qlgen.py
@@ -103,8 +103,8 @@ def _is_generated_stub(file, check_modification=False):
             # no lines
             return False
         if check_modification:
-            # one line already read, if we can read 4 other we are past the normal stub generation
-            line_threshold = 4
+            # one line already read, if we can read 5 other we are past the normal stub generation
+            line_threshold = 5
             if sum(1 for _ in zip(range(line_threshold), contents)) == line_threshold:
                 raise ModifiedStubMarkedAsGeneratedError(
                     f"{file.name} stub was modified but is still marked as generated")

--- a/swift/codegen/test/test_qlgen.py
+++ b/swift/codegen/test/test_qlgen.py
@@ -378,7 +378,7 @@ def test_non_empty_cleanup(opts, generate, renderer):
 
 def test_modified_stub_still_generated(qlgen_opts, renderer):
     stub = qlgen_opts.ql_stub_output / "A.qll"
-    write(stub, "// generated\n\n\n\nsomething\n")
+    write(stub, "// generated\nprivate import foo\n\nclass Bar extends BarBase {\n  int x() { none() }\n}\n")
     with pytest.raises(qlgen.ModifiedStubMarkedAsGeneratedError):
         run_generation(qlgen.generate, qlgen_opts, renderer)
 


### PR DESCRIPTION
It turns out the threshold of 5 lines for stub modification detection
was too strict: in case of a long class name the QL formatter will put
the closing brace of the empty class definition on a new line, leading
to codegen fail with an error thinking the stub was modified.

On the other side of things, also adding a base to a stub class was not
being detected as a modification.

Now the modification test is slightly smarter. If the stub still marked
as generated and

* has more than 6 lines, or
* the contents does not match a regexp aproximation of a plain stub

then codegen will abort. The test will still avoid reading the whole
contents of all the stubs.