### PR TITLE
Swift: make `Element::resolve` final

### DIFF
--- a/swift/codegen/templates/ql_class.mustache
+++ b/swift/codegen/templates/ql_class.mustache
@@ -14,7 +14,7 @@ class {{name}}Base extends {{db_id}}{{#bases}}, {{.}}{{/bases}} {
 
   {{name}}Base getResolveStep() { none() } // overridden by subclasses
 
-  {{name}}Base resolve() {
+  final {{name}}Base resolve() {
     not exists(getResolveStep()) and result = this
     or
     result = getResolveStep().resolve()

--- a/swift/ql/lib/codeql/swift/generated/Element.qll
+++ b/swift/ql/lib/codeql/swift/generated/Element.qll
@@ -8,7 +8,7 @@ class ElementBase extends @element {
 
   ElementBase getResolveStep() { none() } // overridden by subclasses
 
-  ElementBase resolve() {
+  final ElementBase resolve() {
     not exists(getResolveStep()) and result = this
     or
     result = getResolveStep().resolve()


### PR DESCRIPTION
One should only override `getResolveStep` (or `convertsFrom` for `Expr`
classes), as otherwise the resolution/conversion becomes inconsitent.