### PR TITLE
Python: Fix bad join in MRO

### DIFF
--- a/python/ql/lib/semmle/python/pointsto/MRO.qll
+++ b/python/ql/lib/semmle/python/pointsto/MRO.qll
@@ -344,12 +344,12 @@ private class ClassListList extends TClassListList {
     )
   }
 
-  private predicate legalMergeCandidate(ClassObjectInternal cls, ClassListList remaining) {
-    cls = this.getAHead() and remaining = this
+  private predicate legalMergeCandidate(ClassObjectInternal cls, ClassListList remainingList) {
+    cls = this.getAHead() and remainingList = this
     or
-    this.legalMergeCandidate(cls, ConsList(Empty(), remaining))
+    this.legalMergeCandidate(cls, ConsList(Empty(), remainingList))
     or
-    this.legalMergeCandidateNonEmpty(cls, remaining, Empty())
+    this.legalMergeCandidateNonEmpty(cls, remainingList, Empty())
   }
 
   pragma[noinline]

--- a/python/ql/lib/semmle/python/pointsto/MRO.qll
+++ b/python/ql/lib/semmle/python/pointsto/MRO.qll
@@ -419,7 +419,9 @@ private ClassListList list_of_linearization_of_bases_plus_bases(ClassObjectInter
   result = ConsList(bases(cls), EmptyList()) and n = Types::base_count(cls) and n > 1
   or
   exists(ClassListList partial |
-    partial = list_of_linearization_of_bases_plus_bases(cls, n + 1) and
+    partial =
+      list_of_linearization_of_bases_plus_bases(pragma[only_bind_into](cls),
+        pragma[only_bind_into](n + 1)) and
     result = ConsList(Mro::newStyleMro(Types::getBase(cls, n)), partial)
   )
 }


### PR DESCRIPTION
Fixes a bad join in `list_of_linearization_of_bases_plus_bases`.

Previvously, we joined together `ConsList` and `getBase` before filtering
these out using the recursive call. Now we do the recursion first.