### PR TITLE
Java: Improve join-order.

### DIFF
--- a/java/ql/lib/semmle/code/java/dispatch/WrappedInvocation.qll
+++ b/java/ql/lib/semmle/code/java/dispatch/WrappedInvocation.qll
@@ -19,8 +19,9 @@ private predicate runner(Method m, int n, Method runmethod) {
     exists(Parameter p, MethodAccess ma, int j |
       p = m.getParameter(n) and
       ma.getEnclosingCallable() = m and
-      runner(ma.getMethod().getSourceDeclaration(), j, _) and
-      ma.getArgument(j) = p.getAnAccess()
+      runner(pragma[only_bind_into](ma.getMethod().getSourceDeclaration()),
+        pragma[only_bind_into](j), _) and
+      ma.getArgument(pragma[only_bind_into](j)) = p.getAnAccess()
     )
   )
 }


### PR DESCRIPTION
Minor join-order improvement. This was taking a lot of slots in the join-order badness reports.