### PR TITLE
CI: make all jobs that fetch a CodeQL CLI use the fetch-codeql action

### DIFF
--- a/.github/actions/fetch-codeql/action.yml
+++ b/.github/actions/fetch-codeql/action.yml
@@ -3,22 +3,12 @@ description: Fetches the latest version of CodeQL
 runs:
   using: composite
   steps:
-    - name: Select platform - Linux
-      if: runner.os == 'Linux'
-      shell: bash
-      run: echo "GA_CODEQL_CLI_PLATFORM=linux64" >> $GITHUB_ENV
-
-    - name: Select platform - MacOS
-      if: runner.os == 'MacOS'
-      shell: bash
-      run: echo "GA_CODEQL_CLI_PLATFORM=osx64" >> $GITHUB_ENV
-
     - name: Fetch CodeQL
       shell: bash
       run: |
-        LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | grep -v beta | sort --version-sort | tail -1)
-        gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql-$GA_CODEQL_CLI_PLATFORM.zip "$LATEST"
-        unzip -q -d "${RUNNER_TEMP}" codeql-$GA_CODEQL_CLI_PLATFORM.zip
-        echo "${RUNNER_TEMP}/codeql" >> "${GITHUB_PATH}"
+        gh extension install github/gh-codeql
+        gh codeql set-channel release
+        gh codeql version
+        gh codeql version --format=json | jq -r .unpackedLocation >> "${GITHUB_PATH}"
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/check-qldoc.yml
+++ b/.github/workflows/check-qldoc.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "*/ql/lib/**"
       - .github/workflows/check-qldoc.yml
+      - .github/actions/fetch-codeql
     branches:
       - main
       - "rc/*"

--- a/.github/workflows/check-qldoc.yml
+++ b/.github/workflows/check-qldoc.yml
@@ -14,17 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install CodeQL
-        run: |
-          gh extension install github/gh-codeql
-          gh codeql set-channel nightly
-          gh codeql version
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+
+      - name: Install CodeQL
+        uses: ./.github/actions/fetch-codeql
 
       - name: Check QLdoc coverage
         shell: bash
@@ -34,7 +29,7 @@ jobs:
           changed_lib_packs="$(git diff --name-only --diff-filter=ACMRT HEAD^ HEAD | { grep -Po '^(?!swift)[a-z]*/ql/lib' || true; } | sort -u)"
           for pack_dir in ${changed_lib_packs}; do
             lang="${pack_dir%/ql/lib}"
-            gh codeql generate library-doc-coverage --output="${RUNNER_TEMP}/${lang}-current.txt" --dir="${pack_dir}"
+            codeql generate library-doc-coverage --output="${RUNNER_TEMP}/${lang}-current.txt" --dir="${pack_dir}"
           done
           git checkout HEAD^
           for pack_dir in ${changed_lib_packs}; do
@@ -42,7 +37,7 @@ jobs:
             # In this case the right thing to do is to skip the check.
             [[ ! -d "${pack_dir}" ]] && continue
             lang="${pack_dir%/ql/lib}"
-            gh codeql generate library-doc-coverage --output="${RUNNER_TEMP}/${lang}-baseline.txt" --dir="${pack_dir}"
+            codeql generate library-doc-coverage --output="${RUNNER_TEMP}/${lang}-baseline.txt" --dir="${pack_dir}"
             awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${RUNNER_TEMP}/${lang}-current.txt" | sort -u > "${RUNNER_TEMP}/current-undocumented.txt"
             awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${RUNNER_TEMP}/${lang}-baseline.txt" | sort -u > "${RUNNER_TEMP}/baseline-undocumented.txt"
             UNDOCUMENTED="$(grep -f <(comm -13 "${RUNNER_TEMP}/baseline-undocumented.txt" "${RUNNER_TEMP}/current-undocumented.txt") "${RUNNER_TEMP}/${lang}-current.txt" || true)"

--- a/.github/workflows/csv-coverage-metrics.yml
+++ b/.github/workflows/csv-coverage-metrics.yml
@@ -12,6 +12,7 @@ on:
       - main
     paths:
       - ".github/workflows/csv-coverage-metrics.yml"
+      - ".github/actions/fetch-codeql"
 
 jobs:
   publish-java:

--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -3,18 +3,20 @@ name: Check framework coverage changes
 on:
   pull_request:
     paths:
-      - '.github/workflows/csv-coverage-pr-comment.yml'
-      - '*/ql/src/**/*.ql'
-      - '*/ql/src/**/*.qll'
-      - '*/ql/lib/**/*.ql'
-      - '*/ql/lib/**/*.qll'
-      - 'misc/scripts/library-coverage/*.py'
+      - ".github/workflows/csv-coverage-pr-comment.yml"
+      - ".github/workflows/csv-coverage-pr-artifacts.yml"
+      - ".github/actions/fetch-codeql"
+      - "*/ql/src/**/*.ql"
+      - "*/ql/src/**/*.qll"
+      - "*/ql/lib/**/*.ql"
+      - "*/ql/lib/**/*.qll"
+      - "misc/scripts/library-coverage/*.py"
       # input data files
-      - '*/documentation/library-coverage/cwe-sink.csv'
-      - '*/documentation/library-coverage/frameworks.csv'
+      - "*/documentation/library-coverage/cwe-sink.csv"
+      - "*/documentation/library-coverage/frameworks.csv"
     branches:
       - main
-      - 'rc/*'
+      - "rc/*"
 
 jobs:
   generate:
@@ -23,77 +25,72 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github.event) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Clone self (github/codeql) - MERGE
-      uses: actions/checkout@v3
-      with:
-        path: merge
-    - name: Clone self (github/codeql) - BASE
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
-        path: base
-    - run: |
-        git checkout HEAD^1
-        git log -1 --format='%H'
-      working-directory: base
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-    - name: Download CodeQL CLI
-      env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-         gh release download --repo "github/codeql-cli-binaries" --pattern "codeql-linux64.zip"
-    - name: Unzip CodeQL CLI
-      run: unzip -d codeql-cli codeql-linux64.zip
-    - name: Generate CSV files on merge commit of the PR
-      run: |
-        echo "Running generator on merge"
-        PATH="$PATH:codeql-cli/codeql" python merge/misc/scripts/library-coverage/generate-report.py ci merge merge
-        mkdir out_merge
-        cp framework-coverage-*.csv out_merge/
-        cp framework-coverage-*.rst out_merge/
-    - name: Generate CSV files on base commit of the PR
-      run: |
-        echo "Running generator on base"
-        PATH="$PATH:codeql-cli/codeql" python base/misc/scripts/library-coverage/generate-report.py ci base base
-        mkdir out_base
-        cp framework-coverage-*.csv out_base/
-        cp framework-coverage-*.rst out_base/
-    - name: Generate diff of coverage reports
-      run: |
-        python base/misc/scripts/library-coverage/compare-folders.py out_base out_merge comparison.md
-    - name: Upload CSV package list
-      uses: actions/upload-artifact@v3
-      with:
-        name: csv-framework-coverage-merge
-        path: |
-          out_merge/framework-coverage-*.csv
-          out_merge/framework-coverage-*.rst
-    - name: Upload CSV package list
-      uses: actions/upload-artifact@v3
-      with:
-        name: csv-framework-coverage-base
-        path: |
-          out_base/framework-coverage-*.csv
-          out_base/framework-coverage-*.rst
-    - name: Upload comparison results
-      uses: actions/upload-artifact@v3
-      with:
-        name: comparison
-        path: |
-          comparison.md
-    - name: Save PR number
-      run: |
-        mkdir -p pr
-        echo ${{ github.event.pull_request.number }} > pr/NR
-    - name: Upload PR number
-      uses: actions/upload-artifact@v3
-      with:
-        name: pr
-        path: pr/
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github.event) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Clone self (github/codeql) - MERGE
+        uses: actions/checkout@v3
+        with:
+          path: merge
+      - name: Clone self (github/codeql) - BASE
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+          path: base
+      - run: |
+          git checkout HEAD^1
+          git log -1 --format='%H'
+        working-directory: base
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Download CodeQL CLI
+        uses: ./merge/.github/actions/fetch-codeql
+      - name: Generate CSV files on merge commit of the PR
+        run: |
+          echo "Running generator on merge"
+          PATH="$PATH:codeql-cli/codeql" python merge/misc/scripts/library-coverage/generate-report.py ci merge merge
+          mkdir out_merge
+          cp framework-coverage-*.csv out_merge/
+          cp framework-coverage-*.rst out_merge/
+      - name: Generate CSV files on base commit of the PR
+        run: |
+          echo "Running generator on base"
+          PATH="$PATH:codeql-cli/codeql" python base/misc/scripts/library-coverage/generate-report.py ci base base
+          mkdir out_base
+          cp framework-coverage-*.csv out_base/
+          cp framework-coverage-*.rst out_base/
+      - name: Generate diff of coverage reports
+        run: |
+          python base/misc/scripts/library-coverage/compare-folders.py out_base out_merge comparison.md
+      - name: Upload CSV package list
+        uses: actions/upload-artifact@v3
+        with:
+          name: csv-framework-coverage-merge
+          path: |
+            out_merge/framework-coverage-*.csv
+            out_merge/framework-coverage-*.rst
+      - name: Upload CSV package list
+        uses: actions/upload-artifact@v3
+        with:
+          name: csv-framework-coverage-base
+          path: |
+            out_base/framework-coverage-*.csv
+            out_base/framework-coverage-*.rst
+      - name: Upload comparison results
+        uses: actions/upload-artifact@v3
+        with:
+          name: comparison
+          path: |
+            comparison.md
+      - name: Save PR number
+        run: |
+          mkdir -p pr
+          echo ${{ github.event.pull_request.number }} > pr/NR
+      - name: Upload PR number
+        uses: actions/upload-artifact@v3
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/csv-coverage-timeseries.yml
+++ b/.github/workflows/csv-coverage-timeseries.yml
@@ -5,38 +5,31 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - name: Clone self (github/codeql)
-      uses: actions/checkout@v3
-      with:
-        path: script
-    - name: Clone self (github/codeql) for analysis
-      uses: actions/checkout@v3
-      with:
-        path: codeqlModels
-        fetch-depth: 0
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-    - name: Download CodeQL CLI
-      env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-         gh release download --repo "github/codeql-cli-binaries" --pattern "codeql-linux64.zip"
-    - name: Unzip CodeQL CLI
-      run: unzip -d codeql-cli codeql-linux64.zip
-    - name: Build modeled package list
-      run: |
-        CLI=$(realpath "codeql-cli/codeql")
-        echo $CLI
-        PATH="$PATH:$CLI" python script/misc/scripts/library-coverage/generate-timeseries.py codeqlModels
-    - name: Upload timeseries CSV
-      uses: actions/upload-artifact@v3
-      with:
-        name: framework-coverage-timeseries
-        path: framework-coverage-timeseries-*.csv
-
+      - name: Clone self (github/codeql)
+        uses: actions/checkout@v3
+        with:
+          path: script
+      - name: Clone self (github/codeql) for analysis
+        uses: actions/checkout@v3
+        with:
+          path: codeqlModels
+          fetch-depth: 0
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Download CodeQL CLI
+        uses: ./.github/actions/fetch-codeql
+      - name: Build modeled package list
+        run: |
+          CLI=$(realpath "codeql-cli/codeql")
+          echo $CLI
+          PATH="$PATH:$CLI" python script/misc/scripts/library-coverage/generate-timeseries.py codeqlModels
+      - name: Upload timeseries CSV
+        uses: actions/upload-artifact@v3
+        with:
+          name: framework-coverage-timeseries
+          path: framework-coverage-timeseries-*.csv

--- a/.github/workflows/csv-coverage-update.yml
+++ b/.github/workflows/csv-coverage-update.yml
@@ -12,33 +12,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github.event) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Clone self (github/codeql)
-      uses: actions/checkout@v3
-      with:
-        path: ql
-        fetch-depth: 0
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-    - name: Download CodeQL CLI
-      env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-         gh release download --repo "github/codeql-cli-binaries" --pattern "codeql-linux64.zip"
-    - name: Unzip CodeQL CLI
-      run: unzip -d codeql-cli codeql-linux64.zip
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github.event) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Clone self (github/codeql)
+        uses: actions/checkout@v3
+        with:
+          path: ql
+          fetch-depth: 0
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Download CodeQL CLI
+        uses: ./.github/actions/fetch-codeql
+      - name: Generate coverage files
+        run: |
+          PATH="$PATH:codeql-cli/codeql" python ql/misc/scripts/library-coverage/generate-report.py ci ql ql
 
-    - name: Generate coverage files
-      run: |
-        PATH="$PATH:codeql-cli/codeql" python ql/misc/scripts/library-coverage/generate-report.py ci ql ql
-
-    - name: Create pull request with changes
-      env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        python ql/misc/scripts/library-coverage/create-pr.py ql "$GITHUB_REPOSITORY"
+      - name: Create pull request with changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ql/misc/scripts/library-coverage/create-pr.py ql "$GITHUB_REPOSITORY"

--- a/.github/workflows/csv-coverage.yml
+++ b/.github/workflows/csv-coverage.yml
@@ -4,46 +4,39 @@ on:
   workflow_dispatch:
     inputs:
       qlModelShaOverride:
-        description: 'github/codeql repo SHA used for looking up the CSV models'
+        description: "github/codeql repo SHA used for looking up the CSV models"
         required: false
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - name: Clone self (github/codeql)
-      uses: actions/checkout@v3
-      with:
-        path: script
-    - name: Clone self (github/codeql) for analysis
-      uses: actions/checkout@v3
-      with:
-        path: codeqlModels
-        ref: ${{ github.event.inputs.qlModelShaOverride || github.ref }}
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-    - name: Download CodeQL CLI
-      env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-         gh release download --repo "github/codeql-cli-binaries" --pattern "codeql-linux64.zip"
-    - name: Unzip CodeQL CLI
-      run: unzip -d codeql-cli codeql-linux64.zip
-    - name: Build modeled package list
-      run: |
-        PATH="$PATH:codeql-cli/codeql" python script/misc/scripts/library-coverage/generate-report.py ci codeqlModels script
-    - name: Upload CSV package list
-      uses: actions/upload-artifact@v3
-      with:
-        name: framework-coverage-csv
-        path: framework-coverage-*.csv
-    - name: Upload RST package list
-      uses: actions/upload-artifact@v3
-      with:
-        name: framework-coverage-rst
-        path: framework-coverage-*.rst
-
+      - name: Clone self (github/codeql)
+        uses: actions/checkout@v3
+        with:
+          path: script
+      - name: Clone self (github/codeql) for analysis
+        uses: actions/checkout@v3
+        with:
+          path: codeqlModels
+          ref: ${{ github.event.inputs.qlModelShaOverride || github.ref }}
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Download CodeQL CLI
+        uses: ./.github/actions/fetch-codeql
+      - name: Build modeled package list
+        run: |
+          PATH="$PATH:codeql-cli/codeql" python script/misc/scripts/library-coverage/generate-report.py ci codeqlModels script
+      - name: Upload CSV package list
+        uses: actions/upload-artifact@v3
+        with:
+          name: framework-coverage-csv
+          path: framework-coverage-*.csv
+      - name: Upload RST package list
+        uses: actions/upload-artifact@v3
+        with:
+          name: framework-coverage-rst
+          path: framework-coverage-*.rst

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -4,159 +4,111 @@ on:
     paths:
       - "go/**"
       - .github/workflows/go-tests.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
 jobs:
-
   test-linux:
     name: Test Linux (Ubuntu)
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.18.1
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.1
+        id: go
 
-    - name: Set up Go 1.18.1
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.18.1
-      id: go
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Set up CodeQL CLI
-      run: |
-        echo "Removing old CodeQL Directory..."
-        rm -rf $HOME/codeql
-        echo "Done"
-        cd $HOME
-        echo "Downloading CodeQL CLI..."
-        LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | sort --version-sort | grep -v beta | tail -1)
-        gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql-linux64.zip "$LATEST"
-        echo "Done"
-        echo "Unpacking CodeQL CLI..."
-        unzip -q codeql-linux64.zip
-        rm -f codeql-linux64.zip
-        echo "Done"
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+      - name: Set up CodeQL CLI
+        uses: ./.github/actions/fetch-codeql
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Enable problem matchers in repository
+        shell: bash
+        run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
 
-    - name: Enable problem matchers in repository
-      shell: bash
-      run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
+      - name: Build
+        run: |
+          cd go
+          env make
 
-    - name: Build
-      run: |
-        cd go
-        env PATH=$PATH:$HOME/codeql make
+      - name: Check that all QL and Go code is autoformatted
+        run: |
+          cd go
+          env make check-formatting
 
-    - name: Check that all QL and Go code is autoformatted
-      run: |
-        cd go
-        env PATH=$PATH:$HOME/codeql make check-formatting
+      - name: Compile qhelp files to markdown
+        run: |
+          cd go
+          env QHELP_OUT_DIR=qhelp-out make qhelp-to-markdown
 
-    - name: Compile qhelp files to markdown
-      run: |
-        cd go
-        env PATH=$PATH:$HOME/codeql QHELP_OUT_DIR=qhelp-out make qhelp-to-markdown
+      - name: Upload qhelp markdown
+        uses: actions/upload-artifact@v2
+        with:
+          name: qhelp-markdown
+          path: go/qhelp-out/**/*.md
 
-    - name: Upload qhelp markdown
-      uses: actions/upload-artifact@v2
-      with:
-        name: qhelp-markdown
-        path: go/qhelp-out/**/*.md
-
-    - name: Test
-      run: |
-        cd go
-        env PATH=$PATH:$HOME/codeql make test
+      - name: Test
+        run: |
+          cd go
+          env make test
 
   test-mac:
     name: Test MacOS
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
-    - name: Set up Go 1.18.1
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.18.1
-      id: go
+      - name: Set up Go 1.18.1
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.1
+        id: go
 
-    - name: Set up CodeQL CLI
-      run: |
-        echo "Removing old CodeQL Directory..."
-        rm -rf $HOME/codeql
-        echo "Done"
-        cd $HOME
-        echo "Downloading CodeQL CLI..."
-        LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | sort --version-sort | grep -v beta | tail -1)
-        gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql-osx64.zip "$LATEST"
-        echo "Done"
-        echo "Unpacking CodeQL CLI..."
-        unzip -q codeql-osx64.zip
-        rm -f codeql-osx64.zip
-        echo "Done"
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Set up CodeQL CLI
+        uses: ./.github/actions/fetch-codeql
 
-    - name: Enable problem matchers in repository
-      shell: bash
-      run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
+      - name: Enable problem matchers in repository
+        shell: bash
+        run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
 
-    - name: Build
-      run: |
-        cd go
-        env PATH=$PATH:$HOME/codeql make
+      - name: Build
+        run: |
+          cd go
+          make
 
-    - name: Test
-      run: |
-        cd go
-        env PATH=$PATH:$HOME/codeql make test
+      - name: Test
+        run: |
+          cd go
+          make test
 
   test-win:
     name: Test Windows
     runs-on: windows-2019
     steps:
-    - name: Set up Go 1.18.1
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.18.1
-      id: go
+      - name: Set up Go 1.18.1
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.1
+        id: go
 
-    - name: Set up CodeQL CLI
-      run: |
-        echo "Removing old CodeQL Directory..."
-        rm -rf $HOME/codeql
-        echo "Done"
-        cd "$HOME"
-        echo "Downloading CodeQL CLI..."
-        LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | sort --version-sort | grep -v beta | tail -1)
-        gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql-win64.zip "$LATEST"
-        echo "Done"
-        echo "Unpacking CodeQL CLI..."
-        unzip -q -o codeql-win64.zip
-        unzip -q -o codeql-win64.zip codeql/codeql.exe
-        rm -f codeql-win64.zip
-        echo "Done"
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      shell:
-        bash
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Set up CodeQL CLI
+        uses: ./.github/actions/fetch-codeql
 
-    - name: Enable problem matchers in repository
-      shell: bash
-      run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
+      - name: Enable problem matchers in repository
+        shell: bash
+        run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
 
-    - name: Build
-      run: |
-        $Env:Path += ";$HOME\codeql"
-        cd go
-        make
+      - name: Build
+        run: |
+          cd go
+          make
 
-    - name: Test
-      run: |
-        $Env:Path += ";$HOME\codeql"
-        cd go
-        make test
+      - name: Test
+        run: |
+          cd go
+          make test

--- a/.github/workflows/js-ml-tests.yml
+++ b/.github/workflows/js-ml-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "javascript/ql/experimental/adaptivethreatmodeling/**"
       - .github/workflows/js-ml-tests.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
     branches:
       - main
@@ -13,6 +14,7 @@ on:
     paths:
       - "javascript/ql/experimental/adaptivethreatmodeling/**"
       - .github/workflows/js-ml-tests.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
   workflow_dispatch:
 

--- a/.github/workflows/mad_regenerate-models.yml
+++ b/.github/workflows/mad_regenerate-models.yml
@@ -9,6 +9,7 @@ on:
       - main
     paths:
       - ".github/workflows/mad_regenerate-models.yml"
+      - ".github/actions/fetch-codeql"
 
 jobs:
   regenerate-models:

--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -30,8 +30,6 @@ jobs:
     - name: Download CodeQL CLI
       # Look under the `codeql` directory, as this is where we checked out the `github/codeql` repo
       uses: ./codeql/.github/actions/fetch-codeql
-    - name: Unzip CodeQL CLI
-      run: unzip -d codeql-cli codeql-linux64.zip
     - name: Build code scanning query list
       run: |
         python codeql/misc/scripts/generate-code-scanning-query-list.py > code-scanning-query-list.csv

--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/query-list.yml'
+      - '.github/actions/fetch-codeql'
       - 'misc/scripts/generate-code-scanning-query-list.py'
 
 jobs:

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "ruby/**"
       - .github/workflows/ruby-build.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
     branches:
       - main
@@ -13,6 +14,7 @@ on:
     paths:
       - "ruby/**"
       - .github/workflows/ruby-build.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
     branches:
       - main
@@ -175,11 +177,13 @@ jobs:
     needs: [package]
     steps:
       - uses: actions/checkout@v3
+      - name: Fetch CodeQL
+        uses: ./.github/actions/fetch-codeql
+
+      - uses: actions/checkout@v3
         with:
           repository: Shopify/example-ruby-app
           ref: 67a0decc5eb550f3a9228eda53925c3afd40dfe9
-      - name: Fetch CodeQL
-        uses: ./.github/actions/fetch-codeql
 
       - name: Download Ruby bundle
         uses: actions/download-artifact@v3

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -90,19 +90,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Fetch CodeQL
-        run: |
-          LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | grep -v beta | sort --version-sort | tail -1)
-          gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql-linux64.zip "$LATEST"
-          unzip -q codeql-linux64.zip
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        uses: ./.github/actions/fetch-codeql
       - name: Build Query Pack
         run: |
-          codeql/codeql pack create ql/lib --output target/packs
-          codeql/codeql pack install ql/src
-          codeql/codeql pack create ql/src --output target/packs
+          codeql pack create ql/lib --output target/packs
+          codeql pack install ql/src
+          codeql pack create ql/src --output target/packs
           PACK_FOLDER=$(readlink -f target/packs/codeql/ruby-queries/*)
-          codeql/codeql generate query-help --format=sarifv2.1.0 --output="${PACK_FOLDER}/rules.sarif" ql/src
+          codeql generate query-help --format=sarifv2.1.0 --output="${PACK_FOLDER}/rules.sarif" ql/src
           (cd ql/src; find queries \( -name '*.qhelp' -o -name '*.rb' -o -name '*.erb' \) -exec bash -c 'mkdir -p "'"${PACK_FOLDER}"'/$(dirname "{}")"' \; -exec cp "{}" "${PACK_FOLDER}/{}" \;)
       - uses: actions/upload-artifact@v3
         with:
@@ -184,14 +179,8 @@ jobs:
           repository: Shopify/example-ruby-app
           ref: 67a0decc5eb550f3a9228eda53925c3afd40dfe9
       - name: Fetch CodeQL
-        shell: bash
-        run: |
-          LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | grep -v beta | sort --version-sort | tail -1)
-          gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql.zip "$LATEST"
-          unzip -q codeql.zip
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        working-directory: ${{ runner.temp }}
+        uses: ./.github/actions/fetch-codeql
+
       - name: Download Ruby bundle
         uses: actions/download-artifact@v3
         with:
@@ -215,12 +204,12 @@ jobs:
       - name: Run QL test
         shell: bash
         run: |
-          "${{ runner.temp }}/codeql/codeql" test run --search-path "${{ runner.temp }}/ruby-bundle" --additional-packs "${{ runner.temp }}/ruby-bundle" .
+          codeql test run --search-path "${{ runner.temp }}/ruby-bundle" --additional-packs "${{ runner.temp }}/ruby-bundle" .
       - name: Create database
         shell: bash
         run: |
-          "${{ runner.temp }}/codeql/codeql" database create --search-path "${{ runner.temp }}/ruby-bundle" --language ruby --source-root . ../database
+          codeql database create --search-path "${{ runner.temp }}/ruby-bundle" --language ruby --source-root . ../database
       - name: Analyze database
         shell: bash
         run: |
-          "${{ runner.temp }}/codeql/codeql" database analyze --search-path "${{ runner.temp }}/ruby-bundle" --format=sarifv2.1.0 --output=out.sarif ../database ruby-code-scanning.qls
+          codeql database analyze --search-path "${{ runner.temp }}/ruby-bundle" --format=sarifv2.1.0 --output=out.sarif ../database ruby-code-scanning.qls

--- a/.github/workflows/ruby-qltest.yml
+++ b/.github/workflows/ruby-qltest.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "ruby/**"
       - .github/workflows/ruby-qltest.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
     branches:
       - main
@@ -13,6 +14,7 @@ on:
     paths:
       - "ruby/**"
       - .github/workflows/ruby-qltest.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
     branches:
       - main

--- a/.github/workflows/swift-codegen.yml
+++ b/.github/workflows/swift-codegen.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "swift/**"
       - .github/workflows/swift-codegen.yml
+      - .github/actions/fetch-codeql
     branches:
       - main
 

--- a/.github/workflows/swift-integration-tests.yml
+++ b/.github/workflows/swift-integration-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "swift/**"
       - .github/workflows/swift-integration-tests.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
     branches:
       - main

--- a/.github/workflows/swift-qltest.yml
+++ b/.github/workflows/swift-qltest.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "swift/**"
       - .github/workflows/swift-qltest.yml
+      - .github/actions/fetch-codeql
       - codeql-workspace.yml
     branches:
       - main

--- a/.github/workflows/validate-change-notes.yml
+++ b/.github/workflows/validate-change-notes.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "*/ql/*/change-notes/**/*"
       - ".github/workflows/validate-change-notes.yml"
+      - ".github/actions/fetch-codeql"
     branches:
       - main
       - "rc/*"
@@ -12,6 +13,7 @@ on:
     paths:
       - "*/ql/*/change-notes/**/*"
       - ".github/workflows/validate-change-notes.yml"
+      - ".github/actions/fetch-codeql"
 
 jobs:
   check-change-note:


### PR DESCRIPTION
Many of the CI jobs download a copy of the CodeQL CLI. However, they were using different ways of doing that:
* through the `fetch-codeql` action
* using `gh codeql`
* dowloading and unzipping release artifacts from the codeql-cli-binaries repo

 This PR refactors the workflows to all use the `fetch-codeql` Action. The `fetch-codeql` action itself is re-implemented using `gh codeql`

The workflows affected by this change are:
```
.github/workflows/check-qldoc.yml
.github/workflows/csv-coverage-metrics.yml
.github/workflows/js-ml-tests.yml
.github/workflows/mad_modelDiff.yml
.github/workflows/mad_regenerate-models.yml
.github/workflows/qhelp-pr-preview.yml
.github/workflows/query-list.yml
.github/workflows/ruby-dataset-measure.yml
.github/workflows/ruby-qltest.yml
.github/workflows/swift-codegen.yml
.github/workflows/swift-integration-tests.yml
.github/workflows/swift-qltest.yml
.github/workflows/validate-change-notes.yml
```
