### PR TITLE
C++: Add `nomagic` to `VariableAccessInInitializer`

### DIFF
--- a/cpp/ql/src/Likely Bugs/UseInOwnInitializer.ql
+++ b/cpp/ql/src/Likely Bugs/UseInOwnInitializer.ql
@@ -15,6 +15,7 @@ class VariableAccessInInitializer extends VariableAccess {
   Variable var;
   Initializer init;
 
+  pragma[nomagic]
   VariableAccessInInitializer() {
     init.getDeclaration() = var and
     init.getExpr().getAChild*() = this


### PR DESCRIPTION
This predicate has been popping in and out of the join-order badness report on Abseil for a while. 

Before:
```
Tuple counts for UseInOwnInitializer::VariableAccessInInitializer#class#218a1892#bbf/3@c6f2f002 after 4.9s:
  1373964  ~3%     {2} r1 = JOIN Access::VariableAccess#8878f617#f WITH Access::Access::getTarget#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1 'var', Lhs.0 'this'
  
  0        ~0%     {3} r2 = JOIN r1 WITH initialisers_120#join_rhs ON FIRST 2 OUTPUT Lhs.1 'this', Lhs.0 'var', Rhs.2 'init'
  
  87097753 ~1%     {4} r3 = JOIN r1 WITH initialisers_102#join_rhs ON FIRST 1 OUTPUT Rhs.2, Lhs.1 'this', Lhs.0 'var', Rhs.1 'init'
  6        ~0%     {3} r4 = JOIN r3 WITH #Expr::Expr::getAChild#dispred#f0820431Plus#bf ON FIRST 2 OUTPUT Lhs.1 'this', Lhs.2 'var', Lhs.3 'init'
  
  6        ~0%     {3} r5 = r2 UNION r4
                    return r5
...
Tuple counts for UseInOwnInitializer::VariableAccessInInitializer::initializesItself#dispred#f0820431#fff/3@6277d4es after 0ms:
  6 ~0%     {3} r1 = JOIN Access::Access::getTarget#dispred#f0820431#ff WITH UseInOwnInitializer::VariableAccessInInitializer#class#218a1892#bbf ON FIRST 2 OUTPUT Lhs.0 'this', Lhs.1 'v', Rhs.2 'i'
            return r1
```

After:
```
Tuple counts for UseInOwnInitializer::VariableAccessInInitializer#218a1892#fff/3@57979eol after 104ms:
  254149 ~1%      {3} r1 = SCAN initialisers OUTPUT In.1 'var', In.0 'init', In.2 'this'
  236955 ~6%      {3} r2 = JOIN r1 WITH Variable::Variable#class#7a968d4e#b ON FIRST 1 OUTPUT Lhs.2 'this', Lhs.1 'init', Lhs.0 'var'
  
  41890  ~0%      {3} r3 = JOIN r2 WITH Access::VariableAccess#8878f617#f ON FIRST 1 OUTPUT Lhs.0 'this', Lhs.2 'var', Lhs.1 'init'
  
  578539 ~7%      {3} r4 = JOIN r2 WITH #Expr::Expr::getAChild#dispred#f0820431Plus#bf ON FIRST 1 OUTPUT Rhs.1 'this', Lhs.1 'init', Lhs.2 'var'
  180040 ~10%     {3} r5 = JOIN r4 WITH Access::VariableAccess#8878f617#f ON FIRST 1 OUTPUT Lhs.0 'this', Lhs.2 'var', Lhs.1 'init'
  
  221930 ~9%      {3} r6 = r3 UNION r5
                  return r6
...
Tuple counts for UseInOwnInitializer::VariableAccessInInitializer::initializesItself#dispred#f0820431#fff/3@c97e9c9f after 12ms:
  6      ~0%     {3} r1 = JOIN Access::Access::getTarget#dispred#f0820431#ff WITH UseInOwnInitializer::VariableAccessInInitializer#218a1892#fff ON FIRST 2 OUTPUT Lhs.0 'this', Lhs.1 'v', Rhs.2 'i'
                  return r1
```
Notice that the tuple count for `initializesItself` is identical.