### PR TITLE
Dataflow: Replace stage duplication with parameterised modules.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -597,7 +597,7 @@ private predicate hasSinkCallCtx(Configuration config) {
   )
 }
 
-private module Stage1 {
+private module Stage1 implements StageSig {
   class ApApprox = Unit;
 
   class Ap = Unit;
@@ -944,12 +944,9 @@ private module Stage1 {
   predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, config) }
 
   bindingset[node, state, config]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, toReturn, pragma[only_bind_into](config)) and
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+    revFlow(node, _, pragma[only_bind_into](config)) and
     exists(state) and
-    exists(returnAp) and
     exists(ap)
   }
 
@@ -1142,37 +1139,674 @@ private predicate flowIntoCallNodeCand1(
   )
 }
 
-private module Stage2 {
-  module PrevStage = Stage1;
+private signature module StageSig {
+  class Ap;
 
+  predicate revFlow(NodeEx node, Configuration config);
+
+  bindingset[node, state, config]
+  predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config);
+
+  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config);
+
+  predicate storeStepCand(
+    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+    Configuration config
+  );
+
+  predicate readStepCand(NodeEx n1, Content c, NodeEx n2, Configuration config);
+}
+
+private module MkStage<StageSig PrevStage> {
   class ApApprox = PrevStage::Ap;
 
-  class Ap = boolean;
+  signature module StageParam {
+    class Ap;
 
-  class ApNil extends Ap {
-    ApNil() { this = false }
+    class ApNil extends Ap;
+
+    bindingset[result, ap]
+    ApApprox getApprox(Ap ap);
+
+    ApNil getApNil(NodeEx node);
+
+    bindingset[tc, tail]
+    Ap apCons(TypedContent tc, Ap tail);
+
+    Content getHeadContent(Ap ap);
+
+    class ApOption;
+
+    ApOption apNone();
+
+    ApOption apSome(Ap ap);
+
+    class Cc;
+
+    class CcCall extends Cc;
+
+    // TODO: member predicate on CcCall
+    predicate matchesCall(CcCall cc, DataFlowCall call);
+
+    class CcNoCall extends Cc;
+
+    Cc ccNone();
+
+    CcCall ccSomeCall();
+
+    class LocalCc;
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc);
+
+    bindingset[call, c, innercc]
+    CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc);
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc);
+
+    bindingset[node1, state1, config]
+    bindingset[node2, state2, config]
+    predicate localStep(
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
+      ApNil ap, Configuration config, LocalCc lcc
+    );
+
+    predicate flowOutOfCall(
+      DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    );
+
+    predicate flowIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    );
+
+    bindingset[node, state, ap, config]
+    predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config);
+
+    bindingset[ap, contentType]
+    predicate typecheckStore(Ap ap, DataFlowType contentType);
   }
 
-  bindingset[result, ap]
-  private ApApprox getApprox(Ap ap) { any() }
+  module Stage<StageParam Param> implements StageSig {
+    import Param
 
-  private ApNil getApNil(NodeEx node) { PrevStage::revFlow(node, _) and exists(result) }
+    /* Begin: Stage logic. */
+    bindingset[result, apa]
+    private ApApprox unbindApa(ApApprox apa) {
+      pragma[only_bind_out](apa) = pragma[only_bind_out](result)
+    }
 
-  bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+    pragma[nomagic]
+    private predicate flowThroughOutOfCall(
+      DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+      Configuration config
+    ) {
+      flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
+      PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
+        pragma[only_bind_into](config)) and
+      matchesCall(ccc, call)
+    }
 
-  pragma[inline]
-  private Content getHeadContent(Ap ap) { exists(result) and ap = true }
+    /**
+     * Holds if `node` is reachable with access path `ap` from a source in the
+     * configuration `config`.
+     *
+     * The call context `cc` records whether the node is reached through an
+     * argument in a call, and if so, `argAp` records the access path of that
+     * argument.
+     */
+    pragma[nomagic]
+    predicate fwdFlow(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      fwdFlow0(node, state, cc, argAp, ap, config) and
+      PrevStage::revFlow(node, state, unbindApa(getApprox(ap)), config) and
+      filter(node, state, ap, config)
+    }
 
-  class ApOption = BooleanOption;
+    pragma[nomagic]
+    private predicate fwdFlow0(
+      NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      sourceNode(node, state, config) and
+      (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
+      argAp = apNone() and
+      ap = getApNil(node)
+      or
+      exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
+        fwdFlow(mid, state0, cc, argAp, ap0, config) and
+        localCc = getLocalCc(mid, cc)
+      |
+        localStep(mid, state0, node, state, true, _, config, localCc) and
+        ap = ap0
+        or
+        localStep(mid, state0, node, state, false, ap, config, localCc) and
+        ap0 instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        jumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStep(mid, node, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(mid, state0, node, state, config) and
+        cc = ccNone() and
+        argAp = apNone() and
+        ap = getApNil(node)
+      )
+      or
+      // store
+      exists(TypedContent tc, Ap ap0 |
+        fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
+        ap = apCons(tc, ap0)
+      )
+      or
+      // read
+      exists(Ap ap0, Content c |
+        fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
+        fwdFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // flow into a callable
+      exists(ApApprox apa |
+        fwdFlowIn(_, node, state, _, cc, _, ap, config) and
+        apa = getApprox(ap) and
+        if PrevStage::parameterMayFlowThrough(node, _, apa, config)
+        then argAp = apSome(ap)
+        else argAp = apNone()
+      )
+      or
+      // flow out of a callable
+      fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
+      or
+      exists(DataFlowCall call, Ap argAp0 |
+        fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
+        fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      )
+    }
 
-  ApOption apNone() { result = TBooleanNone() }
+    pragma[nomagic]
+    private predicate fwdFlowStore(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      exists(DataFlowType contentType |
+        fwdFlow(node1, state, cc, argAp, ap1, config) and
+        PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
+        typecheckStore(ap1, contentType)
+      )
+    }
 
-  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+    /**
+     * Holds if forward flow with access path `tail` reaches a store of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(TypedContent tc |
+        fwdFlowStore(_, tail, tc, _, _, _, _, config) and
+        tc.getContent() = c and
+        cons = apCons(tc, tail)
+      )
+    }
 
+    pragma[nomagic]
+    private predicate fwdFlowRead(
+      Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
+      Configuration config
+    ) {
+      fwdFlow(node1, state, cc, argAp, ap, config) and
+      PrevStage::readStepCand(node1, c, node2, config) and
+      getHeadContent(ap) = c
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowIn(
+      DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
+      Ap ap, Configuration config
+    ) {
+      exists(ArgNodeEx arg, boolean allowsFieldFlow |
+        fwdFlow(arg, state, outercc, argAp, ap, config) and
+        flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+        innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutNotFromArg(
+      NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(
+        DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
+        DataFlowCallable inner
+      |
+        fwdFlow(ret, state, innercc, argAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        inner = ret.getEnclosingCallable() and
+        ccOut = getCallContextReturn(inner, call, innercc) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate fwdFlowOutFromArg(
+      DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
+        fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
+        flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
+     * and data might flow through the target callable and back out at `call`.
+     */
+    pragma[nomagic]
+    private predicate fwdFlowIsEntered(
+      DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p |
+        fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
+        PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate storeStepFwd(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
+    ) {
+      fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
+      ap2 = apCons(tc, ap1) and
+      fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
+    }
+
+    private predicate readStepFwd(
+      NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
+    ) {
+      fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
+      fwdFlowConsCand(ap1, c, ap2, config)
+    }
+
+    pragma[nomagic]
+    private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
+      exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
+        fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+          pragma[only_bind_into](config)) and
+        fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
+        fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+          pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+          pragma[only_bind_into](config))
+      )
+    }
+
+    pragma[nomagic]
+    private predicate flowThroughIntoCall(
+      DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
+    ) {
+      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
+      fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
+      PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
+      callMayFlowThroughFwd(call, pragma[only_bind_into](config))
+    }
+
+    pragma[nomagic]
+    private predicate returnNodeMayFlowThrough(
+      RetNodeEx ret, FlowState state, Ap ap, Configuration config
+    ) {
+      fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
+    }
+
+    /**
+     * Holds if `node` with access path `ap` is part of a path from a source to a
+     * sink in the configuration `config`.
+     *
+     * The Boolean `toReturn` records whether the node must be returned from the
+     * enclosing callable in order to reach a sink, and if so, `returnAp` records
+     * the access path of the returned value.
+     */
+    pragma[nomagic]
+    predicate revFlow(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      revFlow0(node, state, toReturn, returnAp, ap, config) and
+      fwdFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    private predicate revFlow0(
+      NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      fwdFlow(node, state, _, _, ap, config) and
+      sinkNode(node, state, config) and
+      (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
+      returnAp = apNone() and
+      ap instanceof ApNil
+      or
+      exists(NodeEx mid, FlowState state0 |
+        localStep(node, state, mid, state0, true, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, ap, config)
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
+        localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
+        revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid |
+        jumpStep(node, mid, config) and
+        revFlow(mid, state, _, _, ap, config) and
+        toReturn = false and
+        returnAp = apNone()
+      )
+      or
+      exists(NodeEx mid, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStep(node, mid, config) and
+        revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      exists(NodeEx mid, FlowState state0, ApNil nil |
+        fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
+        additionalJumpStateStep(node, state, mid, state0, config) and
+        revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
+          pragma[only_bind_into](config)) and
+        toReturn = false and
+        returnAp = apNone() and
+        ap instanceof ApNil
+      )
+      or
+      // store
+      exists(Ap ap0, Content c |
+        revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
+        revFlowConsCand(ap0, c, ap, config)
+      )
+      or
+      // read
+      exists(NodeEx mid, Ap ap0 |
+        revFlow(mid, state, toReturn, returnAp, ap0, config) and
+        readStepFwd(node, ap, _, mid, ap0, config)
+      )
+      or
+      // flow into a callable
+      revFlowInNotToReturn(node, state, returnAp, ap, config) and
+      toReturn = false
+      or
+      exists(DataFlowCall call, Ap returnAp0 |
+        revFlowInToReturn(call, node, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+      or
+      // flow out of a callable
+      revFlowOut(_, node, state, _, _, ap, config) and
+      toReturn = true and
+      if returnNodeMayFlowThrough(node, state, ap, config)
+      then returnAp = apSome(ap)
+      else returnAp = apNone()
+    }
+
+    pragma[nomagic]
+    private predicate revFlowStore(
+      Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
+      boolean toReturn, ApOption returnAp, Configuration config
+    ) {
+      revFlow(mid, state, toReturn, returnAp, ap0, config) and
+      storeStepFwd(node, ap, tc, mid, ap0, config) and
+      tc.getContent() = c
+    }
+
+    /**
+     * Holds if reverse flow with access path `tail` reaches a read of `c`
+     * resulting in access path `cons`.
+     */
+    pragma[nomagic]
+    private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
+      exists(NodeEx mid, Ap tail0 |
+        revFlow(mid, _, _, _, tail, config) and
+        tail = pragma[only_bind_into](tail0) and
+        readStepFwd(_, cons, c, mid, tail0, config)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowOut(
+      DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
+      Configuration config
+    ) {
+      exists(NodeEx out, boolean allowsFieldFlow |
+        revFlow(out, state, toReturn, returnAp, ap, config) and
+        flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInNotToReturn(
+      ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, false, returnAp, ap, config) and
+        flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    pragma[nomagic]
+    private predicate revFlowInToReturn(
+      DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
+    ) {
+      exists(ParamNodeEx p, boolean allowsFieldFlow |
+        revFlow(p, state, true, apSome(returnAp), ap, config) and
+        flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+        if allowsFieldFlow = false then ap instanceof ApNil else any()
+      )
+    }
+
+    /**
+     * Holds if an output from `call` is reached in the flow covered by `revFlow`
+     * and data might flow through the target callable resulting in reverse flow
+     * reaching an argument of `call`.
+     */
+    pragma[nomagic]
+    private predicate revFlowIsReturned(
+      DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
+    ) {
+      exists(RetNodeEx ret, FlowState state, CcCall ccc |
+        revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
+        fwdFlow(ret, state, ccc, apSome(_), ap, config) and
+        matchesCall(ccc, call)
+      )
+    }
+
+    pragma[nomagic]
+    predicate storeStepCand(
+      NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
+      Configuration config
+    ) {
+      exists(Ap ap2, Content c |
+        PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
+        revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
+        revFlowConsCand(ap2, c, ap1, config)
+      )
+    }
+
+    predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
+      exists(Ap ap1, Ap ap2 |
+        revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
+        readStepFwd(node1, ap1, c, node2, ap2, config) and
+        revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
+          pragma[only_bind_into](config))
+      )
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Configuration config) {
+      revFlow(node, state, _, _, _, config)
+    }
+
+    predicate revFlow(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, _, _, ap, config)
+    }
+
+    pragma[nomagic]
+    predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
+
+    // use an alias as a workaround for bad functionality-induced joins
+    pragma[nomagic]
+    predicate revFlowAlias(NodeEx node, FlowState state, Ap ap, Configuration config) {
+      revFlow(node, state, ap, config)
+    }
+
+    private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepFwd(_, ap, tc, _, _, config)
+    }
+
+    private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
+      storeStepCand(_, ap, tc, _, _, config)
+    }
+
+    private predicate validAp(Ap ap, Configuration config) {
+      revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
+      or
+      exists(TypedContent head, Ap tail |
+        consCand(head, tail, config) and
+        ap = apCons(head, tail)
+      )
+    }
+
+    predicate consCand(TypedContent tc, Ap ap, Configuration config) {
+      revConsCand(tc, ap, config) and
+      validAp(ap, config)
+    }
+
+    pragma[noinline]
+    private predicate parameterFlow(
+      ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
+    ) {
+      revFlow(p, _, true, apSome(ap0), ap, config) and
+      c = p.getEnclosingCallable()
+    }
+
+    predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
+      exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
+        parameterFlow(p, ap, ap0, c, config) and
+        c = ret.getEnclosingCallable() and
+        revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
+          pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
+        fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
+        kind = ret.getKind() and
+        p.getPosition() = pos and
+        // we don't expect a parameter to return stored in itself, unless explicitly allowed
+        (
+          not kind.(ParamUpdateReturnKind).getPosition() = pos
+          or
+          p.allowParameterReturnInSelf()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
+      exists(
+        Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
+      |
+        revFlow(arg, state, toReturn, returnAp, ap, config) and
+        revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
+        revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
+      )
+    }
+
+    predicate stats(
+      boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
+    ) {
+      fwd = true and
+      nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
+      states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
+          fwdFlow(n, state, cc, argAp, ap, config)
+        )
+      or
+      fwd = false and
+      nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
+      fields = count(TypedContent f0 | consCand(f0, _, config)) and
+      conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
+      states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
+      tuples =
+        count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
+          revFlow(n, state, b, retAp, ap, config)
+        )
+    }
+    /* End: Stage logic. */
+  }
+}
+
+private module BooleanCallContext {
+  class Cc extends boolean {
+    Cc() { this in [true, false] }
+  }
+
+  class CcCall extends Cc {
+    CcCall() { this = true }
+  }
+
+  /** Holds if the call context may be `call`. */
+  predicate matchesCall(CcCall cc, DataFlowCall call) { any() }
+
+  class CcNoCall extends Cc {
+    CcNoCall() { this = false }
+  }
+
+  Cc ccNone() { result = false }
+
+  CcCall ccSomeCall() { result = true }
+
+  class LocalCc = Unit;
+
+  bindingset[node, cc]
+  LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+  bindingset[call, c, outercc]
+  CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+
+  bindingset[call, c, innercc]
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+}
+
+private module Level1CallContext {
   class Cc = CallContext;
 
   class CcCall = CallContextCall;
+
+  pragma[inline]
+  predicate matchesCall(CcCall cc, DataFlowCall call) { cc.matchesCall(call) }
 
   class CcNoCall = CallContextNoCall;
 
@@ -1180,28 +1814,79 @@ private module Stage2 {
 
   CcCall ccSomeCall() { result instanceof CallContextSomeCall }
 
-  private class LocalCc = Unit;
+  module NoLocalCallContext {
+    class LocalCc = Unit;
 
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSiteDispatch(call, c)
-    then result = TSpecificCall(call)
-    else result = TSomeCall()
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSiteDispatch(call, c)
+      then result = TSpecificCall(call)
+      else result = TSomeCall()
+    }
+  }
+
+  module LocalCallContext {
+    class LocalCc = LocalCallContext;
+
+    bindingset[node, cc]
+    LocalCc getLocalCc(NodeEx node, Cc cc) {
+      result =
+        getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
+          node.getEnclosingCallable())
+    }
+
+    bindingset[call, c, outercc]
+    CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+      checkCallContextCall(outercc, call, c) and
+      if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
+    }
   }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+  CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
     checkCallContextReturn(innercc, c, call) and
     if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
   }
+}
 
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
+private module Stage2Param implements MkStage<Stage1>::StageParam {
+  private module PrevStage = Stage1;
+
+  class Ap extends boolean {
+    Ap() { this in [true, false] }
+  }
+
+  class ApNil extends Ap {
+    ApNil() { this = false }
+  }
+
+  bindingset[result, ap]
+  PrevStage::Ap getApprox(Ap ap) { any() }
+
+  ApNil getApNil(NodeEx node) { Stage1::revFlow(node, _) and exists(result) }
+
+  bindingset[tc, tail]
+  Ap apCons(TypedContent tc, Ap tail) { result = true and exists(tc) and exists(tail) }
+
+  pragma[inline]
+  Content getHeadContent(Ap ap) { exists(result) and ap = true }
+
+  class ApOption = BooleanOption;
+
+  ApOption apNone() { result = TBooleanNone() }
+
+  ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
+
+  import Level1CallContext
+  import NoLocalCallContext
 
   bindingset[node1, state1, config]
   bindingset[node2, state2, config]
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -1221,9 +1906,9 @@ private module Stage2 {
     exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand1/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand1/5;
+  predicate flowIntoCall = flowIntoCallNodeCand1/5;
 
   pragma[nomagic]
   private predicate expectsContentCand(NodeEx node, Configuration config) {
@@ -1235,7 +1920,7 @@ private module Stage2 {
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     PrevStage::revFlowState(state, pragma[only_bind_into](config)) and
     exists(ap) and
     not stateBarrier(node, state, config) and
@@ -1248,543 +1933,10 @@ private module Stage2 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 2 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 2 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -1883,14 +2035,13 @@ private module LocalFlowBigStep {
   ) {
     additionalLocalFlowStepNodeCand1(node1, node2, config) and
     state1 = state2 and
-    Stage2::revFlow(node1, pragma[only_bind_into](state1), _, _, false,
-      pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), _, _, false,
+    Stage2::revFlow(node1, pragma[only_bind_into](state1), false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false,
       pragma[only_bind_into](config))
     or
     additionalLocalStateStep(node1, state1, node2, state2, config) and
-    Stage2::revFlow(node1, state1, _, _, false, pragma[only_bind_into](config)) and
-    Stage2::revFlowAlias(node2, state2, _, _, false, pragma[only_bind_into](config))
+    Stage2::revFlow(node1, state1, false, pragma[only_bind_into](config)) and
+    Stage2::revFlowAlias(node2, state2, false, pragma[only_bind_into](config))
   }
 
   /**
@@ -1967,26 +2118,24 @@ private module LocalFlowBigStep {
 
 private import LocalFlowBigStep
 
-private module Stage3 {
-  module PrevStage = Stage2;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage3Param implements MkStage<Stage2>::StageParam {
+  private module PrevStage = Stage2;
 
   class Ap = AccessPathFront;
 
   class ApNil = AccessPathFrontNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.toBoolNonEmpty() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TFrontNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result.getHead() = tc and exists(tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathFrontOption;
 
@@ -1994,44 +2143,18 @@ private module Stage3 {
 
   ApOption apSome(Ap ap) { result = TAccessPathFrontSome(ap) }
 
-  class Cc = boolean;
+  import BooleanCallContext
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
-
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
-
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
-
-  CcCall ccSomeCall() { result = true }
-
-  private class LocalCc = Unit;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) { any() }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
     localFlowBigStep(node1, state1, node2, state2, preservesValue, ap, config, _) and exists(lcc)
   }
 
-  private predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
+  predicate flowOutOfCall = flowOutOfCallNodeCand2/5;
 
-  private predicate flowIntoCall = flowIntoCallNodeCand2/5;
+  predicate flowIntoCall = flowIntoCallNodeCand2/5;
 
   pragma[nomagic]
   private predicate clearSet(NodeEx node, ContentSet c, Configuration config) {
@@ -2067,7 +2190,7 @@ private module Stage3 {
   private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) {
     exists(state) and
     exists(config) and
     not clear(node, ap, config) and
@@ -2080,547 +2203,14 @@ private module Stage3 {
   }
 
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) {
+  predicate typecheckStore(Ap ap, DataFlowType contentType) {
     // We need to typecheck stores here, since reverse flow through a getter
     // might have a different type here compared to inside the getter.
     compatibleTypes(ap.getType(), contentType)
   }
-
-  /* Begin: Stage 3 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 3 logic. */
 }
+
+private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`
@@ -2644,7 +2234,7 @@ private predicate expensiveLen2unfolding(TypedContent tc, Configuration config) 
     tails = strictcount(AccessPathFront apf | Stage3::consCand(tc, apf, config)) and
     nodes =
       strictcount(NodeEx n, FlowState state |
-        Stage3::revFlow(n, state, _, _, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
+        Stage3::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
         or
         flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc), config)
       ) and
@@ -2828,26 +2418,24 @@ private class AccessPathApproxOption extends TAccessPathApproxOption {
   }
 }
 
-private module Stage4 {
-  module PrevStage = Stage3;
-
-  class ApApprox = PrevStage::Ap;
+private module Stage4Param implements MkStage<Stage3>::StageParam {
+  private module PrevStage = Stage3;
 
   class Ap = AccessPathApprox;
 
   class ApNil = AccessPathApproxNil;
 
-  private ApApprox getApprox(Ap ap) { result = ap.getFront() }
+  PrevStage::Ap getApprox(Ap ap) { result = ap.getFront() }
 
-  private ApNil getApNil(NodeEx node) {
+  ApNil getApNil(NodeEx node) {
     PrevStage::revFlow(node, _) and result = TNil(node.getDataFlowType())
   }
 
   bindingset[tc, tail]
-  private Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
+  Ap apCons(TypedContent tc, Ap tail) { result = push(tc, tail) }
 
   pragma[noinline]
-  private Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+  Content getHeadContent(Ap ap) { result = ap.getHead().getContent() }
 
   class ApOption = AccessPathApproxOption;
 
@@ -2855,38 +2443,10 @@ private module Stage4 {
 
   ApOption apSome(Ap ap) { result = TAccessPathApproxSome(ap) }
 
-  class Cc = CallContext;
+  import Level1CallContext
+  import LocalCallContext
 
-  class CcCall = CallContextCall;
-
-  class CcNoCall = CallContextNoCall;
-
-  Cc ccNone() { result instanceof CallContextAny }
-
-  CcCall ccSomeCall() { result instanceof CallContextSomeCall }
-
-  private class LocalCc = LocalCallContext;
-
-  bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
-    checkCallContextCall(outercc, call, c) and
-    if recordDataFlowCallSite(call, c) then result = TSpecificCall(call) else result = TSomeCall()
-  }
-
-  bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
-    checkCallContextReturn(innercc, c, call) and
-    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
-  }
-
-  bindingset[node, cc]
-  private LocalCc getLocalCc(NodeEx node, Cc cc) {
-    result =
-      getLocalCallContext(pragma[only_bind_into](pragma[only_bind_out](cc)),
-        node.getEnclosingCallable())
-  }
-
-  private predicate localStep(
+  predicate localStep(
     NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
     ApNil ap, Configuration config, LocalCc lcc
   ) {
@@ -2894,574 +2454,39 @@ private module Stage4 {
   }
 
   pragma[nomagic]
-  private predicate flowOutOfCall(
+  predicate flowOutOfCall(
     DataFlowCall call, RetNodeEx node1, NodeEx node2, boolean allowsFieldFlow, Configuration config
   ) {
     exists(FlowState state |
       flowOutOfCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   pragma[nomagic]
-  private predicate flowIntoCall(
+  predicate flowIntoCall(
     DataFlowCall call, ArgNodeEx node1, ParamNodeEx node2, boolean allowsFieldFlow,
     Configuration config
   ) {
     exists(FlowState state |
       flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow, config) and
-      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, _, _,
-        pragma[only_bind_into](config)) and
-      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _, _, _,
+      PrevStage::revFlow(node2, pragma[only_bind_into](state), _, pragma[only_bind_into](config)) and
+      PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _,
         pragma[only_bind_into](config))
     )
   }
 
   bindingset[node, state, ap, config]
-  private predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
+  predicate filter(NodeEx node, FlowState state, Ap ap, Configuration config) { any() }
 
   // Type checking is not necessary here as it has already been done in stage 3.
   bindingset[ap, contentType]
-  private predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
-
-  /* Begin: Stage 4 logic. */
-  bindingset[node, state, config]
-  private predicate flowCand(NodeEx node, FlowState state, ApApprox apa, Configuration config) {
-    PrevStage::revFlow(node, state, _, _, apa, config)
-  }
-
-  bindingset[result, apa]
-  private ApApprox unbindApa(ApApprox apa) {
-    pragma[only_bind_out](apa) = pragma[only_bind_out](result)
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughOutOfCall(
-    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
-    Configuration config
-  ) {
-    flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
-    PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config)) and
-    ccc.matchesCall(call)
-  }
-
-  /**
-   * Holds if `node` is reachable with access path `ap` from a source in the
-   * configuration `config`.
-   *
-   * The call context `cc` records whether the node is reached through an
-   * argument in a call, and if so, `argAp` records the access path of that
-   * argument.
-   */
-  pragma[nomagic]
-  predicate fwdFlow(NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config) {
-    fwdFlow0(node, state, cc, argAp, ap, config) and
-    flowCand(node, state, unbindApa(getApprox(ap)), config) and
-    filter(node, state, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlow0(
-    NodeEx node, FlowState state, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    sourceNode(node, state, config) and
-    (if hasSourceCallCtx(config) then cc = ccSomeCall() else cc = ccNone()) and
-    argAp = apNone() and
-    ap = getApNil(node)
-    or
-    exists(NodeEx mid, FlowState state0, Ap ap0, LocalCc localCc |
-      fwdFlow(mid, state0, cc, argAp, ap0, config) and
-      localCc = getLocalCc(mid, cc)
-    |
-      localStep(mid, state0, node, state, true, _, config, localCc) and
-      ap = ap0
-      or
-      localStep(mid, state0, node, state, false, ap, config, localCc) and
-      ap0 instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      fwdFlow(mid, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      jumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(mid, state, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStep(mid, node, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(mid, state0, _, _, nil, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(mid, state0, node, state, config) and
-      cc = ccNone() and
-      argAp = apNone() and
-      ap = getApNil(node)
-    )
-    or
-    // store
-    exists(TypedContent tc, Ap ap0 |
-      fwdFlowStore(_, ap0, tc, node, state, cc, argAp, config) and
-      ap = apCons(tc, ap0)
-    )
-    or
-    // read
-    exists(Ap ap0, Content c |
-      fwdFlowRead(ap0, c, _, node, state, cc, argAp, config) and
-      fwdFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // flow into a callable
-    exists(ApApprox apa |
-      fwdFlowIn(_, node, state, _, cc, _, ap, config) and
-      apa = getApprox(ap) and
-      if PrevStage::parameterMayFlowThrough(node, _, apa, config)
-      then argAp = apSome(ap)
-      else argAp = apNone()
-    )
-    or
-    // flow out of a callable
-    fwdFlowOutNotFromArg(node, state, cc, argAp, ap, config)
-    or
-    exists(DataFlowCall call, Ap argAp0 |
-      fwdFlowOutFromArg(call, node, state, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowStore(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    exists(DataFlowType contentType |
-      fwdFlow(node1, state, cc, argAp, ap1, config) and
-      PrevStage::storeStepCand(node1, unbindApa(getApprox(ap1)), tc, node2, contentType, config) and
-      typecheckStore(ap1, contentType)
-    )
-  }
-
-  /**
-   * Holds if forward flow with access path `tail` reaches a store of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(TypedContent tc |
-      fwdFlowStore(_, tail, tc, _, _, _, _, config) and
-      tc.getContent() = c and
-      cons = apCons(tc, tail)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowRead(
-    Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc, ApOption argAp,
-    Configuration config
-  ) {
-    fwdFlow(node1, state, cc, argAp, ap, config) and
-    PrevStage::readStepCand(node1, c, node2, config) and
-    getHeadContent(ap) = c
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowIn(
-    DataFlowCall call, ParamNodeEx p, FlowState state, Cc outercc, Cc innercc, ApOption argAp,
-    Ap ap, Configuration config
-  ) {
-    exists(ArgNodeEx arg, boolean allowsFieldFlow |
-      fwdFlow(arg, state, outercc, argAp, ap, config) and
-      flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutNotFromArg(
-    NodeEx out, FlowState state, Cc ccOut, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(
-      DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow, CcNoCall innercc,
-      DataFlowCallable inner
-    |
-      fwdFlow(ret, state, innercc, argAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate fwdFlowOutFromArg(
-    DataFlowCall call, NodeEx out, FlowState state, Ap argAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
-      fwdFlow(ret, state, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`
-   * and data might flow through the target callable and back out at `call`.
-   */
-  pragma[nomagic]
-  private predicate fwdFlowIsEntered(
-    DataFlowCall call, Cc cc, ApOption argAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p |
-      fwdFlowIn(call, p, _, cc, _, argAp, ap, config) and
-      PrevStage::parameterMayFlowThrough(p, _, unbindApa(getApprox(ap)), config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate storeStepFwd(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, Ap ap2, Configuration config
-  ) {
-    fwdFlowStore(node1, ap1, tc, node2, _, _, _, config) and
-    ap2 = apCons(tc, ap1) and
-    fwdFlowRead(ap2, tc.getContent(), _, _, _, _, _, config)
-  }
-
-  private predicate readStepFwd(
-    NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2, Configuration config
-  ) {
-    fwdFlowRead(ap1, c, n1, n2, _, _, _, config) and
-    fwdFlowConsCand(ap1, c, ap2, config)
-  }
-
-  pragma[nomagic]
-  private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
-    exists(Ap argAp0, NodeEx out, FlowState state, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, state, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
-      fwdFlowOutFromArg(call, out, state, argAp0, ap, config) and
-      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
-        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
-        pragma[only_bind_into](config))
-    )
-  }
-
-  pragma[nomagic]
-  private predicate flowThroughIntoCall(
-    DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Configuration config
-  ) {
-    flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-    fwdFlow(arg, _, _, _, _, pragma[only_bind_into](config)) and
-    PrevStage::parameterMayFlowThrough(p, _, _, pragma[only_bind_into](config)) and
-    callMayFlowThroughFwd(call, pragma[only_bind_into](config))
-  }
-
-  pragma[nomagic]
-  private predicate returnNodeMayFlowThrough(
-    RetNodeEx ret, FlowState state, Ap ap, Configuration config
-  ) {
-    fwdFlow(ret, state, any(CcCall ccc), apSome(_), ap, config)
-  }
-
-  /**
-   * Holds if `node` with access path `ap` is part of a path from a source to a
-   * sink in the configuration `config`.
-   *
-   * The Boolean `toReturn` records whether the node must be returned from the
-   * enclosing callable in order to reach a sink, and if so, `returnAp` records
-   * the access path of the returned value.
-   */
-  pragma[nomagic]
-  predicate revFlow(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow0(node, state, toReturn, returnAp, ap, config) and
-    fwdFlow(node, state, _, _, ap, config)
-  }
-
-  pragma[nomagic]
-  private predicate revFlow0(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    fwdFlow(node, state, _, _, ap, config) and
-    sinkNode(node, state, config) and
-    (if hasSinkCallCtx(config) then toReturn = true else toReturn = false) and
-    returnAp = apNone() and
-    ap instanceof ApNil
-    or
-    exists(NodeEx mid, FlowState state0 |
-      localStep(node, state, mid, state0, true, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, ap, config)
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, pragma[only_bind_into](state), _, _, ap, pragma[only_bind_into](config)) and
-      localStep(node, pragma[only_bind_into](state), mid, state0, false, _, config, _) and
-      revFlow(mid, state0, toReturn, returnAp, nil, pragma[only_bind_into](config)) and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid |
-      jumpStep(node, mid, config) and
-      revFlow(mid, state, _, _, ap, config) and
-      toReturn = false and
-      returnAp = apNone()
-    )
-    or
-    exists(NodeEx mid, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStep(node, mid, config) and
-      revFlow(pragma[only_bind_into](mid), state, _, _, nil, pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    exists(NodeEx mid, FlowState state0, ApNil nil |
-      fwdFlow(node, _, _, _, ap, pragma[only_bind_into](config)) and
-      additionalJumpStateStep(node, state, mid, state0, config) and
-      revFlow(pragma[only_bind_into](mid), pragma[only_bind_into](state0), _, _, nil,
-        pragma[only_bind_into](config)) and
-      toReturn = false and
-      returnAp = apNone() and
-      ap instanceof ApNil
-    )
-    or
-    // store
-    exists(Ap ap0, Content c |
-      revFlowStore(ap0, c, ap, node, state, _, _, toReturn, returnAp, config) and
-      revFlowConsCand(ap0, c, ap, config)
-    )
-    or
-    // read
-    exists(NodeEx mid, Ap ap0 |
-      revFlow(mid, state, toReturn, returnAp, ap0, config) and
-      readStepFwd(node, ap, _, mid, ap0, config)
-    )
-    or
-    // flow into a callable
-    revFlowInNotToReturn(node, state, returnAp, ap, config) and
-    toReturn = false
-    or
-    exists(DataFlowCall call, Ap returnAp0 |
-      revFlowInToReturn(call, node, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-    or
-    // flow out of a callable
-    revFlowOut(_, node, state, _, _, ap, config) and
-    toReturn = true and
-    if returnNodeMayFlowThrough(node, state, ap, config)
-    then returnAp = apSome(ap)
-    else returnAp = apNone()
-  }
-
-  pragma[nomagic]
-  private predicate revFlowStore(
-    Ap ap0, Content c, Ap ap, NodeEx node, FlowState state, TypedContent tc, NodeEx mid,
-    boolean toReturn, ApOption returnAp, Configuration config
-  ) {
-    revFlow(mid, state, toReturn, returnAp, ap0, config) and
-    storeStepFwd(node, ap, tc, mid, ap0, config) and
-    tc.getContent() = c
-  }
-
-  /**
-   * Holds if reverse flow with access path `tail` reaches a read of `c`
-   * resulting in access path `cons`.
-   */
-  pragma[nomagic]
-  private predicate revFlowConsCand(Ap cons, Content c, Ap tail, Configuration config) {
-    exists(NodeEx mid, Ap tail0 |
-      revFlow(mid, _, _, _, tail, config) and
-      tail = pragma[only_bind_into](tail0) and
-      readStepFwd(_, cons, c, mid, tail0, config)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowOut(
-    DataFlowCall call, RetNodeEx ret, FlowState state, boolean toReturn, ApOption returnAp, Ap ap,
-    Configuration config
-  ) {
-    exists(NodeEx out, boolean allowsFieldFlow |
-      revFlow(out, state, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInNotToReturn(
-    ArgNodeEx arg, FlowState state, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  pragma[nomagic]
-  private predicate revFlowInToReturn(
-    DataFlowCall call, ArgNodeEx arg, FlowState state, Ap returnAp, Ap ap, Configuration config
-  ) {
-    exists(ParamNodeEx p, boolean allowsFieldFlow |
-      revFlow(p, state, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
-      if allowsFieldFlow = false then ap instanceof ApNil else any()
-    )
-  }
-
-  /**
-   * Holds if an output from `call` is reached in the flow covered by `revFlow`
-   * and data might flow through the target callable resulting in reverse flow
-   * reaching an argument of `call`.
-   */
-  pragma[nomagic]
-  private predicate revFlowIsReturned(
-    DataFlowCall call, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    exists(RetNodeEx ret, FlowState state, CcCall ccc |
-      revFlowOut(call, ret, state, toReturn, returnAp, ap, config) and
-      fwdFlow(ret, state, ccc, apSome(_), ap, config) and
-      ccc.matchesCall(call)
-    )
-  }
-
-  pragma[nomagic]
-  predicate storeStepCand(
-    NodeEx node1, Ap ap1, TypedContent tc, NodeEx node2, DataFlowType contentType,
-    Configuration config
-  ) {
-    exists(Ap ap2, Content c |
-      PrevStage::storeStepCand(node1, _, tc, node2, contentType, config) and
-      revFlowStore(ap2, c, ap1, node1, _, tc, node2, _, _, config) and
-      revFlowConsCand(ap2, c, ap1, config)
-    )
-  }
-
-  predicate readStepCand(NodeEx node1, Content c, NodeEx node2, Configuration config) {
-    exists(Ap ap1, Ap ap2 |
-      revFlow(node2, _, _, _, pragma[only_bind_into](ap2), pragma[only_bind_into](config)) and
-      readStepFwd(node1, ap1, c, node2, ap2, config) and
-      revFlowStore(ap1, c, pragma[only_bind_into](ap2), _, _, _, _, _, _,
-        pragma[only_bind_into](config))
-    )
-  }
-
-  predicate revFlow(NodeEx node, FlowState state, Configuration config) {
-    revFlow(node, state, _, _, _, config)
-  }
-
-  pragma[nomagic]
-  predicate revFlow(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(NodeEx node, Configuration config) { revFlow(node, _, _, _, _, config) }
-
-  // use an alias as a workaround for bad functionality-induced joins
-  pragma[nomagic]
-  predicate revFlowAlias(
-    NodeEx node, FlowState state, boolean toReturn, ApOption returnAp, Ap ap, Configuration config
-  ) {
-    revFlow(node, state, toReturn, returnAp, ap, config)
-  }
-
-  private predicate fwdConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepFwd(_, ap, tc, _, _, config)
-  }
-
-  private predicate revConsCand(TypedContent tc, Ap ap, Configuration config) {
-    storeStepCand(_, ap, tc, _, _, config)
-  }
-
-  private predicate validAp(Ap ap, Configuration config) {
-    revFlow(_, _, _, _, ap, config) and ap instanceof ApNil
-    or
-    exists(TypedContent head, Ap tail |
-      consCand(head, tail, config) and
-      ap = apCons(head, tail)
-    )
-  }
-
-  predicate consCand(TypedContent tc, Ap ap, Configuration config) {
-    revConsCand(tc, ap, config) and
-    validAp(ap, config)
-  }
-
-  pragma[noinline]
-  private predicate parameterFlow(
-    ParamNodeEx p, Ap ap, Ap ap0, DataFlowCallable c, Configuration config
-  ) {
-    revFlow(p, _, true, apSome(ap0), ap, config) and
-    c = p.getEnclosingCallable()
-  }
-
-  predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, FlowState state, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
-      parameterFlow(p, ap, ap0, c, config) and
-      c = ret.getEnclosingCallable() and
-      revFlow(pragma[only_bind_into](ret), pragma[only_bind_into](state), true, apSome(_),
-        pragma[only_bind_into](ap0), pragma[only_bind_into](config)) and
-      fwdFlow(ret, state, any(CcCall ccc), apSome(ap), ap0, config) and
-      kind = ret.getKind() and
-      p.getPosition() = pos and
-      // we don't expect a parameter to return stored in itself, unless explicitly allowed
-      (
-        not kind.(ParamUpdateReturnKind).getPosition() = pos
-        or
-        p.allowParameterReturnInSelf()
-      )
-    )
-  }
-
-  pragma[nomagic]
-  predicate callMayFlowThroughRev(DataFlowCall call, Configuration config) {
-    exists(
-      Ap returnAp0, ArgNodeEx arg, FlowState state, boolean toReturn, ApOption returnAp, Ap ap
-    |
-      revFlow(arg, state, toReturn, returnAp, ap, config) and
-      revFlowInToReturn(call, arg, state, returnAp0, ap, config) and
-      revFlowIsReturned(call, toReturn, returnAp, returnAp0, config)
-    )
-  }
-
-  predicate stats(
-    boolean fwd, int nodes, int fields, int conscand, int states, int tuples, Configuration config
-  ) {
-    fwd = true and
-    nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | fwdConsCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | fwdConsCand(f0, ap, config)) and
-    states = count(FlowState state | fwdFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, Cc cc, ApOption argAp, Ap ap |
-        fwdFlow(n, state, cc, argAp, ap, config)
-      )
-    or
-    fwd = false and
-    nodes = count(NodeEx node | revFlow(node, _, _, _, _, config)) and
-    fields = count(TypedContent f0 | consCand(f0, _, config)) and
-    conscand = count(TypedContent f0, Ap ap | consCand(f0, ap, config)) and
-    states = count(FlowState state | revFlow(_, state, _, _, _, config)) and
-    tuples =
-      count(NodeEx n, FlowState state, boolean b, ApOption retAp, Ap ap |
-        revFlow(n, state, b, retAp, ap, config)
-      )
-  }
-  /* End: Stage 4 logic. */
+  predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
+
+private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
 
 bindingset[conf, result]
 private Configuration unbindConf(Configuration conf) {
@@ -3495,7 +2520,7 @@ private newtype TSummaryCtx =
   TSummaryCtxSome(ParamNodeEx p, FlowState state, AccessPath ap) {
     exists(Configuration config |
       Stage4::parameterMayFlowThrough(p, _, ap.getApprox(), config) and
-      Stage4::revFlow(p, state, _, _, _, config)
+      Stage4::revFlow(p, state, _, config)
     )
   }
 
@@ -3553,7 +2578,7 @@ private int count1to2unfold(AccessPathApproxCons1 apa, Configuration config) {
 private int countNodesUsingAccessPath(AccessPathApprox apa, Configuration config) {
   result =
     strictcount(NodeEx n, FlowState state |
-      Stage4::revFlow(n, state, _, _, apa, config) or nodeMayUseSummary(n, state, apa, config)
+      Stage4::revFlow(n, state, apa, config) or nodeMayUseSummary(n, state, apa, config)
     )
 }
 
@@ -3667,7 +2692,7 @@ private newtype TPathNode =
     exists(PathNodeMid mid |
       pathStep(mid, node, state, cc, sc, ap) and
       pragma[only_bind_into](config) = mid.getConfiguration() and
-      Stage4::revFlow(node, state, _, _, ap.getApprox(), pragma[only_bind_into](config))
+      Stage4::revFlow(node, state, ap.getApprox(), pragma[only_bind_into](config))
     )
   } or
   TPathNodeSink(NodeEx node, FlowState state, Configuration config) {
@@ -4207,7 +3232,7 @@ private NodeEx getAnOutNodeFlow(
   ReturnKindExt kind, DataFlowCall call, AccessPathApprox apa, Configuration config
 ) {
   result.asNode() = kind.getAnOutNode(call) and
-  Stage4::revFlow(result, _, _, _, apa, config)
+  Stage4::revFlow(result, _, apa, config)
 }
 
 /**
@@ -4243,7 +3268,7 @@ private predicate parameterCand(
   DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
-    Stage4::revFlow(p, _, _, _, apa, config) and
+    Stage4::revFlow(p, _, apa, config) and
     p.isParameterOf(callable, pos)
   )
 }

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -1936,7 +1936,9 @@ private module Stage2Param implements MkStage<Stage1>::StageParam {
   predicate typecheckStore(Ap ap, DataFlowType contentType) { any() }
 }
 
-private module Stage2 = MkStage<Stage1>::Stage<Stage2Param>;
+private module Stage2 implements StageSig {
+  import MkStage<Stage1>::Stage<Stage2Param>
+}
 
 pragma[nomagic]
 private predicate flowOutOfCallNodeCand2(
@@ -2210,7 +2212,9 @@ private module Stage3Param implements MkStage<Stage2>::StageParam {
   }
 }
 
-private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
+private module Stage3 implements StageSig {
+  import MkStage<Stage2>::Stage<Stage3Param>
+}
 
 /**
  * Holds if `argApf` is recorded as the summary context for flow reaching `node`


### PR DESCRIPTION
Appears to work, although there are some complaints of the form
> Some errors in uninstantiated parameterised modules are not (yet) reported, so non-trivial binding sets on signatures can introduce errors that only future compiler versions will be able to detect

@ginsbach 