### PR TITLE
JS: always sniff file header of TypeScript files

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
@@ -217,9 +217,6 @@ public class FileExtractor {
       }
 
       private boolean hasBadFileHeader(File f, String lcExt, ExtractorConfig config) {
-        if (!".ts".equals(lcExt)) {
-          return false;
-        }
         try (FileInputStream fis = new FileInputStream(f)) {
           byte[] bytes = new byte[fileHeaderSize];
           int length = fis.read(bytes);

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -43,7 +43,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2022-06-08";
+  public static final String EXTRACTOR_VERSION = "2022-06-27";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 


### PR DESCRIPTION
The dist upgrade showed some MPEG Transport Stream (video) files with the extension `.mts` that were accidentally parsed as TypeScript. This is a problem we used to have with `.ts` files but the solution was not applied to `.mts` files when we started extracting those. We now apply this to all TypeScript files (including `.tsx` and `.cts`).