### PR TITLE
Java: Add support for XML InlineExpectationsTest

### DIFF
--- a/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
@@ -21,7 +21,7 @@ private class KtExpectationComment extends KtComment, ExpectationComment {
   override string getContents() { result = this.getText().suffix(2).trim() }
 }
 
-private class XMLExpectationComment extends ExpectationComment instanceof XMLComment {
+private class XmlExpectationComment extends ExpectationComment instanceof XMLComment {
   override string getContents() { result = this.(XMLComment).getText().trim() }
 
   override Location getLocation() { result = this.(XMLComment).getLocation() }

--- a/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
@@ -20,3 +20,15 @@ private class KtExpectationComment extends KtComment, ExpectationComment {
 
   override string getContents() { result = this.getText().suffix(2).trim() }
 }
+
+private class XMLExpectationComment extends ExpectationComment instanceof XMLComment {
+  override string getContents() { result = this.(XMLComment).getText().trim() }
+
+  override Location getLocation() { result = this.(XMLComment).getLocation() }
+
+  override predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
+    this.(XMLComment).hasLocationInfo(path, sl, sc, el, ec)
+  }
+
+  override string toString() { result = this.(XMLComment).toString() }
+}

--- a/java/ql/test/library-tests/xml/Test.java
+++ b/java/ql/test/library-tests/xml/Test.java
@@ -1,0 +1,3 @@
+public class Test {
+
+}

--- a/java/ql/test/library-tests/xml/XMLTest.expected
+++ b/java/ql/test/library-tests/xml/XMLTest.expected
@@ -1,0 +1,2 @@
+| test.xml:4:5:4:32 | attribute=value | Unexpected result: hasXmlResult= |
+| test.xml:5:29:5:52 |  $ hasXmlResult  | Missing result:hasXmlResult= |

--- a/java/ql/test/library-tests/xml/XMLTest.ql
+++ b/java/ql/test/library-tests/xml/XMLTest.ql
@@ -1,0 +1,17 @@
+import semmle.code.xml.XML
+import TestUtilities.InlineExpectationsTest
+
+class XMLTest extends InlineExpectationsTest {
+  XMLTest() { this = "XMLTest" }
+
+  override string getARelevantTag() { result = "hasXmlResult" }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    tag = "hasXmlResult" and
+    exists(XMLAttribute a |
+      a.getLocation() = location and
+      element = a.toString() and
+      value = ""
+    )
+  }
+}

--- a/java/ql/test/library-tests/xml/XMLTest.ql
+++ b/java/ql/test/library-tests/xml/XMLTest.ql
@@ -1,8 +1,8 @@
 import semmle.code.xml.XML
 import TestUtilities.InlineExpectationsTest
 
-class XMLTest extends InlineExpectationsTest {
-  XMLTest() { this = "XMLTest" }
+class XmlTest extends InlineExpectationsTest {
+  XmlTest() { this = "XmlTest" }
 
   override string getARelevantTag() { result = "hasXmlResult" }
 

--- a/java/ql/test/library-tests/xml/test.xml
+++ b/java/ql/test/library-tests/xml/test.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document>
     <element attribute="value">Text</element> <!-- $ hasXmlResult -->
+    <element attribute="value">Text</element> <!-- Missing -->
+    <element>Text</element> <!-- $ hasXmlResult --> <!-- Spurious -->
 </document>

--- a/java/ql/test/library-tests/xml/test.xml
+++ b/java/ql/test/library-tests/xml/test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <element attribute="value">Text</element> <!-- $ hasXmlResult -->
+</document>


### PR DESCRIPTION
This will help write tests for Android queries with results in `AndroidManifest.xml`.