### PR TITLE
C#: Implement correct behavior for `dotnet build` tracing

### DIFF
--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -2,7 +2,54 @@ function RegisterExtractorPack(id)
     local extractor = GetPlatformToolsDirectory() ..
                           'Semmle.Extraction.CSharp.Driver'
     if OperatingSystem == 'windows' then extractor = extractor .. '.exe' end
+
+    function DotnetMatcherBuild(compilerName, compilerPath, compilerArguments,
+                                _languageId)
+        if compilerName ~= 'dotnet' and compilerName ~= 'dotnet.exe' then
+            return nil
+        end
+
+        -- The dotnet CLI has the following usage instructions:
+        -- dotnet [sdk-options] [command] [command-options] [arguments]
+        -- we are interested in dotnet build, which has the following usage instructions:
+        -- dotnet [options] build [<PROJECT | SOLUTION>...]
+        -- For now, parse the command line as follows:
+        -- Everything that starts with `-` (or `/`) will be ignored.
+        -- The first non-option argument is treated as the command.
+        -- if that's `build`, we append `/p:UseSharedCompilation=false` to the command line,
+        -- otherwise we do nothing.
+        local match = false
+        local argv = compilerArguments.argv
+        if OperatingSystem == 'windows' then
+            -- let's hope that this split matches the escaping rules `dotnet` applies to command line arguments
+            -- or, at least, that it is close enough
+            argv =
+                NativeArgumentsToArgv(compilerArguments.nativeArgumentPointer)
+        end
+        for i, arg in ipairs(argv) do
+            -- dotnet options start with either - or / (both are legal)
+            local firstCharacter = string.sub(arg, 1, 1)
+            if not (firstCharacter == '-') and not (firstCharacter == '/') then
+                Log(1, 'Dotnet subcommand detected: %s', arg)
+                if arg == 'build' then match = true end
+                break
+            end
+        end
+        if match then
+            return {
+                order = ORDER_REPLACE,
+                invocation = BuildExtractorInvocation(id, compilerPath,
+                                                      compilerPath,
+                                                      compilerArguments, nil, {
+                    '/p:UseSharedCompilation=false'
+                })
+            }
+        end
+        return nil
+    end
+
     local windowsMatchers = {
+        DotnetMatcherBuild,
         CreatePatternMatcher({'^dotnet%.exe$'}, MatchCompilerName, extractor, {
             prepend = {'--dotnetexec', '--cil'},
             order = ORDER_BEFORE
@@ -10,21 +57,20 @@ function RegisterExtractorPack(id)
         CreatePatternMatcher({'^csc.*%.exe$'}, MatchCompilerName, extractor, {
             prepend = {'--compiler', '"${compiler}"', '--cil'},
             order = ORDER_BEFORE
-
         }),
         CreatePatternMatcher({'^fakes.*%.exe$', 'moles.*%.exe'},
                              MatchCompilerName, nil, {trace = false})
     }
     local posixMatchers = {
-        CreatePatternMatcher({'^mcs%.exe$', '^csc%.exe$'}, MatchCompilerName,
-                             extractor, {
-            prepend = {'--compiler', '"${compiler}"', '--cil'},
-            order = ORDER_BEFORE
-
-        }),
+        DotnetMatcherBuild,
         CreatePatternMatcher({'^mono', '^dotnet$'}, MatchCompilerName,
                              extractor, {
             prepend = {'--dotnetexec', '--cil'},
+            order = ORDER_BEFORE
+        }),
+        CreatePatternMatcher({'^mcs%.exe$', '^csc%.exe$'}, MatchCompilerName,
+                             extractor, {
+            prepend = {'--compiler', '"${compiler}"', '--cil'},
             order = ORDER_BEFORE
         }), function(compilerName, compilerPath, compilerArguments, _languageId)
             if MatchCompilerName('^msbuild$', compilerName, compilerPath,
@@ -49,7 +95,6 @@ function RegisterExtractorPack(id)
     else
         return posixMatchers
     end
-
 end
 
 -- Return a list of minimum supported versions of the configuration file format


### PR DESCRIPTION
For proper C# tracing, `dotnet build` needs the parameter
`/p:UseSharedCompilation=false`. However, we can't pass that to the other
subcommands of `dotnet`, therefore we need to figure out which subcommand
of `dotnet` is being invoked.