### PR TITLE
JS: add security-extended-twice suite (JS only)

### DIFF
--- a/javascript/ql/src/codeql-suites/javascript-security-extended-twice.qls
+++ b/javascript/ql/src/codeql-suites/javascript-security-extended-twice.qls
@@ -1,0 +1,8 @@
+- description: Security-extended-twice queries for JavaScript
+- queries: .
+- apply: security-extended-twice-selectors.yml
+  from: codeql/suite-helpers
+# javascript special case: the ml-powered queries are still an opt-in feature
+- exclude:
+    query path:
+      - /^experimental\/adaptivethreatmodeling\/.*/

--- a/misc/suite-helpers/security-extended-twice-selectors.yml
+++ b/misc/suite-helpers/security-extended-twice-selectors.yml
@@ -1,0 +1,8 @@
+- description: Selectors for selecting the security-extended-twice queries for a language
+- apply: security-extended-selectors.yml
+# also include the community-contributed security queries
+- include:
+    query path:
+      - /^experimental\/.*/
+    tags contain:
+      - security


### PR DESCRIPTION
As discussed [internally](https://github.com/github/codeql-team/issues/751), this adds a query suite that contains the security-extended suite *and* the security queries from the experimental directory.

The security-extended-twice-selectors.yml file works for all languages, but has only been enabled for JS in this PR.

To make use of this in other languages, copy the javascript-security-extended-twice.qls file, and adjust the language naming appropriately. The JS special case at the bottom of that file ought to be removed for other languages, but it is benign to keep it.

Naming is open for discussion, perhaps in a separate PR?

Sample use:

```
ql $ gh codeql resolve queries src/codeql-suites/javascript-security-extended.qls > once.txt       
ql $ gh codeql resolve queries src/codeql-suites/javascript-security-extended-twice.qls > twice.txt
ql $                                                                                               
diff once.txt twice.txt                                                                       
103a104,105
> ...../semmle-code/ql/javascript/ql/src/experimental/Security/CWE-094/UntrustedCheckout.ql
> ...../semmle-code/ql/javascript/ql/src/experimental/Security/CWE-918/SSRF.ql
```