### PR TITLE
C++: Support link targets for global and namespace variables

### DIFF
--- a/cpp/ql/lib/change-notes/2022-08-22-link-targets-for-variables.md
+++ b/cpp/ql/lib/change-notes/2022-08-22-link-targets-for-variables.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added support for getting the link targets of global and namespace variables.

--- a/cpp/ql/lib/semmle/code/cpp/Linkage.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Linkage.qll
@@ -41,6 +41,15 @@ class LinkTarget extends @link_target {
    * translation units which contributed to this link target.
    */
   Class getAClass() { link_parent(unresolveElement(result), this) }
+
+  /**
+   * Gets a global or namespace variable which was compiled into this
+   * link target, or had its declaration included by one of the translation
+   * units which contributed to this link target.
+   */
+  GlobalOrNamespaceVariable getAGlobalOrNamespaceVariable() {
+    link_parent(unresolveElement(result), this)
+  }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Variable.qll
@@ -471,6 +471,9 @@ class GlobalOrNamespaceVariable extends Variable, @globalvariable {
   override Type getType() { globalvariables(underlyingElement(this), unresolveElement(result), _) }
 
   override Element getEnclosingElement() { none() }
+
+  /** Gets a link target which compiled or referenced this global or namespace variable. */
+  LinkTarget getALinkTarget() { this = result.getAGlobalOrNamespaceVariable() }
 }
 
 /**


### PR DESCRIPTION
This can be safely merged before the internal PR. The new predicates will just be no-ops as long as the internal PR isn't merged. DCA ran on internal PR.