### PR TITLE
Java: Improve join-order for `not haveIntersection`.

### DIFF
--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -1194,8 +1194,8 @@ private Type erase(Type t) {
 }
 
 /**
- * Is there a common (reflexive, transitive) subtype of the erasures of
- * types `t1` and `t2`?
+ * Holds if there is a common (reflexive, transitive) subtype of the erasures of
+ * types `t1` and `t2`.
  *
  * If there is no such common subtype, then the two types are disjoint.
  * However, the converse is not true; for example, the parameterized types
@@ -1209,6 +1209,25 @@ pragma[inline]
 predicate haveIntersection(RefType t1, RefType t2) {
   exists(RefType e1, RefType e2 | e1 = erase(t1) and e2 = erase(t2) |
     erasedHaveIntersection(e1, e2)
+  )
+}
+
+/**
+ * Holds if there is no common (reflexive, transitive) subtype of the erasures
+ * of types `t1` and `t2`.
+ *
+ * If there is no such common subtype, then the two types are disjoint.
+ * However, the converse is not true; for example, the parameterized types
+ * `List<Integer>` and `Collection<String>` are disjoint,
+ * but their erasures (`List` and `Collection`, respectively)
+ * do have common subtypes (such as `List` itself).
+ *
+ * For the definition of the notion of *erasure* see JLS v8, section 4.6 (Type Erasure).
+ */
+bindingset[t1, t2]
+predicate notHaveIntersection(RefType t1, RefType t2) {
+  exists(RefType e1, RefType e2 | e1 = erase(t1) and e2 = erase(t2) |
+    not erasedHaveIntersection(e1, e2)
   )
 }
 

--- a/java/ql/src/Likely Bugs/Collections/ContainsTypeMismatch.ql
+++ b/java/ql/src/Likely Bugs/Collections/ContainsTypeMismatch.ql
@@ -118,7 +118,7 @@ class MismatchedContainerAccess extends MethodAccess {
       containerAccess(package, type, p, this.getCallee().getSignature(), i)
     |
       t = this.getCallee().getDeclaringType() and
-      t.getAnAncestor().getSourceDeclaration() = g and
+      t.getASourceSupertype*().getSourceDeclaration() = g and
       g.hasQualifiedName(package, type) and
       indirectlyInstantiates(t, g, p, result)
     )
@@ -139,7 +139,7 @@ from MismatchedContainerAccess ma, RefType typearg, RefType argtype, int idx
 where
   typearg = ma.getReceiverElementType(idx).getSourceDeclaration() and
   argtype = ma.getArgumentType(idx) and
-  not haveIntersection(typearg, argtype)
+  notHaveIntersection(typearg, argtype)
 select ma.getArgument(idx),
   "Actual argument type '" + argtype.getName() + "'" +
     " is incompatible with expected argument type '" + typearg.getName() + "'."

--- a/java/ql/src/Likely Bugs/Collections/RemoveTypeMismatch.ql
+++ b/java/ql/src/Likely Bugs/Collections/RemoveTypeMismatch.ql
@@ -88,7 +88,7 @@ class MismatchedContainerModification extends MethodAccess {
       containerModification(package, type, p, this.getCallee().getSignature(), i)
     |
       t = this.getCallee().getDeclaringType() and
-      t.getAnAncestor().getSourceDeclaration() = g and
+      t.getASourceSupertype*().getSourceDeclaration() = g and
       g.hasQualifiedName(package, type) and
       indirectlyInstantiates(t, g, p, result)
     )
@@ -109,7 +109,7 @@ from MismatchedContainerModification ma, RefType elementtype, RefType argtype, i
 where
   elementtype = ma.getReceiverElementType(idx).getSourceDeclaration() and
   argtype = ma.getArgumentType(idx) and
-  not haveIntersection(elementtype, argtype)
+  notHaveIntersection(elementtype, argtype)
 select ma.getArgument(idx),
   "Actual argument type '" + argtype.getName() + "'" +
     " is incompatible with expected argument type '" + elementtype.getName() + "'."

--- a/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
@@ -57,7 +57,7 @@ where
     else recvtp = ma.getMethod().getDeclaringType()
   ) and
   argtp = ma.getArgumentType() and
-  not haveIntersection(recvtp, argtp)
+  notHaveIntersection(recvtp, argtp)
 select ma,
   "Call to equals() comparing incomparable types " + recvtp.getName() + " and " + argtp.getName() +
     "."


### PR DESCRIPTION
This effectively pulls the functional `erase(..)` calls out of the negation context, which improves the join-order, as we'll then end up with a simple filter `not erasedHaveIntersection(e1, e2)`. Prior to this the negation body would order the predicates `erase; erasedHaveIntersection; erase`, which was fairly bad.

Also, drive-by changed a couple of `.getAnAncestor().getSourceDeclaration()` to `.getASourceSupertype*().getSourceDeclaration()` as the latter performed better.