### PR TITLE
Swift: yet another fix to stub revert prevention

### DIFF
--- a/swift/codegen/test/test_qlgen.py
+++ b/swift/codegen/test/test_qlgen.py
@@ -366,7 +366,7 @@ def test_non_empty_cleanup(opts, generate, renderer):
     test_c = opts.ql_test_output / "B.txt"
     write(ql_a)
     write(ql_b)
-    write(stub_a, "// generated\nfoo\n")
+    write(stub_a, "// generated\nprivate import bla\n\nclass foo extends bar {\n}\n")
     write(stub_b, "bar\n")
     write(test_a)
     write(test_b)
@@ -378,7 +378,15 @@ def test_non_empty_cleanup(opts, generate, renderer):
 
 def test_modified_stub_still_generated(qlgen_opts, renderer):
     stub = qlgen_opts.ql_stub_output / "A.qll"
-    write(stub, "// generated\nprivate import foo\n\nclass Bar extends BarBase {\n  int x() { none() }\n}\n")
+    write(stub, "// generated\nprivate import bla\n\nclass foo extends bar, baz {\n}\n")
+    with pytest.raises(qlgen.ModifiedStubMarkedAsGeneratedError):
+        run_generation(qlgen.generate, qlgen_opts, renderer)
+
+
+def test_extended_stub_still_generated(qlgen_opts, renderer):
+    stub = qlgen_opts.ql_stub_output / "A.qll"
+    write(stub,
+          "// generated\nprivate import bla\n\nclass foo extends bar {\n}\n\nclass other {\n  other() { none() }\n}")
     with pytest.raises(qlgen.ModifiedStubMarkedAsGeneratedError):
         run_generation(qlgen.generate, qlgen_opts, renderer)
 


### PR DESCRIPTION
Adding a base to a stub class was not being detected as a modification.

Now the modification test is slightly smarter. If the stub still marked
as generated and

* has more than 6 lines, or
* the contents does not match a regexp aproximation of a plain stub

then codegen will abort. The test will still avoid reading the whole
contents of all the stubs.