### PR TITLE
C++: Add tests for `AnalysedExpr::isNullCheck` and `AnalysedExpr::isValidCheck`

### DIFF
--- a/cpp/ql/test/library-tests/controlflow/nullness/nullness.expected
+++ b/cpp/ql/test/library-tests/controlflow/nullness/nullness.expected
@@ -1,0 +1,15 @@
+| test.cpp:9:9:9:9 | v | test.cpp:5:13:5:13 | v | is not null | is valid |
+| test.cpp:10:9:10:10 | ! ... | test.cpp:5:13:5:13 | v | is null | is not valid |
+| test.cpp:11:9:11:14 | ... == ... | test.cpp:5:13:5:13 | v | is null | is not valid |
+| test.cpp:12:9:12:17 | ... == ... | test.cpp:5:13:5:13 | v | is not null | is valid |
+| test.cpp:13:9:13:14 | ... != ... | test.cpp:5:13:5:13 | v | is not null | is valid |
+| test.cpp:14:9:14:17 | ... != ... | test.cpp:5:13:5:13 | v | is null | is not valid |
+| test.cpp:15:8:15:23 | call to __builtin_expect | test.cpp:5:13:5:13 | v | is not null | is valid |
+| test.cpp:16:8:16:23 | call to __builtin_expect | test.cpp:5:13:5:13 | v | is null | is not valid |
+| test.cpp:17:9:17:17 | ... && ... | test.cpp:5:13:5:13 | v | is not null | is valid |
+| test.cpp:18:9:18:17 | ... && ... | test.cpp:5:13:5:13 | v | is not null | is not valid |
+| test.cpp:19:9:19:18 | ... && ... | test.cpp:5:13:5:13 | v | is null | is not valid |
+| test.cpp:20:9:20:18 | ... && ... | test.cpp:5:13:5:13 | v | is not null | is not valid |
+| test.cpp:21:9:21:14 | ... = ... | test.cpp:5:13:5:13 | v | is null | is not valid |
+| test.cpp:21:9:21:14 | ... = ... | test.cpp:7:10:7:10 | b | is not null | is valid |
+| test.cpp:22:17:22:17 | b | test.cpp:7:10:7:10 | b | is not null | is valid |

--- a/cpp/ql/test/library-tests/controlflow/nullness/nullness.ql
+++ b/cpp/ql/test/library-tests/controlflow/nullness/nullness.ql
@@ -1,0 +1,9 @@
+import cpp
+
+from AnalysedExpr a, LocalScopeVariable v, string isNullCheck, string isValidCheck
+where
+  a.getParent() instanceof IfStmt and
+  v.getAnAccess().getEnclosingStmt() = a.getParent() and
+  (if a.isNullCheck(v) then isNullCheck = "is null" else isNullCheck = "is not null") and
+  (if a.isValidCheck(v) then isValidCheck = "is valid" else isValidCheck = "is not valid")
+select a, v, isNullCheck, isValidCheck

--- a/cpp/ql/test/library-tests/controlflow/nullness/test.cpp
+++ b/cpp/ql/test/library-tests/controlflow/nullness/test.cpp
@@ -1,0 +1,23 @@
+// semmle-extractor-options: -std=c++17
+
+long __builtin_expect(long);
+     
+void f(int *v) {
+    int *w;
+    bool b;
+
+    if (v) {}
+    if (!v) {}
+    if (v == 0) {}
+    if ((!v) == 0) {}
+    if (v != 0) {}
+    if ((!v) != 0) {}
+    if(__builtin_expect((long)v)) {}
+    if(__builtin_expect((long)!v)) {}
+    if (true && v) {}
+    if (v && true) {}
+    if (true && !v) {}
+    if (!v && true) {}
+    if (b = !v) {}
+    if (b = !v; b) {}
+}


### PR DESCRIPTION
For the benefit of https://github.com/github/codeql/pull/9785. It seems we didn't have any tests covering this.