### PR TITLE
Swift: Set 'swift/string-length-conflation' to precision `high`

### DIFF
--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity error
  * @security-severity 7.8
- * @precision TODO
+ * @precision high
  * @id swift/string-length-conflation
  * @tags security
  *       external/cwe/cwe-135

--- a/swift/ql/src/queries/placeholder.ql
+++ b/swift/ql/src/queries/placeholder.ql
@@ -1,9 +1,0 @@
-/**
- * @kind problem
- * @id swift/placeholder
- */
-
-import swift
-
-from IntegerLiteralExpr lit
-select lit, "A literal"


### PR DESCRIPTION
... and delete the placeholder query we had in the `queries` directory. The placeholder query was only necessary to have a non-empty query suite to run DCA on, and now that this query is on precision `high` we can create a proper Code Scanning suite.