### PR TITLE
C++: Speed up boolConversionLowerBound (and boolConversionUpperBound).

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -1118,24 +1118,39 @@ private predicate exprIsUsedAsBool(Expr expr) {
 }
 
 /**
+ * Helper predicate for `boolConversionLowerBound` / `boolConversionUpperBound`.
+ */
+private float boolConversionLowerBound0(Expr expr) {
+  exprIsUsedAsBool(expr) and
+  result = getTruncatedLowerBounds(expr)
+}
+
+/**
+ * Helper predicate for `boolConversionLowerBound` / `boolConversionUpperBound`.
+ */
+private float boolConversionUpperBound0(Expr expr) {
+  exprIsUsedAsBool(expr) and
+  result = getTruncatedUpperBounds(expr)
+}
+
+/**
  * Gets the lower bound of the conversion `(bool)expr`. If we can prove that
  * the value of `expr` is never 0 then `lb = 1`. Otherwise `lb = 0`.
  */
 private float boolConversionLowerBound(Expr expr) {
   // Case 1: if the range for `expr` includes the value 0,
   // then `result = 0`.
-  exprIsUsedAsBool(expr) and
-  exists(float lb | lb = getTruncatedLowerBounds(expr) and not lb > 0) and
-  exists(float ub | ub = getTruncatedUpperBounds(expr) and not ub < 0) and
+  exists(float lb | lb = boolConversionLowerBound0(expr) and not lb > 0) and
+  exists(float ub | ub = boolConversionUpperBound0(expr) and not ub < 0) and
   result = 0
   or
   // Case 2a: if the range for `expr` does not include the value 0,
   // then `result = 1`.
-  exprIsUsedAsBool(expr) and getTruncatedLowerBounds(expr) > 0 and result = 1
+  boolConversionLowerBound0(expr) > 0 and result = 1
   or
   // Case 2b: if the range for `expr` does not include the value 0,
   // then `result = 1`.
-  exprIsUsedAsBool(expr) and getTruncatedUpperBounds(expr) < 0 and result = 1
+  boolConversionUpperBound0(expr) < 0 and result = 1
   or
   // Case 3: the type of `expr` is not arithmetic. For example, it might
   // be a pointer.
@@ -1149,22 +1164,20 @@ private float boolConversionLowerBound(Expr expr) {
 private float boolConversionUpperBound(Expr expr) {
   // Case 1a: if the upper bound of the operand is <= 0, then the upper
   // bound might be 0.
-  exprIsUsedAsBool(expr) and getTruncatedUpperBounds(expr) <= 0 and result = 0
+  boolConversionUpperBound0(expr) <= 0 and result = 0
   or
   // Case 1b: if the upper bound of the operand is not <= 0, then the upper
   // bound is 1.
-  exprIsUsedAsBool(expr) and
-  exists(float ub | ub = getTruncatedUpperBounds(expr) and not ub <= 0) and
+  exists(float ub | ub = boolConversionUpperBound0(expr) and not ub <= 0) and
   result = 1
   or
   // Case 2a: if the lower bound of the operand is >= 0, then the upper
   // bound might be 0.
-  exprIsUsedAsBool(expr) and getTruncatedLowerBounds(expr) >= 0 and result = 0
+  boolConversionLowerBound0(expr) >= 0 and result = 0
   or
   // Case 2b: if the lower bound of the operand is not >= 0, then the upper
   // bound is 1.
-  exprIsUsedAsBool(expr) and
-  exists(float lb | lb = getTruncatedLowerBounds(expr) and not lb >= 0) and
+  exists(float lb | lb = boolConversionLowerBound0(expr) and not lb >= 0) and
   result = 1
   or
   // Case 3: the type of `expr` is not arithmetic. For example, it might


### PR DESCRIPTION
Possible improvement to `SimpleRangeAnalysis::boolConversionLowerBound`, motivated by a recent regression in the DCA tuple sums reports for this predicate (though I think it regressed at least one more time before this) - https://github.com/github/codeql-dca-main/issues/5626):

<html>
<body>
<!--StartFragment-->

kamailio__kamailio | cpp/unsigned-difference-expression-compared-zero:SimpleRangeAnalysis::boolConversionLowerBound#a97350a1#ff#40d9bkw9dl49ghmceol5t3dj26s# (standard) | 1 | 1 | ❌ | 13030410 | 0 | 17596713 | 0 | 4566303 | 0.35
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --


<!--EndFragment-->
</body>
</html>

The change takes some repeat calculations out into separate predicates, with the aim of discouraging repeat calculations and encouraging `exprIsUsedAsBool` to be joined with `getTruncated*Bounds` early.  Following this change, when I run `cpp/unsigned-difference-expression-compared-zero` locally on `kamailio__kamailio` I no longer see `boolConversionLowerBound` in the most expensive predicates report (nor do I see either of the two new predicates).

DCA run of this change [here](https://github.com/github/codeql-dca-main/issues/5638):
 - I think we can ignore the failures in this DCA run, these are projects we've been having problems with in recent nightly runs.
 - sadly the 'Tuple sums, per source and predicate' table is truncated (and the 'complete table' link doesn't work for me), but under 'Tuple sums, per source' we can see an improvement:

<html>
<body>
<!--StartFragment-->

kamailio__kamailio | 1 | 1 | ✔ | ✗ | 42276185596 | 0 | 42068619900 | 0 | -207565696 | -0.00491
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --


<br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>

@rdmarsh2 - mentioned to keep you in the loop as I believe you are currently working on SimpleRangeAnalysis.

@jketema - mentioned as I know you're working on some other DCA regressions / issues at the moment.