### PR TITLE
Swift: Add a Locatable.getFile() shortcut similar to the one in CPP.

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/Locatable.qll
+++ b/swift/ql/lib/codeql/swift/elements/Locatable.qll
@@ -1,4 +1,5 @@
 private import codeql.swift.generated.Locatable
+private import codeql.swift.elements.File
 
 class Locatable extends LocatableBase {
   pragma[nomagic]
@@ -7,4 +8,9 @@ class Locatable extends LocatableBase {
     or
     not exists(LocatableBase.super.getLocation()) and result instanceof UnknownLocation
   }
+
+  /**
+   * Gets the primary file where this element occurs.
+   */
+  File getFile() { result = getLocation().getFile() }
 }


### PR DESCRIPTION
In one version of a test I tried to use this and couldn't, because it didn't exist.  Its a nice shortcut to have.