### PR TITLE
Kotlin: Special-case String.charAt naming

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/utils/JvmNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/JvmNames.kt
@@ -51,6 +51,8 @@ private val specialFunctions = mapOf(
     makeDescription(FqName("java.lang.Number"), "toFloat") to "floatValue",
     makeDescription(StandardNames.FqNames.number.toSafe(), "toDouble") to "doubleValue",
     makeDescription(FqName("java.lang.Number"), "toDouble") to "doubleValue",
+    makeDescription(StandardNames.FqNames.string.toSafe(), "get") to "charAt",
+    makeDescription(FqName("java.lang.String"), "get") to "charAt",
 )
 
 private val specialFunctionShortNames = specialFunctions.keys.map { it.functionName }.toSet()

--- a/java/ql/test/kotlin/library-tests/reflection/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/reflection/PrintAst.expected
@@ -8,7 +8,7 @@ reflection.kt:
 #   46|           0: [TypeAccess] String
 #   47|       5: [BlockStmt] { ... }
 #   47|         0: [ReturnStmt] return ...
-#   47|           0: [MethodAccess] get(...)
+#   47|           0: [MethodAccess] charAt(...)
 #   47|             -1: [ExtensionReceiverAccess] this
 #   47|             0: [SubExpr] ... - ...
 #   47|               0: [MethodAccess] length(...)

--- a/java/ql/test/kotlin/library-tests/string-charat/Test.java
+++ b/java/ql/test/kotlin/library-tests/string-charat/Test.java
@@ -1,0 +1,5 @@
+public class Test {
+
+  public char f(String s) { return s.charAt(0); }
+
+}

--- a/java/ql/test/kotlin/library-tests/string-charat/test.expected
+++ b/java/ql/test/kotlin/library-tests/string-charat/test.expected
@@ -1,0 +1,2 @@
+| Test.java:3:36:3:46 | charAt(...) |
+| test.kt:2:20:2:23 | charAt(...) |

--- a/java/ql/test/kotlin/library-tests/string-charat/test.kt
+++ b/java/ql/test/kotlin/library-tests/string-charat/test.kt
@@ -1,0 +1,2 @@
+
+fun f(x: String) = x[0]

--- a/java/ql/test/kotlin/library-tests/string-charat/test.ql
+++ b/java/ql/test/kotlin/library-tests/string-charat/test.ql
@@ -1,0 +1,4 @@
+import java
+
+from MethodAccess ma
+select ma


### PR DESCRIPTION
In the Kotlin universe this is called `get` so that Kotlin programmers can use the `[]` operator on `String`s.