### PR TITLE
Kotlin: annotation properties should be java.lang.Class not KClass

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -1103,7 +1103,50 @@ open class KotlinUsesExtractor(
         return "@\"$prefix;{$parentId}.$name($paramTypeIds){$returnTypeId}${typeArgSuffix}\""
     }
 
+    val javaLangClass by lazy {
+        val result = pluginContext.referenceClass(FqName("java.lang.Class"))?.owner
+        result?.let { extractExternalClassLater(it) }
+        result
+    }
+
+    fun kClassToJavaClass(t: IrType): IrType {
+        when(t) {
+            is IrSimpleType -> {
+                if (t.classifier == pluginContext.irBuiltIns.kClassClass) {
+                    javaLangClass?.let { jlc ->
+                        return jlc.symbol.typeWithArguments(t.arguments)
+                    }
+                } else if (t.isArray() || t.isNullableArray()) {
+                    val elementType = t.getArrayElementType(pluginContext.irBuiltIns)
+                    val replacedElementType = kClassToJavaClass(elementType)
+                    if (replacedElementType !== elementType) {
+                        val newArg = makeTypeProjection(replacedElementType, (t.arguments[0] as IrTypeProjection).variance)
+                        return t.classOrNull!!.typeWithArguments(listOf(newArg)).codeQlWithHasQuestionMark(t.isNullableArray())
+                    }
+                }
+            }
+        }
+        return t
+    }
+
+    fun isAnnotationClassField(f: IrField) =
+        f.correspondingPropertySymbol?.let {
+            isAnnotationClassProperty(it)
+        } ?: false
+
+    fun isAnnotationClassProperty(p: IrPropertySymbol) =
+        p.owner.parentClassOrNull?.kind == ClassKind.ANNOTATION_CLASS
+
     fun getAdjustedReturnType(f: IrFunction) : IrType {
+        // Replace annotation val accessor types as needed:
+        (f as? IrSimpleFunction)?.correspondingPropertySymbol?.let {
+            if (isAnnotationClassProperty(it) && f == it.owner.getter) {
+                val replaced = kClassToJavaClass(f.returnType)
+                if (replaced != f.returnType)
+                    return replaced
+            }
+        }
+
         // The return type of `java.util.concurrent.ConcurrentHashMap<K,V>.keySet/0` is defined as `Set<K>` in the stubs inside the Android SDK.
         // This does not match the Java SDK return type: `ConcurrentHashMap.KeySetView<K,V>`, so it's adjusted here.
         // This is a deliberate change in the Android SDK: https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-31/blob/2c56b25f619575bea12f9c5520ed2259620084ac/java/util/concurrent/ConcurrentHashMap.java#L1244-L1249

--- a/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/PrintAst.expected
@@ -1,0 +1,82 @@
+test.kt:
+#    0| [CompilationUnit] test
+#    3|   1: [Interface] A
+#    3|     1: [Constructor] A
+#-----|       4: (Parameters)
+#    3|         0: [Parameter] c1
+#    3|           0: [TypeAccess] Class<?>
+#    3|             0: [WildcardTypeAccess] ? ...
+#    3|         1: [Parameter] c2
+#    3|           0: [TypeAccess] Class<? extends CharSequence>
+#    3|             0: [WildcardTypeAccess] ? ...
+#    3|               0: [TypeAccess] CharSequence
+#    3|         2: [Parameter] c3
+#    3|           0: [TypeAccess] Class<String>
+#    3|             0: [TypeAccess] String
+#    3|         3: [Parameter] c4
+#    3|           0: [TypeAccess] Class<?>[]
+#    3|             0: [TypeAccess] Class<?>
+#    3|               0: [WildcardTypeAccess] ? ...
+#    3|       5: [BlockStmt] { ... }
+#    3|         0: [SuperConstructorInvocationStmt] super(...)
+#    3|         1: [BlockStmt] { ... }
+#    3|           0: [ExprStmt] <Expr>;
+#    3|             0: [KtInitializerAssignExpr] ...=...
+#    3|               0: [VarAccess] c1
+#    3|           1: [ExprStmt] <Expr>;
+#    3|             0: [KtInitializerAssignExpr] ...=...
+#    3|               0: [VarAccess] c2
+#    3|           2: [ExprStmt] <Expr>;
+#    3|             0: [KtInitializerAssignExpr] ...=...
+#    3|               0: [VarAccess] c3
+#    3|           3: [ExprStmt] <Expr>;
+#    3|             0: [KtInitializerAssignExpr] ...=...
+#    3|               0: [VarAccess] c4
+#    3|     2: [FieldDeclaration] Class<?> c1;
+#    3|       -1: [TypeAccess] Class<?>
+#    3|         0: [WildcardTypeAccess] ? ...
+#    3|       0: [VarAccess] c1
+#    3|     3: [Method] c1
+#    3|       3: [TypeAccess] Class<?>
+#    3|         0: [WildcardTypeAccess] ? ...
+#    3|       5: [BlockStmt] { ... }
+#    3|         0: [ReturnStmt] return ...
+#    3|           0: [VarAccess] this.c1
+#    3|             -1: [ThisAccess] this
+#    3|     4: [FieldDeclaration] Class<? extends CharSequence> c2;
+#    3|       -1: [TypeAccess] Class<? extends CharSequence>
+#    3|         0: [WildcardTypeAccess] ? ...
+#    3|           0: [TypeAccess] CharSequence
+#    3|       0: [VarAccess] c2
+#    3|     5: [Method] c2
+#    3|       3: [TypeAccess] Class<? extends CharSequence>
+#    3|         0: [WildcardTypeAccess] ? ...
+#    3|           0: [TypeAccess] CharSequence
+#    3|       5: [BlockStmt] { ... }
+#    3|         0: [ReturnStmt] return ...
+#    3|           0: [VarAccess] this.c2
+#    3|             -1: [ThisAccess] this
+#    3|     6: [FieldDeclaration] Class<String> c3;
+#    3|       -1: [TypeAccess] Class<String>
+#    3|         0: [TypeAccess] String
+#    3|       0: [VarAccess] c3
+#    3|     7: [Method] c3
+#    3|       3: [TypeAccess] Class<String>
+#    3|         0: [TypeAccess] String
+#    3|       5: [BlockStmt] { ... }
+#    3|         0: [ReturnStmt] return ...
+#    3|           0: [VarAccess] this.c3
+#    3|             -1: [ThisAccess] this
+#    3|     8: [FieldDeclaration] Class<?>[] c4;
+#    3|       -1: [TypeAccess] Class<?>[]
+#    3|         0: [TypeAccess] Class<?>
+#    3|           0: [WildcardTypeAccess] ? ...
+#    3|       0: [VarAccess] c4
+#    3|     9: [Method] c4
+#    3|       3: [TypeAccess] Class<?>[]
+#    3|         0: [TypeAccess] Class<?>
+#    3|           0: [WildcardTypeAccess] ? ...
+#    3|       5: [BlockStmt] { ... }
+#    3|         0: [ReturnStmt] return ...
+#    3|           0: [VarAccess] this.c4
+#    3|             -1: [ThisAccess] this

--- a/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/PrintAst.qlref
+++ b/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/PrintAst.qlref
@@ -1,0 +1,1 @@
+semmle/code/java/PrintAst.ql

--- a/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/test.expected
+++ b/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/test.expected
@@ -1,0 +1,37 @@
+classExprs
+| test.kt:3:20:3:36 | ...=... | Class<?> |
+| test.kt:3:20:3:36 | Class<?> | Class<?> |
+| test.kt:3:20:3:36 | Class<?> | Class<?> |
+| test.kt:3:20:3:36 | Class<?> | Class<?> |
+| test.kt:3:20:3:36 | c1 | Class<?> |
+| test.kt:3:20:3:36 | c1 | Class<?> |
+| test.kt:3:20:3:36 | this.c1 | Class<?> |
+| test.kt:3:39:3:70 | ...=... | Class<? extends CharSequence> |
+| test.kt:3:39:3:70 | Class<? extends CharSequence> | Class<? extends CharSequence> |
+| test.kt:3:39:3:70 | Class<? extends CharSequence> | Class<? extends CharSequence> |
+| test.kt:3:39:3:70 | Class<? extends CharSequence> | Class<? extends CharSequence> |
+| test.kt:3:39:3:70 | c2 | Class<? extends CharSequence> |
+| test.kt:3:39:3:70 | c2 | Class<? extends CharSequence> |
+| test.kt:3:39:3:70 | this.c2 | Class<? extends CharSequence> |
+| test.kt:3:73:3:94 | ...=... | Class<String> |
+| test.kt:3:73:3:94 | Class<String> | Class<String> |
+| test.kt:3:73:3:94 | Class<String> | Class<String> |
+| test.kt:3:73:3:94 | Class<String> | Class<String> |
+| test.kt:3:73:3:94 | c3 | Class<String> |
+| test.kt:3:73:3:94 | c3 | Class<String> |
+| test.kt:3:73:3:94 | this.c3 | Class<String> |
+| test.kt:3:97:3:120 | ...=... | Class<?>[] |
+| test.kt:3:97:3:120 | Class<?> | Class<?> |
+| test.kt:3:97:3:120 | Class<?> | Class<?> |
+| test.kt:3:97:3:120 | Class<?> | Class<?> |
+| test.kt:3:97:3:120 | Class<?>[] | Class<?>[] |
+| test.kt:3:97:3:120 | Class<?>[] | Class<?>[] |
+| test.kt:3:97:3:120 | Class<?>[] | Class<?>[] |
+| test.kt:3:97:3:120 | c4 | Class<?>[] |
+| test.kt:3:97:3:120 | c4 | Class<?>[] |
+| test.kt:3:97:3:120 | this.c4 | Class<?>[] |
+#select
+| test.kt:3:20:3:36 | c1 | Class<?> |
+| test.kt:3:39:3:70 | c2 | Class<? extends CharSequence> |
+| test.kt:3:73:3:94 | c3 | Class<String> |
+| test.kt:3:97:3:120 | c4 | Class<?>[] |

--- a/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/test.kt
+++ b/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/test.kt
@@ -1,0 +1,3 @@
+import kotlin.reflect.KClass
+
+annotation class A(val c1: KClass<*>, val c2: KClass<out CharSequence>, val c3: KClass<String>, val c4: Array<KClass<*>>) { }

--- a/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/test.ql
+++ b/java/ql/test/kotlin/library-tests/annotation-accessor-result-type/test.ql
@@ -1,0 +1,10 @@
+import java
+
+query predicate classExprs(Expr e, string tstr) {
+  tstr = e.getType().toString() and
+  tstr.matches("%Class%")
+}
+
+from Method m
+where m.getDeclaringType().fromSource()
+select m, m.getReturnType().toString()


### PR DESCRIPTION
As documented at https://kotlinlang.org/docs/annotations.html#constructors, annotation properties of type KClass get rewritten when targeting the JVM.