### PR TITLE
Use 'gh codeql' with the nightly release for CI jobs

### DIFF
--- a/.github/actions/fetch-codeql/action.yml
+++ b/.github/actions/fetch-codeql/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
         gh extension install github/gh-codeql
-        gh codeql set-channel release
+        gh codeql set-channel nightly
         gh codeql version
         gh codeql version --format=json | jq -r .unpackedLocation >> "${GITHUB_PATH}"
       env:


### PR DESCRIPTION
This pull request changes the default CodeQL version used by CI jobs to be the `nightly` release. Before we used the latest stable release which could lag behind the bleeding edge main branch of CodeQL quite a bit causing friction.

