### PR TITLE
Swift: Possible improvement to ApplyExpr.toString

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
@@ -11,8 +11,7 @@ class ApplyExpr extends ApplyExprBase {
     not exists(this.getStaticTarget()) and
     result = "call to " + this.getFunction().toString()
     or
-    not exists(this.getStaticTarget()) and
-    not exists(this.getFunction()) and
+    not exists(this.getFunction()) and // (this implies there is no `getStaticTarget` either)
     result = "call to ..."
   }
 }

--- a/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
@@ -9,6 +9,10 @@ class ApplyExpr extends ApplyExprBase {
     result = "call to " + this.getStaticTarget().toString()
     or
     not exists(this.getStaticTarget()) and
+    result = "call to " + this.getFunction().toString()
+    or
+    not exists(this.getStaticTarget()) and
+    not exists(this.getFunction()) and
     result = "call to ..."
   }
 }

--- a/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
@@ -9,7 +9,7 @@ class ApplyExpr extends ApplyExprBase {
     result = "call to " + this.getStaticTarget().toString()
     or
     not exists(this.getStaticTarget()) and
-    result = "call to " + this.getFunction().toString()
+    result = this.getFunction().toString()
     or
     not exists(this.getFunction()) and // (this implies there is no `getStaticTarget` either)
     result = "call to ..."

--- a/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
@@ -9,9 +9,10 @@ class ApplyExpr extends ApplyExprBase {
     result = "call to " + this.getStaticTarget().toString()
     or
     not exists(this.getStaticTarget()) and
-    result = this.getFunction().toString()
+    result = "call to " + this.getFunction().(ApplyExpr).getStaticTarget().toString()
     or
-    not exists(this.getFunction()) and // (this implies there is no `getStaticTarget` either)
+    not exists(this.getStaticTarget()) and
+    not exists(this.getFunction().(ApplyExpr).getStaticTarget()) and
     result = "call to ..."
   }
 }

--- a/swift/ql/test/library-tests/elements/expr/applyexpr/applyexpr.expected
+++ b/swift/ql/test/library-tests/elements/expr/applyexpr/applyexpr.expected
@@ -1,3 +1,3 @@
-| applyexpr.swift:3:3:3:7 | bar | getFunction:bar |
+| applyexpr.swift:3:3:3:7 | call to ... | getFunction:bar |
 | applyexpr.swift:6:1:6:38 | call to foo(_:) | getArgument(0):: { ... }, getFunction:foo(_:), getStaticTarget:foo(_:) |
 | applyexpr.swift:6:7:6:35 | call to print(_:separator:terminator:) | getArgument(0):: [...], getArgument(1):separator: default separator, getArgument(2):terminator: default terminator, getFunction:print(_:separator:terminator:), getStaticTarget:print(_:separator:terminator:) |

--- a/swift/ql/test/library-tests/elements/expr/applyexpr/applyexpr.expected
+++ b/swift/ql/test/library-tests/elements/expr/applyexpr/applyexpr.expected
@@ -1,0 +1,3 @@
+| applyexpr.swift:3:3:3:7 | bar | getFunction:bar |
+| applyexpr.swift:6:1:6:38 | call to foo(_:) | getArgument(0):: { ... }, getFunction:foo(_:), getStaticTarget:foo(_:) |
+| applyexpr.swift:6:7:6:35 | call to print(_:separator:terminator:) | getArgument(0):: [...], getArgument(1):separator: default separator, getArgument(2):terminator: default terminator, getFunction:print(_:separator:terminator:), getStaticTarget:print(_:separator:terminator:) |

--- a/swift/ql/test/library-tests/elements/expr/applyexpr/applyexpr.ql
+++ b/swift/ql/test/library-tests/elements/expr/applyexpr/applyexpr.ql
@@ -1,0 +1,11 @@
+import swift
+
+string describe(ApplyExpr e) {
+  result = "getFunction:" + e.getFunction().toString() or
+  result = "getStaticTarget:" + e.getStaticTarget().toString() or
+  exists(int ix | result = "getArgument(" + ix.toString() + "):" + e.getArgument(ix).toString())
+}
+
+from ApplyExpr e
+where e.getFile().getBaseName() != ""
+select e, concat(describe(e), ", ")

--- a/swift/ql/test/library-tests/elements/expr/applyexpr/applyexpr.swift
+++ b/swift/ql/test/library-tests/elements/expr/applyexpr/applyexpr.swift
@@ -1,0 +1,6 @@
+
+func foo(_ bar: () -> ()) {
+  bar()
+}
+
+foo({ print("I am a lambda :wave:") })

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
@@ -3,4 +3,4 @@
 | arithmeticoperation.swift:8:6:8:10 | ... call to *(_:_:) ... | BinaryArithmeticOperation, MulExpr |
 | arithmeticoperation.swift:9:6:9:10 | ... call to /(_:_:) ... | BinaryArithmeticOperation, DivExpr |
 | arithmeticoperation.swift:10:6:10:10 | ... call to %(_:_:) ... | BinaryArithmeticOperation, RemExpr |
-| arithmeticoperation.swift:11:6:11:7 | call to call to -(_:) | UnaryArithmeticOperation, UnaryMinusExpr |
+| arithmeticoperation.swift:11:6:11:7 | call to -(_:) | UnaryArithmeticOperation, UnaryMinusExpr |

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
@@ -3,4 +3,4 @@
 | arithmeticoperation.swift:8:6:8:10 | ... call to *(_:_:) ... | BinaryArithmeticOperation, MulExpr |
 | arithmeticoperation.swift:9:6:9:10 | ... call to /(_:_:) ... | BinaryArithmeticOperation, DivExpr |
 | arithmeticoperation.swift:10:6:10:10 | ... call to %(_:_:) ... | BinaryArithmeticOperation, RemExpr |
-| arithmeticoperation.swift:11:6:11:7 | call to ... | UnaryArithmeticOperation, UnaryMinusExpr |
+| arithmeticoperation.swift:11:6:11:7 | call to call to -(_:) | UnaryArithmeticOperation, UnaryMinusExpr |

--- a/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.expected
@@ -1,6 +1,6 @@
 | logicaloperation.swift:4:6:4:11 | ... call to &&(_:_:) ... | BinaryLogicalExpr, LogicalAndExpr |
 | logicaloperation.swift:5:6:5:11 | ... call to \|\|(_:_:) ... | BinaryLogicalExpr, LogicalOrExpr |
-| logicaloperation.swift:6:6:6:7 | call to call to !(_:) | NotExpr, UnaryLogicalOperation |
-| logicaloperation.swift:7:6:7:21 | call to call to !(_:) | NotExpr, UnaryLogicalOperation |
+| logicaloperation.swift:6:6:6:7 | call to !(_:) | NotExpr, UnaryLogicalOperation |
+| logicaloperation.swift:7:6:7:21 | call to !(_:) | NotExpr, UnaryLogicalOperation |
 | logicaloperation.swift:7:8:7:20 | ... call to \|\|(_:_:) ... | BinaryLogicalExpr, LogicalOrExpr |
 | logicaloperation.swift:7:9:7:14 | ... call to &&(_:_:) ... | BinaryLogicalExpr, LogicalAndExpr |

--- a/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/logicaloperation/logicaloperation.expected
@@ -1,6 +1,6 @@
 | logicaloperation.swift:4:6:4:11 | ... call to &&(_:_:) ... | BinaryLogicalExpr, LogicalAndExpr |
 | logicaloperation.swift:5:6:5:11 | ... call to \|\|(_:_:) ... | BinaryLogicalExpr, LogicalOrExpr |
-| logicaloperation.swift:6:6:6:7 | call to ... | NotExpr, UnaryLogicalOperation |
-| logicaloperation.swift:7:6:7:21 | call to ... | NotExpr, UnaryLogicalOperation |
+| logicaloperation.swift:6:6:6:7 | call to call to !(_:) | NotExpr, UnaryLogicalOperation |
+| logicaloperation.swift:7:6:7:21 | call to call to !(_:) | NotExpr, UnaryLogicalOperation |
 | logicaloperation.swift:7:8:7:20 | ... call to \|\|(_:_:) ... | BinaryLogicalExpr, LogicalOrExpr |
 | logicaloperation.swift:7:9:7:14 | ... call to &&(_:_:) ... | BinaryLogicalExpr, LogicalAndExpr |


### PR DESCRIPTION
Possible improvement to `ApplyExpr.toString`.

The first three commits were originally part of https://github.com/github/codeql/pull/9737 (but have since been removed from there), where @MathiasVP [said](https://github.com/github/codeql/pull/9737#discussion_r908691911):

> I like the output a lot more now, but I'm not sure we're getting the improved output for the right reasons. It looks like we're now generating `"call to f()"` when we can resolve the call to a static call target `f`, but we print just `"f()"` when we cannot resolve it to a target.
>
> The reason the output looks a lot better now is that the cases where there isn't a static call target are all examples where `getFunction` returns a strange `DotSyntaxCallExpr` (or `SelfApplyExpr`, or `ConstructorRefCallExpr`) which all have strings that look like `"call to f()"` (because they fall into the category of calls where we can resolve the target).
>
> For example, I think the call to `bar()` in the example below will get a confusing `toString` (since it'll just be the string `"bar"` and not `"call to bar"` even though it's a call to bar and not a reference to the variable).
>
> ```swift
> func foo(_ bar: () -> ()) {
>   bar()
> }
>
> foo({ print("I am a lambda :wave:") })
> ```

As a fourth commit I've added the above as a test and it works (or rather doesn't) as anticipated.  The obvious fix would be to make a special case for `DotSyntaxCallExpr` vs everything else, but that might just be a rabbit hole of special cases - ideally I would like to find a cleaner answer.