### PR TITLE
Kotlin: don't extract private setters of external classes

### DIFF
--- a/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/hasprops.kt
+++ b/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/hasprops.kt
@@ -1,0 +1,9 @@
+class HasProps {
+
+  var accessorsPublic = 1
+
+  var setterPrivate = 3
+    private set
+
+}
+

--- a/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/test.expected
+++ b/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/test.expected
@@ -1,0 +1,7 @@
+| hasprops.kt:3:3:3:25 | getAccessorsPublic |
+| hasprops.kt:3:3:3:25 | setAccessorsPublic |
+| hasprops.kt:5:3:6:15 | getSetterPrivate |
+| hasprops.kt:6:13:6:15 | setSetterPrivate$private |
+| usesprops.kt:1:1:9:1 | user |
+| usesprops.kt:3:3:3:58 | useGetters |
+| usesprops.kt:5:3:7:3 | useSetter |

--- a/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/test.py
+++ b/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/test.py
@@ -1,0 +1,3 @@
+from create_database_utils import *
+
+run_codeql_database_create(["kotlinc hasprops.kt", "kotlinc usesprops.kt -cp ."], lang="java")

--- a/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/test.ql
+++ b/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/test.ql
@@ -1,0 +1,5 @@
+import java
+
+from Method m
+where m.fromSource()
+select m

--- a/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/usesprops.kt
+++ b/java/ql/integration-tests/posix-only/kotlin/private_property_accessors/usesprops.kt
@@ -1,0 +1,9 @@
+fun user(hp: HasProps) {
+
+  fun useGetters() = hp.accessorsPublic + hp.setterPrivate
+
+  fun useSetter(x: Int) {
+    hp.accessorsPublic = x
+  }
+
+}


### PR DESCRIPTION
Previously these would get extracted unlike other private methods even if the class was a standard library or other external class. This could cause inconsistencies because if we also compiled the class from source we could end up deciding different names for the property's setter: setXyz$private when seen from source, and setXyz without a
suffix when seen as an external .class file. Avoiding extracting these functions from the external perspective both restores consistency with other kinds of method and avoids these consistency problems.