### PR TITLE
Swift: Don't join on index in `swift/string-length-conflation`

### DIFF
--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -63,8 +63,8 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
       c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
       call.getFunction().(ApplyExpr).getStaticTarget() = f and
       f.getName() = methodName and
-      f.getParam(arg).getName() = paramName and
-      call.getArgument(arg).getExpr() = node.asExpr() and
+      f.getParam(pragma[only_bind_into](arg)).getName() = paramName and
+      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
       flowstate = "String" // `String` length flowing into `NSString`
     )
     or
@@ -74,8 +74,8 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
       funcName = "NSMakeRange(_:_:)" and
       paramName = ["loc", "len"] and
       call.getStaticTarget().getName() = funcName and
-      call.getStaticTarget().getParam(arg).getName() = paramName and
-      call.getArgument(arg).getExpr() = node.asExpr() and
+      call.getStaticTarget().getParam(pragma[only_bind_into](arg)).getName() = paramName and
+      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
       flowstate = "String" // `String` length flowing into `NSString`
     )
   }


### PR DESCRIPTION
Before:
```ql
Tuple counts for StringLengthConflation::StringLengthConflationConfiguration::isSink#dispred#f0820431#cpe#23#ff/2@a077435u after 44.9s:
    8437     ~4%      {4} r1 = SCAN ApplyExpr::ApplyExprBase::getArgument#dispred#f0820431#fff OUTPUT In.0, "String", In.1, In.2
    3936     ~2%      {4} r2 = JOIN r1 WITH call_exprs ON FIRST 1 OUTPUT Lhs.2, "String", Lhs.0, Lhs.3
    
    95328723 ~3%      {5} r3 = JOIN r2 WITH Callable::CallableBase::getParam#dispred#f0820431#fff_102#join_rhs ON FIRST 1 OUTPUT Lhs.2, Rhs.1, "String", Lhs.3, Rhs.2
    886      ~2%      {4} r4 = JOIN r3 WITH ApplyExpr::ApplyExpr::getStaticTarget#dispred#f0820431#ff ON FIRST 2 OUTPUT Lhs.4, "String", Lhs.0, Lhs.3
    886      ~0%      {6} r5 = JOIN r4 WITH var_decls ON FIRST 1 OUTPUT "String", Lhs.2, Lhs.3, Lhs.0, Rhs.1, Rhs.2
    4        ~0%      {6} r6 = SELECT r5 ON In.4 = "loc" OR In.4 = "len"
    4        ~0%      {3} r7 = SCAN r6 OUTPUT In.2, "String", In.1
    4        ~0%      {3} r8 = JOIN r7 WITH Argument::ArgumentBase::getExpr#dispred#f0820431#ff ON FIRST 1 OUTPUT Lhs.2, "String", Rhs.1
    4        ~0%      {4} r9 = JOIN r8 WITH ApplyExpr::ApplyExpr::getStaticTarget#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, "NSMakeRange(_:_:)", "String", Lhs.2
    4        ~0%      {2} r10 = JOIN r9 WITH abstract_function_decls ON FIRST 2 OUTPUT Lhs.3, "String"
    4        ~0%      {2} r11 = JOIN r10 WITH DataFlowPrivate::Cached::TExprNode#80e64a43#fff_12#join_rhs ON FIRST 1 OUTPUT Rhs.1 'node', "String"
    
    95328723 ~1%      {5} r12 = JOIN r2 WITH Callable::CallableBase::getParam#dispred#f0820431#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.2, "String", Lhs.2, Lhs.3, Rhs.1
    95328723 ~18%     {5} r13 = JOIN r12 WITH var_decls ON FIRST 1 OUTPUT Lhs.4, "String", Lhs.2, Lhs.3, Rhs.1
    81548018 ~1%      {6} r14 = JOIN r13 WITH abstract_function_decls ON FIRST 1 OUTPUT Lhs.0, "String", Lhs.2, Lhs.3, Lhs.4, Rhs.1
    60156522 ~5%      {7} r15 = JOIN r14 WITH IterableDeclContext::IterableDeclContextBase::getAMember#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, "String", Lhs.2, Lhs.3, Lhs.0, Lhs.4, Lhs.5
    3782380  ~0%      {7} r16 = JOIN r15 WITH class_decls ON FIRST 1 OUTPUT Lhs.0, "String", Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
    3782373  ~9%      {8} r17 = JOIN r16 WITH type_decls ON FIRST 1 OUTPUT "String", Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.0, Rhs.1
    0        ~0%      {8} r18 = SELECT r17 ON In.7 = "NSRange" AND In.5 = "init(location:length:)" AND (In.4 = "location" OR In.4 = "length") OR (In.7 = "NSString" OR In.7 = "NSMutableString") AND In.5 = "character(at:)" AND In.4 = "at" OR (In.7 = "NSString" OR In.7 = "NSMutableString") AND In.5 = "substring(from:)" AND In.4 = "from" OR (In.7 = "NSString" OR In.7 = "NSMutableString") AND In.5 = "substring(to:)" AND In.4 = "to" OR In.7 = "NSMutableString" AND In.5 = "insert(_:at:)" AND In.4 = "at"
    0        ~0%      {4} r19 = SCAN r18 OUTPUT In.1, "String", In.2, In.3
    0        ~0%      {4} r20 = JOIN r19 WITH ApplyExpr::ApplyExprBase::getFunction#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.3, "String", Lhs.2
    0        ~0%      {2} r21 = JOIN r20 WITH ApplyExpr::ApplyExpr::getStaticTarget#dispred#f0820431#ff ON FIRST 2 OUTPUT Lhs.3, "String"
    0        ~0%      {2} r22 = JOIN r21 WITH Argument::ArgumentBase::getExpr#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, "String"
    0        ~0%      {2} r23 = JOIN r22 WITH DataFlowPrivate::Cached::TExprNode#80e64a43#fff_12#join_rhs ON FIRST 1 OUTPUT Rhs.1 'node', "String"
    
    4        ~0%      {2} r24 = r11 UNION r23
                      return r24
```

After:
```ql
Tuple counts for StringLengthConflation::StringLengthConflationConfiguration::isSink#dispred#f0820431#cpe#23#ff/2@f6045agb after 17ms:
  49053 ~0%      {4} r1 = SCAN Callable::CallableBase::getParam#dispred#f0820431#fff OUTPUT In.2, "String", In.0, In.1
  49053 ~2%      {6} r2 = JOIN r1 WITH var_decls ON FIRST 1 OUTPUT "String", Lhs.2, Lhs.3, Lhs.0, Rhs.1, Rhs.2
  60    ~0%      {6} r3 = SELECT r2 ON In.4 = "loc" OR In.4 = "len"
  60    ~0%      {3} r4 = SCAN r3 OUTPUT In.1, "String", In.2
  8     ~0%      {3} r5 = JOIN r4 WITH ApplyExpr::ApplyExpr::getStaticTarget#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, "String", Lhs.2
  4     ~0%      {3} r6 = JOIN r5 WITH call_exprs ON FIRST 1 OUTPUT Lhs.0, Lhs.2, "String"
  4     ~0%      {3} r7 = JOIN r6 WITH ApplyExpr::ApplyExprBase::getArgument#dispred#f0820431#fff ON FIRST 2 OUTPUT Rhs.2, "String", Lhs.0
  4     ~0%      {3} r8 = JOIN r7 WITH Argument::ArgumentBase::getExpr#dispred#f0820431#ff ON FIRST 1 OUTPUT Lhs.2, "String", Rhs.1
  4     ~0%      {4} r9 = JOIN r8 WITH ApplyExpr::ApplyExpr::getStaticTarget#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, "NSMakeRange(_:_:)", "String", Lhs.2
  4     ~0%      {2} r10 = JOIN r9 WITH abstract_function_decls ON FIRST 2 OUTPUT Lhs.3, "String"
  4     ~0%      {2} r11 = JOIN r10 WITH DataFlowPrivate::Cached::TExprNode#80e64a43#fff_12#join_rhs ON FIRST 1 OUTPUT Rhs.1 'node', "String"
  
  8437  ~4%      {4} r12 = SCAN ApplyExpr::ApplyExprBase::getArgument#dispred#f0820431#fff OUTPUT In.0, "String", In.1, In.2
  3936  ~1%      {4} r13 = JOIN r12 WITH call_exprs ON FIRST 1 OUTPUT Lhs.0, "String", Lhs.3, Lhs.2
  3936  ~0%      {4} r14 = JOIN r13 WITH ApplyExpr::ApplyExprBase::getFunction#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, "String", Lhs.2, Lhs.3
  2948  ~2%      {4} r15 = JOIN r14 WITH ApplyExpr::ApplyExpr::getStaticTarget#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.3, "String", Lhs.2
  4357  ~0%      {4} r16 = JOIN r15 WITH Callable::CallableBase::getParam#dispred#f0820431#fff ON FIRST 2 OUTPUT Rhs.2, "String", Lhs.3, Lhs.0
  4357  ~49%     {4} r17 = JOIN r16 WITH var_decls ON FIRST 1 OUTPUT Lhs.3, "String", Lhs.2, Rhs.1
  2897  ~0%      {5} r18 = JOIN r17 WITH abstract_function_decls ON FIRST 1 OUTPUT Lhs.0, "String", Lhs.2, Lhs.3, Rhs.1
  1628  ~2%      {5} r19 = JOIN r18 WITH IterableDeclContext::IterableDeclContextBase::getAMember#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, "String", Lhs.2, Lhs.3, Lhs.4
  155   ~1%      {5} r20 = JOIN r19 WITH class_decls ON FIRST 1 OUTPUT Lhs.0, "String", Lhs.2, Lhs.3, Lhs.4
  155   ~0%      {6} r21 = JOIN r20 WITH type_decls ON FIRST 1 OUTPUT "String", Lhs.2, Lhs.3, Lhs.4, Lhs.0, Rhs.1
  0     ~0%      {6} r22 = SELECT r21 ON In.5 = "NSRange" AND In.3 = "init(location:length:)" AND (In.2 = "location" OR In.2 = "length") OR (In.5 = "NSString" OR In.5 = "NSMutableString") AND In.3 = "character(at:)" AND In.2 = "at" OR (In.5 = "NSString" OR In.5 = "NSMutableString") AND In.3 = "substring(from:)" AND In.2 = "from" OR (In.5 = "NSString" OR In.5 = "NSMutableString") AND In.3 = "substring(to:)" AND In.2 = "to" OR In.5 = "NSMutableString" AND In.3 = "insert(_:at:)" AND In.2 = "at"
  0     ~0%      {2} r23 = SCAN r22 OUTPUT In.1, "String"
  0     ~0%      {2} r24 = JOIN r23 WITH Argument::ArgumentBase::getExpr#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, "String"
  0     ~0%      {2} r25 = JOIN r24 WITH DataFlowPrivate::Cached::TExprNode#80e64a43#fff_12#join_rhs ON FIRST 1 OUTPUT Rhs.1 'node', "String"
  
  4     ~0%      {2} r26 = r11 UNION r25
                  return r26
```