### PR TITLE
C++: Fix join-order problem in `cpp/return-stack-allocated-memory`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -74,13 +74,12 @@ class ReturnStackAllocatedMemoryConfig extends MustFlowConfiguration {
 
 from
   MustFlowPathNode source, MustFlowPathNode sink, VariableAddressInstruction var,
-  ReturnStackAllocatedMemoryConfig conf, Function f
+  ReturnStackAllocatedMemoryConfig conf
 where
-  conf.hasFlowPath(source, sink) and
+  conf.hasFlowPath(pragma[only_bind_into](source), pragma[only_bind_into](sink)) and
   source.getNode().asInstruction() = var and
   // Only raise an alert if we're returning from the _same_ callable as the on that
   // declared the stack variable.
-  var.getEnclosingFunction() = pragma[only_bind_into](f) and
-  sink.getNode().getEnclosingCallable() = pragma[only_bind_into](f)
+  var.getEnclosingFunction() = sink.getNode().getEnclosingCallable()
 select sink.getNode(), source, sink, "May return stack-allocated memory from $@.", var.getAst(),
   var.getAst().toString()


### PR DESCRIPTION
Before on Abseil:
```
Evaluated relational algebra for predicate #select#cpe#12356#fffff@3ffb21o1 with tuple counts:
         1235939  ~0%    {2} r1 = SCAN functions OUTPUT In.0, In.0
         1235939  ~0%    {2} r2 = JOIN r1 WITH functions ON FIRST 1 OUTPUT Lhs.1, Lhs.0
        33500841  ~0%    {2} r3 = JOIN r2 WITH DataFlowUtil::Node::getEnclosingCallable#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
          280683  ~3%    {3} r4 = JOIN r3 WITH MustFlow::MkLocalPathNode#0227f5a1#fff ON FIRST 1 OUTPUT Rhs.2, Lhs.1, Lhs.0
           40970  ~2%    {4} r5 = JOIN r4 WITH MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.0
           40970  ~0%    {5} r6 = JOIN r5 WITH MustFlow::MkLocalPathNode#0227f5a1#fff_20#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.0
           40970  ~1%    {5} r7 = JOIN r6 WITH DataFlowUtil::Cached::TInstructionNode#47741e1f#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4
           40970  ~1%    {5} r8 = JOIN r7 WITH project#Instruction::VariableAddressInstruction#class#577b6a83#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4
           40970  ~0%    {6} r9 = JOIN r8 WITH SSAConstruction::Cached::getInstructionAst#2b11997e#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
           40970  ~2%    {7} r10 = JOIN r9 WITH SSAConstruction::Cached::getInstructionAst#2b11997e#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Rhs.1
               0  ~0%    {6} r11 = JOIN r10 WITH Instruction::Instruction::getEnclosingFunction#dispred#f0820431#3#ff ON FIRST 2 OUTPUT Rhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
               0  ~0%    {5} r12 = JOIN r11 WITH functions ON FIRST 1 OUTPUT Lhs.5, Lhs.1, Lhs.2, Lhs.3, Lhs.4
               0  ~0%    {5} r13 = JOIN r12 WITH Element::ElementBase::toString#dispred#f0820431#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.3, Lhs.2, Lhs.4, Rhs.1
                         return r13
```

After:
```
Evaluated relational algebra for predicate #select#cpe#12356#fffff@1dbc97kv with tuple counts:
        40970  ~0%    {2} r1 = SCAN MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23 OUTPUT In.1, In.0
        40970  ~0%    {3} r2 = JOIN r1 WITH MustFlow::MkLocalPathNode#0227f5a1#fff_20#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
        40970  ~7%    {4} r3 = JOIN r2 WITH MustFlow::MkLocalPathNode#0227f5a1#fff_20#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Lhs.2
        40970  ~2%    {4} r4 = JOIN r3 WITH DataFlowUtil::Cached::TInstructionNode#47741e1f#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
        40970  ~2%    {4} r5 = JOIN r4 WITH project#Instruction::VariableAddressInstruction#class#577b6a83#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3
        40970  ~0%    {5} r6 = JOIN r5 WITH SSAConstruction::Cached::getInstructionAst#2b11997e#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Rhs.1
        40970  ~1%    {6} r7 = JOIN r6 WITH SSAConstruction::Cached::getInstructionAst#2b11997e#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
        40970  ~0%    {6} r8 = JOIN r7 WITH Instruction::Instruction::getEnclosingFunction#dispred#f0820431#3#ff ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1, Lhs.2, Lhs.4, Lhs.5
            0  ~0%    {5} r9 = JOIN r8 WITH DataFlowUtil::Node::getEnclosingCallable#dispred#f0820431#fb ON FIRST 2 OUTPUT Lhs.5, Lhs.2, Lhs.3, Lhs.0, Lhs.4
            0  ~0%    {5} r10 = JOIN r9 WITH Element::ElementBase::toString#dispred#f0820431#ff ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Lhs.4, Rhs.1
                      return r10
```