### PR TITLE
Python: Fix bad join in `ScopeEntryDefinition`

### DIFF
--- a/python/ql/lib/semmle/python/essa/Essa.qll
+++ b/python/ql/lib/semmle/python/essa/Essa.qll
@@ -632,7 +632,9 @@ class DeletionDefinition extends EssaNodeDefinition {
  */
 class ScopeEntryDefinition extends EssaNodeDefinition {
   ScopeEntryDefinition() {
-    this.getDefiningNode() = this.getSourceVariable().getScopeEntryDefinition() and
+    this.getDefiningNode() =
+      pragma[only_bind_into](pragma[only_bind_out](this.getSourceVariable()))
+          .getScopeEntryDefinition() and
     not this instanceof ImplicitSubModuleDefinition
   }
 

--- a/python/ql/lib/semmle/python/essa/Essa.qll
+++ b/python/ql/lib/semmle/python/essa/Essa.qll
@@ -633,8 +633,7 @@ class DeletionDefinition extends EssaNodeDefinition {
 class ScopeEntryDefinition extends EssaNodeDefinition {
   ScopeEntryDefinition() {
     this.getDefiningNode() =
-      pragma[only_bind_into](pragma[only_bind_out](this.getSourceVariable()))
-          .getScopeEntryDefinition() and
+      pragma[only_bind_out](this.getSourceVariable()).getScopeEntryDefinition() and
     not this instanceof ImplicitSubModuleDefinition
   }
 


### PR DESCRIPTION
Before:

```
Tuple counts for Essa::ScopeEntryDefinition#class#24e22a14#f/1@45e0d8dh after 10.5s:
2133368   ~1%     {2} r1 = Essa::TEssaNodeDefinition#24e22a14#ffff_03#join_rhs AND NOT Essa::ImplicitSubModuleDefinition#class#24e22a14#f(Lhs.1 'this')
534478950 ~0%     {2} r2 = JOIN r1 WITH Definitions::SsaSourceVariable::getScopeEntryDefinition#dispred#f0820431#ff ON FIRST 1 OUTPUT Lhs.1 'this', Rhs.1
581249    ~4%     {1} r3 = JOIN r2 WITH Essa::EssaNodeDefinition::getDefiningNode#dispred#f0820431#ff ON FIRST 2 OUTPUT Lhs.0 'this'
                return r3
```

Let's see if pushing the `getDefiningNode` join further up improves the number of intermediary tuples. (Intuitively it should, since there should only be one defining node for any given `EssaNodeDefinition`.)

To do this, we unbind the `this.getSourceVariable()` part, which encourages the compiler to put this join later.

After:

```
Tuple counts for Essa::ScopeEntryDefinition#class#24e22a14#f/1@30758cv4 after 300ms:
2133569 ~1%     {2} r1 = SCAN Essa::TEssaNodeDefinition#24e22a14#ffff OUTPUT In.0, In.3 'this'
2133368 ~1%     {2} r2 = r1 AND NOT Essa::ImplicitSubModuleDefinition#class#24e22a14#f(Lhs.1 'this')
2133368 ~0%     {2} r3 = JOIN r2 WITH Definitions::SsaSourceVariable#class#486534ab#f ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.0
2133368 ~0%     {3} r4 = JOIN r3 WITH Essa::EssaNodeDefinition::getDefiningNode#dispred#f0820431#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.0 'this'
581249  ~4%     {1} r5 = JOIN r4 WITH Definitions::SsaSourceVariable::getScopeEntryDefinition#dispred#f0820431#ff ON FIRST 2 OUTPUT Lhs.2 'this'
                return r5
```

Much better (and our intuition is confirmed -- joining with `getDefiningNode` did not increase the number of tuples).