### PR TITLE
Ensure the <lang>-lgtm-full.qls suites include definitions.ql queries

### DIFF
--- a/cpp/ql/src/codeql-suites/cpp-lgtm-full.qls
+++ b/cpp/ql/src/codeql-suites/cpp-lgtm-full.qls
@@ -3,6 +3,9 @@
 - apply: lgtm-selectors.yml
   from: codeql/suite-helpers
 - apply: codeql-suites/exclude-slow-queries.yml
+# Include contextual queries from cpp-all
+- queries: .
+  from: codeql/cpp-all
 # These are only for IDE use.
 - exclude:
     tags contain:

--- a/csharp/ql/src/codeql-suites/csharp-lgtm-full.qls
+++ b/csharp/ql/src/codeql-suites/csharp-lgtm-full.qls
@@ -2,6 +2,9 @@
 - queries: .
 - apply: lgtm-selectors.yml
   from: codeql/suite-helpers
+# Include contextual queries from csharp-all
+- queries: .
+  from: codeql/csharp-all
 # These are only for IDE use.
 - exclude:
     tags contain:

--- a/go/ql/src/codeql-suites/go-lgtm-full.qls
+++ b/go/ql/src/codeql-suites/go-lgtm-full.qls
@@ -2,6 +2,9 @@
 - queries: .
 - apply: lgtm-selectors.yml
   from: codeql/suite-helpers
+# Include contextual queries from go-all
+- queries: .
+  from: codeql/go-all
 # These are only for IDE use.
 - exclude:
     tags contain:

--- a/java/ql/src/codeql-suites/java-lgtm-full.qls
+++ b/java/ql/src/codeql-suites/java-lgtm-full.qls
@@ -2,6 +2,9 @@
 - queries: .
 - apply: lgtm-selectors.yml
   from: codeql/suite-helpers
+# Include contextual queries from java-all
+- queries: .
+  from: codeql/java-all
 # These are only for IDE use.
 - exclude:
     tags contain:

--- a/javascript/ql/src/codeql-suites/javascript-lgtm-full.qls
+++ b/javascript/ql/src/codeql-suites/javascript-lgtm-full.qls
@@ -2,6 +2,9 @@
 - queries: .
 - apply: lgtm-selectors.yml
   from: codeql/suite-helpers
+# Include contextual queries from javascript-all
+- queries: .
+  from: codeql/javascript-all
 # These are only for IDE use.
 - exclude:
     tags contain:

--- a/python/ql/src/codeql-suites/python-lgtm-full.qls
+++ b/python/ql/src/codeql-suites/python-lgtm-full.qls
@@ -2,6 +2,9 @@
 - queries: .
 - apply: lgtm-selectors.yml
   from: codeql/suite-helpers
+# Include contextual queries from python-all
+- queries: .
+  from: codeql/python-all
 # These are only for IDE use.
 - exclude:
     tags contain:

--- a/ruby/ql/src/codeql-suites/ruby-lgtm-full.qls
+++ b/ruby/ql/src/codeql-suites/ruby-lgtm-full.qls
@@ -2,6 +2,9 @@
 - queries: .
 - apply: lgtm-selectors.yml
   from: codeql/suite-helpers
+# Include contextual queries from ruby-all
+- queries: .
+  from: codeql/ruby-all
 # These are only for IDE use.
 - exclude:
     tags contain:
@@ -9,4 +12,3 @@
       - ide-contextual-queries/local-references
 - include:
     id: rb/lines-of-code-in-files
-


### PR DESCRIPTION
In #9744, these queries were moved from `src` to `lib`. Now they are
no longer part of the <lang>-full-suite.qls, so these suites need to
be expanded to include them.

Please make sure that the new suite instruction should go before the `exclude` instruction. This will ensure that `ide-contextual-queries/local-definitions` and `ide-contextual-queries/local-references` are excluded. I think that's what we want.