### PR TITLE
Kotlin: fix for-loop iterators over primitive or wildcard types

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -2124,7 +2124,13 @@ open class KotlinFileExtractor(
                 }
                 isFunction(target, "kotlin", "(some array type)", { isArrayType(it) }, "iterator") && c.origin == IrStatementOrigin.FOR_LOOP_ITERATOR -> {
                     findTopLevelFunctionOrWarn("kotlin.jvm.internal.iterator", "kotlin.jvm.internal.ArrayIteratorKt", c)?.let { iteratorFn ->
-                        extractRawMethodAccess(iteratorFn, c, callable, parent, idx, enclosingStmt, listOf(c.dispatchReceiver), null, null, listOf((c.dispatchReceiver!!.type as IrSimpleType).arguments.first().typeOrNull!!))
+                        val typeArgs = (c.dispatchReceiver!!.type as IrSimpleType).arguments.map {
+                            when(it) {
+                                is IrTypeProjection -> it.type
+                                else -> pluginContext.irBuiltIns.anyNType
+                            }
+                        }
+                        extractRawMethodAccess(iteratorFn, c, callable, parent, idx, enclosingStmt, listOf(c.dispatchReceiver), null, null, typeArgs)
                     }
                 }
                 isFunction(target, "kotlin", "(some array type)", { isArrayType(it) }, "get") && c.origin == IrStatementOrigin.GET_ARRAY_ELEMENT -> {

--- a/java/ql/test/kotlin/library-tests/for-array-iterators/test.expected
+++ b/java/ql/test/kotlin/library-tests/for-array-iterators/test.expected
@@ -1,0 +1,9 @@
+| test.kt:5:14:5:14 | hasNext(...) |
+| test.kt:5:14:5:14 | iterator(...) |
+| test.kt:5:14:5:14 | next(...) |
+| test.kt:6:14:6:14 | hasNext(...) |
+| test.kt:6:14:6:14 | iterator(...) |
+| test.kt:6:14:6:14 | next(...) |
+| test.kt:7:14:7:14 | hasNext(...) |
+| test.kt:7:14:7:14 | iterator(...) |
+| test.kt:7:14:7:14 | next(...) |

--- a/java/ql/test/kotlin/library-tests/for-array-iterators/test.kt
+++ b/java/ql/test/kotlin/library-tests/for-array-iterators/test.kt
@@ -1,0 +1,11 @@
+fun test(x: Array<String>, y: Array<*>, z: IntArray): Int {
+
+  var ret = 0
+
+  for (el in x) { ret += 1 }
+  for (el in y) { ret += 1 }
+  for (el in z) { ret += 1 }
+
+  return ret 
+
+}

--- a/java/ql/test/kotlin/library-tests/for-array-iterators/test.ql
+++ b/java/ql/test/kotlin/library-tests/for-array-iterators/test.ql
@@ -1,0 +1,4 @@
+import java
+
+from MethodAccess ma
+select ma


### PR DESCRIPTION
`Array<*>` can't be queried for an argument type, and `IntArray` doesn't have an argument at all; both were previously causing the extractor to fail to extract the whole file due to throwing an exception.