### PR TITLE
Swift: Add ArithmeticOperation.qll library

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
@@ -15,6 +15,9 @@ class ArithmeticOperation extends Expr {
     this instanceof UnaryArithmeticOperation
   }
 
+  /**
+   * Gets an operand of this arithmetic operation.
+   */
   Expr getAnOperand() {
     result = this.(BinaryArithmeticOperation).getAnOperand()
     or

--- a/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
@@ -31,7 +31,15 @@ class ArithmeticOperation extends Expr {
  * a + b
  * ```
  */
-abstract class BinaryArithmeticOperation extends BinaryExpr { }
+class BinaryArithmeticOperation extends BinaryExpr {
+  BinaryArithmeticOperation() {
+    this instanceof AddExpr or
+    this instanceof SubExpr or
+    this instanceof MulExpr or
+    this instanceof DivExpr or
+    this instanceof RemExpr
+  }
+}
 
 /**
  * An add expression.
@@ -39,7 +47,7 @@ abstract class BinaryArithmeticOperation extends BinaryExpr { }
  * a + b
  * ```
  */
-class AddExpr extends BinaryArithmeticOperation {
+class AddExpr extends BinaryExpr {
   AddExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "+(_:_:)" }
 }
 
@@ -49,7 +57,7 @@ class AddExpr extends BinaryArithmeticOperation {
  * a - b
  * ```
  */
-class SubExpr extends BinaryArithmeticOperation {
+class SubExpr extends BinaryExpr {
   SubExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "-(_:_:)" }
 }
 
@@ -59,7 +67,7 @@ class SubExpr extends BinaryArithmeticOperation {
  * a * b
  * ```
  */
-class MulExpr extends BinaryArithmeticOperation {
+class MulExpr extends BinaryExpr {
   MulExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "*(_:_:)" }
 }
 
@@ -69,7 +77,7 @@ class MulExpr extends BinaryArithmeticOperation {
  * a / b
  * ```
  */
-class DivExpr extends BinaryArithmeticOperation {
+class DivExpr extends BinaryExpr {
   DivExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "/(_:_:)" }
 }
 
@@ -79,7 +87,7 @@ class DivExpr extends BinaryArithmeticOperation {
  * a % b
  * ```
  */
-class RemExpr extends BinaryArithmeticOperation {
+class RemExpr extends BinaryExpr {
   RemExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "%(_:_:)" }
 }
 
@@ -89,7 +97,9 @@ class RemExpr extends BinaryArithmeticOperation {
  * -a
  * ```
  */
-abstract class UnaryArithmeticOperation extends PrefixUnaryExpr { }
+class UnaryArithmeticOperation extends PrefixUnaryExpr {
+  UnaryArithmeticOperation() { this instanceof UnaryMinusExpr }
+}
 
 /**
  * A unary minus expression.
@@ -97,6 +107,6 @@ abstract class UnaryArithmeticOperation extends PrefixUnaryExpr { }
  * -a
  * ```
  */
-class UnaryMinusExpr extends UnaryArithmeticOperation {
+class UnaryMinusExpr extends PrefixUnaryExpr {
   UnaryMinusExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "-(_:)" }
 }

--- a/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
@@ -1,0 +1,99 @@
+private import codeql.swift.elements.expr.Expr
+private import codeql.swift.elements.expr.BinaryExpr
+private import codeql.swift.elements.expr.PrefixUnaryExpr
+private import codeql.swift.elements.expr.DotSyntaxCallExpr
+
+/**
+ * An arithmetic operation, such as:
+ * ```
+ * a + b
+ * ```
+ */
+class ArithmeticOperation extends Expr {
+  ArithmeticOperation() {
+    this instanceof BinaryArithmeticOperation or
+    this instanceof UnaryArithmeticOperation
+  }
+
+  Expr getAnOperand() {
+    result = this.(BinaryArithmeticOperation).getAnOperand()
+    or
+    result = this.(UnaryArithmeticOperation).getOperand()
+  }
+}
+
+/**
+ * A binary arithmetic operation, such as:
+ * ```
+ * a + b
+ * ```
+ */
+abstract class BinaryArithmeticOperation extends BinaryExpr { }
+
+/**
+ * An add expression.
+ * ```
+ * a + b
+ * ```
+ */
+class AddExpr extends BinaryArithmeticOperation {
+  AddExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "+(_:_:)" }
+}
+
+/**
+ * A subtract expression.
+ * ```
+ * a - b
+ * ```
+ */
+class SubExpr extends BinaryArithmeticOperation {
+  SubExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "-(_:_:)" }
+}
+
+/**
+ * A multiply expression.
+ * ```
+ * a * b
+ * ```
+ */
+class MulExpr extends BinaryArithmeticOperation {
+  MulExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "*(_:_:)" }
+}
+
+/**
+ * A divide expression.
+ * ```
+ * a / b
+ * ```
+ */
+class DivExpr extends BinaryArithmeticOperation {
+  DivExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "/(_:_:)" }
+}
+
+/**
+ * A remainder expression.
+ * ```
+ * a % b
+ * ```
+ */
+class RemExpr extends BinaryArithmeticOperation {
+  RemExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "%(_:_:)" }
+}
+
+/**
+ * A unary arithmetic operation, such as:
+ * ```
+ * -a
+ * ```
+ */
+abstract class UnaryArithmeticOperation extends PrefixUnaryExpr { }
+
+/**
+ * A unary minus expression.
+ * ```
+ * -a
+ * ```
+ */
+class UnaryMinusExpr extends UnaryArithmeticOperation {
+  UnaryMinusExpr() { this.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = "-(_:)" }
+}

--- a/swift/ql/lib/codeql/swift/elements/expr/LogicalOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/LogicalOperation.qll
@@ -6,31 +6,19 @@ private import codeql.swift.elements.expr.DeclRefExpr
 private import codeql.swift.elements.decl.ConcreteFuncDecl
 
 private predicate unaryHasName(PrefixUnaryExpr e, string name) {
-  e.getFunction()
-      .(DotSyntaxCallExpr)
-      .getFunction()
-      .(DeclRefExpr)
-      .getDecl()
-      .(ConcreteFuncDecl)
-      .getName() = name
+  e.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = name
 }
 
 private predicate binaryHasName(BinaryExpr e, string name) {
-  e.getFunction()
-      .(DotSyntaxCallExpr)
-      .getFunction()
-      .(DeclRefExpr)
-      .getDecl()
-      .(ConcreteFuncDecl)
-      .getName() = name
+  e.getFunction().(DotSyntaxCallExpr).getStaticTarget().getName() = name
 }
 
 class LogicalAndExpr extends BinaryExpr {
-  LogicalAndExpr() { binaryHasName(this, "&&") }
+  LogicalAndExpr() { binaryHasName(this, "&&(_:_:)") }
 }
 
 class LogicalOrExpr extends BinaryExpr {
-  LogicalOrExpr() { binaryHasName(this, "||") }
+  LogicalOrExpr() { binaryHasName(this, "||(_:_:)") }
 }
 
 class BinaryLogicalOperation extends BinaryExpr {
@@ -41,7 +29,7 @@ class BinaryLogicalOperation extends BinaryExpr {
 }
 
 class NotExpr extends PrefixUnaryExpr {
-  NotExpr() { unaryHasName(this, "!") }
+  NotExpr() { unaryHasName(this, "!(_:)") }
 }
 
 class UnaryLogicalOperation extends PrefixUnaryExpr {

--- a/swift/ql/lib/swift.qll
+++ b/swift/ql/lib/swift.qll
@@ -1,5 +1,6 @@
 /** Top-level import for the Swift language pack */
 
 import codeql.swift.elements
+import codeql.swift.elements.expr.ArithmeticOperation
 import codeql.swift.elements.expr.LogicalOperation
 import codeql.swift.elements.decl.MethodDecl

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -1670,11 +1670,17 @@ cfg.swift:
 #-----|  -> 2
 
 #  185| ... call to <=(_:_:) ...
-#-----|  -> { ... }
+#-----| false -> [false] ... call to &&(_:_:) ...
+#-----| true -> { ... }
 
 #  185| ... call to &&(_:_:) ...
 #-----| exception -> exit m1(x:) (normal)
-#-----|  -> { ... }
+#-----| false -> [false] ... call to &&(_:_:) ...
+#-----| true -> { ... }
+
+#  185| [false] ... call to &&(_:_:) ...
+#-----| exception -> exit m1(x:) (normal)
+#-----| false -> [false] ... call to &&(_:_:) ...
 
 #  185| ... call to &&(_:_:) ...
 #-----| exception -> exit m1(x:) (normal)
@@ -1682,7 +1688,11 @@ cfg.swift:
 #-----| false -> print(_:separator:terminator:)
 
 #  185| StmtCondition
-#-----|  -> &&(_:_:)
+#-----|  -> <=(_:_:)
+
+#  185| [false] ... call to &&(_:_:) ...
+#-----| exception -> exit m1(x:) (normal)
+#-----| false -> print(_:separator:terminator:)
 
 #  185| <=(_:_:)
 #-----|  -> Int.Type
@@ -1696,29 +1706,59 @@ cfg.swift:
 #  185| 2
 #-----|  -> ... call to <=(_:_:) ...
 
-#  185| &&(_:_:)
-#-----|  -> Bool.Type
+#  185| x
+#-----|  -> 0
 
-#  185| Bool.Type
-#-----|  -> call to &&(_:_:)
+#  185| ... call to >(_:_:) ...
+#-----|  -> return ...
 
-#  185| call to &&(_:_:)
-#-----|  -> <=(_:_:)
-
-#  185| { ... }
+#  185| return ...
 #-----|  -> ... call to &&(_:_:) ...
 
-#  185| &&(_:_:)
-#-----|  -> Bool.Type
+#  185| { ... }
+#-----|  -> >(_:_:)
 
-#  185| Bool.Type
-#-----|  -> call to &&(_:_:)
+#  185| >(_:_:)
+#-----|  -> Int.Type
 
-#  185| call to &&(_:_:)
-#-----|  -> &&(_:_:)
+#  185| Int.Type
+#-----|  -> call to >(_:_:)
+
+#  185| call to >(_:_:)
+#-----|  -> x
+
+#  185| 0
+#-----|  -> ... call to >(_:_:) ...
+
+#  185| call to ...
+#-----|  -> return ...
+
+#  185| return ...
+#-----|  -> ... call to &&(_:_:) ...
 
 #  185| { ... }
-#-----|  -> ... call to &&(_:_:) ...
+#-----|  -> ==(_:_:)
+
+#  185| (...)
+#-----|  -> call to ...
+
+#  185| x
+#-----|  -> 5
+
+#  185| ... call to ==(_:_:) ...
+#-----|  -> (...)
+
+#  185| ==(_:_:)
+#-----|  -> Int.Type
+
+#  185| Int.Type
+#-----|  -> call to ==(_:_:)
+
+#  185| call to ==(_:_:)
+#-----|  -> x
+
+#  185| 5
+#-----|  -> ... call to ==(_:_:) ...
 
 #  186| print(_:separator:terminator:)
 #-----|  -> x is 1
@@ -2058,48 +2098,14 @@ cfg.swift:
 #  224| if ... then { ... }
 #-----|  -> StmtCondition
 
-#  224| !(_:)
-#-----|  -> Bool.Type
-
-#  224| Bool.Type
-#-----|  -> call to !(_:)
-
-#  224| call to !(_:)
+#  224| StmtCondition
 #-----|  -> true
 
-#  224| StmtCondition
-#-----|  -> !(_:)
-
-#  224| call to ...
+#  224| [false] call to ...
 #-----| false -> exit constant_condition() (normal)
-#-----| true -> print(_:separator:terminator:)
 
 #  224| true
-#-----|  -> call to ...
-
-#  225| print(_:separator:terminator:)
-#-----|  -> Impossible
-
-#  225| call to print(_:separator:terminator:)
-#-----|  -> exit constant_condition() (normal)
-
-#  225| default separator
-#-----|  -> default terminator
-
-#  225| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  225| (Any) ...
-#-----|  -> [...]
-
-#  225| Impossible
-#-----|  -> (Any) ...
-
-#  225| [...]
-#-----|  -> default separator
-
-#  225| [...]
-#-----|  -> [...]
+#-----| true -> [false] call to ...
 
 #  229| empty_else(b:)
 #-----|  -> b
@@ -2197,7 +2203,7 @@ cfg.swift:
 #-----|  -> StmtCondition
 
 #  238| StmtCondition
-#-----|  -> ||(_:_:)
+#-----|  -> b1
 
 #  238| [false] (...)
 #-----| false -> exit disjunct(b1:b2:) (normal)
@@ -2206,24 +2212,26 @@ cfg.swift:
 #-----| true -> print(_:separator:terminator:)
 
 #  238| b1
-#-----|  -> { ... }
+#-----| true -> [true] ... call to ||(_:_:) ...
+#-----| false -> { ... }
 
 #  238| ... call to ||(_:_:) ...
 #-----| exception -> exit disjunct(b1:b2:) (normal)
 #-----| false -> [false] (...)
 #-----| true -> [true] (...)
 
-#  238| Bool.Type
-#-----|  -> call to ||(_:_:)
+#  238| [true] ... call to ||(_:_:) ...
+#-----| exception -> exit disjunct(b1:b2:) (normal)
+#-----| true -> [true] (...)
 
-#  238| call to ||(_:_:)
-#-----|  -> b1
+#  238| b2
+#-----|  -> return ...
 
-#  238| ||(_:_:)
-#-----|  -> Bool.Type
+#  238| return ...
+#-----|  -> ... call to ||(_:_:) ...
 
 #  238| { ... }
-#-----|  -> ... call to ||(_:_:) ...
+#-----|  -> b2
 
 #  239| print(_:separator:terminator:)
 #-----|  -> b1 or b2

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
@@ -1,0 +1,6 @@
+| arithmeticoperation.swift:6:6:6:10 | ... call to +(_:_:) ... | AddExpr, BinaryArithmeticOperation |
+| arithmeticoperation.swift:7:6:7:10 | ... call to -(_:_:) ... | BinaryArithmeticOperation, SubExpr |
+| arithmeticoperation.swift:8:6:8:10 | ... call to *(_:_:) ... | BinaryArithmeticOperation, MulExpr |
+| arithmeticoperation.swift:9:6:9:10 | ... call to /(_:_:) ... | BinaryArithmeticOperation, DivExpr |
+| arithmeticoperation.swift:10:6:10:10 | ... call to %(_:_:) ... | BinaryArithmeticOperation, RemExpr |
+| arithmeticoperation.swift:11:6:11:7 | call to ... | UnaryArithmeticOperation, UnaryMinusExpr |

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.ql
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.ql
@@ -1,14 +1,21 @@
 import swift
 
 string describe(ArithmeticOperation e) {
-	(e instanceof BinaryArithmeticOperation and result = "BinaryArithmeticOperation") or
-	(e instanceof AddExpr and result = "AddExpr") or
-	(e instanceof SubExpr and result = "SubExpr") or
-	(e instanceof MulExpr and result = "MulExpr") or
-	(e instanceof DivExpr and result = "DivExpr") or
-	(e instanceof RemExpr and result = "RemExpr") or
-	(e instanceof UnaryArithmeticOperation and result = "UnaryArithmeticOperation") or
-	(e instanceof UnaryMinusExpr and result = "UnaryMinusExpr")
+  e instanceof BinaryArithmeticOperation and result = "BinaryArithmeticOperation"
+  or
+  e instanceof AddExpr and result = "AddExpr"
+  or
+  e instanceof SubExpr and result = "SubExpr"
+  or
+  e instanceof MulExpr and result = "MulExpr"
+  or
+  e instanceof DivExpr and result = "DivExpr"
+  or
+  e instanceof RemExpr and result = "RemExpr"
+  or
+  e instanceof UnaryArithmeticOperation and result = "UnaryArithmeticOperation"
+  or
+  e instanceof UnaryMinusExpr and result = "UnaryMinusExpr"
 }
 
 from ArithmeticOperation e

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.ql
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.ql
@@ -1,0 +1,15 @@
+import swift
+
+string describe(ArithmeticOperation e) {
+	(e instanceof BinaryArithmeticOperation and result = "BinaryArithmeticOperation") or
+	(e instanceof AddExpr and result = "AddExpr") or
+	(e instanceof SubExpr and result = "SubExpr") or
+	(e instanceof MulExpr and result = "MulExpr") or
+	(e instanceof DivExpr and result = "DivExpr") or
+	(e instanceof RemExpr and result = "RemExpr") or
+	(e instanceof UnaryArithmeticOperation and result = "UnaryArithmeticOperation") or
+	(e instanceof UnaryMinusExpr and result = "UnaryMinusExpr")
+}
+
+from ArithmeticOperation e
+select e, concat(describe(e), ", ")

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
@@ -1,0 +1,12 @@
+
+func test(c: Bool, x: Int, y: Int, z: Int) {
+	var v = 0
+
+	// arithmetic operations
+	v = x + y;
+	v = x - 1;
+	v = 2 * y;
+	v = 3 / 4;
+	v = x % y;
+	v = -x;
+}

--- a/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.expected
@@ -1,0 +1,6 @@
+| logicaloperation.swift:4:6:4:11 | ... call to &&(_:_:) ... | BinaryLogicalExpr, LogicalAndExpr |
+| logicaloperation.swift:5:6:5:11 | ... call to \|\|(_:_:) ... | BinaryLogicalExpr, LogicalOrExpr |
+| logicaloperation.swift:6:6:6:7 | call to ... | NotExpr, UnaryLogicalOperation |
+| logicaloperation.swift:7:6:7:21 | call to ... | NotExpr, UnaryLogicalOperation |
+| logicaloperation.swift:7:8:7:20 | ... call to \|\|(_:_:) ... | BinaryLogicalExpr, LogicalOrExpr |
+| logicaloperation.swift:7:9:7:14 | ... call to &&(_:_:) ... | BinaryLogicalExpr, LogicalAndExpr |

--- a/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.ql
+++ b/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.ql
@@ -1,11 +1,15 @@
 import swift
 
 string describe(LogicalOperation e) {
-	(e instanceof BinaryLogicalOperation and result = "BinaryLogicalExpr") or
-	(e instanceof LogicalAndExpr and result = "LogicalAndExpr") or
-	(e instanceof LogicalOrExpr and result = "LogicalOrExpr") or
-	(e instanceof UnaryLogicalOperation and result = "UnaryLogicalOperation") or
-	(e instanceof NotExpr and result = "NotExpr")
+  e instanceof BinaryLogicalOperation and result = "BinaryLogicalExpr"
+  or
+  e instanceof LogicalAndExpr and result = "LogicalAndExpr"
+  or
+  e instanceof LogicalOrExpr and result = "LogicalOrExpr"
+  or
+  e instanceof UnaryLogicalOperation and result = "UnaryLogicalOperation"
+  or
+  e instanceof NotExpr and result = "NotExpr"
 }
 
 from LogicalOperation e

--- a/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.ql
+++ b/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.ql
@@ -1,0 +1,12 @@
+import swift
+
+string describe(LogicalOperation e) {
+	(e instanceof BinaryLogicalOperation and result = "BinaryLogicalExpr") or
+	(e instanceof LogicalAndExpr and result = "LogicalAndExpr") or
+	(e instanceof LogicalOrExpr and result = "LogicalOrExpr") or
+	(e instanceof UnaryLogicalOperation and result = "UnaryLogicalOperation") or
+	(e instanceof NotExpr and result = "NotExpr")
+}
+
+from LogicalOperation e
+select e, concat(describe(e), ", ")

--- a/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.swift
@@ -1,0 +1,8 @@
+
+func test(a: Bool, b: Bool, c: Bool) {
+	// logical operations
+	if (a && b) {}
+	if (a || b) {}
+	if (!a) {}
+	if (!((a && b) || c)) {}
+}


### PR DESCRIPTION
Add an `ArithmeticOperation.qll` library, and make various related changes:
 - add tests for `ArithmeticOperation.qll` and `LogicalOperation.qll`.
 - fix `LogicalOperation.qll` to account for function call `getName` now including the argument pattern.
   - we'd have caught this sooner if there had been a test.
   - also simplified the QL in that library slightly.
 - change `ApplyExpr` to produce a slightly better `toString` in some cases.  I'd really like someone to review this change as I'm not sure how general what I've written is.

I'd also like to know if we're happy with the naming of `BinaryExpr`, `BinaryArithmeticOperation`, `AddExpr` etc, before this stuff becomes more established and difficult to change.