### PR TITLE
Fix lots of misspellings 

### DIFF
--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -40,6 +40,7 @@ jobs:
           "${CODEQL}" pack create
           cd .codeql/pack/codeql/ql/0.0.0
           zip "${PACKZIP}" -r .
+          rm -rf *
         env:
           CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
           PACKZIP: ${{ runner.temp }}/query-pack.zip
@@ -117,6 +118,7 @@ jobs:
           fi
           cd pack
           zip -rq ../codeql-ql.zip .
+          rm -rf *
       - uses: actions/upload-artifact@v3
         with:
           name: codeql-ql-pack

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/BasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/BasicBlocks.qll
@@ -231,7 +231,7 @@ class BasicBlock extends ControlFlowNodeBase {
     exists(Function f | f.getBlock() = this)
     or
     exists(TryStmt t, BasicBlock tryblock |
-      // a `Handler` preceeds the `CatchBlock`, and is always the beginning
+      // a `Handler` precedes the `CatchBlock`, and is always the beginning
       // of a new `BasicBlock` (see `primitive_basic_block_entry_node`).
       this.(Handler).getTryStmt() = t and
       tryblock.isReachable() and

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
@@ -218,7 +218,7 @@ private class CallAllocationExpr extends AllocationExpr, FunctionCall {
       exists(target.getReallocPtrArg()) and
       this.getArgument(target.getSizeArg()).getValue().toInt() = 0
     ) and
-    // these are modelled directly (and more accurately), avoid duplication
+    // these are modeled directly (and more accurately), avoid duplication
     not exists(NewOrNewArrayExpr new | new.getAllocatorCall() = this)
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/Overflow.qll
@@ -50,7 +50,7 @@ VariableAccess varUse(LocalScopeVariable v) { result = v.getAnAccess() }
  * Holds if `e` potentially overflows and `use` is an operand of `e` that is not guarded.
  */
 predicate missingGuardAgainstOverflow(Operation e, VariableAccess use) {
-  // Since `e` is guarenteed to be a `BinaryArithmeticOperation`, a `UnaryArithmeticOperation` or
+  // Since `e` is guaranteed to be a `BinaryArithmeticOperation`, a `UnaryArithmeticOperation` or
   // an `AssignArithmeticOperation` by the other constraints in this predicate, we know that
   // `convertedExprMightOverflowPositively` will have a result even when `e` is not analyzable
   // by `SimpleRangeAnalysis`.
@@ -80,7 +80,7 @@ predicate missingGuardAgainstOverflow(Operation e, VariableAccess use) {
  * Holds if `e` potentially underflows and `use` is an operand of `e` that is not guarded.
  */
 predicate missingGuardAgainstUnderflow(Operation e, VariableAccess use) {
-  // Since `e` is guarenteed to be a `BinaryArithmeticOperation`, a `UnaryArithmeticOperation` or
+  // Since `e` is guaranteed to be a `BinaryArithmeticOperation`, a `UnaryArithmeticOperation` or
   // an `AssignArithmeticOperation` by the other constraints in this predicate, we know that
   // `convertedExprMightOverflowNegatively` will have a result even when `e` is not analyzable
   // by `SimpleRangeAnalysis`.

--- a/cpp/ql/src/Likely Bugs/Likely Typos/AssignWhereCompareMeant.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/AssignWhereCompareMeant.ql
@@ -68,7 +68,7 @@ class BooleanControllingAssignmentInExpr extends BooleanControllingAssignment {
     // if((a = b) && use_value(a)) { ... }
     // ```
     // where the assignment is meant to update the value of `a` before it's used in some other boolean
-    // subexpression that is guarenteed to be evaluate _after_ the assignment.
+    // subexpression that is guaranteed to be evaluate _after_ the assignment.
     this.isParenthesised() and
     exists(LogicalAndExpr parent, Variable var, VariableAccess access |
       var = this.getLValue().(VariableAccess).getTarget() and

--- a/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
@@ -51,7 +51,7 @@ predicate illDefinedDecrForStmt(
     (
       upperBound(initialCondition) < lowerBound(terminalCondition) and
       (
-        // exclude cases where the loop counter is `unsigned` (where wrapping behaviour can be used deliberately)
+        // exclude cases where the loop counter is `unsigned` (where wrapping behavior can be used deliberately)
         v.getUnspecifiedType().(IntegralType).isSigned() or
         initialCondition.getValue().toInt() = 0
       )

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -1288,7 +1288,7 @@ module Statements {
     }
 
     final override predicate first(ControlFlowElement first) {
-      // Unlike most other statements, `foreach` statements are not modelled in
+      // Unlike most other statements, `foreach` statements are not modeled in
       // pre-order, because we use the `foreach` node itself to represent the
       // emptiness test that determines whether to execute the loop body
       first(this.getIterableExpr(), first)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
@@ -149,7 +149,7 @@ private module Cached {
     // Taint members
     readStep(nodeFrom, any(TaintedMember m).(FieldOrProperty).getContent(), nodeTo)
     or
-    // Although flow through collections is modelled precisely using stores/reads, we still
+    // Although flow through collections is modeled precisely using stores/reads, we still
     // allow flow out of a _tainted_ collection. This is needed in order to support taint-
     // tracking configurations where the source is a collection
     readStep(nodeFrom, TElementContent(), nodeTo)

--- a/go/ql/lib/semmle/go/Expr.qll
+++ b/go/ql/lib/semmle/go/Expr.qll
@@ -1671,7 +1671,7 @@ class MulExpr extends @mulexpr, ArithmeticBinaryExpr {
 }
 
 /**
- * A divison or quotient expression using `/`.
+ * A division or quotient expression using `/`.
  *
  * Examples:
  *

--- a/go/ql/lib/semmle/go/dataflow/FlowSummary.qll
+++ b/go/ql/lib/semmle/go/dataflow/FlowSummary.qll
@@ -1,5 +1,5 @@
 /**
- * Provides classes and predicates for definining flow summaries.
+ * Provides classes and predicates for defining flow summaries.
  */
 
 import go

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplCommon.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplCommon.qll
@@ -280,7 +280,7 @@ cached
 private module Cached {
   /**
    * If needed, call this predicate from `DataFlowImplSpecific.qll` in order to
-   * force a stage-dependency on the `DataFlowImplCommon.qll` stage and therby
+   * force a stage-dependency on the `DataFlowImplCommon.qll` stage and thereby
    * collapsing the two stages.
    */
   cached

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -110,7 +110,7 @@ predicate jumpStep(Node n1, Node n2) {
  * value of `node1`.
  */
 predicate storeStep(Node node1, Content c, Node node2) {
-  // a write `(*p).f = rhs` is modelled as two store steps: `rhs` is flows into field `f` of `(*p)`,
+  // a write `(*p).f = rhs` is modeled as two store steps: `rhs` is flows into field `f` of `(*p)`,
   // which in turn flows into the pointer content of `p`
   exists(Write w, Field f, DataFlow::Node base, DataFlow::Node rhs | w.writesField(base, f, rhs) |
     node1 = rhs and

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -269,7 +269,7 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
   }
 
   /**
-   * Holds if `guard` markes a point in the control-flow graph where this node
+   * Holds if `guard` marks a point in the control-flow graph where this node
    * is known to validate `nd`, which is represented by `ap`.
    *
    * This predicate exists to enforce a good join order in `getAGuardedNode`.
@@ -280,7 +280,7 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
   }
 
   /**
-   * Holds if `guard` markes a point in the control-flow graph where this node
+   * Holds if `guard` marks a point in the control-flow graph where this node
    * is known to validate `nd`.
    */
   private predicate guards(Node g, ControlFlow::ConditionGuardNode guard, Node nd) {

--- a/go/ql/lib/semmle/go/frameworks/stdlib/NetHttp.qll
+++ b/go/ql/lib/semmle/go/frameworks/stdlib/NetHttp.qll
@@ -149,7 +149,7 @@ module NetHttp {
       )
       or
       exists(TaintTracking::FunctionModel model |
-        // A modelled function conveying taint from some input to the response writer,
+        // A modeled function conveying taint from some input to the response writer,
         // e.g. `io.Copy(responseWriter, someTaintedReader)`
         model.taintStep(this, responseWriter) and
         responseWriter.getType().implements("net/http", "ResponseWriter")

--- a/go/ql/lib/semmle/go/security/ExternalAPIs.qll
+++ b/go/ql/lib/semmle/go/security/ExternalAPIs.qll
@@ -65,7 +65,7 @@ class ExternalAPIDataNode extends DataFlow::Node {
       this = call.getReceiver() and
       i = -1
     ) and
-    // Not defined in the code that is being analysed
+    // Not defined in the code that is being analyzed
     not exists(call.getACallee().getBody()) and
     // Not a function pointer, unless it's declared at package scope
     not isProbableLocalFunctionPointer(call) and
@@ -124,7 +124,7 @@ Package getAPackageWithFunctionModels() {
 Package getAPackageWithModels() {
   result = getAPackageWithFunctionModels()
   or
-  // An incomplete list of packages which have been modelled but do not have any function models
+  // An incomplete list of packages which have been modeled but do not have any function models
   result.getPath() in [
       Logrus::packagePath(), GolangOrgXNetWebsocket::packagePath(), GorillaWebsocket::packagePath()
     ]

--- a/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
+++ b/go/ql/lib/semmle/go/security/IncorrectIntegerConversionLib.qll
@@ -98,7 +98,7 @@ class ConversionWithoutBoundsCheckConfig extends TaintTracking::Configuration {
       ) and
       // `effectiveBitSize` could be any value between 0 and 64, but we
       // can round it up to the nearest size of an integer type without
-      // changing behaviour.
+      // changing behavior.
       sourceBitSize = min(int b | b in [0, 8, 16, 32, 64] and b >= effectiveBitSize)
     )
   }

--- a/go/ql/lib/semmle/go/security/Xss.qll
+++ b/go/ql/lib/semmle/go/security/Xss.qll
@@ -14,7 +14,7 @@ module SharedXss {
     /**
      * Gets the kind of vulnerability to report in the alert message.
      *
-     * Defaults to `Cross-site scripting`, but may be overriden for sinks
+     * Defaults to `Cross-site scripting`, but may be overridden for sinks
      * that do not allow script injection, but injection of other undesirable HTML elements.
      */
     string getVulnerabilityKind() { result = "Cross-site scripting" }

--- a/go/ql/src/experimental/CWE-807/SensitiveConditionBypass.ql
+++ b/go/ql/src/experimental/CWE-807/SensitiveConditionBypass.ql
@@ -20,9 +20,9 @@ from
 where
   // there should be a flow between source and the operand sink
   config.hasFlowPath(source, operand) and
-  // both the operand should belong to the same comparision expression
+  // both the operand should belong to the same comparison expression
   operand.getNode().asExpr() = comp.getAnOperand() and
-  // get the ConditionGuardNode corresponding to the comparision expr.
+  // get the ConditionGuardNode corresponding to the comparison expr.
   guard.getCondition() = comp and
   // the sink `sensitiveSink` should be sensitive,
   isSensitive(sensitiveSink, classification) and

--- a/java/ql/lib/semmle/code/java/frameworks/android/Intent.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Intent.qll
@@ -283,7 +283,7 @@ private class IntentBundleFlowSteps extends SummaryModelCsv {
         "android.os;Bundle;true;putStringArrayList;;;Argument[1];Argument[-1].MapValue;value;manual",
         "android.os;Bundle;true;readFromParcel;;;Argument[0];Argument[-1].MapKey;taint;manual",
         "android.os;Bundle;true;readFromParcel;;;Argument[0];Argument[-1].MapValue;taint;manual",
-        // currently only the Extras part of the intent and the data field are fully modelled
+        // currently only the Extras part of the intent and the data field are fully modeled
         "android.content;Intent;false;Intent;(Intent);;Argument[0].SyntheticField[android.content.Intent.extras].MapKey;Argument[-1].SyntheticField[android.content.Intent.extras].MapKey;value;manual",
         "android.content;Intent;false;Intent;(Intent);;Argument[0].SyntheticField[android.content.Intent.extras].MapValue;Argument[-1].SyntheticField[android.content.Intent.extras].MapValue;value;manual",
         "android.content;Intent;false;Intent;(String,Uri);;Argument[1];Argument[-1].SyntheticField[android.content.Intent.data];value;manual",

--- a/java/ql/lib/semmle/code/java/frameworks/guava/Cache.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/guava/Cache.qll
@@ -13,7 +13,7 @@ private class GuavaBaseCsv extends SummaryModelCsv {
         // lambda flow from Argument[1] not implemented
         "com.google.common.cache;Cache;true;get;(Object,Callable);;Argument[-1].MapValue;ReturnValue;value;manual",
         "com.google.common.cache;Cache;true;getIfPresent;(Object);;Argument[-1].MapValue;ReturnValue;value;manual",
-        // the true flow to MapKey of ReturnValue for getAllPresent is the intersection of the these inputs, but intersections cannot be modelled fully accurately.
+        // the true flow to MapKey of ReturnValue for getAllPresent is the intersection of the these inputs, but intersections cannot be modeled fully accurately.
         "com.google.common.cache;Cache;true;getAllPresent;(Iterable);;Argument[-1].MapKey;ReturnValue.MapKey;value;manual",
         "com.google.common.cache;Cache;true;getAllPresent;(Iterable);;Argument[0].Element;ReturnValue.MapKey;value;manual",
         "com.google.common.cache;Cache;true;getAllPresent;(Iterable);;Argument[-1].MapValue;ReturnValue.MapValue;value;manual",

--- a/java/ql/lib/semmle/code/java/frameworks/guava/Collections.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/guava/Collections.qll
@@ -13,8 +13,8 @@ private class GuavaCollectCsv extends SummaryModelCsv {
     row =
       [
         //"package;type;overrides;name;signature;ext;inputspec;outputspec;kind",
-        // Methods depending on lambda flow are not currently modelled
-        // Methods depending on stronger aliasing properties than we support are also not modelled.
+        // Methods depending on lambda flow are not currently modeled
+        // Methods depending on stronger aliasing properties than we support are also not modeled.
         "com.google.common.collect;ArrayListMultimap;true;create;(Multimap);;Argument[0].MapKey;ReturnValue.MapKey;value;manual",
         "com.google.common.collect;ArrayListMultimap;true;create;(Multimap);;Argument[0].MapValue;ReturnValue.MapValue;value;manual",
         "com.google.common.collect;ArrayTable;true;create;(Iterable,Iterable);;Argument[0].Element;ReturnValue.SyntheticField[com.google.common.collect.Table.rowKey];value;manual",

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
@@ -160,7 +160,7 @@ private class SpringXssSink extends XSS::XssSink {
     |
       // If a Spring request mapping method is either annotated with @ResponseBody (or equivalent),
       // or returns a HttpEntity or sub-type, then the return value of the method is converted into
-      // a HTTP reponse using a HttpMessageConverter implementation. The implementation is chosen
+      // a HTTP response using a HttpMessageConverter implementation. The implementation is chosen
       // based on the return type of the method, and the Accept header of the request.
       //
       // By default, the only message converter which produces a response which is vulnerable to

--- a/java/ql/lib/semmle/code/java/regex/RegexTreeView.qll
+++ b/java/ql/lib/semmle/code/java/regex/RegexTreeView.qll
@@ -6,7 +6,7 @@ private import semmle.code.java.regex.regex
 /**
  * An element containing a regular expression term, that is, either
  * a string literal (parsed as a regular expression; the root of the parse tree)
- * or another regular expression term (a decendent of the root).
+ * or another regular expression term (a descendant of the root).
  *
  * For sequences and alternations, we require at least two children.
  * Otherwise, we wish to represent the term differently.
@@ -52,7 +52,7 @@ private newtype TRegExpParent =
 /**
  * An element containing a regular expression term, that is, either
  * a string literal (parsed as a regular expression; the root of the parse tree)
- * or another regular expression term (a decendent of the root).
+ * or another regular expression term (a descendant of the root).
  */
 class RegExpParent extends TRegExpParent {
   /** Gets a textual representation of this element. */

--- a/java/ql/lib/semmle/code/java/regex/regex.qll
+++ b/java/ql/lib/semmle/code/java/regex/regex.qll
@@ -62,7 +62,7 @@ abstract class RegexString extends StringLiteral {
 
   /**
    * Helper predicate for `quote`.
-   * Holds if the char at `pos` is the one-based `index`th occurence of a quote delimiter (`\Q` or `\E`)
+   * Holds if the char at `pos` is the one-based `index`th occurrence of a quote delimiter (`\Q` or `\E`)
    * Result is `true` for `\Q` and `false` for `\E`.
    */
   private boolean quoteDelimiter(int index, int pos) {

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
@@ -3,7 +3,7 @@
  *
  * This test checks several components of the endpoint filters for each query to see whether they
  * filter out any known sinks. It explicitly does not check the endpoint filtering step that's based
- * on whether the endpoint is an argument to a modelled function, since this necessarily filters out
+ * on whether the endpoint is an argument to a modeled function, since this necessarily filters out
  * all known sinks. However, we can test all the other filtering steps against the set of known
  * sinks.
  *

--- a/javascript/ql/lib/semmle/javascript/PrintAst.qll
+++ b/javascript/ql/lib/semmle/javascript/PrintAst.qll
@@ -36,7 +36,7 @@ private predicate isNotNeeded(Locatable el) {
   el.getLocation().getStartLine() = 0 and
   el.getLocation().getStartColumn() = 0
   or
-  // relaxing aggresive type inference.
+  // relaxing aggressive type inference.
   none()
 }
 

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -245,7 +245,7 @@ module Routing {
      */
     pragma[inline]
     private predicate isGuardedByNodeInternal(Node guard) {
-      // Look for a common ancestor `fork` whose child leading to `guard` ("base1") preceeds
+      // Look for a common ancestor `fork` whose child leading to `guard` ("base1") precedes
       // the child leading to `this` ("base2").
       //
       // Schematically:

--- a/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
@@ -198,7 +198,7 @@ module XML {
     override predicate resolvesEntities(XML::EntityKind kind) { kind = InternalEntity() }
 
     // The result is an XMLDocument (https://developer.mozilla.org/en-US/docs/Web/API/XMLDocument).
-    // The API of the XMLDocument is not modelled.
+    // The API of the XMLDocument is not modeled.
     override DataFlow::Node getAResult() { result.asExpr() = this }
   }
 

--- a/javascript/ql/src/Declarations/UnreachableMethodOverloads.ql
+++ b/javascript/ql/src/Declarations/UnreachableMethodOverloads.ql
@@ -111,7 +111,7 @@ private MethodSignature getMethodSignatureWithFingerprint(
  * Holds if the two method signatures are overloads of each other and have the same parameter types.
  */
 predicate signaturesMatch(MethodSignature method, MethodSignature other) {
-  // the intial search for another overload in a single call for better join-order.
+  // the initial search for another overload in a single call for better join-order.
   other =
     getMethodSignatureWithFingerprint(method.getDeclaringType(), method.getName(),
       method.getBody().getNumParameter(), getKind(method)) and

--- a/python/ql/lib/semmle/python/Files.qll
+++ b/python/ql/lib/semmle/python/Files.qll
@@ -21,7 +21,7 @@ class File extends Container, @file {
 
   /** Whether this file is a source code file. */
   predicate fromSource() {
-    /* If we start to analyse .pyc files, then this will have to change. */
+    /* If we start to analyze .pyc files, then this will have to change. */
     any()
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowUtil.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowUtil.qll
@@ -71,7 +71,7 @@ deprecated Node importNode(string name) {
   // ```
   //
   // Where `foo_module_tracker` is a type tracker that tracks references to the `foo` module.
-  // Because named imports are modelled as `AttrRead`s, the statement `from foo import bar as baz`
+  // Because named imports are modeled as `AttrRead`s, the statement `from foo import bar as baz`
   // is interpreted as if it was an assignment `baz = foo.bar`, which means `baz` gets tracked as a
   // reference to `foo.bar`, as desired.
   exists(ImportExpr imp_expr |

--- a/python/ql/lib/semmle/python/frameworks/internal/SubclassFinder.qll
+++ b/python/ql/lib/semmle/python/frameworks/internal/SubclassFinder.qll
@@ -42,7 +42,7 @@ private module NotExposed {
   // Implementation below
   // ---------------------------------------------------------------------------
   //
-  // We are looking to find all subclassed of the already modelled classes, and ideally
+  // We are looking to find all subclassed of the already modeled classes, and ideally
   // we would identify an `API::Node` for each (then `toString` would give the API
   // path).
   //

--- a/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIs.qll
+++ b/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIs.qll
@@ -35,7 +35,7 @@ private import semmle.python.objects.ObjectInternal
 //    functionality into `BuiltinFunctionValue` and `BuiltinMethodValue`, but will
 //    probably require some more work: for this query, it's totally ok to use
 //    `builtins.open` for the code `open(f)`, but well, it requires a bit of thinking to
-//    figure out if that is desireable in general. I simply skipped a corner here!
+//    figure out if that is desirable in general. I simply skipped a corner here!
 // 4. TaintTrackingPrivate: Nothing else gives us access to `defaultAdditionalTaintStep` :(
 /**
  * A callable that is considered a "safe" external API from a security perspective.

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -23,7 +23,7 @@ class AstNode extends TAstNode {
 
   /** Gets the location of the AST node. */
   cached
-  Location getLocation() { result = this.getFullLocation() } // overriden in some subclasses
+  Location getLocation() { result = this.getFullLocation() } // overridden in some subclasses
 
   /** Gets the location that spans the entire AST node. */
   cached

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
@@ -233,7 +233,7 @@ module AstConsistency {
     not exists(node.getParent()) and
     not node.getLocation().getStartColumn() = 1 and // startcolumn = 1 <=> top level in file <=> fine to have no parent
     exists(node.toString()) and // <- there are a few parse errors in "global-data-flow-java-1.ql", this way we filter them out.
-    not node instanceof YAML::YAMLNode and // parents for YAML does't work
+    not node instanceof YAML::YAMLNode and // parents for YAML doesn't work
     not (node instanceof QLDoc and node.getLocation().getFile().getExtension() = "dbscheme") // qldoc in dbschemes are not hooked up
   }
 

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
@@ -233,7 +233,7 @@ module AstConsistency {
     not exists(node.getParent()) and
     not node.getLocation().getStartColumn() = 1 and // startcolumn = 1 <=> top level in file <=> fine to have no parent
     exists(node.toString()) and // <- there are a few parse errors in "global-data-flow-java-1.ql", this way we filter them out.
-    not node instanceof YAML::YAMLNode and // parents for YAML doens't work
+    not node instanceof YAML::YAMLNode and // parents for YAML does't work
     not (node instanceof QLDoc and node.getLocation().getFile().getExtension() = "dbscheme") // qldoc in dbschemes are not hooked up
   }
 

--- a/ql/ql/src/codeql_ql/style/MisspellingQuery.qll
+++ b/ql/ql/src/codeql_ql/style/MisspellingQuery.qll
@@ -52,8 +52,8 @@ bindingset[s]
 string getACommentWord(string s) { result = s.regexpFind("\\b\\w+\\b", _, _) }
 
 string getAWord(AstNode node, string kind) {
-  result = getACommentWord(node.(QLDoc).getContents()).toLowerCase() and
-  kind = "QLDoc comment"
+  result = getACommentWord(node.(Comment).getContents()).toLowerCase() and
+  kind = "comment"
   or
   exists(string nodeKind |
     result = getACamelCaseWord(getName(node, nodeKind)).toLowerCase() and

--- a/ql/ql/test/queries/style/Misspelling/Misspelling.expected
+++ b/ql/ql/test/queries/style/Misspelling/Misspelling.expected
@@ -1,6 +1,6 @@
-| Test.qll:1:1:3:3 | QLDoc | This QLDoc comment contains the common misspelling 'mispelled', which should instead be 'misspelled'. |
+| Test.qll:1:1:3:3 | QLDoc | This comment contains the common misspelling 'mispelled', which should instead be 'misspelled'. |
 | Test.qll:4:7:4:26 | Class PublicallyAccessible | This class name contains the common misspelling 'publically', which should instead be 'publicly'. |
 | Test.qll:5:3:5:20 | FieldDecl | This field name contains the common misspelling 'occurences', which should instead be 'occurrences'. |
 | Test.qll:10:13:10:23 | ClassPredicate hasAgrument | This classPredicate name contains the common misspelling 'agrument', which should instead be 'argument'. |
-| Test.qll:13:1:16:3 | QLDoc | This QLDoc comment contains the non-US spelling 'colour', which should instead be 'color'. |
+| Test.qll:13:1:16:3 | QLDoc | This comment contains the non-US spelling 'colour', which should instead be 'color'. |
 | Test.qll:17:7:17:17 | Class AnalysedInt | This class name contains the non-US spelling 'analysed', which should instead be 'analyzed'. |

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -96,7 +96,7 @@ private module Cached {
     or
     FlowSummaryImpl::Private::Steps::summaryLocalStep(nodeFrom, nodeTo, false)
     or
-    // Although flow through collections is modelled precisely using stores/reads, we still
+    // Although flow through collections is modeled precisely using stores/reads, we still
     // allow flow out of a _tainted_ collection. This is needed in order to support taint-
     // tracking configurations where the source is a collection.
     exists(DataFlow::ContentSet c | readStep(nodeFrom, c, nodeTo) |

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
@@ -40,7 +40,7 @@ module ActiveSupport {
        * Flow summary for methods which transform the receiver in some way, possibly preserving taint.
        */
       private class StringTransformSummary extends SummarizedCallable {
-        // We're modelling a lot of different methods, so we make up a name for this summary.
+        // We're modeling a lot of different methods, so we make up a name for this summary.
         StringTransformSummary() { this = "ActiveSupportStringTransform" }
 
         override MethodCall getACall() {

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -40,7 +40,7 @@ private import codeql.ruby.dataflow.internal.DataFlowDispatch as DataFlowDispatc
  */
 bindingset[package]
 predicate isPackageUsed(string package) {
-  // For now everything is modelled as an access path starting at any top-level, so the package name has no effect.
+  // For now everything is modeled as an access path starting at any top-level, so the package name has no effect.
   //
   // We allow an arbitrary package name so that the model can record the name of the package in case it's needed in the future.
   //

--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowElements.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowElements.qll
@@ -91,11 +91,11 @@ predicate isPropertyObserverElement(
 }
 
 class ControlFlowElement extends TControlFlowElement {
-  string toString() { none() } // overriden in subclasses
+  string toString() { none() } // overridden in subclasses
 
   AstNode asAstNode() { none() }
 
-  Location getLocation() { none() } // overriden in subclasses
+  Location getLocation() { none() } // overridden in subclasses
 }
 
 class AstElement extends ControlFlowElement, TAstElement {

--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
@@ -286,7 +286,7 @@ module Stmts {
       astLast(ast.getAnElement().getPattern().getFullyUnresolved(), last, c) and
       not c.(MatchingCompletion).isMatch()
       or
-      // Stop if we sucesfully evaluated all the conditionals
+      // Stop if we successfully evaluated all the conditionals
       (
         astLast(ast.getLastElement().getBoolean().getFullyConverted(), last, c)
         or
@@ -470,7 +470,7 @@ module Stmts {
       }
 
       final override predicate first(ControlFlowElement first) {
-        // Unlike most other statements, `foreach` statements are not modelled in
+        // Unlike most other statements, `foreach` statements are not modeled in
         // pre-order, because we use the `foreach` node itself to represent the
         // emptiness test that determines whether to execute the loop body
         astFirst(ast.getSequence().getFullyConverted(), first)
@@ -605,7 +605,7 @@ module Stmts {
         c.(MatchingCompletion).isNonMatch()
         or
         // Or because, there is no guard (in which case we can also finish the evaluation
-        // here on a succesful match).
+        // here on a successful match).
         c.(MatchingCompletion).isMatch() and
         not ast.hasGuard()
       )

--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
@@ -1364,7 +1364,7 @@ module Exprs {
       or
       // And finally, we visit the body that potentially mutates the local variable.
       // Note that the CFG for the body will skip the first element in the
-      // body because it's guarenteed to be the variable declaration
+      // body because it's guaranteed to be the variable declaration
       // that we've already visited at i = 0. See the explanation
       // in `BraceStmtTree` for why this is necessary.
       i = 2 and


### PR DESCRIPTION
The [fix common misspellings throughout github/codeql](https://github.com/github/codeql/pull/9832/commits/e8489004c3731dcd5fd20982931852f4318aad0f) commit was written by my patching utility.  

Cherry-picked a commit that cleans up the compiled query pack from https://github.com/github/codeql/pull/9884. (Avoids duplicated alerts).  