### PR TITLE
Swift: fix test case

### DIFF
--- a/swift/ql/test/extractor-tests/generated/type/InOutType/in_out.swift
+++ b/swift/ql/test/extractor-tests/generated/type/InOutType/in_out.swift
@@ -8,5 +8,5 @@ struct S {
   mutating func bar() {}
 }
 
-var s: S
+var s: S = S()
 s.bar()


### PR DESCRIPTION
Swift compiler refuses to compile this file, the test failure exposed via https://github.com/github/codeql/pull/9702

```bash
> swift in_out.swift
in_out.swift:12:3: error: variable 's' passed by reference before being initialized
s.bar()
  ^
in_out.swift:11:5: note: variable defined here
var s: S
    ^
```