### PR TITLE
Swift: rework inter-process race strategy

### DIFF
--- a/swift/extractor/infra/BUILD.bazel
+++ b/swift/extractor/infra/BUILD.bazel
@@ -2,9 +2,11 @@ load("//swift:rules.bzl", "swift_cc_library")
 
 swift_cc_library(
     name = "infra",
+    srcs = glob(["*.cpp"]),
     hdrs = glob(["*.h"]),
     visibility = ["//swift:__subpackages__"],
     deps = [
         "//swift/extractor/trap",
+        "//swift/tools/prebuilt:swift-llvm-support",
     ],
 )

--- a/swift/extractor/infra/ExclusiveFile.cpp
+++ b/swift/extractor/infra/ExclusiveFile.cpp
@@ -1,0 +1,68 @@
+#include "swift/extractor/infra/ExclusiveFile.h"
+
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Path.h>
+
+namespace codeql {
+namespace {
+[[noreturn]] void unrecoverableError(const char* action,
+                                     const std::string& arg,
+                                     std::error_code ec) {
+  std::cerr << "Unable to " << action << ": " << arg << " (" << ec.message() << ")\n";
+  std::abort();
+}
+
+[[noreturn]] void unrecoverableError(const char* action, const std::string& arg) {
+  unrecoverableError(action, arg, {errno, std::system_category()});
+}
+
+void ensureParent(const std::string& path) {
+  auto parent = llvm::sys::path::parent_path(path);
+  if (auto ec = llvm::sys::fs::create_directories(parent)) {
+    unrecoverableError("create directory", parent.str(), ec);
+  }
+}
+
+}  // namespace
+
+ExclusiveFile::ExclusiveFile(std::string working, std::string target)
+    : workingPath{std::move(working)}, targetPath{std::move(target)} {
+  namespace fs = llvm::sys::fs;
+  int fd = -1;
+  ensureParent(workingPath);
+  ensureParent(targetPath);
+  if (auto ec = fs::openFileForWrite(targetPath, fd, fs::CD_CreateNew, fs::OF_Text)) {
+    if (ec == std::errc::file_exists) {
+      // we lost the race, do nothing (owned() will return false)
+      return;
+    }
+    unrecoverableError("open file for writing", targetPath, ec);
+  }
+  fs::closeFile(fd);
+  errno = 0;
+  out.open(workingPath);
+  checkOutput("open file for writing");
+}
+
+bool ExclusiveFile::owned() const {
+  return out && out.is_open();
+}
+
+void ExclusiveFile::commit() {
+  assert(owned());
+  namespace fs = llvm::sys::fs;
+  if (out.is_open()) {
+    out.close();
+    if (auto ec = fs::rename(workingPath, targetPath)) {
+      unrecoverableError("rename file", targetPath, ec);
+    }
+  }
+}
+
+void ExclusiveFile::checkOutput(const char* action) {
+  if (!out) {
+    unrecoverableError(action, workingPath);
+  }
+}
+
+}  // namespace codeql

--- a/swift/extractor/infra/ExclusiveFile.h
+++ b/swift/extractor/infra/ExclusiveFile.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <cstdio>
+#include <cerrno>
+#include <system_error>
+#include <sstream>
+
+namespace codeql {
+
+// Only the first process trying to open an `ExclusiveFile` for a given `target` is allowed to do
+// so, all others will have an instance with `owned() == false` and failing on any other operation.
+// The content streamed to the `ExclusiveFile` is written to `working`, and is moved onto target
+// only when `commit()` is called
+class ExclusiveFile {
+  std::string workingPath;
+  std::string targetPath;
+  std::ofstream out;
+
+ public:
+  ExclusiveFile(std::string working, std::string target);
+
+  bool owned() const;
+  void commit();
+
+  template <typename T>
+  ExclusiveFile& operator<<(T&& value) {
+    errno = 0;
+    out << value;
+    checkOutput("write to file");
+    return *this;
+  }
+
+ private:
+  void checkOutput(const char* action);
+};
+
+}  // namespace codeql

--- a/swift/extractor/trap/TrapFile.cpp
+++ b/swift/extractor/trap/TrapFile.cpp
@@ -1,0 +1,3 @@
+#include "TrapFile.h"
+
+namespace codeql {}  // namespace codeql

--- a/swift/extractor/trap/TrapFile.h
+++ b/swift/extractor/trap/TrapFile.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "swift/extractor/trap/TrapLabel.h"
+#include "swift/extractor/trap/TrapOutput.h"
+
+namespace codeql {
+
+class TrapFile {
+  uint64_t id{0};
+  TrapOutput out;
+
+ public:
+  template <typename Tag>
+  TrapLabel<Tag> createLabel() {
+    auto ret = allocateLabel<Tag>();
+    out.assignStar(ret);
+    return ret;
+  }
+
+  template <typename Tag, typename... Args>
+  TrapLabel<Tag> createLabel(Args&&... args) {
+    auto ret = allocateLabel<Tag>();
+    out.assignKey(ret, std::forward<Args>(args)...);
+    return ret;
+  }
+
+  template <typename... Args>
+  void debug(const Args&... args) {
+    out.debug(args...);
+  }
+
+  template <typename Entry>
+  void emit(const Entry& e) {
+    out.emit(e);
+  }
+
+ private:
+  template <typename Tag>
+  TrapLabel<Tag> allocateLabel() {
+    return TrapLabel<Tag>::unsafeCreateFromExplicitId(id++);
+  }
+};
+
+}  // namespace codeql

--- a/swift/extractor/trap/TrapOutput.h
+++ b/swift/extractor/trap/TrapOutput.h
@@ -2,18 +2,16 @@
 
 #include <memory>
 #include "swift/extractor/trap/TrapLabel.h"
+#include "swift/extractor/infra/ExclusiveFile.h"
 
 namespace codeql {
 
-// Sink for trap emissions and label assignments. This abstracts away `ofstream` operations
-// like `ofstream`, an explicit bool operator is provided, that return false if something
-// went wrong
-// TODO better error handling
+// Sink for trap emissions and label assignments. This abstracts away streaming operations
 class TrapOutput {
-  std::ostream& out_;
+  ExclusiveFile& out_;
 
  public:
-  explicit TrapOutput(std::ostream& out) : out_{out} {}
+  explicit TrapOutput(ExclusiveFile& out) : out_{out} {}
 
   template <typename Tag>
   void assignStar(TrapLabel<Tag> label) {
@@ -41,8 +39,9 @@ class TrapOutput {
 
   template <typename... Args>
   void debug(const Args&... args) {
-    out_ << "/* DEBUG:\n";
-    (out_ << ... << args) << "\n*/\n";
+    print("/* DEBUG:");
+    print(args...);
+    print("*/");
   }
 
  private:


### PR DESCRIPTION
An `ExclusiveFile` class is introduced, that is successfully created
only for the first process that starts processing it.

An `ExclusiveFile` is created from a working (temporary) path and a
target path. First the target file is touched with
`llvm::sys::fs::openFileForWrite` with `CD_CreateNew` (effectively
wrapping around `O_EXCL`), so that any following process trying to do
the same will be aware that someone else already started the work. Then
the actual trap content will still be written to the temporary path.
`ExclusiveFile::commit` can be called to move the temporeary content
to the target file.

Some of the file system logic contained in `SwiftExtractor.cpp` has been
moved to this class, and two TODOs are solved:
* introducing a better inter process file collision avoidance strategy
  (in particular this will save unneeded work, as previously all
  processes would extract everything, each throwing away what was
  previously extracted)
* better error handling for trap output operations: if unable to write
  to the trap file (or carry out other basic file operations), we just
  abort.