### PR TITLE
JS: add navigation.navigate as an XSS / URL sink

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -106,6 +106,10 @@ module ClientSideUrlRedirect {
       ) and
       xss = true
       or
+      // A call to `navigation.navigate`
+      this = DataFlow::globalVarRef("navigation").getAMethodCall("navigate").getArgument(0) and
+      xss = true
+      or
       // An assignment to `location`
       exists(Assignment assgn | isLocation(assgn.getTarget()) and astNode = assgn.getRhs()) and
       xss = true

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -1026,6 +1026,10 @@ nodes
 | tst.js:476:20:476:22 | url |
 | tst.js:486:22:486:24 | url |
 | tst.js:486:22:486:24 | url |
+| tst.js:491:23:491:35 | location.hash |
+| tst.js:491:23:491:35 | location.hash |
+| tst.js:491:23:491:45 | locatio ... bstr(1) |
+| tst.js:491:23:491:45 | locatio ... bstr(1) |
 | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:45 | documen ... .search |
@@ -2081,6 +2085,10 @@ edges
 | tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
 | tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
 | tst.js:471:13:471:46 | documen ... bstr(1) | tst.js:471:7:471:46 | url |
+| tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) |
+| tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) |
+| tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) |
+| tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
@@ -2354,6 +2362,7 @@ edges
 | tst.js:475:25:475:27 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:475:25:475:27 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
 | tst.js:476:20:476:22 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:476:20:476:22 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
 | tst.js:486:22:486:24 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:486:22:486:24 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:491:23:491:45 | locatio ... bstr(1) | tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) | Cross-site scripting vulnerability due to $@. | tst.js:491:23:491:35 | location.hash | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:45 | documen ... .search | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -1038,6 +1038,10 @@ nodes
 | tst.js:476:20:476:22 | url |
 | tst.js:486:22:486:24 | url |
 | tst.js:486:22:486:24 | url |
+| tst.js:491:23:491:35 | location.hash |
+| tst.js:491:23:491:35 | location.hash |
+| tst.js:491:23:491:45 | locatio ... bstr(1) |
+| tst.js:491:23:491:45 | locatio ... bstr(1) |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
@@ -2143,6 +2147,10 @@ edges
 | tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
 | tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
 | tst.js:471:13:471:46 | documen ... bstr(1) | tst.js:471:7:471:46 | url |
+| tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) |
+| tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) |
+| tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) |
+| tst.js:491:23:491:35 | location.hash | tst.js:491:23:491:45 | locatio ... bstr(1) |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
@@ -487,4 +487,6 @@ function urlStuff() {
   }
 
   window.open(location.hash.substr(1)); // OK - any JavaScript is executed in another context
+
+  navigation.navigate(location.hash.substr(1)); // NOT OK
 }


### PR DESCRIPTION
Browsers like Chrome already implement the [Navigation API](https://wicg.github.io/navigation-api/), and some developers are already using it.  

(When [I try to search for it](https://cs.github.com/?scopeName=All+repos&scope=&q=navigation.navigate%28) all that turns up is React code, which is not the same API). 

[Evaluation was unevenful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/navigation__nightly-old__CustomSuite/reports). 