### PR TITLE
Swift: add `--no-cleanup` to integration tests

### DIFF
--- a/swift/integration-tests/create_database_utils.py
+++ b/swift/integration-tests/create_database_utils.py
@@ -12,7 +12,7 @@ def run_codeql_database_create(cmds, lang, keep_trap=True):
     codeql_root = pathlib.Path(__file__).parents[2]
     cmd = [
         "codeql", "database", "create",
-        "-s", ".", "-l", "swift", "--internal-use-lua-tracing", f"--search-path={codeql_root}",
+        "-s", ".", "-l", "swift", "--internal-use-lua-tracing", f"--search-path={codeql_root}", "--no-cleanup",
     ]
     if keep_trap:
         cmd.append("--keep-trap")


### PR DESCRIPTION
This enables having more information in the DB check results.