### PR TITLE
Docs: Update supported languages page with links to CLI and pack information

### DIFF
--- a/docs/codeql/codeql-overview/supported-languages-and-frameworks.rst
+++ b/docs/codeql/codeql-overview/supported-languages-and-frameworks.rst
@@ -11,14 +11,17 @@ CodeQL.
 Languages and compilers
 #######################
 
-CodeQL supports the following languages and compilers.
+The current versions of the CodeQL CLI (`changelog <https://github.com/github/codeql-cli-binaries/blob/main/CHANGELOG.md>`__, `releases <https://github.com/github/codeql-cli-binaries/releases>`__),
+CodeQL library packs (`source <https://github.com/github/codeql/tree/codeql-cli/latest>`__),
+and CodeQL bundle (`releases <https://github.com/github/codeql-action/releases>`__)
+support the following languages and compilers.
 
 .. include:: ../support/reusables/versions-compilers.rst
 
 Frameworks and libraries
 ########################
 
-The libraries and queries in the current version of CodeQL have been explicitly checked against the libraries and frameworks listed below.
+The current versions of the CodeQL library and query packs (`source <https://github.com/github/codeql/tree/codeql-cli/latest>`__) have been explicitly checked against the libraries and frameworks listed below.
 
 .. pull-quote::
 

--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -1,6 +1,10 @@
 C and C++ built-in support
 ================================
 
+Provided by the current versions of the
+CodeQL query pack ``codeql/cpp-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/cpp/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/cpp/ql/src>`__)
+and the CodeQL library pack ``codeql/cpp-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/cpp/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/cpp/ql/lib>`__).
+
 .. csv-table::
    :header-rows: 1
    :class: fullWidthTable
@@ -13,6 +17,10 @@ C and C++ built-in support
 
 C# built-in support
 ================================
+
+Provided by the current versions of the
+CodeQL query pack ``codeql/csharp-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/csharp/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/csharp/ql/src>`__)
+and the CodeQL library pack ``codeql/csharp-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/csharp/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/csharp/ql/lib>`__).
 
 .. csv-table::
    :header-rows: 1
@@ -32,6 +40,10 @@ C# built-in support
 
 Go built-in support
 ================================
+
+Provided by the current versions of the
+CodeQL query pack ``codeql/go-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/go/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/go/ql/src>`__)
+and the CodeQL library pack ``codeql/go-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/go/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/go/ql/lib>`__).
 
 .. csv-table::
    :header-rows: 1
@@ -84,6 +96,10 @@ Go built-in support
 Java built-in support
 ==================================
 
+Provided by the current versions of the
+CodeQL query pack ``codeql/java-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/java/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/java/ql/src>`__)
+and the CodeQL library pack ``codeql/java-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/java/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/java/ql/lib>`__).
+
 .. csv-table::
    :header-rows: 1
    :class: fullWidthTable
@@ -112,6 +128,10 @@ Java built-in support
 
 JavaScript and TypeScript built-in support
 =======================================================
+
+Provided by the current versions of the
+CodeQL query pack ``codeql/javascript-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/javascript/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/javascript/ql/src>`__)
+and the CodeQL library pack ``codeql/javascript-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/javascript/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/javascript/ql/lib>`__).
 
 .. csv-table::
    :header-rows: 1
@@ -155,6 +175,10 @@ JavaScript and TypeScript built-in support
 
 Python built-in support
 ====================================
+
+Provided by the current versions of the
+CodeQL query pack ``codeql/python-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/python/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/python/ql/src>`__)
+and the CodeQL library pack ``codeql/python-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/python/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/python/ql/lib>`__).
 
 .. csv-table::
    :header-rows: 1


### PR DESCRIPTION
Include links to the CLI changelog, CLI releases, bundle releases, pack changelogs, and pack source.

Clarify that this support information applies to the current version of the CLI, bundle, query packs, and library packs.

Reviewer notes:
- I'm slightly unsure how often to mention the CodeQL bundle. We should mention it somewhere, but it feels like too much to mention it everywhere we mention the query or library packs. I've compromised by mentioning it only where we mention the CLI.