### PR TITLE
Ruby: fix deprecation warning

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/Railties.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Railties.qll
@@ -24,7 +24,7 @@ module Railties {
           API::getTopLevelMember("Rails")
               .getMember("Generators")
               .getMember("Actions")
-              .getAUse()
+              .getAValueReachableFromSource()
               .asExpr()
               .getExpr()
       )


### PR DESCRIPTION
Fixes a semantic merge conflict between https://github.com/github/codeql/pull/9574 and https://github.com/github/codeql/pull/9364 causing a deprecation warning during compilation.