### PR TITLE
Java: Add support for JUnit5 assertions in the nullness queries.

### DIFF
--- a/java/ql/lib/change-notes/2022-07-27-nullness-junit5.md
+++ b/java/ql/lib/change-notes/2022-07-27-nullness-junit5.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* The JUnit5 version of `AssertNotNull` is now recognized, which removes
+  related false positives in the nullness queries.

--- a/java/ql/lib/semmle/code/java/frameworks/Assertions.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Assertions.qll
@@ -2,7 +2,8 @@
  * A library providing uniform access to various assertion frameworks.
  *
  * Currently supports `org.junit.Assert`, `junit.framework.*`,
- * `com.google.common.base.Preconditions`, and `java.util.Objects`.
+ * `org.junit.jupiter.api.Assertions`, `com.google.common.base.Preconditions`,
+ * and `java.util.Objects`.
  */
 
 import java
@@ -17,7 +18,11 @@ private newtype AssertKind =
 private predicate assertionMethod(Method m, AssertKind kind) {
   exists(RefType junit |
     m.getDeclaringType() = junit and
-    (junit.hasQualifiedName("org.junit", "Assert") or junit.hasQualifiedName("junit.framework", _))
+    (
+      junit.hasQualifiedName("org.junit", "Assert") or
+      junit.hasQualifiedName("junit.framework", _) or
+      junit.hasQualifiedName("org.junit.jupiter.api", "Assertions")
+    )
   |
     m.hasName("assertNotNull") and kind = AssertKindNotNull()
     or


### PR DESCRIPTION
JUnit5 `AssertNotNull` was not recognized since the package name had changed from JUnit4.

Fixes https://github.com/github/codeql/issues/9901