### PR TITLE
Swift: Improvements to the string length conflation query

### DIFF
--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -84,6 +84,12 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
       flowstate = "String" // `String` length flowing into `NSString`
     )
   }
+
+  override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    // allow flow through `+` and `-`.
+    node2.asExpr().(AddExpr).getAnOperand() = node1.asExpr() or
+    node2.asExpr().(SubExpr).getAnOperand() = node1.asExpr()
+  }
 }
 
 from

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -14,6 +14,11 @@ import swift
 import codeql.swift.dataflow.DataFlow
 import DataFlow::PathGraph
 
+/**
+ * A configuration for tracking string lengths originating from source that is
+ * a `String` or an `NSString` object, to a sink of a different kind that
+ * expects an incompatible measure of length.
+ */
 class StringLengthConflationConfiguration extends DataFlow::Configuration {
   StringLengthConflationConfiguration() { this = "StringLengthConflationConfiguration" }
 

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,8 +1,36 @@
 edges
+| StringLengthConflation.swift:101:34:101:36 | .count :  | StringLengthConflation.swift:101:34:101:44 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:102:36:102:38 | .count :  | StringLengthConflation.swift:102:36:102:46 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:107:36:107:38 | .count :  | StringLengthConflation.swift:107:36:107:46 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:108:38:108:40 | .count :  | StringLengthConflation.swift:108:38:108:48 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:113:34:113:36 | .count :  | StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:114:36:114:38 | .count :  | StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:120:28:120:30 | .count :  | StringLengthConflation.swift:120:28:120:38 | ... call to -(_:_:) ... |
 nodes
 | StringLengthConflation.swift:72:33:72:35 | .count | semmle.label | .count |
 | StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
+| StringLengthConflation.swift:101:34:101:36 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:101:34:101:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:102:36:102:38 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:102:36:102:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:107:36:107:38 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:107:36:107:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:108:38:108:40 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:108:38:108:48 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:113:34:113:36 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:114:36:114:38 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:120:28:120:30 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:120:28:120:38 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 subpaths
 #select
 | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:101:34:101:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:101:34:101:36 | .count :  | StringLengthConflation.swift:101:34:101:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:102:36:102:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:102:36:102:38 | .count :  | StringLengthConflation.swift:102:36:102:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:107:36:107:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:107:36:107:38 | .count :  | StringLengthConflation.swift:107:36:107:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:108:38:108:48 | ... call to -(_:_:) ... | StringLengthConflation.swift:108:38:108:40 | .count :  | StringLengthConflation.swift:108:38:108:48 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:113:34:113:36 | .count :  | StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:114:36:114:38 | .count :  | StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:120:28:120:38 | ... call to -(_:_:) ... | StringLengthConflation.swift:120:28:120:30 | .count :  | StringLengthConflation.swift:120:28:120:38 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
@@ -98,26 +98,26 @@ func test(s: String) {
 
     let nstr1 = ns.character(at: ns.length - 1) // GOOD
     let nmstr1 = nms.character(at: nms.length - 1) // GOOD
-    let nstr2 = ns.character(at: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
-    let nmstr2 = nms.character(at: s.count - 1) // BAD: String length used in NString [NOT DETECTED]
+    let nstr2 = ns.character(at: s.count - 1) // BAD: String length used in NSString
+    let nmstr2 = nms.character(at: s.count - 1) // BAD: String length used in NString
     print("character '\(nstr1)' '\(nmstr1)' / '\(nstr2)' '\(nmstr2)'")
 
     let nstr3 = ns.substring(from: ns.length - 1) // GOOD
     let nmstr3 = nms.substring(from: nms.length - 1) // GOOD
-    let nstr4 = ns.substring(from: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
-    let nmstr4 = nms.substring(from: s.count - 1) // BAD: String length used in NString [NOT DETECTED]
+    let nstr4 = ns.substring(from: s.count - 1) // BAD: String length used in NSString
+    let nmstr4 = nms.substring(from: s.count - 1) // BAD: String length used in NString
     print("substring from '\(nstr3)' '\(nmstr3)' / '\(nstr4)' '\(nmstr4)'")
 
     let nstr5 = ns.substring(to: ns.length - 1) // GOOD
     let nmstr5 = nms.substring(to: nms.length - 1) // GOOD
-    let nstr6 = ns.substring(to: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
-    let nmstr6 = nms.substring(to: s.count - 1) // BAD: String length used in NString [NOT DETECTED]
+    let nstr6 = ns.substring(to: s.count - 1) // BAD: String length used in NSString
+    let nmstr6 = nms.substring(to: s.count - 1) // BAD: String length used in NString
     print("substring to '\(nstr5)' '\(nmstr5)' / '\(nstr6)' '\(nmstr6)'")
 
     let nmstr7 = NSMutableString(string: s)
     nmstr7.insert("*", at: nms.length - 1) // GOOD
     let nmstr8 = NSMutableString(string: s)
-    nmstr8.insert("*", at: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
+    nmstr8.insert("*", at: s.count - 1) // BAD: String length used in NSString
     print("insert '\(nmstr7)' / '\(nmstr8)'")
 }
 

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
@@ -50,28 +50,28 @@ func test(s: String) {
     // --- constructing a String.Index from integer ---
 
     let ix1 = String.Index(encodedOffset: s.count) // GOOD
-    let ix2 = String.Index(encodedOffset: ns.length) // BAD: NSString length used in String.Index
-    let ix3 = String.Index(encodedOffset: s.utf8.count) // BAD: String.utf8 length used in String.Index
-    let ix4 = String.Index(encodedOffset: s.utf16.count) // BAD: String.utf16 length used in String.Index
-    let ix5 = String.Index(encodedOffset: s.unicodeScalars.count) // BAD: string.unicodeScalars length used in String.Index
+    let ix2 = String.Index(encodedOffset: ns.length) // BAD: NSString length used in String.Index [NOT DETECTED]
+    let ix3 = String.Index(encodedOffset: s.utf8.count) // BAD: String.utf8 length used in String.Index [NOT DETECTED]
+    let ix4 = String.Index(encodedOffset: s.utf16.count) // BAD: String.utf16 length used in String.Index [NOT DETECTED]
+    let ix5 = String.Index(encodedOffset: s.unicodeScalars.count) // BAD: string.unicodeScalars length used in String.Index [NOT DETECTED]
     print("String.Index '\(ix1.encodedOffset)' / '\(ix2.encodedOffset)' '\(ix3.encodedOffset)' '\(ix4.encodedOffset)' '\(ix5.encodedOffset)'")
 
     let ix6 = s.index(s.startIndex, offsetBy: s.count / 2) // GOOD
-    let ix7 = s.index(s.startIndex, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index
+    let ix7 = s.index(s.startIndex, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index [NOT DETECTED]
     print("index '\(ix6.encodedOffset)' / '\(ix7.encodedOffset)'")
 
     var ix8 = s.startIndex
     s.formIndex(&ix8, offsetBy: s.count / 2) // GOOD
     var ix9 = s.startIndex
-    s.formIndex(&ix9, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index
+    s.formIndex(&ix9, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index [NOT DETECTED]
     print("formIndex '\(ix8.encodedOffset)' / '\(ix9.encodedOffset)'")
 
     // --- constructing an NSRange from integers ---
 
     let range1 = NSMakeRange(0, ns.length) // GOOD
     let range2 = NSMakeRange(0, s.count) // BAD: String length used in NSMakeRange
-    let range3 = NSMakeRange(0, s.reversed().count) // BAD: String length used in NSMakeRange
-    let range4 = NSMakeRange(0, s.distance(from: s.startIndex, to: s.endIndex))  // BAD: String length used in NSMakeRange
+    let range3 = NSMakeRange(0, s.reversed().count) // BAD: String length used in NSMakeRange [NOT DETECTED]
+    let range4 = NSMakeRange(0, s.distance(from: s.startIndex, to: s.endIndex))  // BAD: String length used in NSMakeRange [NOT DETECTED]
     print("NSMakeRange '\(range1.description)' / '\(range2.description)' '\(range3.description)' '\(range4.description)'")
 
     let range5 = NSRange(location: 0, length: ns.length) // GOOD
@@ -81,43 +81,43 @@ func test(s: String) {
     // --- String operations using an integer directly ---
 
     let str1 = s.dropFirst(s.count - 1) // GOOD
-    let str2 = s.dropFirst(ns.length - 1) // BAD: NSString length used in String
+    let str2 = s.dropFirst(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
     print("dropFirst '\(str1)' / '\(str2)'")
 
     let str3 = s.dropLast(s.count - 1) // GOOD
-    let str4 = s.dropLast(ns.length - 1) // BAD: NSString length used in String
+    let str4 = s.dropLast(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
     print("dropLast '\(str3)' / '\(str4)'")
 
     let str5 = s.prefix(s.count - 1) // GOOD
-    let str6 = s.prefix(ns.length - 1) // BAD: NSString length used in String
+    let str6 = s.prefix(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
     print("prefix '\(str5)' / '\(str6)'")
 
     let str7 = s.suffix(s.count - 1) // GOOD
-    let str8 = s.suffix(ns.length - 1) // BAD: NSString length used in String
+    let str8 = s.suffix(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
     print("suffix '\(str7)' / '\(str8)'")
 
     let nstr1 = ns.character(at: ns.length - 1) // GOOD
     let nmstr1 = nms.character(at: nms.length - 1) // GOOD
-    let nstr2 = ns.character(at: s.count - 1) // BAD: String length used in NSString
-    let nmstr2 = nms.character(at: s.count - 1) // BAD: String length used in NString
+    let nstr2 = ns.character(at: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
+    let nmstr2 = nms.character(at: s.count - 1) // BAD: String length used in NString [NOT DETECTED]
     print("character '\(nstr1)' '\(nmstr1)' / '\(nstr2)' '\(nmstr2)'")
 
     let nstr3 = ns.substring(from: ns.length - 1) // GOOD
     let nmstr3 = nms.substring(from: nms.length - 1) // GOOD
-    let nstr4 = ns.substring(from: s.count - 1) // BAD: String length used in NSString
-    let nmstr4 = nms.substring(from: s.count - 1) // BAD: String length used in NString
+    let nstr4 = ns.substring(from: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
+    let nmstr4 = nms.substring(from: s.count - 1) // BAD: String length used in NString [NOT DETECTED]
     print("substring from '\(nstr3)' '\(nmstr3)' / '\(nstr4)' '\(nmstr4)'")
 
     let nstr5 = ns.substring(to: ns.length - 1) // GOOD
     let nmstr5 = nms.substring(to: nms.length - 1) // GOOD
-    let nstr6 = ns.substring(to: s.count - 1) // BAD: String length used in NSString
-    let nmstr6 = nms.substring(to: s.count - 1) // BAD: String length used in NString
+    let nstr6 = ns.substring(to: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
+    let nmstr6 = nms.substring(to: s.count - 1) // BAD: String length used in NString [NOT DETECTED]
     print("substring to '\(nstr5)' '\(nmstr5)' / '\(nstr6)' '\(nmstr6)'")
 
     let nmstr7 = NSMutableString(string: s)
     nmstr7.insert("*", at: nms.length - 1) // GOOD
     let nmstr8 = NSMutableString(string: s)
-    nmstr8.insert("*", at: s.count - 1) // BAD: String length used in NSString
+    nmstr8.insert("*", at: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
     print("insert '\(nmstr7)' / '\(nmstr8)'")
 }
 


### PR DESCRIPTION
Improvements to the string length conflation query:
 - allow taint-like flow though `+` and `-`
   - when we have taint flow for Swift we may want to consider using it, but I'm not sure.  For `+` and `-` there's a very strong case that that the code still working with a conflated string length value and is unlikely to have fixed that value somehow.
   - this change greatly increases the proportion of test cases we catch.
 - add QLDoc to the `StringLengthConflationConfiguration` class.