### PR TITLE
QL: Query for detecting unused parameter in override methods

### DIFF
--- a/ql/ql/src/codeql_ql/performance/VarUnusedInDisjunctQuery.qll
+++ b/ql/ql/src/codeql_ql/performance/VarUnusedInDisjunctQuery.qll
@@ -1,0 +1,27 @@
+import ql
+
+/**
+ * Holds if we assume `t` is a small type, and
+ * variables of this type are therefore not an issue in cartesian products.
+ */
+predicate isSmallType(Type t) {
+  t.getName() = "string" // DataFlow::Configuration and the like
+  or
+  exists(NewType newType | newType = t.getDeclaration() |
+    forex(NewTypeBranch branch | branch = newType.getABranch() | branch.getArity() = 0)
+  )
+  or
+  t.getName() = "boolean"
+  or
+  exists(NewType newType | newType = t.getDeclaration() |
+    forex(NewTypeBranch branch | branch = newType.getABranch() |
+      isSmallType(branch.getReturnType())
+    )
+  )
+  or
+  exists(NewTypeBranch branch | t = branch.getReturnType() |
+    forall(Type param | param = branch.getParameterType(_) | isSmallType(param))
+  )
+  or
+  isSmallType(t.getASuperType())
+}

--- a/ql/ql/src/queries/performance/VarUnusedInDisjunct.ql
+++ b/ql/ql/src/queries/performance/VarUnusedInDisjunct.ql
@@ -10,6 +10,7 @@
  */
 
 import ql
+import codeql_ql.performance.VarUnusedInDisjunctQuery
 
 /**
  * Holds if `node` bind `var` in a (transitive) child node.
@@ -46,32 +47,6 @@ predicate alwaysBindsVar(VarDef var, AstNode node) {
   )
   or
   exists(IfFormula ifForm | ifForm = node | alwaysBindsVar(var, ifForm.getCondition()))
-}
-
-/**
- * Holds if we assume `t` is a small type, and
- * variables of this type are therefore not an issue in cartesian products.
- */
-predicate isSmallType(Type t) {
-  t.getName() = "string" // DataFlow::Configuration and the like
-  or
-  exists(NewType newType | newType = t.getDeclaration() |
-    forex(NewTypeBranch branch | branch = newType.getABranch() | branch.getArity() = 0)
-  )
-  or
-  t.getName() = "boolean"
-  or
-  exists(NewType newType | newType = t.getDeclaration() |
-    forex(NewTypeBranch branch | branch = newType.getABranch() |
-      isSmallType(branch.getReturnType())
-    )
-  )
-  or
-  exists(NewTypeBranch branch | t = branch.getReturnType() |
-    forall(Type param | param = branch.getParameterType(_) | isSmallType(param))
-  )
-  or
-  isSmallType(t.getASuperType())
 }
 
 /**

--- a/ql/ql/src/queries/style/OverrideAny.ql
+++ b/ql/ql/src/queries/style/OverrideAny.ql
@@ -1,0 +1,40 @@
+/**
+ * @name Override with unmentioned parameter
+ * @description A predicate that overrides the default behavior but doesn't mention a parameter is suspicious.
+ * @kind problem
+ * @problem.severity warning
+ * @id ql/override-any
+ * @precision very-high
+ */
+
+import ql
+import codeql_ql.performance.VarUnusedInDisjunctQuery
+
+AstNode param(Predicate pred, string name, Type t) {
+  result = pred.getParameter(_) and
+  result.(VarDecl).getName() = name and
+  result.(VarDecl).getType() = t
+  or
+  result = pred.getReturnTypeExpr() and
+  name = "result" and
+  t = pred.getReturnType()
+}
+
+predicate hasAccess(Predicate pred, string name) {
+  exists(param(pred, name, _).(VarDecl).getAnAccess())
+  or
+  name = "result" and
+  exists(param(pred, name, _)) and
+  exists(ResultAccess res | res.getEnclosingPredicate() = pred)
+}
+
+from Predicate pred, AstNode param, string name, Type paramType
+where
+  pred.hasAnnotation("override") and
+  param = param(pred, name, paramType) and
+  not hasAccess(pred, name) and
+  not pred.getBody() instanceof NoneCall and
+  exists(pred.getBody()) and
+  not isSmallType(pred.getParent().(Class).getType()) and
+  not isSmallType(paramType)
+select pred, "Override predicate doesn't mention $@.", param, name

--- a/ql/ql/src/queries/style/OverrideAny.ql
+++ b/ql/ql/src/queries/style/OverrideAny.ql
@@ -37,4 +37,5 @@ where
   exists(pred.getBody()) and
   not isSmallType(pred.getParent().(Class).getType()) and
   not isSmallType(paramType)
-select pred, "Override predicate doesn't mention $@.", param, name
+select pred, "Override predicate doesn't mention $@. Maybe mention it in a 'exists(" + name + ")'?",
+  param, name

--- a/ql/ql/src/queries/style/OverrideAny.ql
+++ b/ql/ql/src/queries/style/OverrideAny.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity warning
  * @id ql/override-any
- * @precision very-high
+ * @precision high
  */
 
 import ql


### PR DESCRIPTION
All current results are benign because the type of the unmentioned parameter is small.  
But it is very hard to statically determine that the  type is small. (E.g. one is an abstract class, where all (transitive) overrides are small).  

The fix to remove the alert for the benign results is just to insert `exists(param)` instead of `any()`.   

I did try to remove the `pred.hasAnnotation("override")` restriction, but that just gave me more noise.  