### PR TITLE
Ruby: skip .git folder

### DIFF
--- a/ruby/autobuilder/src/main.rs
+++ b/ruby/autobuilder/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> std::io::Result<()> {
         .arg("--include-extension=.erb")
         .arg("--include-extension=.gemspec")
         .arg("--include=**/Gemfile")
+        .arg("--exclude=**/.git")
         .arg("--size-limit=5m")
         .arg("--language=ruby")
         .arg("--working-dir=.")


### PR DESCRIPTION
CodeQL should not scan the `.git` folder when looking for Ruby source files. Most of the time scanning the `.git` folder is harmless, but it may cause syntax errors when some branch names happen to end with `.rb`.