### PR TITLE
C++: Remove internal `microsoft` tags from queries

### DIFF
--- a/cpp/ql/src/Likely Bugs/Likely Typos/IncorrectNotOperatorUsage.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/IncorrectNotOperatorUsage.ql
@@ -10,7 +10,6 @@
  * @precision medium
  * @tags security
  *       external/cwe/cwe-480
- *       external/microsoft/c6317
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Likely Typos/UsingStrcpyAsBoolean.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/UsingStrcpyAsBoolean.ql
@@ -7,8 +7,7 @@
  * @problem.severity error
  * @precision high
  * @id cpp/string-copy-return-value-as-boolean
- * @tags external/microsoft/C6324
- *       correctness
+ * @tags correctness
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
@@ -7,7 +7,6 @@
  * @id cpp/inconsistent-loop-direction
  * @tags correctness
  *       external/cwe/cwe-835
- *       external/microsoft/6293
  * @msrc.severity important
  */
 

--- a/cpp/ql/src/Security/CWE/CWE-253/HResultBooleanConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-253/HResultBooleanConversion.ql
@@ -8,11 +8,6 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-253
- *       external/microsoft/C6214
- *       external/microsoft/C6215
- *       external/microsoft/C6216
- *       external/microsoft/C6217
- *       external/microsoft/C6230
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
@@ -9,7 +9,6 @@
  * @msrc.severity important
  * @tags security
  *       external/cwe/cwe-428
- *       external/microsoft/C6277
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -10,7 +10,6 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-704
- *       external/microsoft/c/c6276
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
@@ -11,7 +11,6 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-732
- *       external/microsoft/C6248
  */
 
 import cpp


### PR DESCRIPTION
This PR removes the internal `microsoft` tags on the remaining seven queries. Now, `grep`'ing for `"external/microsoft"` gives no more results in `.ql` files.