### PR TITLE
Swift: More improvements to swift/string-length-conflation

### DIFF
--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -23,7 +23,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
   StringLengthConflationConfiguration() { this = "StringLengthConflationConfiguration" }
 
   override predicate isSource(DataFlow::Node node, string flowstate) {
-    // result of a call to to `String.count`
+    // result of a call to `String.count`
     exists(MemberRefExpr member |
       member.getBaseExpr().getType().getName() = "String" and
       member.getMember().(VarDecl).getName() = "count" and
@@ -31,7 +31,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
       flowstate = "String"
     )
     or
-    // result of a call to to `NSString.length`
+    // result of a call to `NSString.length`
     exists(MemberRefExpr member |
       member.getBaseExpr().getType().getName() = ["NSString", "NSMutableString"] and
       member.getMember().(VarDecl).getName() = "length" and

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -95,17 +95,25 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
     // arguments to function calls...
     exists(string funcName, string paramName, CallExpr call, int arg |
       (
-        // `dropFirst`, `dropLast`, `removeFirst`, `removeLast`
+        // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
         funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
         paramName = "k"
         or
-        // `prefix`, `suffix`
+        // `String.prefix`, `String.suffix`
         funcName = ["prefix(_:)", "suffix(_:)"] and
         paramName = "maxLength"
         or
         // `String.Index.init`
         funcName = "init(encodedOffset:)" and
         paramName = "offset"
+        or
+        // `String.index`
+        funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
+        paramName = "n"
+        or
+        // `String.formIndex`
+        funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and
+        paramName = "distance"
       ) and
       call.getFunction().(ApplyExpr).getStaticTarget().getName() = funcName and
       call.getFunction()
@@ -119,9 +127,8 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
   }
 
   override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    // allow flow through `+` and `-`.
-    node2.asExpr().(AddExpr).getAnOperand() = node1.asExpr() or
-    node2.asExpr().(SubExpr).getAnOperand() = node1.asExpr()
+    // allow flow through `+`, `-`, `*` etc.
+    node2.asExpr().(ArithmeticOperation).getAnOperand() = node1.asExpr()
   }
 }
 

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -102,6 +102,10 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
         // `prefix`, `suffix`
         funcName = ["prefix(_:)", "suffix(_:)"] and
         paramName = "maxLength"
+        or
+        // `String.Index.init`
+        funcName = "init(encodedOffset:)" and
+        paramName = "offset"
       ) and
       call.getFunction().(ApplyExpr).getStaticTarget().getName() = funcName and
       call.getFunction()

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,36 +1,36 @@
 edges
-| StringLengthConflation.swift:101:34:101:36 | .count :  | StringLengthConflation.swift:101:34:101:44 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:102:36:102:38 | .count :  | StringLengthConflation.swift:102:36:102:46 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:107:36:107:38 | .count :  | StringLengthConflation.swift:107:36:107:46 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:108:38:108:40 | .count :  | StringLengthConflation.swift:108:38:108:48 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:113:34:113:36 | .count :  | StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:114:36:114:38 | .count :  | StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:120:28:120:30 | .count :  | StringLengthConflation.swift:120:28:120:38 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:119:36:119:38 | .count :  | StringLengthConflation.swift:119:36:119:46 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:120:38:120:40 | .count :  | StringLengthConflation.swift:120:38:120:48 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:125:34:125:36 | .count :  | StringLengthConflation.swift:125:34:125:44 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:126:36:126:38 | .count :  | StringLengthConflation.swift:126:36:126:46 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:132:28:132:30 | .count :  | StringLengthConflation.swift:132:28:132:38 | ... call to -(_:_:) ... |
 nodes
 | StringLengthConflation.swift:72:33:72:35 | .count | semmle.label | .count |
 | StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
-| StringLengthConflation.swift:101:34:101:36 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:101:34:101:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:102:36:102:38 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:102:36:102:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:107:36:107:38 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:107:36:107:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:108:38:108:40 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:108:38:108:48 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:113:34:113:36 | .count :  | semmle.label | .count :  |
 | StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:114:36:114:38 | .count :  | semmle.label | .count :  |
 | StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:120:28:120:30 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:120:28:120:38 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:119:36:119:38 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:119:36:119:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:120:38:120:40 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:120:38:120:48 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:125:34:125:36 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:125:34:125:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:126:36:126:38 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:126:36:126:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:132:28:132:30 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:132:28:132:38 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 subpaths
 #select
 | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:101:34:101:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:101:34:101:36 | .count :  | StringLengthConflation.swift:101:34:101:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:102:36:102:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:102:36:102:38 | .count :  | StringLengthConflation.swift:102:36:102:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:107:36:107:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:107:36:107:38 | .count :  | StringLengthConflation.swift:107:36:107:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:108:38:108:48 | ... call to -(_:_:) ... | StringLengthConflation.swift:108:38:108:40 | .count :  | StringLengthConflation.swift:108:38:108:48 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:113:34:113:36 | .count :  | StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:114:36:114:38 | .count :  | StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:120:28:120:38 | ... call to -(_:_:) ... | StringLengthConflation.swift:120:28:120:30 | .count :  | StringLengthConflation.swift:120:28:120:38 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:119:36:119:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:119:36:119:38 | .count :  | StringLengthConflation.swift:119:36:119:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:120:38:120:48 | ... call to -(_:_:) ... | StringLengthConflation.swift:120:38:120:40 | .count :  | StringLengthConflation.swift:120:38:120:48 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:125:34:125:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:125:34:125:36 | .count :  | StringLengthConflation.swift:125:34:125:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:126:36:126:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:126:36:126:38 | .count :  | StringLengthConflation.swift:126:36:126:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:132:28:132:38 | ... call to -(_:_:) ... | StringLengthConflation.swift:132:28:132:30 | .count :  | StringLengthConflation.swift:132:28:132:38 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -13,6 +13,7 @@ edges
 | StringLengthConflation.swift:135:36:135:38 | .count :  | StringLengthConflation.swift:135:36:135:46 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:141:28:141:30 | .count :  | StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... |
 nodes
+| StringLengthConflation.swift:53:43:53:46 | .length | semmle.label | .length |
 | StringLengthConflation.swift:72:33:72:35 | .count | semmle.label | .count |
 | StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
 | StringLengthConflation.swift:93:28:93:31 | .length :  | semmle.label | .length :  |
@@ -43,6 +44,7 @@ nodes
 | StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 subpaths
 #select
+| StringLengthConflation.swift:53:43:53:46 | .length | StringLengthConflation.swift:53:43:53:46 | .length | StringLengthConflation.swift:53:43:53:46 | .length | This NSString length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... | StringLengthConflation.swift:93:28:93:31 | .length :  | StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,4 +1,10 @@
 edges
+| StringLengthConflation.swift:93:28:93:31 | .length :  | StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:97:27:97:30 | .length :  | StringLengthConflation.swift:97:27:97:39 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:101:25:101:28 | .length :  | StringLengthConflation.swift:101:25:101:37 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:105:25:105:28 | .length :  | StringLengthConflation.swift:105:25:105:37 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:111:23:111:26 | .length :  | StringLengthConflation.swift:111:23:111:35 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:117:22:117:25 | .length :  | StringLengthConflation.swift:117:22:117:34 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:122:34:122:36 | .count :  | StringLengthConflation.swift:122:34:122:44 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:123:36:123:38 | .count :  | StringLengthConflation.swift:123:36:123:46 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:128:36:128:38 | .count :  | StringLengthConflation.swift:128:36:128:46 | ... call to -(_:_:) ... |
@@ -9,6 +15,18 @@ edges
 nodes
 | StringLengthConflation.swift:72:33:72:35 | .count | semmle.label | .count |
 | StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
+| StringLengthConflation.swift:93:28:93:31 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:97:27:97:30 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:97:27:97:39 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:101:25:101:28 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:101:25:101:37 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:105:25:105:28 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:105:25:105:37 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:111:23:111:26 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:111:23:111:35 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:117:22:117:25 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:117:22:117:34 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:122:34:122:36 | .count :  | semmle.label | .count :  |
 | StringLengthConflation.swift:122:34:122:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:123:36:123:38 | .count :  | semmle.label | .count :  |
@@ -27,6 +45,12 @@ subpaths
 #select
 | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... | StringLengthConflation.swift:93:28:93:31 | .length :  | StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:97:27:97:39 | ... call to -(_:_:) ... | StringLengthConflation.swift:97:27:97:30 | .length :  | StringLengthConflation.swift:97:27:97:39 | ... call to -(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:101:25:101:37 | ... call to -(_:_:) ... | StringLengthConflation.swift:101:25:101:28 | .length :  | StringLengthConflation.swift:101:25:101:37 | ... call to -(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:105:25:105:37 | ... call to -(_:_:) ... | StringLengthConflation.swift:105:25:105:28 | .length :  | StringLengthConflation.swift:105:25:105:37 | ... call to -(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:111:23:111:35 | ... call to -(_:_:) ... | StringLengthConflation.swift:111:23:111:26 | .length :  | StringLengthConflation.swift:111:23:111:35 | ... call to -(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:117:22:117:34 | ... call to -(_:_:) ... | StringLengthConflation.swift:117:22:117:25 | .length :  | StringLengthConflation.swift:117:22:117:34 | ... call to -(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:122:34:122:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:122:34:122:36 | .count :  | StringLengthConflation.swift:122:34:122:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:123:36:123:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:123:36:123:38 | .count :  | StringLengthConflation.swift:123:36:123:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:128:36:128:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:128:36:128:38 | .count :  | StringLengthConflation.swift:128:36:128:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,36 +1,36 @@
 edges
-| StringLengthConflation.swift:113:34:113:36 | .count :  | StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:114:36:114:38 | .count :  | StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:119:36:119:38 | .count :  | StringLengthConflation.swift:119:36:119:46 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:120:38:120:40 | .count :  | StringLengthConflation.swift:120:38:120:48 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:125:34:125:36 | .count :  | StringLengthConflation.swift:125:34:125:44 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:126:36:126:38 | .count :  | StringLengthConflation.swift:126:36:126:46 | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:132:28:132:30 | .count :  | StringLengthConflation.swift:132:28:132:38 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:122:34:122:36 | .count :  | StringLengthConflation.swift:122:34:122:44 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:123:36:123:38 | .count :  | StringLengthConflation.swift:123:36:123:46 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:128:36:128:38 | .count :  | StringLengthConflation.swift:128:36:128:46 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:129:38:129:40 | .count :  | StringLengthConflation.swift:129:38:129:48 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:134:34:134:36 | .count :  | StringLengthConflation.swift:134:34:134:44 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:135:36:135:38 | .count :  | StringLengthConflation.swift:135:36:135:46 | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:141:28:141:30 | .count :  | StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... |
 nodes
 | StringLengthConflation.swift:72:33:72:35 | .count | semmle.label | .count |
 | StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
-| StringLengthConflation.swift:113:34:113:36 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:114:36:114:38 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:119:36:119:38 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:119:36:119:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:120:38:120:40 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:120:38:120:48 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:125:34:125:36 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:125:34:125:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:126:36:126:38 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:126:36:126:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
-| StringLengthConflation.swift:132:28:132:30 | .count :  | semmle.label | .count :  |
-| StringLengthConflation.swift:132:28:132:38 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:122:34:122:36 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:122:34:122:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:123:36:123:38 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:123:36:123:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:128:36:128:38 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:128:36:128:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:129:38:129:40 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:129:38:129:48 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:134:34:134:36 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:134:34:134:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:135:36:135:38 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:135:36:135:46 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
+| StringLengthConflation.swift:141:28:141:30 | .count :  | semmle.label | .count :  |
+| StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 subpaths
 #select
 | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:113:34:113:36 | .count :  | StringLengthConflation.swift:113:34:113:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:114:36:114:38 | .count :  | StringLengthConflation.swift:114:36:114:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:119:36:119:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:119:36:119:38 | .count :  | StringLengthConflation.swift:119:36:119:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:120:38:120:48 | ... call to -(_:_:) ... | StringLengthConflation.swift:120:38:120:40 | .count :  | StringLengthConflation.swift:120:38:120:48 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:125:34:125:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:125:34:125:36 | .count :  | StringLengthConflation.swift:125:34:125:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:126:36:126:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:126:36:126:38 | .count :  | StringLengthConflation.swift:126:36:126:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
-| StringLengthConflation.swift:132:28:132:38 | ... call to -(_:_:) ... | StringLengthConflation.swift:132:28:132:30 | .count :  | StringLengthConflation.swift:132:28:132:38 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:122:34:122:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:122:34:122:36 | .count :  | StringLengthConflation.swift:122:34:122:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:123:36:123:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:123:36:123:38 | .count :  | StringLengthConflation.swift:123:36:123:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:128:36:128:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:128:36:128:38 | .count :  | StringLengthConflation.swift:128:36:128:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:129:38:129:48 | ... call to -(_:_:) ... | StringLengthConflation.swift:129:38:129:40 | .count :  | StringLengthConflation.swift:129:38:129:48 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:134:34:134:44 | ... call to -(_:_:) ... | StringLengthConflation.swift:134:34:134:36 | .count :  | StringLengthConflation.swift:134:34:134:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:135:36:135:46 | ... call to -(_:_:) ... | StringLengthConflation.swift:135:36:135:38 | .count :  | StringLengthConflation.swift:135:36:135:46 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
+| StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... | StringLengthConflation.swift:141:28:141:30 | .count :  | StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,4 +1,6 @@
 edges
+| StringLengthConflation.swift:60:47:60:50 | .length :  | StringLengthConflation.swift:60:47:60:59 | ... call to /(_:_:) ... |
+| StringLengthConflation.swift:66:33:66:36 | .length :  | StringLengthConflation.swift:66:33:66:45 | ... call to /(_:_:) ... |
 | StringLengthConflation.swift:93:28:93:31 | .length :  | StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:97:27:97:30 | .length :  | StringLengthConflation.swift:97:27:97:39 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:101:25:101:28 | .length :  | StringLengthConflation.swift:101:25:101:37 | ... call to -(_:_:) ... |
@@ -14,6 +16,10 @@ edges
 | StringLengthConflation.swift:141:28:141:30 | .count :  | StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... |
 nodes
 | StringLengthConflation.swift:53:43:53:46 | .length | semmle.label | .length |
+| StringLengthConflation.swift:60:47:60:50 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:60:47:60:59 | ... call to /(_:_:) ... | semmle.label | ... call to /(_:_:) ... |
+| StringLengthConflation.swift:66:33:66:36 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:66:33:66:45 | ... call to /(_:_:) ... | semmle.label | ... call to /(_:_:) ... |
 | StringLengthConflation.swift:72:33:72:35 | .count | semmle.label | .count |
 | StringLengthConflation.swift:78:47:78:49 | .count | semmle.label | .count |
 | StringLengthConflation.swift:93:28:93:31 | .length :  | semmle.label | .length :  |
@@ -45,6 +51,8 @@ nodes
 subpaths
 #select
 | StringLengthConflation.swift:53:43:53:46 | .length | StringLengthConflation.swift:53:43:53:46 | .length | StringLengthConflation.swift:53:43:53:46 | .length | This NSString length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:60:47:60:59 | ... call to /(_:_:) ... | StringLengthConflation.swift:60:47:60:50 | .length :  | StringLengthConflation.swift:60:47:60:59 | ... call to /(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:66:33:66:45 | ... call to /(_:_:) ... | StringLengthConflation.swift:66:33:66:36 | .length :  | StringLengthConflation.swift:66:33:66:45 | ... call to /(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | StringLengthConflation.swift:78:47:78:49 | .count | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... | StringLengthConflation.swift:93:28:93:31 | .length :  | StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
@@ -90,31 +90,31 @@ func test(s: String) {
     // --- String operations using an integer directly ---
 
     let str1 = s.dropFirst(s.count - 1) // GOOD
-    let str2 = s.dropFirst(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
+    let str2 = s.dropFirst(ns.length - 1) // BAD: NSString length used in String
     print("dropFirst '\(str1)' / '\(str2)'")
 
     let str3 = s.dropLast(s.count - 1) // GOOD
-    let str4 = s.dropLast(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
+    let str4 = s.dropLast(ns.length - 1) // BAD: NSString length used in String
     print("dropLast '\(str3)' / '\(str4)'")
 
     let str5 = s.prefix(s.count - 1) // GOOD
-    let str6 = s.prefix(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
+    let str6 = s.prefix(ns.length - 1) // BAD: NSString length used in String
     print("prefix '\(str5)' / '\(str6)'")
 
     let str7 = s.suffix(s.count - 1) // GOOD
-    let str8 = s.suffix(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
+    let str8 = s.suffix(ns.length - 1) // BAD: NSString length used in String
     print("suffix '\(str7)' / '\(str8)'")
 
     var str9 = s
     str9.removeFirst(s.count - 1) // GOOD
     var str10 = s
-    str10.removeFirst(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
+    str10.removeFirst(ns.length - 1) // BAD: NSString length used in String
     print("removeFirst '\(str9)' / '\(str10)'")
 
     var str11 = s
     str11.removeLast(s.count - 1) // GOOD
     var str12 = s
-    str12.removeLast(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
+    str12.removeLast(ns.length - 1) // BAD: NSString length used in String
     print("removeLast '\(str11)' / '\(str12)'")
 
     let nstr1 = ns.character(at: ns.length - 1) // GOOD

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
@@ -96,6 +96,18 @@ func test(s: String) {
     let str8 = s.suffix(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
     print("suffix '\(str7)' / '\(str8)'")
 
+    var str9 = s
+    str9.removeFirst(s.count - 1) // GOOD
+    var str10 = s
+    str10.removeFirst(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
+    print("removeFirst '\(str9)' / '\(str10)'")
+
+    var str11 = s
+    str11.removeLast(s.count - 1) // GOOD
+    var str12 = s
+    str12.removeLast(ns.length - 1) // BAD: NSString length used in String [NOT DETECTED]
+    print("removeLast '\(str11)' / '\(str12)'")
+
     let nstr1 = ns.character(at: ns.length - 1) // GOOD
     let nmstr1 = nms.character(at: nms.length - 1) // GOOD
     let nstr2 = ns.character(at: s.count - 1) // BAD: String length used in NSString

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
@@ -57,13 +57,13 @@ func test(s: String) {
     print("String.Index '\(ix1.encodedOffset)' / '\(ix2.encodedOffset)' '\(ix3.encodedOffset)' '\(ix4.encodedOffset)' '\(ix5.encodedOffset)'")
 
     let ix6 = s.index(s.startIndex, offsetBy: s.count / 2) // GOOD
-    let ix7 = s.index(s.startIndex, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index [NOT DETECTED]
+    let ix7 = s.index(s.startIndex, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index
     print("index '\(ix6.encodedOffset)' / '\(ix7.encodedOffset)'")
 
     var ix8 = s.startIndex
     s.formIndex(&ix8, offsetBy: s.count / 2) // GOOD
     var ix9 = s.startIndex
-    s.formIndex(&ix9, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index [NOT DETECTED]
+    s.formIndex(&ix9, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index
     print("formIndex '\(ix8.encodedOffset)' / '\(ix9.encodedOffset)'")
 
     // --- constructing an NSRange from integers ---

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
@@ -50,7 +50,7 @@ func test(s: String) {
     // --- constructing a String.Index from integer ---
 
     let ix1 = String.Index(encodedOffset: s.count) // GOOD
-    let ix2 = String.Index(encodedOffset: ns.length) // BAD: NSString length used in String.Index [NOT DETECTED]
+    let ix2 = String.Index(encodedOffset: ns.length) // BAD: NSString length used in String.Index
     let ix3 = String.Index(encodedOffset: s.utf8.count) // BAD: String.utf8 length used in String.Index [NOT DETECTED]
     let ix4 = String.Index(encodedOffset: s.utf16.count) // BAD: String.utf16 length used in String.Index [NOT DETECTED]
     let ix5 = String.Index(encodedOffset: s.unicodeScalars.count) // BAD: string.unicodeScalars length used in String.Index [NOT DETECTED]

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
@@ -28,12 +28,12 @@ class NSMutableString : NSString
 class NSRange
 {
     init(location: Int, length: Int) { self.description = "" }
+    init<R, S>(_ r: R, in: S) { self.description = "" }
 
     private(set) var description: String
 }
 
 func NSMakeRange(_ loc: Int, _ len: Int) -> NSRange { return NSRange(location: loc, length: len) }
-
 
 
 
@@ -77,6 +77,15 @@ func test(s: String) {
     let range5 = NSRange(location: 0, length: ns.length) // GOOD
     let range6 = NSRange(location: 0, length: s.count) // BAD: String length used in NSMakeRange
     print("NSRange '\(range5.description)' / '\(range6.description)'")
+
+    // --- converting Range to NSRange ---
+
+    let range7 = s.startIndex ..< s.endIndex
+    let range8 = NSRange(range7, in: s) // GOOD
+    let location = s.distance(from: s.startIndex, to: range7.lowerBound)
+    let length = s.distance(from: range7.lowerBound, to: range7.upperBound)
+    let range9 = NSRange(location: location, length: length) // BAD [NOT DETECTED]
+    print("NSRange '\(range8.description)' / '\(range9.description)'")
 
     // --- String operations using an integer directly ---
 


### PR DESCRIPTION
More improvements to `swift/string-length-conflation`:
 - conflation in the `String` -> `NSString` direction is now detected 🎉 
 - slightly more data flow is permitted (in particular through operators `*`, `/`)
 - additional test cases

Notably for the `String` and `String.Index` member functions, I can't find a way of checking the associated class is correct (i.e. that we're looking at a call to `String.index` not `foo.index`).  While this would be nice to have, in practice since we match on the argument and parameter names as well, so I think false positives are unlikely.