### PR TITLE
C++: Speedup `cpp/return-stack-allocated-memory`

### DIFF
--- a/cpp/ql/lib/change-notes/2022-08-02-must-flow-local-only-flow.md
+++ b/cpp/ql/lib/change-notes/2022-08-02-must-flow-local-only-flow.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* A new class predicate `MustFlowConfiguration::allowInterproceduralFlow` has been added to the `semmle.code.cpp.ir.dataflow.MustFlow` library. The new predicate can be overridden to disable interprocedural flow.

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -100,12 +100,6 @@ edges
 | test.cpp:190:10:190:13 | Unary | test.cpp:190:10:190:13 | (reference dereference) |
 | test.cpp:190:10:190:13 | Unary | test.cpp:190:10:190:13 | (reference to) |
 | test.cpp:190:10:190:13 | pRef | test.cpp:190:10:190:13 | Unary |
-| test.cpp:225:14:225:15 | px | test.cpp:226:10:226:11 | Load |
-| test.cpp:226:10:226:11 | Load | test.cpp:226:10:226:11 | px |
-| test.cpp:226:10:226:11 | px | test.cpp:226:10:226:11 | StoreValue |
-| test.cpp:231:16:231:17 | & ... | test.cpp:225:14:225:15 | px |
-| test.cpp:231:17:231:17 | Unary | test.cpp:231:16:231:17 | & ... |
-| test.cpp:231:17:231:17 | x | test.cpp:231:17:231:17 | Unary |
 nodes
 | test.cpp:17:9:17:11 | & ... | semmle.label | & ... |
 | test.cpp:17:9:17:11 | StoreValue | semmle.label | StoreValue |
@@ -221,13 +215,6 @@ nodes
 | test.cpp:190:10:190:13 | Unary | semmle.label | Unary |
 | test.cpp:190:10:190:13 | Unary | semmle.label | Unary |
 | test.cpp:190:10:190:13 | pRef | semmle.label | pRef |
-| test.cpp:225:14:225:15 | px | semmle.label | px |
-| test.cpp:226:10:226:11 | Load | semmle.label | Load |
-| test.cpp:226:10:226:11 | StoreValue | semmle.label | StoreValue |
-| test.cpp:226:10:226:11 | px | semmle.label | px |
-| test.cpp:231:16:231:17 | & ... | semmle.label | & ... |
-| test.cpp:231:17:231:17 | Unary | semmle.label | Unary |
-| test.cpp:231:17:231:17 | x | semmle.label | x |
 #select
 | test.cpp:17:9:17:11 | StoreValue | test.cpp:17:10:17:11 | mc | test.cpp:17:9:17:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:17:10:17:11 | mc | mc |
 | test.cpp:25:9:25:11 | StoreValue | test.cpp:23:18:23:19 | mc | test.cpp:25:9:25:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:23:18:23:19 | mc | mc |


### PR DESCRIPTION
When we created the `MustFlow` library in https://github.com/github/codeql/pull/8368 we added a somewhat ugly check in `cpp/return-stack-allocated-memory` to prevent FPs from occurring when we flow into callables.

However, this condition was only checked _after_ the dataflow graph had been computed. This meant that lots of edges was added even though they were immediately thrown out by the `var.getEnclosingFunction() = sink.getNode().getEnclosingCallable()` conjunct in the `select` body.

The problem can be seen on this snapshot:

```ql
Evaluated relational algebra for predicate MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23@0c7142k3 with tuple counts:
  6911  ~0%   {2} r1 = JOIN MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23#higher_order_body WITH boundedFastTC(MustFlow::MustFlowPathNode::getASuccessor#dispred#f0820431#ff,MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23#higher_order_body) ON FIRST 1 OUTPUT Rhs.1, Lhs.0
  580  ~0%    {2} r2 = JOIN r1 WITH MustFlow::MustFlowPathSink#class#0227f5a1#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.0
              return r2
...
Evaluated relational algebra for predicate #select#cpe#12356#fffff@3f5ee98d with tuple counts:
  580  ~0%    {2} r1 = SCAN MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23 OUTPUT In.1, In.0
  580  ~0%    {3} r2 = JOIN r1 WITH MustFlow::MkLocalPathNode#0227f5a1#fff_20#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
  580  ~1%    {4} r3 = JOIN r2 WITH MustFlow::MkLocalPathNode#0227f5a1#fff_20#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Lhs.2
  580  ~3%    {4} r4 = JOIN r3 WITH DataFlowUtil::Cached::TInstructionNode#47741e1f#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
  580  ~3%    {4} r5 = JOIN r4 WITH project#Instruction::VariableAddressInstruction#class#577b6a83#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3
  580  ~3%    {5} r6 = JOIN r5 WITH SSAConstruction::Cached::getInstructionAst#2b11997e#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Rhs.1
  580  ~0%    {6} r7 = JOIN r6 WITH SSAConstruction::Cached::getInstructionAst#2b11997e#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
  580  ~0%    {6} r8 = JOIN r7 WITH Instruction::Instruction::getEnclosingFunction#dispred#f0820431#3#ff ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1, Lhs.2, Lhs.4, Lhs.5
    5  ~0%    {5} r9 = JOIN r8 WITH DataFlowUtil::Node::getEnclosingCallable#dispred#f0820431#fb ON FIRST 2 OUTPUT Lhs.5, Lhs.2, Lhs.3, Lhs.0, Lhs.4
    5  ~0%    {5} r10 = JOIN r9 WITH Element::ElementBase::toString#dispred#f0820431#ff ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Lhs.4, Rhs.1
              return r10
```

Notice that we compute 580 `source/sink` pairs, and only at the very end of the `select` predicate do we filter them out to those pairs that have equal enclosing callables.

Instead, this PR adds a `allowInterproceduralFlow` predicate that can be set to `none()` to disable the problematic flow as we're computing the graph. This means that:
1. We get far fewer edges in the graph
2. We don't have to compare enclosing callables in the `select` body.

So now the pipeline looks like:

```ql
Evaluated relational algebra for predicate MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23@0fca37si with tuple counts:
  18  ~0%    {2} r1 = JOIN MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23#higher_order_body WITH boundedFastTC(MustFlow::MustFlowPathNode::getASuccessor#dispred#f0820431#ff,MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23#higher_order_body) ON FIRST 1 OUTPUT Rhs.1, Lhs.0
   5  ~0%    {2} r2 = JOIN r1 WITH MustFlow::MustFlowPathSink#class#0227f5a1#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.0
             return r2
...
Evaluated relational algebra for predicate #select#cpe#12356#fffff@dfb66314 with tuple counts:
  5  ~0%    {2} r1 = SCAN MustFlow::MustFlowConfiguration::hasFlowPath#dispred#f0820431#fff#cpe#23 OUTPUT In.1, In.0
  5  ~0%    {3} r2 = JOIN r1 WITH MustFlow::MkLocalPathNode#0227f5a1#fff_20#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
  5  ~0%    {4} r3 = JOIN r2 WITH MustFlow::MkLocalPathNode#0227f5a1#fff_20#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Lhs.2
  5  ~0%    {4} r4 = JOIN r3 WITH DataFlowUtil::Cached::TInstructionNode#47741e1f#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
  5  ~0%    {4} r5 = JOIN r4 WITH project#Instruction::VariableAddressInstruction#class#577b6a83#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3
  5  ~0%    {5} r6 = JOIN r5 WITH SSAConstruction::Cached::getInstructionAst#2b11997e#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Rhs.1
  5  ~0%    {5} r7 = JOIN r6 WITH SSAConstruction::Cached::getInstructionAst#2b11997e#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4
  5  ~0%    {5} r8 = JOIN r7 WITH Element::ElementBase::toString#dispred#f0820431#ff ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Lhs.4, Rhs.1
            return r8
```

The changes to the `.expected` file also shows a smaller `edge` relation, as expected (no pun intended!)