### PR TITLE
Python: Add `Str` class

### DIFF
--- a/python/ql/lib/semmle/python/Exprs.qll
+++ b/python/ql/lib/semmle/python/Exprs.qll
@@ -617,10 +617,10 @@ private string non_byte_prefix() {
 }
 
 /** A string constant. This is a placeholder class -- use `StrConst` instead. */
-class Str extends Str_ { }
+class Str = StrConst;
 
 /** A string constant. */
-class StrConst extends Str, ImmutableLiteral {
+class StrConst extends Str_, ImmutableLiteral {
   /* syntax: "hello" */
   predicate isUnicode() {
     this.getPrefix() = unicode_prefix()

--- a/python/ql/lib/semmle/python/Exprs.qll
+++ b/python/ql/lib/semmle/python/Exprs.qll
@@ -616,8 +616,11 @@ private string non_byte_prefix() {
   not result.charAt(_) in ["b", "B"]
 }
 
+/** A string constant. This is a placeholder class -- use `StrConst` instead. */
+class Str extends Str_ { }
+
 /** A string constant. */
-class StrConst extends Str_, ImmutableLiteral {
+class StrConst extends Str, ImmutableLiteral {
   /* syntax: "hello" */
   predicate isUnicode() {
     this.getPrefix() = unicode_prefix()


### PR DESCRIPTION
This makes the AST viewer (which annotates string constant nodes as `Str`, and not `StrConst`) a bit more consistent.

Fixes #9833. 

It might be even better to instead flip the inheritance and make `Str` the lowest class in the hierarchy. That way, it would have access to all of the methods on `StrConst` (and indeed, we might consider just deprecating that class).

---
This is a very minor change, so I don't think a change note is required.