### PR TITLE
JS: exclude variables in .vue files form js/unused-local-variable

### DIFF
--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -144,6 +144,9 @@ predicate whitelisted(UnusedLocal v) {
   // exclude variables mentioned in JSDoc comments in externs
   mentionedInJSDocComment(v)
   or
+  // the attributes in .vue files are not extracted, so we can get false positives in those.
+  v.getADeclaration().getFile().getExtension() = "vue"
+  or
   // exclude variables used to filter out unwanted properties
   isPropertyFilter(v)
   or


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/9777 

The attributes in `.vue` files are not currently extracted, so there is no pretty way for us to detect whether a variable is used or not.    
So I've excluded `.vue` files from the query.  

[An evaluation](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-9794-9ed7aa9__nightly-old__CustomSuite/reports) shows no performance penalty.  
But unfortunately it also removes a bunch of TPs.