### PR TITLE
Swift: make trap key prefixes readable

### DIFF
--- a/swift/codegen/generators/trapgen.py
+++ b/swift/codegen/generators/trapgen.py
@@ -86,11 +86,10 @@ def generate(opts, renderer):
         renderer.render(cpp.TrapList(entries, opts.dbscheme), out / dir / "TrapEntries")
 
     tags = []
-    for index, tag in enumerate(toposort_flatten(tag_graph)):
+    for tag in toposort_flatten(tag_graph):
         tags.append(cpp.Tag(
             name=get_tag_name(tag),
             bases=[get_tag_name(b) for b in sorted(tag_graph[tag])],
-            index=index,
             id=tag,
         ))
     renderer.render(cpp.TagList(tags, opts.dbscheme), out / "TrapTags")

--- a/swift/codegen/lib/cpp.py
+++ b/swift/codegen/lib/cpp.py
@@ -83,7 +83,6 @@ class TagBase:
 class Tag:
     name: str
     bases: List[TagBase]
-    index: int
     id: str
 
     def __post_init__(self):

--- a/swift/codegen/templates/trap_tags_h.mustache
+++ b/swift/codegen/templates/trap_tags_h.mustache
@@ -7,7 +7,7 @@ namespace codeql {
 
 // {{id}}
 struct {{name}}Tag {{#has_bases}}: {{#bases}}{{^first}}, {{/first}}{{base}}Tag{{/bases}} {{/has_bases}}{
-  static constexpr const char* prefix = "{{index}}";
+  static constexpr const char* prefix = "{{name}}";
 };
 {{/tags}}
 }

--- a/swift/codegen/test/test_cpp.py
+++ b/swift/codegen/test/test_cpp.py
@@ -65,7 +65,7 @@ def test_trap_has_first_field_marked():
 def test_tag_has_first_base_marked():
     bases = ["a", "b", "c"]
     expected = [cpp.TagBase("a", first=True), cpp.TagBase("b"), cpp.TagBase("c")]
-    t = cpp.Tag("name", bases, 0, "id")
+    t = cpp.Tag("name", bases, "id")
     assert t.bases == expected
 
 
@@ -75,7 +75,7 @@ def test_tag_has_first_base_marked():
     (["a", "b"], True)
 ])
 def test_tag_has_bases(bases, expected):
-    t = cpp.Tag("name", bases, 0, "id")
+    t = cpp.Tag("name", bases, "id")
     assert t.has_bases is expected
 
 

--- a/swift/codegen/test/test_trapgen.py
+++ b/swift/codegen/test/test_trapgen.py
@@ -162,10 +162,10 @@ def test_one_union_tags(generate_tags):
     assert generate_tags([
         dbscheme.Union(lhs="@left_hand_side", rhs=["@b", "@a", "@c"]),
     ]) == [
-        cpp.Tag(name="LeftHandSide", bases=[], index=0, id="@left_hand_side"),
-        cpp.Tag(name="A", bases=["LeftHandSide"], index=1, id="@a"),
-        cpp.Tag(name="B", bases=["LeftHandSide"], index=2, id="@b"),
-        cpp.Tag(name="C", bases=["LeftHandSide"], index=3, id="@c"),
+        cpp.Tag(name="LeftHandSide", bases=[], id="@left_hand_side"),
+        cpp.Tag(name="A", bases=["LeftHandSide"], id="@a"),
+        cpp.Tag(name="B", bases=["LeftHandSide"], id="@b"),
+        cpp.Tag(name="C", bases=["LeftHandSide"], id="@c"),
     ]
 
 
@@ -175,12 +175,12 @@ def test_multiple_union_tags(generate_tags):
         dbscheme.Union(lhs="@a", rhs=["@b", "@c"]),
         dbscheme.Union(lhs="@e", rhs=["@c", "@f"]),
     ]) == [
-        cpp.Tag(name="D", bases=[], index=0, id="@d"),
-        cpp.Tag(name="E", bases=[], index=1, id="@e"),
-        cpp.Tag(name="A", bases=["D"], index=2, id="@a"),
-        cpp.Tag(name="F", bases=["E"], index=3, id="@f"),
-        cpp.Tag(name="B", bases=["A"], index=4, id="@b"),
-        cpp.Tag(name="C", bases=["A", "E"], index=5, id="@c"),
+        cpp.Tag(name="D", bases=[], id="@d"),
+        cpp.Tag(name="E", bases=[], id="@e"),
+        cpp.Tag(name="A", bases=["D"], id="@a"),
+        cpp.Tag(name="F", bases=["E"], id="@f"),
+        cpp.Tag(name="B", bases=["A"], id="@b"),
+        cpp.Tag(name="C", bases=["A", "E"], id="@c"),
     ]
 
 


### PR DESCRIPTION
This replaces numeric tag-based prefixes with the actual tag name.
While this means in general slightly larger trap files, it aids
debugging them for a human.

In the future we can make this conditional on some kind of trap debug
option, but for the moment it does not seem detrimental.