### PR TITLE
Python: Fix binding incorrect predicate.

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/internal/SubclassFinder.qll
+++ b/python/ql/lib/semmle/python/frameworks/internal/SubclassFinder.qll
@@ -74,9 +74,7 @@ private module NotExposed {
   }
 
   /** DEPRECATED: Alias for fullyQualifiedToApiGraphPath */
-  deprecated string fullyQualifiedToAPIGraphPath(string fullyQaulified) {
-    result = fullyQualifiedToApiGraphPath(fullyQaulified)
-  }
+  deprecated predicate fullyQualifiedToAPIGraphPath = fullyQualifiedToApiGraphPath/1;
 
   bindingset[this]
   abstract class FindSubclassesSpec extends string {


### PR DESCRIPTION
This predicate needs a `bindingset` annotation to work, however it seems cleaner to just be an alias.