### PR TITLE
Kotlin: note that raw inner classes nest within a raw outer

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -318,7 +318,7 @@ open class KotlinFileExtractor(
             // Extract the outer <-> inner class relationship, passing on any type arguments in excess to this class' parameters if this is an inner class.
             // For example, in `class Outer<T> { inner class Inner<S> { } }`, `Inner<Int, String>` nests within `Outer<Int>` and raw `Inner<>` within `Outer<>`,
             // but for a similar non-`inner` (in Java terms, static nested) class both `Inner<Int>` and `Inner<>` nest within the unbound type `Outer`.
-            val useBoundOuterType = (c.isInner || c.isLocal) && (c.parents.firstNotNullOfOrNull {
+            val useBoundOuterType = (c.isInner || c.isLocal) && (c.parents.map { // Would use `firstNotNullOfOrNull`, but this doesn't exist in Kotlin 1.4
                 when(it) {
                     is IrClass -> when {
                         it.typeParameters.isNotEmpty() -> true // Type parameters visible to this class -- extract an enclosing bound or raw type.
@@ -327,7 +327,7 @@ open class KotlinFileExtractor(
                     }
                     else -> null // Look through enclosing non-class entities (this may need to change)
                 }
-            } ?: false)
+            }.firstOrNull { it != null } ?: false)
 
             extractEnclosingClass(c, id, locId, if (useBoundOuterType) argsIncludingOuterClasses?.drop(c.typeParameters.size) else listOf())
 

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -6,6 +6,7 @@ import com.github.codeql.utils.versions.functionN
 import com.github.codeql.utils.versions.getIrStubFromDescriptor
 import com.semmle.extractor.java.OdasaOutput
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.parents
 import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.builtins.functions.BuiltInFunctionArity
 import org.jetbrains.kotlin.descriptors.*
@@ -314,8 +315,21 @@ open class KotlinFileExtractor(
             val locId = getLocation(c, argsIncludingOuterClasses)
             tw.writeHasLocation(id, locId)
 
-            // Extract the outer <-> inner class relationship, passing on any type arguments in excess to this class' parameters.
-            extractEnclosingClass(c, id, locId, argsIncludingOuterClasses?.drop(c.typeParameters.size) ?: listOf())
+            // Extract the outer <-> inner class relationship, passing on any type arguments in excess to this class' parameters if this is an inner class.
+            // For example, in `class Outer<T> { inner class Inner<S> { } }`, `Inner<Int, String>` nests within `Outer<Int>` and raw `Inner<>` within `Outer<>`,
+            // but for a similar non-`inner` (in Java terms, static nested) class both `Inner<Int>` and `Inner<>` nest within the unbound type `Outer`.
+            val useBoundOuterType = (c.isInner || c.isLocal) && (c.parents.firstNotNullOfOrNull {
+                when(it) {
+                    is IrClass -> when {
+                        it.typeParameters.isNotEmpty() -> true // Type parameters visible to this class -- extract an enclosing bound or raw type.
+                        !(it.isInner || it.isLocal) -> false // No type parameters seen yet, and this is a static class -- extract an enclosing unbound type.
+                        else -> null // No type parameters seen here, but may be visible enclosing type parameters; keep searching.
+                    }
+                    else -> null // Look through enclosing non-class entities (this may need to change)
+                }
+            } ?: false)
+
+            extractEnclosingClass(c, id, locId, if (useBoundOuterType) argsIncludingOuterClasses?.drop(c.typeParameters.size) else listOf())
 
             return id
         }
@@ -458,7 +472,8 @@ open class KotlinFileExtractor(
         }
     }
 
-    private fun extractEnclosingClass(innerDeclaration: IrDeclaration, innerId: Label<out DbClassorinterface>, innerLocId: Label<DbLocation>, parentClassTypeArguments: List<IrTypeArgument>) {
+    // If `parentClassTypeArguments` is null, the parent class is a raw type.
+    private fun extractEnclosingClass(innerDeclaration: IrDeclaration, innerId: Label<out DbClassorinterface>, innerLocId: Label<DbLocation>, parentClassTypeArguments: List<IrTypeArgument>?) {
         with("enclosing class", innerDeclaration) {
             var parent: IrDeclarationParent? = innerDeclaration.parent
             while (parent != null) {

--- a/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/JavaUser.java
+++ b/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/JavaUser.java
@@ -21,6 +21,15 @@ public class JavaUser {
     String result4 = d.identity("goodbye");
     Short result5 = e.returnSixth(1, "hello", 1.0f, 1.0, 1L, (short)1);
 
+    OuterGeneric<String>.InnerNotGeneric innerGetterTest = (new OuterGeneric<String>()).getInnerNotGeneric();
+    OuterNotGeneric.InnerGeneric<String> innerGetterTest2 = (new OuterNotGeneric()).getInnerGeneric();
+
+    TypeParamVisibility<String> tpv = new TypeParamVisibility<String>();
+    TypeParamVisibility<String>.VisibleBecauseInner<String> visibleBecauseInner = tpv.getVisibleBecauseInner();
+    TypeParamVisibility<String>.VisibleBecauseInnerIndirectContainer.VisibleBecauseInnerIndirect<String> visibleBecauseInnerIndirect = tpv.getVisibleBecauseInnerIndirect();
+    TypeParamVisibility.NotVisibleBecauseStatic<String> notVisibleBecauseStatic = tpv.getNotVisibleBecauseStatic();
+    TypeParamVisibility.NotVisibleBecauseStaticIndirectContainer.NotVisibleBecauseStaticIndirect<String> notVisibleBecauseStaticIndirect = tpv.getNotVisibleBecauseStaticIndirect();
+
   }
 
 }

--- a/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/KotlinUser.kt
+++ b/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/KotlinUser.kt
@@ -22,6 +22,15 @@ class User {
     val result4 = d.identity("goodbye")
     val result5 = e.returnSixth(1, "hello", 1.0f, 1.0, 1L, 1.toShort())
 
+    val innerGetterTest = OuterGeneric<String>().getInnerNotGeneric()
+    val innerGetterTest2 = OuterNotGeneric().getInnerGeneric()
+
+    val tpv = TypeParamVisibility<String>()
+    val visibleBecauseInner = tpv.getVisibleBecauseInner();
+    val visibleBecauseInnerIndirect = tpv.getVisibleBecauseInnerIndirect()
+    val notVisibleBecauseStatic = tpv.getNotVisibleBecauseStatic()
+    val notVisibleBecauseStaticIndirect = tpv.getNotVisibleBecauseStaticIndirect()
+
   }
 
 }

--- a/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/libsrc/extlib/OuterGeneric.java
+++ b/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/libsrc/extlib/OuterGeneric.java
@@ -8,6 +8,8 @@ public class OuterGeneric<T> {
 
   }
 
+  public InnerNotGeneric getInnerNotGeneric() { return null; }
+
   public class InnerGeneric<S> {
 
     public <R> InnerGeneric(R r) { }

--- a/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/libsrc/extlib/OuterNotGeneric.java
+++ b/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/libsrc/extlib/OuterNotGeneric.java
@@ -8,4 +8,10 @@ public class OuterNotGeneric {
 
   }
 
+  public InnerGeneric<String> getInnerGeneric() {
+
+    return new InnerGeneric<String>();
+
+  }
+
 }

--- a/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/libsrc/extlib/TypeParamVisibility.java
+++ b/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/libsrc/extlib/TypeParamVisibility.java
@@ -1,0 +1,29 @@
+package extlib;
+
+public class TypeParamVisibility<T> {
+
+  public class VisibleBecauseInner<S> { }
+
+  public class VisibleBecauseInnerIndirectContainer {
+
+    public class VisibleBecauseInnerIndirect<S> { }
+
+  }
+
+  public static class NotVisibleBecauseStatic<S> { }
+
+  public static class NotVisibleBecauseStaticIndirectContainer {
+
+    public class NotVisibleBecauseStaticIndirect<S> { }
+
+  }
+
+  public VisibleBecauseInner<String> getVisibleBecauseInner() { return new VisibleBecauseInner<String>(); }
+
+  public VisibleBecauseInnerIndirectContainer.VisibleBecauseInnerIndirect<String> getVisibleBecauseInnerIndirect() { return (new VisibleBecauseInnerIndirectContainer()).new VisibleBecauseInnerIndirect<String>(); }
+
+  public NotVisibleBecauseStatic<String> getNotVisibleBecauseStatic() { return new NotVisibleBecauseStatic(); }
+
+  public NotVisibleBecauseStaticIndirectContainer.NotVisibleBecauseStaticIndirect<String> getNotVisibleBecauseStaticIndirect() { return (new NotVisibleBecauseStaticIndirectContainer()).new NotVisibleBecauseStaticIndirect<String>(); }
+
+}

--- a/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/test.expected
+++ b/java/ql/integration-tests/posix-only/kotlin/nested_generic_types/test.expected
@@ -59,6 +59,15 @@ callArgs
 | JavaUser.java:22:21:22:70 | returnSixth(...) | JavaUser.java:22:53:22:55 | 1.0 | 3 |
 | JavaUser.java:22:21:22:70 | returnSixth(...) | JavaUser.java:22:58:22:59 | 1L | 4 |
 | JavaUser.java:22:21:22:70 | returnSixth(...) | JavaUser.java:22:62:22:69 | (...)... | 5 |
+| JavaUser.java:24:60:24:108 | getInnerNotGeneric(...) | JavaUser.java:24:61:24:86 | new OuterGeneric<String>(...) | -1 |
+| JavaUser.java:24:61:24:86 | new OuterGeneric<String>(...) | JavaUser.java:24:65:24:84 | OuterGeneric<String> | -3 |
+| JavaUser.java:25:61:25:101 | getInnerGeneric(...) | JavaUser.java:25:62:25:82 | new OuterNotGeneric(...) | -1 |
+| JavaUser.java:25:62:25:82 | new OuterNotGeneric(...) | JavaUser.java:25:66:25:80 | OuterNotGeneric | -3 |
+| JavaUser.java:27:39:27:71 | new TypeParamVisibility<String>(...) | JavaUser.java:27:43:27:69 | TypeParamVisibility<String> | -3 |
+| JavaUser.java:28:83:28:110 | getVisibleBecauseInner(...) | JavaUser.java:28:83:28:85 | tpv | -1 |
+| JavaUser.java:29:136:29:171 | getVisibleBecauseInnerIndirect(...) | JavaUser.java:29:136:29:138 | tpv | -1 |
+| JavaUser.java:30:83:30:114 | getNotVisibleBecauseStatic(...) | JavaUser.java:30:83:30:85 | tpv | -1 |
+| JavaUser.java:31:140:31:179 | getNotVisibleBecauseStaticIndirect(...) | JavaUser.java:31:140:31:142 | tpv | -1 |
 | KotlinUser.kt:9:13:9:31 | new OuterGeneric<Integer>(...) | KotlinUser.kt:9:13:9:31 | OuterGeneric<Integer> | -3 |
 | KotlinUser.kt:9:33:9:63 | new InnerGeneric<String>(...) | KotlinUser.kt:9:13:9:31 | new OuterGeneric<Integer>(...) | -2 |
 | KotlinUser.kt:9:33:9:63 | new InnerGeneric<String>(...) | KotlinUser.kt:9:33:9:63 | InnerGeneric<String> | -3 |
@@ -116,6 +125,15 @@ callArgs
 | KotlinUser.kt:23:21:23:71 | returnSixth(...) | KotlinUser.kt:23:56:23:57 | 1 | 4 |
 | KotlinUser.kt:23:21:23:71 | returnSixth(...) | KotlinUser.kt:23:62:23:70 | shortValue(...) | 5 |
 | KotlinUser.kt:23:62:23:70 | shortValue(...) | KotlinUser.kt:23:60:23:60 | 1 | -1 |
+| KotlinUser.kt:25:27:25:48 | new OuterGeneric<String>(...) | KotlinUser.kt:25:27:25:48 | OuterGeneric<String> | -3 |
+| KotlinUser.kt:25:50:25:69 | getInnerNotGeneric(...) | KotlinUser.kt:25:27:25:48 | new OuterGeneric<String>(...) | -1 |
+| KotlinUser.kt:26:28:26:44 | new OuterNotGeneric(...) | KotlinUser.kt:26:28:26:44 | OuterNotGeneric | -3 |
+| KotlinUser.kt:26:46:26:62 | getInnerGeneric(...) | KotlinUser.kt:26:28:26:44 | new OuterNotGeneric(...) | -1 |
+| KotlinUser.kt:28:15:28:43 | new TypeParamVisibility<String>(...) | KotlinUser.kt:28:15:28:43 | TypeParamVisibility<String> | -3 |
+| KotlinUser.kt:29:35:29:58 | getVisibleBecauseInner(...) | KotlinUser.kt:29:31:29:33 | tpv | -1 |
+| KotlinUser.kt:30:43:30:74 | getVisibleBecauseInnerIndirect(...) | KotlinUser.kt:30:39:30:41 | tpv | -1 |
+| KotlinUser.kt:31:39:31:66 | getNotVisibleBecauseStatic(...) | KotlinUser.kt:31:35:31:37 | tpv | -1 |
+| KotlinUser.kt:32:47:32:82 | getNotVisibleBecauseStaticIndirect(...) | KotlinUser.kt:32:43:32:45 | tpv | -1 |
 genericTypes
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | S |
 | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | InnerStaticGeneric | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | S |
@@ -127,6 +145,11 @@ genericTypes
 | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | A |
 | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | B |
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | S |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | NotVisibleBecauseStatic | extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | S |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | NotVisibleBecauseStaticIndirect | extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | S |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner | extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | S |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect | extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | S |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | T |
 paramTypes
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | S |
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | String |
@@ -149,6 +172,18 @@ paramTypes
 | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams<Integer,String> | String |
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | S |
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | String |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | NotVisibleBecauseStatic | S |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | NotVisibleBecauseStatic<String> | String |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | NotVisibleBecauseStaticIndirect | S |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | NotVisibleBecauseStaticIndirect<String> | String |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner | S |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner<String> | String |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner<String> | String |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect | S |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect<String> | String |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect<String> | String |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility | T |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | String |
 constructors
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | InnerGeneric(java.lang.Object) |
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | InnerGeneric(java.lang.Object,java.lang.Object) |
@@ -171,6 +206,14 @@ constructors
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | InnerGeneric() |
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | InnerGeneric<String>() |
 | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric | OuterNotGeneric() |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | NotVisibleBecauseStatic | NotVisibleBecauseStatic() |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | NotVisibleBecauseStaticIndirect | NotVisibleBecauseStaticIndirect() |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer.class:0:0:0:0 | NotVisibleBecauseStaticIndirectContainer | NotVisibleBecauseStaticIndirectContainer() |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner | VisibleBecauseInner() |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect | VisibleBecauseInnerIndirect() |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer.class:0:0:0:0 | VisibleBecauseInnerIndirectContainer | VisibleBecauseInnerIndirectContainer() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility | TypeParamVisibility() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | TypeParamVisibility<String>() |
 methods
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | returnsecond | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | returnsecond(java.lang.Object,java.lang.Object) |
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | returnsecond | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | returnsecond(java.lang.Object,java.lang.Object,java.lang.Object) |
@@ -181,14 +224,27 @@ methods
 | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | identity | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> | identity(java.lang.String) |
 | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | identity | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | InnerStaticGeneric | identity(java.lang.Object) |
 | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | identity | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | InnerStaticGeneric<String> | identity(java.lang.String) |
+| extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | getInnerNotGeneric | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric | getInnerNotGeneric() |
+| extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | getInnerNotGeneric | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> | getInnerNotGeneric() |
+| extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | getInnerNotGeneric | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> | getInnerNotGeneric() |
 | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | returnSixth | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | InnerManyParams | returnSixth(java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object) |
 | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | returnSixth | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | InnerManyParams<Long,Short> | returnSixth(java.lang.Integer,java.lang.String,java.lang.Float,java.lang.Double,java.lang.Long,java.lang.Short) |
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | identity | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | identity(java.lang.Object) |
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | identity | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | identity(java.lang.String) |
+| extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | getInnerGeneric | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric | getInnerGeneric() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getNotVisibleBecauseStatic | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility | getNotVisibleBecauseStatic() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getNotVisibleBecauseStatic | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | getNotVisibleBecauseStatic() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getNotVisibleBecauseStaticIndirect | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility | getNotVisibleBecauseStaticIndirect() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getNotVisibleBecauseStaticIndirect | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | getNotVisibleBecauseStaticIndirect() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getVisibleBecauseInner | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility | getVisibleBecauseInner() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getVisibleBecauseInner | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | getVisibleBecauseInner() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getVisibleBecauseInnerIndirect | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility | getVisibleBecauseInnerIndirect() |
+| extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getVisibleBecauseInnerIndirect | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | getVisibleBecauseInnerIndirect() |
 nestedTypes
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric |
 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> |
 | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric |
+| extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<> |
 | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> |
 | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> |
 | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | InnerStaticGeneric | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric |
@@ -198,7 +254,26 @@ nestedTypes
 | extlib.jar/extlib/OuterManyParams$MiddleManyParams.class:0:0:0:0 | MiddleManyParams | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams |
 | extlib.jar/extlib/OuterManyParams$MiddleManyParams.class:0:0:0:0 | MiddleManyParams<Float,Double> | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams<Integer,String> |
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric |
+| extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<> | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric |
 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | NotVisibleBecauseStatic | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | NotVisibleBecauseStatic<> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | NotVisibleBecauseStatic<String> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | NotVisibleBecauseStaticIndirect | extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer.class:0:0:0:0 | NotVisibleBecauseStaticIndirectContainer |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | NotVisibleBecauseStaticIndirect<> | extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer.class:0:0:0:0 | NotVisibleBecauseStaticIndirectContainer |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | NotVisibleBecauseStaticIndirect<String> | extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer.class:0:0:0:0 | NotVisibleBecauseStaticIndirectContainer |
+| extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer.class:0:0:0:0 | NotVisibleBecauseStaticIndirectContainer | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner<> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<> |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner<String> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner<String> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect | extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer.class:0:0:0:0 | VisibleBecauseInnerIndirectContainer |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect<> | extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer.class:0:0:0:0 | VisibleBecauseInnerIndirectContainer<> |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect<String> | extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer.class:0:0:0:0 | VisibleBecauseInnerIndirectContainer |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect<String> | extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer.class:0:0:0:0 | VisibleBecauseInnerIndirectContainer<> |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer.class:0:0:0:0 | VisibleBecauseInnerIndirectContainer | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer.class:0:0:0:0 | VisibleBecauseInnerIndirectContainer<> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<> |
+| extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer.class:0:0:0:0 | VisibleBecauseInnerIndirectContainer<> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> |
 javaKotlinCalleeAgreement
 | JavaUser.java:16:22:16:47 | returnsecond(...) | KotlinUser.kt:17:21:17:44 | returnsecond(...) | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | returnsecond |
 | JavaUser.java:17:23:17:53 | returnsecond(...) | KotlinUser.kt:18:22:18:50 | returnsecond(...) | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | returnsecond |
@@ -207,6 +282,12 @@ javaKotlinCalleeAgreement
 | JavaUser.java:20:22:20:40 | identity(...) | KotlinUser.kt:21:21:21:37 | identity(...) | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | identity |
 | JavaUser.java:21:22:21:42 | identity(...) | KotlinUser.kt:22:21:22:39 | identity(...) | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | identity |
 | JavaUser.java:22:21:22:70 | returnSixth(...) | KotlinUser.kt:23:21:23:71 | returnSixth(...) | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | returnSixth |
+| JavaUser.java:24:60:24:108 | getInnerNotGeneric(...) | KotlinUser.kt:25:50:25:69 | getInnerNotGeneric(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | getInnerNotGeneric |
+| JavaUser.java:25:61:25:101 | getInnerGeneric(...) | KotlinUser.kt:26:46:26:62 | getInnerGeneric(...) | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | getInnerGeneric |
+| JavaUser.java:28:83:28:110 | getVisibleBecauseInner(...) | KotlinUser.kt:29:35:29:58 | getVisibleBecauseInner(...) | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getVisibleBecauseInner |
+| JavaUser.java:29:136:29:171 | getVisibleBecauseInnerIndirect(...) | KotlinUser.kt:30:43:30:74 | getVisibleBecauseInnerIndirect(...) | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getVisibleBecauseInnerIndirect |
+| JavaUser.java:30:83:30:114 | getNotVisibleBecauseStatic(...) | KotlinUser.kt:31:39:31:66 | getNotVisibleBecauseStatic(...) | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getNotVisibleBecauseStatic |
+| JavaUser.java:31:140:31:179 | getNotVisibleBecauseStaticIndirect(...) | KotlinUser.kt:32:47:32:82 | getNotVisibleBecauseStaticIndirect(...) | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | getNotVisibleBecauseStaticIndirect |
 javaKotlinConstructorAgreement
 | JavaUser.java:7:52:7:110 | new InnerGeneric<String>(...) | KotlinUser.kt:9:33:9:63 | new InnerGeneric<String>(...) | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
 | JavaUser.java:7:53:7:79 | new OuterGeneric<Integer>(...) | KotlinUser.kt:9:13:9:31 | new OuterGeneric<Integer>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> |
@@ -224,12 +305,19 @@ javaKotlinConstructorAgreement
 | JavaUser.java:10:48:10:74 | new OuterGeneric<Integer>(...) | KotlinUser.kt:10:14:10:32 | new OuterGeneric<Integer>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> |
 | JavaUser.java:10:48:10:74 | new OuterGeneric<Integer>(...) | KotlinUser.kt:11:13:11:31 | new OuterGeneric<Integer>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> |
 | JavaUser.java:11:48:11:73 | new OuterGeneric<String>(...) | KotlinUser.kt:12:14:12:35 | new OuterGeneric<String>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> |
+| JavaUser.java:11:48:11:73 | new OuterGeneric<String>(...) | KotlinUser.kt:25:27:25:48 | new OuterGeneric<String>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> |
 | JavaUser.java:12:46:12:95 | new InnerGeneric<String>(...) | KotlinUser.kt:13:31:13:52 | new InnerGeneric<String>(...) | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
 | JavaUser.java:12:47:12:67 | new OuterNotGeneric(...) | KotlinUser.kt:13:13:13:29 | new OuterNotGeneric(...) | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric |
+| JavaUser.java:12:47:12:67 | new OuterNotGeneric(...) | KotlinUser.kt:26:28:26:44 | new OuterNotGeneric(...) | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric |
 | JavaUser.java:13:49:13:111 | new InnerStaticGeneric<String>(...) | KotlinUser.kt:14:26:14:63 | new InnerStaticGeneric<String>(...) | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | InnerStaticGeneric<String> |
 | JavaUser.java:14:103:14:248 | new InnerManyParams<Long,Short>(...) | KotlinUser.kt:15:69:15:100 | new InnerManyParams<Long,Short>(...) | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | InnerManyParams<Long,Short> |
 | JavaUser.java:14:104:14:200 | new MiddleManyParams<Float,Double>(...) | KotlinUser.kt:15:41:15:67 | new MiddleManyParams<Float,Double>(...) | extlib.jar/extlib/OuterManyParams$MiddleManyParams.class:0:0:0:0 | MiddleManyParams<Float,Double> |
 | JavaUser.java:14:105:14:152 | new OuterManyParams<Integer,String>(...) | KotlinUser.kt:15:13:15:39 | new OuterManyParams<Integer,String>(...) | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams<Integer,String> |
+| JavaUser.java:24:61:24:86 | new OuterGeneric<String>(...) | KotlinUser.kt:12:14:12:35 | new OuterGeneric<String>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> |
+| JavaUser.java:24:61:24:86 | new OuterGeneric<String>(...) | KotlinUser.kt:25:27:25:48 | new OuterGeneric<String>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> |
+| JavaUser.java:25:62:25:82 | new OuterNotGeneric(...) | KotlinUser.kt:13:13:13:29 | new OuterNotGeneric(...) | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric |
+| JavaUser.java:25:62:25:82 | new OuterNotGeneric(...) | KotlinUser.kt:26:28:26:44 | new OuterNotGeneric(...) | extlib.jar/extlib/OuterNotGeneric.class:0:0:0:0 | OuterNotGeneric |
+| JavaUser.java:27:39:27:71 | new TypeParamVisibility<String>(...) | KotlinUser.kt:28:15:28:43 | new TypeParamVisibility<String>(...) | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> |
 javaKotlinLocalTypeAgreement
 | JavaUser.java:7:5:7:111 | InnerGeneric<String> a | KotlinUser.kt:9:5:9:63 | InnerGeneric<String> a | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
 | JavaUser.java:7:5:7:111 | InnerGeneric<String> a | KotlinUser.kt:10:5:10:65 | InnerGeneric<String> a2 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
@@ -239,9 +327,20 @@ javaKotlinLocalTypeAgreement
 | JavaUser.java:9:5:9:139 | InnerGeneric<String> a3 | KotlinUser.kt:10:5:10:65 | InnerGeneric<String> a2 | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
 | JavaUser.java:10:5:10:98 | InnerNotGeneric<> b | KotlinUser.kt:11:5:11:49 | InnerNotGeneric<> b | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> |
 | JavaUser.java:11:5:11:97 | InnerNotGeneric<> b2 | KotlinUser.kt:12:5:12:53 | InnerNotGeneric<> b2 | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> |
+| JavaUser.java:11:5:11:97 | InnerNotGeneric<> b2 | KotlinUser.kt:25:5:25:69 | InnerNotGeneric<> innerGetterTest | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> |
 | JavaUser.java:12:5:12:96 | InnerGeneric<String> c | KotlinUser.kt:13:5:13:52 | InnerGeneric<String> c | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
+| JavaUser.java:12:5:12:96 | InnerGeneric<String> c | KotlinUser.kt:26:5:26:62 | InnerGeneric<String> innerGetterTest2 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
 | JavaUser.java:13:5:13:112 | InnerStaticGeneric<String> d | KotlinUser.kt:14:5:14:63 | InnerStaticGeneric<String> d | extlib.jar/extlib/OuterGeneric$InnerStaticGeneric.class:0:0:0:0 | InnerStaticGeneric<String> |
 | JavaUser.java:14:5:14:249 | InnerManyParams<Long,Short> e | KotlinUser.kt:15:5:15:100 | InnerManyParams<Long,Short> e | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | InnerManyParams<Long,Short> |
+| JavaUser.java:24:5:24:109 | InnerNotGeneric<> innerGetterTest | KotlinUser.kt:12:5:12:53 | InnerNotGeneric<> b2 | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> |
+| JavaUser.java:24:5:24:109 | InnerNotGeneric<> innerGetterTest | KotlinUser.kt:25:5:25:69 | InnerNotGeneric<> innerGetterTest | extlib.jar/extlib/OuterGeneric$InnerNotGeneric.class:0:0:0:0 | InnerNotGeneric<> |
+| JavaUser.java:25:5:25:102 | InnerGeneric<String> innerGetterTest2 | KotlinUser.kt:13:5:13:52 | InnerGeneric<String> c | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
+| JavaUser.java:25:5:25:102 | InnerGeneric<String> innerGetterTest2 | KotlinUser.kt:26:5:26:62 | InnerGeneric<String> innerGetterTest2 | extlib.jar/extlib/OuterNotGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> |
+| JavaUser.java:27:5:27:72 | TypeParamVisibility<String> tpv | KotlinUser.kt:28:5:28:43 | TypeParamVisibility<String> tpv | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> |
+| JavaUser.java:28:5:28:111 | VisibleBecauseInner<String> visibleBecauseInner | KotlinUser.kt:29:5:29:58 | VisibleBecauseInner<String> visibleBecauseInner | extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInner.class:0:0:0:0 | VisibleBecauseInner<String> |
+| JavaUser.java:29:5:29:172 | VisibleBecauseInnerIndirect<String> visibleBecauseInnerIndirect | KotlinUser.kt:30:5:30:74 | VisibleBecauseInnerIndirect<String> visibleBecauseInnerIndirect | extlib.jar/extlib/TypeParamVisibility$VisibleBecauseInnerIndirectContainer$VisibleBecauseInnerIndirect.class:0:0:0:0 | VisibleBecauseInnerIndirect<String> |
+| JavaUser.java:30:5:30:115 | NotVisibleBecauseStatic<String> notVisibleBecauseStatic | KotlinUser.kt:31:5:31:66 | NotVisibleBecauseStatic<String> notVisibleBecauseStatic | extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStatic.class:0:0:0:0 | NotVisibleBecauseStatic<String> |
+| JavaUser.java:31:5:31:180 | NotVisibleBecauseStaticIndirect<String> notVisibleBecauseStaticIndirect | KotlinUser.kt:32:5:32:82 | NotVisibleBecauseStaticIndirect<String> notVisibleBecauseStaticIndirect | extlib.jar/extlib/TypeParamVisibility$NotVisibleBecauseStaticIndirectContainer$NotVisibleBecauseStaticIndirect.class:0:0:0:0 | NotVisibleBecauseStaticIndirect<String> |
 #select
 | JavaUser.java:7:52:7:110 | new InnerGeneric<String>(...) | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | JavaUser.java:7:99:7:104 | String |
 | JavaUser.java:7:53:7:79 | new OuterGeneric<Integer>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> | JavaUser.java:7:70:7:76 | Integer |
@@ -259,6 +358,8 @@ javaKotlinLocalTypeAgreement
 | JavaUser.java:14:104:14:200 | new MiddleManyParams<Float,Double>(...) | extlib.jar/extlib/OuterManyParams$MiddleManyParams.class:0:0:0:0 | MiddleManyParams<Float,Double> | extlib.jar/extlib/OuterManyParams$MiddleManyParams.class:0:0:0:0 | MiddleManyParams<Float,Double> | JavaUser.java:14:183:14:188 | Double |
 | JavaUser.java:14:105:14:152 | new OuterManyParams<Integer,String>(...) | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams<Integer,String> | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams<Integer,String> | JavaUser.java:14:125:14:131 | Integer |
 | JavaUser.java:14:105:14:152 | new OuterManyParams<Integer,String>(...) | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams<Integer,String> | extlib.jar/extlib/OuterManyParams.class:0:0:0:0 | OuterManyParams<Integer,String> | JavaUser.java:14:134:14:139 | String |
+| JavaUser.java:24:61:24:86 | new OuterGeneric<String>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> | JavaUser.java:24:78:24:83 | String |
+| JavaUser.java:27:39:27:71 | new TypeParamVisibility<String>(...) | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | JavaUser.java:27:63:27:68 | String |
 | KotlinUser.kt:9:13:9:31 | new OuterGeneric<Integer>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> | KotlinUser.kt:9:13:9:31 | Integer |
 | KotlinUser.kt:9:33:9:63 | new InnerGeneric<String>(...) | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | extlib.jar/extlib/OuterGeneric$InnerGeneric.class:0:0:0:0 | InnerGeneric<String> | KotlinUser.kt:9:33:9:63 | String |
 | KotlinUser.kt:10:14:10:32 | new OuterGeneric<Integer>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<Integer> | KotlinUser.kt:10:14:10:32 | Integer |
@@ -273,3 +374,5 @@ javaKotlinLocalTypeAgreement
 | KotlinUser.kt:15:41:15:67 | new MiddleManyParams<Float,Double>(...) | extlib.jar/extlib/OuterManyParams$MiddleManyParams.class:0:0:0:0 | MiddleManyParams<Float,Double> | extlib.jar/extlib/OuterManyParams$MiddleManyParams.class:0:0:0:0 | MiddleManyParams<Float,Double> | KotlinUser.kt:15:41:15:67 | Float |
 | KotlinUser.kt:15:69:15:100 | new InnerManyParams<Long,Short>(...) | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | InnerManyParams<Long,Short> | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | InnerManyParams<Long,Short> | KotlinUser.kt:15:69:15:100 | Long |
 | KotlinUser.kt:15:69:15:100 | new InnerManyParams<Long,Short>(...) | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | InnerManyParams<Long,Short> | extlib.jar/extlib/OuterManyParams$MiddleManyParams$InnerManyParams.class:0:0:0:0 | InnerManyParams<Long,Short> | KotlinUser.kt:15:69:15:100 | Short |
+| KotlinUser.kt:25:27:25:48 | new OuterGeneric<String>(...) | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> | extlib.jar/extlib/OuterGeneric.class:0:0:0:0 | OuterGeneric<String> | KotlinUser.kt:25:27:25:48 | String |
+| KotlinUser.kt:28:15:28:43 | new TypeParamVisibility<String>(...) | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | extlib.jar/extlib/TypeParamVisibility.class:0:0:0:0 | TypeParamVisibility<String> | KotlinUser.kt:28:15:28:43 | String |


### PR DESCRIPTION
Previously the Java extractor did this but the Kotlin extractor nested them within an unbound outer type.