### PR TITLE
Swift: add a test case showing module loading problem

### DIFF
--- a/swift/integration-tests/partial-modules/A/Package.swift
+++ b/swift/integration-tests/partial-modules/A/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "A",
+    products: [
+        .library(
+            name: "A",
+            targets: ["A"]),
+    ],
+    targets: [
+        .target(
+            name: "A",
+            dependencies: []),
+    ]
+)

--- a/swift/integration-tests/partial-modules/A/Sources/A/A.swift
+++ b/swift/integration-tests/partial-modules/A/Sources/A/A.swift
@@ -1,0 +1,5 @@
+public struct A {
+    public private(set) var text = Atext
+
+    public init() {}
+}

--- a/swift/integration-tests/partial-modules/A/Sources/A/Asup.swift
+++ b/swift/integration-tests/partial-modules/A/Sources/A/Asup.swift
@@ -1,0 +1,1 @@
+let Atext = "Hello, A"

--- a/swift/integration-tests/partial-modules/B/Package.swift
+++ b/swift/integration-tests/partial-modules/B/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "B",
+    products: [
+        .library(
+            name: "B",
+            targets: ["B"]),
+    ],
+    targets: [
+        .target(
+            name: "B",
+            dependencies: []),
+    ]
+)

--- a/swift/integration-tests/partial-modules/B/Sources/B/B.swift
+++ b/swift/integration-tests/partial-modules/B/Sources/B/B.swift
@@ -1,0 +1,5 @@
+public struct B {
+    public private(set) var text = Btext
+
+    public init() {}
+}

--- a/swift/integration-tests/partial-modules/B/Sources/B/Bsup.swift
+++ b/swift/integration-tests/partial-modules/B/Sources/B/Bsup.swift
@@ -1,0 +1,1 @@
+let Btext = "Hello, B"

--- a/swift/integration-tests/partial-modules/Package.swift
+++ b/swift/integration-tests/partial-modules/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "partial-modules",
+    products: [
+        .library(
+            name: "partial-modules",
+            targets: ["partial-modules"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(path: "./A"),
+        .package(path: "./B"),
+    ],
+    targets: [
+        .target(
+            name: "partial-modules",
+            dependencies: ["A", "B"]),
+    ]
+)

--- a/swift/integration-tests/partial-modules/Sources/partial-modules/partial_modules.swift
+++ b/swift/integration-tests/partial-modules/Sources/partial-modules/partial_modules.swift
@@ -1,0 +1,11 @@
+import A
+import B
+
+public struct partial_modules {
+    public init() {
+        let a = A()
+        let b = B()
+        print(a.text)
+        print(b.text)
+    }
+}

--- a/swift/integration-tests/partial-modules/Unknown.ql
+++ b/swift/integration-tests/partial-modules/Unknown.ql
@@ -1,0 +1,4 @@
+import swift
+
+from UnresolvedDotExpr e
+select e

--- a/swift/integration-tests/partial-modules/test.py
+++ b/swift/integration-tests/partial-modules/test.py
@@ -1,0 +1,7 @@
+from create_database_utils import *
+
+run_codeql_database_create([
+ 'env',
+ 'swift package clean',
+ 'swift build'
+], lang='swift', keep_trap=True)


### PR DESCRIPTION
Extractor fails to load separate modules that were built by another
version of an actual compiler.

The test currently fails, but I'd like to get it in separately from [the fix](https://github.com/github/codeql/pull/9702) in order to reduce the other PR diff.