### PR TITLE
Swift: More improvements for the string length conflation query

### DIFF
--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -41,88 +41,87 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
   }
 
   override predicate isSink(DataFlow::Node node, string flowstate) {
-    // arguments to method calls...
-    exists(
-      string className, string methodName, string paramName, ClassDecl c, AbstractFunctionDecl f,
-      CallExpr call, int arg
-    |
-      (
-        // `NSRange.init`
-        className = "NSRange" and
-        methodName = "init(location:length:)" and
-        paramName = ["location", "length"]
-        or
-        // `NSString.character`
-        className = ["NSString", "NSMutableString"] and
-        methodName = "character(at:)" and
-        paramName = "at"
-        or
-        // `NSString.character`
-        className = ["NSString", "NSMutableString"] and
-        methodName = "substring(from:)" and
-        paramName = "from"
-        or
-        // `NSString.character`
-        className = ["NSString", "NSMutableString"] and
-        methodName = "substring(to:)" and
-        paramName = "to"
-        or
-        // `NSMutableString.insert`
-        className = "NSMutableString" and
-        methodName = "insert(_:at:)" and
-        paramName = "at"
-      ) and
-      c.getName() = className and
-      c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
-      call.getFunction().(ApplyExpr).getStaticTarget() = f and
-      f.getName() = methodName and
-      f.getParam(pragma[only_bind_into](arg)).getName() = paramName and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
-      flowstate = "String" // `String` length flowing into `NSString`
-    )
-    or
-    // arguments to function calls...
-    exists(string funcName, string paramName, CallExpr call, int arg |
-      // `NSMakeRange`
-      funcName = "NSMakeRange(_:_:)" and
-      paramName = ["loc", "len"] and
-      call.getStaticTarget().getName() = funcName and
-      call.getStaticTarget().getParam(pragma[only_bind_into](arg)).getName() = paramName and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
-      flowstate = "String" // `String` length flowing into `NSString`
-    )
-    or
-    // arguments to function calls...
-    exists(string funcName, string paramName, CallExpr call, int arg |
-      (
-        // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
-        funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
-        paramName = "k"
-        or
-        // `String.prefix`, `String.suffix`
-        funcName = ["prefix(_:)", "suffix(_:)"] and
-        paramName = "maxLength"
-        or
-        // `String.Index.init`
-        funcName = "init(encodedOffset:)" and
-        paramName = "offset"
-        or
-        // `String.index`
-        funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
-        paramName = "n"
-        or
-        // `String.formIndex`
-        funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and
-        paramName = "distance"
-      ) and
-      call.getFunction().(ApplyExpr).getStaticTarget().getName() = funcName and
-      call.getFunction()
-          .(ApplyExpr)
-          .getStaticTarget()
-          .getParam(pragma[only_bind_into](arg))
-          .getName() = paramName and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
-      flowstate = "NSString" // `NSString` length flowing into `String`
+    exists(CallExpr call, string paramName, int arg |
+      // arguments to method calls...
+      exists(string className, string methodName, ClassDecl c, AbstractFunctionDecl f |
+        (
+          // `NSRange.init`
+          className = "NSRange" and
+          methodName = "init(location:length:)" and
+          paramName = ["location", "length"]
+          or
+          // `NSString.character`
+          className = ["NSString", "NSMutableString"] and
+          methodName = "character(at:)" and
+          paramName = "at"
+          or
+          // `NSString.character`
+          className = ["NSString", "NSMutableString"] and
+          methodName = "substring(from:)" and
+          paramName = "from"
+          or
+          // `NSString.character`
+          className = ["NSString", "NSMutableString"] and
+          methodName = "substring(to:)" and
+          paramName = "to"
+          or
+          // `NSMutableString.insert`
+          className = "NSMutableString" and
+          methodName = "insert(_:at:)" and
+          paramName = "at"
+        ) and
+        c.getName() = className and
+        c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
+        call.getFunction().(ApplyExpr).getStaticTarget() = f and
+        f.getName() = methodName and
+        f.getParam(pragma[only_bind_into](arg)).getName() = paramName and
+        call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
+        flowstate = "String" // `String` length flowing into `NSString`
+      )
+      or
+      // arguments to function calls...
+      exists(string funcName |
+        // `NSMakeRange`
+        funcName = "NSMakeRange(_:_:)" and
+        paramName = ["loc", "len"] and
+        call.getStaticTarget().getName() = funcName and
+        call.getStaticTarget().getParam(pragma[only_bind_into](arg)).getName() = paramName and
+        call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
+        flowstate = "String" // `String` length flowing into `NSString`
+      )
+      or
+      // arguments to function calls...
+      exists(string funcName |
+        (
+          // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
+          funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
+          paramName = "k"
+          or
+          // `String.prefix`, `String.suffix`
+          funcName = ["prefix(_:)", "suffix(_:)"] and
+          paramName = "maxLength"
+          or
+          // `String.Index.init`
+          funcName = "init(encodedOffset:)" and
+          paramName = "offset"
+          or
+          // `String.index`
+          funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
+          paramName = "n"
+          or
+          // `String.formIndex`
+          funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and
+          paramName = "distance"
+        ) and
+        call.getFunction().(ApplyExpr).getStaticTarget().getName() = funcName and
+        call.getFunction()
+            .(ApplyExpr)
+            .getStaticTarget()
+            .getParam(pragma[only_bind_into](arg))
+            .getName() = paramName and
+        call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
+        flowstate = "NSString" // `NSString` length flowing into `String`
+      )
     )
   }
 

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -74,7 +74,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
             paramName = "at"
           ) and
           c.getName() = className and
-          c.getAMember() = funcDecl and // TODO: will this even work if its defined in a parent class?
+          c.getAMember() = funcDecl and
           call.getFunction().(ApplyExpr).getStaticTarget() = funcDecl and
           flowstate = "String" // `String` length flowing into `NSString`
         )

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -44,80 +44,76 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
     exists(
       AbstractFunctionDecl funcDecl, CallExpr call, string funcName, string paramName, int arg
     |
-      // arguments to method calls...
-      exists(string className, ClassDecl c |
-        (
-          // `NSRange.init`
-          className = "NSRange" and
-          funcName = "init(location:length:)" and
-          paramName = ["location", "length"]
-          or
-          // `NSString.character`
-          className = ["NSString", "NSMutableString"] and
-          funcName = "character(at:)" and
-          paramName = "at"
-          or
-          // `NSString.character`
-          className = ["NSString", "NSMutableString"] and
-          funcName = "substring(from:)" and
-          paramName = "from"
-          or
-          // `NSString.character`
-          className = ["NSString", "NSMutableString"] and
-          funcName = "substring(to:)" and
-          paramName = "to"
-          or
-          // `NSMutableString.insert`
-          className = "NSMutableString" and
-          funcName = "insert(_:at:)" and
-          paramName = "at"
-        ) and
-        c.getName() = className and
-        c.getAMember() = funcDecl and // TODO: will this even work if its defined in a parent class?
-        call.getFunction().(ApplyExpr).getStaticTarget() = funcDecl and
-        funcDecl.getName() = funcName and
-        funcDecl.getParam(pragma[only_bind_into](arg)).getName() = paramName and
-        call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
-        flowstate = "String" // `String` length flowing into `NSString`
-      )
-      or
-      // arguments to function calls...
-      // `NSMakeRange`
-      funcName = "NSMakeRange(_:_:)" and
-      paramName = ["loc", "len"] and
-      call.getStaticTarget() = funcDecl and
-      funcDecl.getName() = funcName and
-      funcDecl.getParam(pragma[only_bind_into](arg)).getName() = paramName and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
-      flowstate = "String" // `String` length flowing into `NSString`
-      or
-      // arguments to function calls...
       (
-        // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
-        funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
-        paramName = "k"
+        // arguments to method calls...
+        exists(string className, ClassDecl c |
+          (
+            // `NSRange.init`
+            className = "NSRange" and
+            funcName = "init(location:length:)" and
+            paramName = ["location", "length"]
+            or
+            // `NSString.character`
+            className = ["NSString", "NSMutableString"] and
+            funcName = "character(at:)" and
+            paramName = "at"
+            or
+            // `NSString.character`
+            className = ["NSString", "NSMutableString"] and
+            funcName = "substring(from:)" and
+            paramName = "from"
+            or
+            // `NSString.character`
+            className = ["NSString", "NSMutableString"] and
+            funcName = "substring(to:)" and
+            paramName = "to"
+            or
+            // `NSMutableString.insert`
+            className = "NSMutableString" and
+            funcName = "insert(_:at:)" and
+            paramName = "at"
+          ) and
+          c.getName() = className and
+          c.getAMember() = funcDecl and // TODO: will this even work if its defined in a parent class?
+          call.getFunction().(ApplyExpr).getStaticTarget() = funcDecl and
+          flowstate = "String" // `String` length flowing into `NSString`
+        )
         or
-        // `String.prefix`, `String.suffix`
-        funcName = ["prefix(_:)", "suffix(_:)"] and
-        paramName = "maxLength"
+        // arguments to function calls...
+        // `NSMakeRange`
+        funcName = "NSMakeRange(_:_:)" and
+        paramName = ["loc", "len"] and
+        call.getStaticTarget() = funcDecl and
+        flowstate = "String" // `String` length flowing into `NSString`
         or
-        // `String.Index.init`
-        funcName = "init(encodedOffset:)" and
-        paramName = "offset"
-        or
-        // `String.index`
-        funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
-        paramName = "n"
-        or
-        // `String.formIndex`
-        funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and
-        paramName = "distance"
+        // arguments to function calls...
+        (
+          // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
+          funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
+          paramName = "k"
+          or
+          // `String.prefix`, `String.suffix`
+          funcName = ["prefix(_:)", "suffix(_:)"] and
+          paramName = "maxLength"
+          or
+          // `String.Index.init`
+          funcName = "init(encodedOffset:)" and
+          paramName = "offset"
+          or
+          // `String.index`
+          funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
+          paramName = "n"
+          or
+          // `String.formIndex`
+          funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and
+          paramName = "distance"
+        ) and
+        call.getFunction().(ApplyExpr).getStaticTarget() = funcDecl and
+        flowstate = "NSString" // `NSString` length flowing into `String`
       ) and
-      call.getFunction().(ApplyExpr).getStaticTarget() = funcDecl and
       funcDecl.getName() = funcName and
       funcDecl.getParam(pragma[only_bind_into](arg)).getName() = paramName and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
-      flowstate = "NSString" // `NSString` length flowing into `String`
+      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr()
     )
   }
 

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -41,87 +41,83 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
   }
 
   override predicate isSink(DataFlow::Node node, string flowstate) {
-    exists(CallExpr call, string paramName, int arg |
+    exists(CallExpr call, string funcName, string paramName, int arg |
       // arguments to method calls...
-      exists(string className, string methodName, ClassDecl c, AbstractFunctionDecl f |
+      exists(string className, ClassDecl c, AbstractFunctionDecl f |
         (
           // `NSRange.init`
           className = "NSRange" and
-          methodName = "init(location:length:)" and
+          funcName = "init(location:length:)" and
           paramName = ["location", "length"]
           or
           // `NSString.character`
           className = ["NSString", "NSMutableString"] and
-          methodName = "character(at:)" and
+          funcName = "character(at:)" and
           paramName = "at"
           or
           // `NSString.character`
           className = ["NSString", "NSMutableString"] and
-          methodName = "substring(from:)" and
+          funcName = "substring(from:)" and
           paramName = "from"
           or
           // `NSString.character`
           className = ["NSString", "NSMutableString"] and
-          methodName = "substring(to:)" and
+          funcName = "substring(to:)" and
           paramName = "to"
           or
           // `NSMutableString.insert`
           className = "NSMutableString" and
-          methodName = "insert(_:at:)" and
+          funcName = "insert(_:at:)" and
           paramName = "at"
         ) and
         c.getName() = className and
         c.getAMember() = f and // TODO: will this even work if its defined in a parent class?
         call.getFunction().(ApplyExpr).getStaticTarget() = f and
-        f.getName() = methodName and
+        f.getName() = funcName and
         f.getParam(pragma[only_bind_into](arg)).getName() = paramName and
         call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
         flowstate = "String" // `String` length flowing into `NSString`
       )
       or
       // arguments to function calls...
-      exists(string funcName |
-        // `NSMakeRange`
-        funcName = "NSMakeRange(_:_:)" and
-        paramName = ["loc", "len"] and
-        call.getStaticTarget().getName() = funcName and
-        call.getStaticTarget().getParam(pragma[only_bind_into](arg)).getName() = paramName and
-        call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
-        flowstate = "String" // `String` length flowing into `NSString`
-      )
+      // `NSMakeRange`
+      funcName = "NSMakeRange(_:_:)" and
+      paramName = ["loc", "len"] and
+      call.getStaticTarget().getName() = funcName and
+      call.getStaticTarget().getParam(pragma[only_bind_into](arg)).getName() = paramName and
+      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
+      flowstate = "String" // `String` length flowing into `NSString`
       or
       // arguments to function calls...
-      exists(string funcName |
-        (
-          // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
-          funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
-          paramName = "k"
-          or
-          // `String.prefix`, `String.suffix`
-          funcName = ["prefix(_:)", "suffix(_:)"] and
-          paramName = "maxLength"
-          or
-          // `String.Index.init`
-          funcName = "init(encodedOffset:)" and
-          paramName = "offset"
-          or
-          // `String.index`
-          funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
-          paramName = "n"
-          or
-          // `String.formIndex`
-          funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and
-          paramName = "distance"
-        ) and
-        call.getFunction().(ApplyExpr).getStaticTarget().getName() = funcName and
-        call.getFunction()
-            .(ApplyExpr)
-            .getStaticTarget()
-            .getParam(pragma[only_bind_into](arg))
-            .getName() = paramName and
-        call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
-        flowstate = "NSString" // `NSString` length flowing into `String`
-      )
+      (
+        // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
+        funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
+        paramName = "k"
+        or
+        // `String.prefix`, `String.suffix`
+        funcName = ["prefix(_:)", "suffix(_:)"] and
+        paramName = "maxLength"
+        or
+        // `String.Index.init`
+        funcName = "init(encodedOffset:)" and
+        paramName = "offset"
+        or
+        // `String.index`
+        funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
+        paramName = "n"
+        or
+        // `String.formIndex`
+        funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and
+        paramName = "distance"
+      ) and
+      call.getFunction().(ApplyExpr).getStaticTarget().getName() = funcName and
+      call.getFunction()
+          .(ApplyExpr)
+          .getStaticTarget()
+          .getParam(pragma[only_bind_into](arg))
+          .getName() = paramName and
+      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr() and
+      flowstate = "NSString" // `NSString` length flowing into `String`
     )
   }
 

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -86,7 +86,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
         call.getStaticTarget() = funcDecl and
         flowstate = "String" // `String` length flowing into `NSString`
         or
-        // arguments to function calls...
+        // arguments to method calls...
         (
           // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
           funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
@@ -111,6 +111,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
         call.getFunction().(ApplyExpr).getStaticTarget() = funcDecl and
         flowstate = "NSString" // `NSString` length flowing into `String`
       ) and
+      // match up `funcName`, `paramName`, `arg`, `node`.
       funcDecl.getName() = funcName and
       funcDecl.getParam(pragma[only_bind_into](arg)).getName() = paramName and
       call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr()

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -1,4 +1,5 @@
 edges
+| StringLengthConflation2.swift:37:34:37:36 | .count :  | StringLengthConflation2.swift:37:34:37:44 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:60:47:60:50 | .length :  | StringLengthConflation.swift:60:47:60:59 | ... call to /(_:_:) ... |
 | StringLengthConflation.swift:66:33:66:36 | .length :  | StringLengthConflation.swift:66:33:66:45 | ... call to /(_:_:) ... |
 | StringLengthConflation.swift:93:28:93:31 | .length :  | StringLengthConflation.swift:93:28:93:40 | ... call to -(_:_:) ... |
@@ -15,6 +16,8 @@ edges
 | StringLengthConflation.swift:135:36:135:38 | .count :  | StringLengthConflation.swift:135:36:135:46 | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:141:28:141:30 | .count :  | StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... |
 nodes
+| StringLengthConflation2.swift:37:34:37:36 | .count :  | semmle.label | .count :  |
+| StringLengthConflation2.swift:37:34:37:44 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 | StringLengthConflation.swift:53:43:53:46 | .length | semmle.label | .length |
 | StringLengthConflation.swift:60:47:60:50 | .length :  | semmle.label | .length :  |
 | StringLengthConflation.swift:60:47:60:59 | ... call to /(_:_:) ... | semmle.label | ... call to /(_:_:) ... |
@@ -50,6 +53,7 @@ nodes
 | StringLengthConflation.swift:141:28:141:38 | ... call to -(_:_:) ... | semmle.label | ... call to -(_:_:) ... |
 subpaths
 #select
+| StringLengthConflation2.swift:37:34:37:44 | ... call to -(_:_:) ... | StringLengthConflation2.swift:37:34:37:36 | .count :  | StringLengthConflation2.swift:37:34:37:44 | ... call to -(_:_:) ... | This String length is used in an NSString, but it may not be equivalent. |
 | StringLengthConflation.swift:53:43:53:46 | .length | StringLengthConflation.swift:53:43:53:46 | .length | StringLengthConflation.swift:53:43:53:46 | .length | This NSString length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:60:47:60:59 | ... call to /(_:_:) ... | StringLengthConflation.swift:60:47:60:50 | .length :  | StringLengthConflation.swift:60:47:60:59 | ... call to /(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:66:33:66:45 | ... call to /(_:_:) ... | StringLengthConflation.swift:66:33:66:36 | .length :  | StringLengthConflation.swift:66:33:66:45 | ... call to /(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation2.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation2.swift
@@ -1,0 +1,42 @@
+// this test is in a separate file, because we want to test with a slightly different library
+// implementation. In this version, some of the functions of `NSString` are in fact implemented
+// in a base class `NSStringBase`.
+
+// --- stubs ---
+
+func print(_ items: Any...) {}
+
+typealias unichar = UInt16
+
+class NSObject
+{
+}
+
+class NSStringBase : NSObject
+{
+    func substring(from: Int) -> String { return "" }
+}
+
+class NSString : NSStringBase
+{
+    init(string: String) { length = string.count }
+
+    func substring(to: Int) -> String { return "" }
+
+    private(set) var length: Int
+}
+
+// --- tests ---
+
+func test(s: String) {
+    let ns = NSString(string: s)
+
+    let nstr1 = ns.substring(from: ns.length - 1) // GOOD
+    let nstr2 = ns.substring(from: s.count - 1) // BAD: String length used in NSString [NOT DETECTED]
+    let nstr3 = ns.substring(to: ns.length - 1) // GOOD
+    let nstr4 = ns.substring(to: s.count - 1) // BAD: String length used in NSString
+    print("substrings '\(nstr1)' '\(nstr2)' / '\(nstr3)' '\(nstr4)'")
+}
+
+// `begin :thumbsup: end`, with thumbs up emoji and skin tone modifier
+test(s: "begin \u{0001F44D}\u{0001F3FF} end")


### PR DESCRIPTION
More improvements for the string length conflation query:
 - added a test for a potential issue with implementations of `NSString` that has been discussed before, where member functions are defined in a parent class rather than directly in `NSString` itself.  At the moment I believe we can't *fix* this issue because we don't have information about base classes, but at least now it is documented with a test.
 - clean up the QL for `isSink` (less code duplication).
 