### PR TITLE
Control Flow: extend ordering

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -916,7 +916,7 @@ module TestOutput {
             s
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString()
           )
       ).toString()
   }

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -881,7 +881,12 @@ import Cached
  * graph is restricted to nodes from `RelevantNode`.
  */
 module TestOutput {
-  abstract class RelevantNode extends Node { }
+  abstract class RelevantNode extends Node {
+    /**
+     * Gets a string used to resolve ties in node and edge ordering.
+     */
+    string getOrderDisambuigation() { result = "" }
+  }
 
   query predicate nodes(RelevantNode n, string attr, string val) {
     attr = "semmle.order" and
@@ -894,7 +899,8 @@ module TestOutput {
             p
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), p.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), p.toString(),
+              p.getOrderDisambuigation()
           )
       ).toString()
   }
@@ -916,7 +922,8 @@ module TestOutput {
             s
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString(),
+              s.getOrderDisambuigation()
           )
       ).toString()
   }

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -916,7 +916,7 @@ module TestOutput {
             s
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString()
           )
       ).toString()
   }

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -881,7 +881,12 @@ import Cached
  * graph is restricted to nodes from `RelevantNode`.
  */
 module TestOutput {
-  abstract class RelevantNode extends Node { }
+  abstract class RelevantNode extends Node {
+    /**
+     * Gets a string used to resolve ties in node and edge ordering.
+     */
+    string getOrderDisambuigation() { result = "" }
+  }
 
   query predicate nodes(RelevantNode n, string attr, string val) {
     attr = "semmle.order" and
@@ -894,7 +899,8 @@ module TestOutput {
             p
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), p.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), p.toString(),
+              p.getOrderDisambuigation()
           )
       ).toString()
   }
@@ -916,7 +922,8 @@ module TestOutput {
             s
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString(),
+              s.getOrderDisambuigation()
           )
       ).toString()
   }

--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -916,7 +916,7 @@ module TestOutput {
             s
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString()
           )
       ).toString()
   }

--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -881,7 +881,12 @@ import Cached
  * graph is restricted to nodes from `RelevantNode`.
  */
 module TestOutput {
-  abstract class RelevantNode extends Node { }
+  abstract class RelevantNode extends Node {
+    /**
+     * Gets a string used to resolve ties in node and edge ordering.
+     */
+    string getOrderDisambuigation() { result = "" }
+  }
 
   query predicate nodes(RelevantNode n, string attr, string val) {
     attr = "semmle.order" and
@@ -894,7 +899,8 @@ module TestOutput {
             p
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), p.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), p.toString(),
+              p.getOrderDisambuigation()
           )
       ).toString()
   }
@@ -916,7 +922,8 @@ module TestOutput {
             s
             order by
               l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString()
+              l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString(), s.toString(),
+              s.getOrderDisambuigation()
           )
       ).toString()
   }


### PR DESCRIPTION
In Swift we encountered a situation where ordering of nodes and edges in the control flow graph was not stable between test runs.

This patch:
* adds the successor string representation to the edge ordering
* adds an overridable `getOrderDisambiguation` method to both node and edge orderings

This is used in https://github.com/github/codeql/pull/9891

This is currently only used in tests.