### PR TITLE
Ruby/QL: speed up trap writing by putting BufWriter in front of GzEncoder

### DIFF
--- a/ql/extractor/src/trap.rs
+++ b/ql/extractor/src/trap.rs
@@ -61,12 +61,15 @@ impl Writer {
 
     pub fn write_to_file(&self, path: &Path, compression: Compression) -> std::io::Result<()> {
         let trap_file = std::fs::File::create(path)?;
-        let mut trap_file = BufWriter::new(trap_file);
         match compression {
-            Compression::None => self.write_trap_entries(&mut trap_file),
+            Compression::None => {
+                let mut trap_file = BufWriter::new(trap_file);
+                self.write_trap_entries(&mut trap_file)
+            }
             Compression::Gzip => {
-                let mut compressed_writer = GzEncoder::new(trap_file, flate2::Compression::fast());
-                self.write_trap_entries(&mut compressed_writer)
+                let trap_file = GzEncoder::new(trap_file, flate2::Compression::fast());
+                let mut trap_file = BufWriter::new(trap_file);
+                self.write_trap_entries(&mut trap_file)
             }
         }
     }

--- a/ruby/extractor/src/trap.rs
+++ b/ruby/extractor/src/trap.rs
@@ -61,12 +61,15 @@ impl Writer {
 
     pub fn write_to_file(&self, path: &Path, compression: Compression) -> std::io::Result<()> {
         let trap_file = std::fs::File::create(path)?;
-        let mut trap_file = BufWriter::new(trap_file);
         match compression {
-            Compression::None => self.write_trap_entries(&mut trap_file),
+            Compression::None => {
+                let mut trap_file = BufWriter::new(trap_file);
+                self.write_trap_entries(&mut trap_file)
+            }
             Compression::Gzip => {
-                let mut compressed_writer = GzEncoder::new(trap_file, flate2::Compression::fast());
-                self.write_trap_entries(&mut compressed_writer)
+                let trap_file = GzEncoder::new(trap_file, flate2::Compression::fast());
+                let mut trap_file = BufWriter::new(trap_file);
+                self.write_trap_entries(&mut trap_file)
             }
         }
     }


### PR DESCRIPTION
Previously, the `BufWriter` came *after* the `GzEncoder` in the chain of writers (i.e. the `GzEncoder` wrapped the `BufWriter`), which meant that we were gzip-encoding every tiny string as soon it was formatted, and the `BufWriter` was just adding buffering between the `GzEncoder`'s output and the file.

Now we invert the relationship, so as we format strings they get buffered by `BufWriter`, and only when its buffer gets full does it pass the data on to `GzEncoder`. It's much more efficient for the `GzEncoder` to perform its compression less often on larger amounts of data in each go.

I think this problem has existed since the very early days of the Ruby extractor, but it didn't cause a noticeable slowdown until the recent refactoring in #9878.

That's because, before the refactoring, we [wrote the entire TRAP file to a temporary `String`](https://github.com/github/codeql/blob/27be3dff541f369604aac970bd982a673c179185/ruby/extractor/src/extractor.rs#L706-L710), effectively implementing our own crude buffering. I removed this during the refactoring (it shouldn't be necessary if we use a `BufWriter`, right?), and that exposed the problem with the inverted `GzEncoder`-`BufWriter` relationship.