### PR TITLE
Ruby: Simplify flow summaries for hash literals

### DIFF
--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -55,473 +55,481 @@ edges
 | hash_flow.rb:68:13:68:39 | ...[...] [element :a] :  | hash_flow.rb:69:10:69:14 | hash4 [element :a] :  |
 | hash_flow.rb:68:22:68:31 | call to taint :  | hash_flow.rb:68:13:68:39 | ...[...] [element :a] :  |
 | hash_flow.rb:69:10:69:14 | hash4 [element :a] :  | hash_flow.rb:69:10:69:18 | ...[...] |
-| hash_flow.rb:76:13:76:42 | call to [] [element :a] :  | hash_flow.rb:77:10:77:14 | hash1 [element :a] :  |
-| hash_flow.rb:76:26:76:35 | call to taint :  | hash_flow.rb:76:13:76:42 | call to [] [element :a] :  |
-| hash_flow.rb:77:10:77:14 | hash1 [element :a] :  | hash_flow.rb:77:10:77:18 | ...[...] |
-| hash_flow.rb:85:15:85:24 | call to taint :  | hash_flow.rb:88:30:88:33 | hash [element :a] :  |
-| hash_flow.rb:88:13:88:34 | call to try_convert [element :a] :  | hash_flow.rb:89:10:89:14 | hash2 [element :a] :  |
-| hash_flow.rb:88:30:88:33 | hash [element :a] :  | hash_flow.rb:88:13:88:34 | call to try_convert [element :a] :  |
-| hash_flow.rb:89:10:89:14 | hash2 [element :a] :  | hash_flow.rb:89:10:89:18 | ...[...] |
-| hash_flow.rb:97:21:97:30 | call to taint :  | hash_flow.rb:98:10:98:10 | b |
-| hash_flow.rb:105:9:105:12 | [post] hash [element :a] :  | hash_flow.rb:106:10:106:13 | hash [element :a] :  |
-| hash_flow.rb:105:9:105:34 | call to store :  | hash_flow.rb:107:10:107:10 | b |
-| hash_flow.rb:105:24:105:33 | call to taint :  | hash_flow.rb:105:9:105:12 | [post] hash [element :a] :  |
-| hash_flow.rb:105:24:105:33 | call to taint :  | hash_flow.rb:105:9:105:34 | call to store :  |
-| hash_flow.rb:106:10:106:13 | hash [element :a] :  | hash_flow.rb:106:10:106:17 | ...[...] |
-| hash_flow.rb:110:9:110:12 | [post] hash [element] :  | hash_flow.rb:111:10:111:13 | hash [element] :  |
-| hash_flow.rb:110:9:110:12 | [post] hash [element] :  | hash_flow.rb:112:10:112:13 | hash [element] :  |
-| hash_flow.rb:110:9:110:33 | call to store :  | hash_flow.rb:113:10:113:10 | c |
-| hash_flow.rb:110:23:110:32 | call to taint :  | hash_flow.rb:110:9:110:12 | [post] hash [element] :  |
-| hash_flow.rb:110:23:110:32 | call to taint :  | hash_flow.rb:110:9:110:33 | call to store :  |
-| hash_flow.rb:111:10:111:13 | hash [element] :  | hash_flow.rb:111:10:111:17 | ...[...] |
-| hash_flow.rb:112:10:112:13 | hash [element] :  | hash_flow.rb:112:10:112:17 | ...[...] |
-| hash_flow.rb:120:15:120:24 | call to taint :  | hash_flow.rb:123:5:123:8 | hash [element :a] :  |
-| hash_flow.rb:120:15:120:24 | call to taint :  | hash_flow.rb:126:5:126:8 | hash [element :a] :  |
-| hash_flow.rb:123:5:123:8 | hash [element :a] :  | hash_flow.rb:123:18:123:29 | key_or_value :  |
-| hash_flow.rb:123:18:123:29 | key_or_value :  | hash_flow.rb:124:14:124:25 | key_or_value |
-| hash_flow.rb:126:5:126:8 | hash [element :a] :  | hash_flow.rb:126:22:126:26 | value :  |
-| hash_flow.rb:126:22:126:26 | value :  | hash_flow.rb:128:14:128:18 | value |
-| hash_flow.rb:136:15:136:25 | call to taint :  | hash_flow.rb:139:9:139:12 | hash [element :a] :  |
-| hash_flow.rb:136:15:136:25 | call to taint :  | hash_flow.rb:143:9:143:12 | hash [element :a] :  |
-| hash_flow.rb:139:9:139:12 | hash [element :a] :  | hash_flow.rb:139:9:139:22 | call to assoc [element 1] :  |
-| hash_flow.rb:139:9:139:22 | call to assoc [element 1] :  | hash_flow.rb:141:10:141:10 | b [element 1] :  |
-| hash_flow.rb:139:9:139:22 | call to assoc [element 1] :  | hash_flow.rb:142:10:142:10 | b [element 1] :  |
-| hash_flow.rb:141:10:141:10 | b [element 1] :  | hash_flow.rb:141:10:141:13 | ...[...] |
-| hash_flow.rb:142:10:142:10 | b [element 1] :  | hash_flow.rb:142:10:142:13 | ...[...] |
-| hash_flow.rb:143:9:143:12 | hash [element :a] :  | hash_flow.rb:143:9:143:21 | call to assoc [element 1] :  |
-| hash_flow.rb:143:9:143:21 | call to assoc [element 1] :  | hash_flow.rb:144:10:144:10 | c [element 1] :  |
-| hash_flow.rb:144:10:144:10 | c [element 1] :  | hash_flow.rb:144:10:144:13 | ...[...] |
-| hash_flow.rb:162:15:162:25 | call to taint :  | hash_flow.rb:165:9:165:12 | hash [element :a] :  |
-| hash_flow.rb:165:9:165:12 | hash [element :a] :  | hash_flow.rb:165:9:165:20 | call to compact [element :a] :  |
-| hash_flow.rb:165:9:165:20 | call to compact [element :a] :  | hash_flow.rb:166:10:166:10 | a [element :a] :  |
-| hash_flow.rb:166:10:166:10 | a [element :a] :  | hash_flow.rb:166:10:166:14 | ...[...] |
-| hash_flow.rb:174:15:174:25 | call to taint :  | hash_flow.rb:177:9:177:12 | hash [element :a] :  |
-| hash_flow.rb:177:9:177:12 | hash [element :a] :  | hash_flow.rb:177:9:177:23 | call to delete :  |
-| hash_flow.rb:177:9:177:23 | call to delete :  | hash_flow.rb:178:10:178:10 | a |
-| hash_flow.rb:186:15:186:25 | call to taint :  | hash_flow.rb:189:9:189:12 | hash [element :a] :  |
-| hash_flow.rb:186:15:186:25 | call to taint :  | hash_flow.rb:194:10:194:13 | hash [element :a] :  |
-| hash_flow.rb:189:9:189:12 | [post] hash [element :a] :  | hash_flow.rb:194:10:194:13 | hash [element :a] :  |
-| hash_flow.rb:189:9:189:12 | hash [element :a] :  | hash_flow.rb:189:9:189:12 | [post] hash [element :a] :  |
-| hash_flow.rb:189:9:189:12 | hash [element :a] :  | hash_flow.rb:189:9:192:7 | call to delete_if [element :a] :  |
-| hash_flow.rb:189:9:189:12 | hash [element :a] :  | hash_flow.rb:189:33:189:37 | value :  |
-| hash_flow.rb:189:9:192:7 | call to delete_if [element :a] :  | hash_flow.rb:193:10:193:10 | a [element :a] :  |
-| hash_flow.rb:189:33:189:37 | value :  | hash_flow.rb:191:14:191:18 | value |
-| hash_flow.rb:193:10:193:10 | a [element :a] :  | hash_flow.rb:193:10:193:14 | ...[...] |
-| hash_flow.rb:194:10:194:13 | hash [element :a] :  | hash_flow.rb:194:10:194:17 | ...[...] |
-| hash_flow.rb:202:15:202:25 | call to taint :  | hash_flow.rb:209:10:209:13 | hash [element :a] :  |
-| hash_flow.rb:205:19:205:29 | call to taint :  | hash_flow.rb:211:10:211:13 | hash [element :c, element :d] :  |
-| hash_flow.rb:209:10:209:13 | hash [element :a] :  | hash_flow.rb:209:10:209:21 | call to dig |
-| hash_flow.rb:211:10:211:13 | hash [element :c, element :d] :  | hash_flow.rb:211:10:211:24 | call to dig |
-| hash_flow.rb:219:15:219:25 | call to taint :  | hash_flow.rb:222:9:222:12 | hash [element :a] :  |
-| hash_flow.rb:222:9:222:12 | hash [element :a] :  | hash_flow.rb:222:9:225:7 | call to each [element :a] :  |
-| hash_flow.rb:222:9:222:12 | hash [element :a] :  | hash_flow.rb:222:28:222:32 | value :  |
-| hash_flow.rb:222:9:225:7 | call to each [element :a] :  | hash_flow.rb:226:10:226:10 | x [element :a] :  |
-| hash_flow.rb:222:28:222:32 | value :  | hash_flow.rb:224:14:224:18 | value |
-| hash_flow.rb:226:10:226:10 | x [element :a] :  | hash_flow.rb:226:10:226:14 | ...[...] |
-| hash_flow.rb:234:15:234:25 | call to taint :  | hash_flow.rb:237:9:237:12 | hash [element :a] :  |
-| hash_flow.rb:237:9:237:12 | hash [element :a] :  | hash_flow.rb:237:9:239:7 | call to each_key [element :a] :  |
-| hash_flow.rb:237:9:239:7 | call to each_key [element :a] :  | hash_flow.rb:240:10:240:10 | x [element :a] :  |
-| hash_flow.rb:240:10:240:10 | x [element :a] :  | hash_flow.rb:240:10:240:14 | ...[...] |
-| hash_flow.rb:248:15:248:25 | call to taint :  | hash_flow.rb:251:9:251:12 | hash [element :a] :  |
-| hash_flow.rb:251:9:251:12 | hash [element :a] :  | hash_flow.rb:251:9:254:7 | call to each_pair [element :a] :  |
-| hash_flow.rb:251:9:251:12 | hash [element :a] :  | hash_flow.rb:251:33:251:37 | value :  |
-| hash_flow.rb:251:9:254:7 | call to each_pair [element :a] :  | hash_flow.rb:255:10:255:10 | x [element :a] :  |
-| hash_flow.rb:251:33:251:37 | value :  | hash_flow.rb:253:14:253:18 | value |
-| hash_flow.rb:255:10:255:10 | x [element :a] :  | hash_flow.rb:255:10:255:14 | ...[...] |
-| hash_flow.rb:263:15:263:25 | call to taint :  | hash_flow.rb:266:9:266:12 | hash [element :a] :  |
-| hash_flow.rb:266:9:266:12 | hash [element :a] :  | hash_flow.rb:266:9:268:7 | call to each_value [element :a] :  |
-| hash_flow.rb:266:9:266:12 | hash [element :a] :  | hash_flow.rb:266:29:266:33 | value :  |
-| hash_flow.rb:266:9:268:7 | call to each_value [element :a] :  | hash_flow.rb:269:10:269:10 | x [element :a] :  |
-| hash_flow.rb:266:29:266:33 | value :  | hash_flow.rb:267:14:267:18 | value |
-| hash_flow.rb:269:10:269:10 | x [element :a] :  | hash_flow.rb:269:10:269:14 | ...[...] |
-| hash_flow.rb:279:15:279:25 | call to taint :  | hash_flow.rb:282:9:282:12 | hash [element :c] :  |
-| hash_flow.rb:282:9:282:12 | hash [element :c] :  | hash_flow.rb:282:9:282:28 | call to except [element :c] :  |
-| hash_flow.rb:282:9:282:28 | call to except [element :c] :  | hash_flow.rb:285:10:285:10 | x [element :c] :  |
-| hash_flow.rb:285:10:285:10 | x [element :c] :  | hash_flow.rb:285:10:285:14 | ...[...] |
-| hash_flow.rb:293:15:293:25 | call to taint :  | hash_flow.rb:297:9:297:12 | hash [element :a] :  |
-| hash_flow.rb:293:15:293:25 | call to taint :  | hash_flow.rb:301:9:301:12 | hash [element :a] :  |
-| hash_flow.rb:293:15:293:25 | call to taint :  | hash_flow.rb:303:9:303:12 | hash [element :a] :  |
-| hash_flow.rb:293:15:293:25 | call to taint :  | hash_flow.rb:307:9:307:12 | hash [element :a] :  |
-| hash_flow.rb:295:15:295:25 | call to taint :  | hash_flow.rb:297:9:297:12 | hash [element :c] :  |
-| hash_flow.rb:295:15:295:25 | call to taint :  | hash_flow.rb:307:9:307:12 | hash [element :c] :  |
-| hash_flow.rb:297:9:297:12 | hash [element :a] :  | hash_flow.rb:297:9:299:7 | call to fetch :  |
-| hash_flow.rb:297:9:297:12 | hash [element :c] :  | hash_flow.rb:297:9:299:7 | call to fetch :  |
-| hash_flow.rb:297:9:299:7 | call to fetch :  | hash_flow.rb:300:10:300:10 | b |
-| hash_flow.rb:297:20:297:30 | call to taint :  | hash_flow.rb:297:37:297:37 | x :  |
-| hash_flow.rb:297:37:297:37 | x :  | hash_flow.rb:298:14:298:14 | x |
-| hash_flow.rb:301:9:301:12 | hash [element :a] :  | hash_flow.rb:301:9:301:22 | call to fetch :  |
-| hash_flow.rb:301:9:301:22 | call to fetch :  | hash_flow.rb:302:10:302:10 | b |
-| hash_flow.rb:303:9:303:12 | hash [element :a] :  | hash_flow.rb:303:9:303:35 | call to fetch :  |
-| hash_flow.rb:303:9:303:35 | call to fetch :  | hash_flow.rb:304:10:304:10 | b |
-| hash_flow.rb:303:24:303:34 | call to taint :  | hash_flow.rb:303:9:303:35 | call to fetch :  |
-| hash_flow.rb:305:9:305:35 | call to fetch :  | hash_flow.rb:306:10:306:10 | b |
-| hash_flow.rb:305:24:305:34 | call to taint :  | hash_flow.rb:305:9:305:35 | call to fetch :  |
-| hash_flow.rb:307:9:307:12 | hash [element :a] :  | hash_flow.rb:307:9:307:34 | call to fetch :  |
-| hash_flow.rb:307:9:307:12 | hash [element :c] :  | hash_flow.rb:307:9:307:34 | call to fetch :  |
-| hash_flow.rb:307:9:307:34 | call to fetch :  | hash_flow.rb:308:10:308:10 | b |
-| hash_flow.rb:307:23:307:33 | call to taint :  | hash_flow.rb:307:9:307:34 | call to fetch :  |
-| hash_flow.rb:315:15:315:25 | call to taint :  | hash_flow.rb:319:9:319:12 | hash [element :a] :  |
-| hash_flow.rb:315:15:315:25 | call to taint :  | hash_flow.rb:324:9:324:12 | hash [element :a] :  |
-| hash_flow.rb:315:15:315:25 | call to taint :  | hash_flow.rb:326:9:326:12 | hash [element :a] :  |
-| hash_flow.rb:317:15:317:25 | call to taint :  | hash_flow.rb:319:9:319:12 | hash [element :c] :  |
-| hash_flow.rb:317:15:317:25 | call to taint :  | hash_flow.rb:326:9:326:12 | hash [element :c] :  |
-| hash_flow.rb:319:9:319:12 | hash [element :a] :  | hash_flow.rb:319:9:322:7 | call to fetch_values [element] :  |
-| hash_flow.rb:319:9:319:12 | hash [element :c] :  | hash_flow.rb:319:9:322:7 | call to fetch_values [element] :  |
-| hash_flow.rb:319:9:322:7 | call to fetch_values [element] :  | hash_flow.rb:323:10:323:10 | b [element] :  |
-| hash_flow.rb:319:27:319:37 | call to taint :  | hash_flow.rb:319:44:319:44 | x :  |
-| hash_flow.rb:319:44:319:44 | x :  | hash_flow.rb:320:14:320:14 | x |
-| hash_flow.rb:321:9:321:19 | call to taint :  | hash_flow.rb:319:9:322:7 | call to fetch_values [element] :  |
-| hash_flow.rb:323:10:323:10 | b [element] :  | hash_flow.rb:323:10:323:13 | ...[...] |
-| hash_flow.rb:324:9:324:12 | hash [element :a] :  | hash_flow.rb:324:9:324:29 | call to fetch_values [element] :  |
-| hash_flow.rb:324:9:324:29 | call to fetch_values [element] :  | hash_flow.rb:325:10:325:10 | b [element] :  |
-| hash_flow.rb:325:10:325:10 | b [element] :  | hash_flow.rb:325:10:325:13 | ...[...] |
-| hash_flow.rb:326:9:326:12 | hash [element :a] :  | hash_flow.rb:326:9:326:31 | call to fetch_values [element] :  |
-| hash_flow.rb:326:9:326:12 | hash [element :c] :  | hash_flow.rb:326:9:326:31 | call to fetch_values [element] :  |
-| hash_flow.rb:326:9:326:31 | call to fetch_values [element] :  | hash_flow.rb:327:10:327:10 | b [element] :  |
-| hash_flow.rb:327:10:327:10 | b [element] :  | hash_flow.rb:327:10:327:13 | ...[...] |
-| hash_flow.rb:334:15:334:25 | call to taint :  | hash_flow.rb:338:9:338:12 | hash [element :a] :  |
-| hash_flow.rb:336:15:336:25 | call to taint :  | hash_flow.rb:338:9:338:12 | hash [element :c] :  |
-| hash_flow.rb:338:9:338:12 | hash [element :a] :  | hash_flow.rb:338:9:342:7 | call to filter [element :a] :  |
-| hash_flow.rb:338:9:338:12 | hash [element :a] :  | hash_flow.rb:338:30:338:34 | value :  |
-| hash_flow.rb:338:9:338:12 | hash [element :c] :  | hash_flow.rb:338:30:338:34 | value :  |
-| hash_flow.rb:338:9:342:7 | call to filter [element :a] :  | hash_flow.rb:343:11:343:11 | b [element :a] :  |
-| hash_flow.rb:338:30:338:34 | value :  | hash_flow.rb:340:14:340:18 | value |
-| hash_flow.rb:343:11:343:11 | b [element :a] :  | hash_flow.rb:343:11:343:15 | ...[...] :  |
-| hash_flow.rb:343:11:343:15 | ...[...] :  | hash_flow.rb:343:10:343:16 | ( ... ) |
-| hash_flow.rb:350:15:350:25 | call to taint :  | hash_flow.rb:354:5:354:8 | hash [element :a] :  |
-| hash_flow.rb:352:15:352:25 | call to taint :  | hash_flow.rb:354:5:354:8 | hash [element :c] :  |
-| hash_flow.rb:354:5:354:8 | [post] hash [element :a] :  | hash_flow.rb:359:11:359:14 | hash [element :a] :  |
-| hash_flow.rb:354:5:354:8 | hash [element :a] :  | hash_flow.rb:354:5:354:8 | [post] hash [element :a] :  |
-| hash_flow.rb:354:5:354:8 | hash [element :a] :  | hash_flow.rb:354:27:354:31 | value :  |
-| hash_flow.rb:354:5:354:8 | hash [element :c] :  | hash_flow.rb:354:27:354:31 | value :  |
-| hash_flow.rb:354:27:354:31 | value :  | hash_flow.rb:356:14:356:18 | value |
-| hash_flow.rb:359:11:359:14 | hash [element :a] :  | hash_flow.rb:359:11:359:18 | ...[...] :  |
-| hash_flow.rb:359:11:359:18 | ...[...] :  | hash_flow.rb:359:10:359:19 | ( ... ) |
-| hash_flow.rb:366:15:366:25 | call to taint :  | hash_flow.rb:370:9:370:12 | hash [element :a] :  |
-| hash_flow.rb:368:15:368:25 | call to taint :  | hash_flow.rb:370:9:370:12 | hash [element :c] :  |
-| hash_flow.rb:370:9:370:12 | hash [element :a] :  | hash_flow.rb:370:9:370:20 | call to flatten [element] :  |
-| hash_flow.rb:370:9:370:12 | hash [element :c] :  | hash_flow.rb:370:9:370:20 | call to flatten [element] :  |
-| hash_flow.rb:370:9:370:20 | call to flatten [element] :  | hash_flow.rb:371:11:371:11 | b [element] :  |
-| hash_flow.rb:371:11:371:11 | b [element] :  | hash_flow.rb:371:11:371:14 | ...[...] :  |
-| hash_flow.rb:371:11:371:14 | ...[...] :  | hash_flow.rb:371:10:371:15 | ( ... ) |
-| hash_flow.rb:378:15:378:25 | call to taint :  | hash_flow.rb:382:9:382:12 | hash [element :a] :  |
-| hash_flow.rb:380:15:380:25 | call to taint :  | hash_flow.rb:382:9:382:12 | hash [element :c] :  |
-| hash_flow.rb:382:9:382:12 | [post] hash [element :a] :  | hash_flow.rb:387:11:387:14 | hash [element :a] :  |
-| hash_flow.rb:382:9:382:12 | hash [element :a] :  | hash_flow.rb:382:9:382:12 | [post] hash [element :a] :  |
-| hash_flow.rb:382:9:382:12 | hash [element :a] :  | hash_flow.rb:382:9:386:7 | call to keep_if [element :a] :  |
-| hash_flow.rb:382:9:382:12 | hash [element :a] :  | hash_flow.rb:382:31:382:35 | value :  |
-| hash_flow.rb:382:9:382:12 | hash [element :c] :  | hash_flow.rb:382:31:382:35 | value :  |
-| hash_flow.rb:382:9:386:7 | call to keep_if [element :a] :  | hash_flow.rb:388:11:388:11 | b [element :a] :  |
-| hash_flow.rb:382:31:382:35 | value :  | hash_flow.rb:384:14:384:18 | value |
-| hash_flow.rb:387:11:387:14 | hash [element :a] :  | hash_flow.rb:387:11:387:18 | ...[...] :  |
-| hash_flow.rb:387:11:387:18 | ...[...] :  | hash_flow.rb:387:10:387:19 | ( ... ) |
-| hash_flow.rb:388:11:388:11 | b [element :a] :  | hash_flow.rb:388:11:388:15 | ...[...] :  |
-| hash_flow.rb:388:11:388:15 | ...[...] :  | hash_flow.rb:388:10:388:16 | ( ... ) |
-| hash_flow.rb:395:15:395:25 | call to taint :  | hash_flow.rb:404:12:404:16 | hash1 [element :a] :  |
-| hash_flow.rb:397:15:397:25 | call to taint :  | hash_flow.rb:404:12:404:16 | hash1 [element :c] :  |
-| hash_flow.rb:400:15:400:25 | call to taint :  | hash_flow.rb:404:24:404:28 | hash2 [element :d] :  |
-| hash_flow.rb:402:15:402:25 | call to taint :  | hash_flow.rb:404:24:404:28 | hash2 [element :f] :  |
-| hash_flow.rb:404:12:404:16 | hash1 [element :a] :  | hash_flow.rb:404:12:408:7 | call to merge [element :a] :  |
-| hash_flow.rb:404:12:404:16 | hash1 [element :a] :  | hash_flow.rb:404:40:404:48 | old_value :  |
-| hash_flow.rb:404:12:404:16 | hash1 [element :a] :  | hash_flow.rb:404:51:404:59 | new_value :  |
-| hash_flow.rb:404:12:404:16 | hash1 [element :c] :  | hash_flow.rb:404:12:408:7 | call to merge [element :c] :  |
-| hash_flow.rb:404:12:404:16 | hash1 [element :c] :  | hash_flow.rb:404:40:404:48 | old_value :  |
-| hash_flow.rb:404:12:404:16 | hash1 [element :c] :  | hash_flow.rb:404:51:404:59 | new_value :  |
-| hash_flow.rb:404:12:408:7 | call to merge [element :a] :  | hash_flow.rb:409:11:409:14 | hash [element :a] :  |
-| hash_flow.rb:404:12:408:7 | call to merge [element :c] :  | hash_flow.rb:411:11:411:14 | hash [element :c] :  |
-| hash_flow.rb:404:12:408:7 | call to merge [element :d] :  | hash_flow.rb:412:11:412:14 | hash [element :d] :  |
-| hash_flow.rb:404:12:408:7 | call to merge [element :f] :  | hash_flow.rb:414:11:414:14 | hash [element :f] :  |
-| hash_flow.rb:404:24:404:28 | hash2 [element :d] :  | hash_flow.rb:404:12:408:7 | call to merge [element :d] :  |
-| hash_flow.rb:404:24:404:28 | hash2 [element :d] :  | hash_flow.rb:404:40:404:48 | old_value :  |
-| hash_flow.rb:404:24:404:28 | hash2 [element :d] :  | hash_flow.rb:404:51:404:59 | new_value :  |
-| hash_flow.rb:404:24:404:28 | hash2 [element :f] :  | hash_flow.rb:404:12:408:7 | call to merge [element :f] :  |
-| hash_flow.rb:404:24:404:28 | hash2 [element :f] :  | hash_flow.rb:404:40:404:48 | old_value :  |
-| hash_flow.rb:404:24:404:28 | hash2 [element :f] :  | hash_flow.rb:404:51:404:59 | new_value :  |
-| hash_flow.rb:404:40:404:48 | old_value :  | hash_flow.rb:406:14:406:22 | old_value |
-| hash_flow.rb:404:51:404:59 | new_value :  | hash_flow.rb:407:14:407:22 | new_value |
-| hash_flow.rb:409:11:409:14 | hash [element :a] :  | hash_flow.rb:409:11:409:18 | ...[...] :  |
-| hash_flow.rb:409:11:409:18 | ...[...] :  | hash_flow.rb:409:10:409:19 | ( ... ) |
-| hash_flow.rb:411:11:411:14 | hash [element :c] :  | hash_flow.rb:411:11:411:18 | ...[...] :  |
-| hash_flow.rb:411:11:411:18 | ...[...] :  | hash_flow.rb:411:10:411:19 | ( ... ) |
-| hash_flow.rb:412:11:412:14 | hash [element :d] :  | hash_flow.rb:412:11:412:18 | ...[...] :  |
-| hash_flow.rb:412:11:412:18 | ...[...] :  | hash_flow.rb:412:10:412:19 | ( ... ) |
-| hash_flow.rb:414:11:414:14 | hash [element :f] :  | hash_flow.rb:414:11:414:18 | ...[...] :  |
-| hash_flow.rb:414:11:414:18 | ...[...] :  | hash_flow.rb:414:10:414:19 | ( ... ) |
-| hash_flow.rb:421:15:421:25 | call to taint :  | hash_flow.rb:430:12:430:16 | hash1 [element :a] :  |
-| hash_flow.rb:423:15:423:25 | call to taint :  | hash_flow.rb:430:12:430:16 | hash1 [element :c] :  |
-| hash_flow.rb:426:15:426:25 | call to taint :  | hash_flow.rb:430:25:430:29 | hash2 [element :d] :  |
-| hash_flow.rb:428:15:428:25 | call to taint :  | hash_flow.rb:430:25:430:29 | hash2 [element :f] :  |
-| hash_flow.rb:430:12:430:16 | [post] hash1 [element :a] :  | hash_flow.rb:442:11:442:15 | hash1 [element :a] :  |
-| hash_flow.rb:430:12:430:16 | [post] hash1 [element :c] :  | hash_flow.rb:444:11:444:15 | hash1 [element :c] :  |
-| hash_flow.rb:430:12:430:16 | [post] hash1 [element :d] :  | hash_flow.rb:445:11:445:15 | hash1 [element :d] :  |
-| hash_flow.rb:430:12:430:16 | [post] hash1 [element :f] :  | hash_flow.rb:447:11:447:15 | hash1 [element :f] :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :a] :  | hash_flow.rb:430:12:430:16 | [post] hash1 [element :a] :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :a] :  | hash_flow.rb:430:12:434:7 | call to merge! [element :a] :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :a] :  | hash_flow.rb:430:41:430:49 | old_value :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :a] :  | hash_flow.rb:430:52:430:60 | new_value :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :c] :  | hash_flow.rb:430:12:430:16 | [post] hash1 [element :c] :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :c] :  | hash_flow.rb:430:12:434:7 | call to merge! [element :c] :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :c] :  | hash_flow.rb:430:41:430:49 | old_value :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :c] :  | hash_flow.rb:430:52:430:60 | new_value :  |
-| hash_flow.rb:430:12:434:7 | call to merge! [element :a] :  | hash_flow.rb:435:11:435:14 | hash [element :a] :  |
-| hash_flow.rb:430:12:434:7 | call to merge! [element :c] :  | hash_flow.rb:437:11:437:14 | hash [element :c] :  |
-| hash_flow.rb:430:12:434:7 | call to merge! [element :d] :  | hash_flow.rb:438:11:438:14 | hash [element :d] :  |
-| hash_flow.rb:430:12:434:7 | call to merge! [element :f] :  | hash_flow.rb:440:11:440:14 | hash [element :f] :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :d] :  | hash_flow.rb:430:12:430:16 | [post] hash1 [element :d] :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :d] :  | hash_flow.rb:430:12:434:7 | call to merge! [element :d] :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :d] :  | hash_flow.rb:430:41:430:49 | old_value :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :d] :  | hash_flow.rb:430:52:430:60 | new_value :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :f] :  | hash_flow.rb:430:12:430:16 | [post] hash1 [element :f] :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :f] :  | hash_flow.rb:430:12:434:7 | call to merge! [element :f] :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :f] :  | hash_flow.rb:430:41:430:49 | old_value :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :f] :  | hash_flow.rb:430:52:430:60 | new_value :  |
-| hash_flow.rb:430:41:430:49 | old_value :  | hash_flow.rb:432:14:432:22 | old_value |
-| hash_flow.rb:430:52:430:60 | new_value :  | hash_flow.rb:433:14:433:22 | new_value |
-| hash_flow.rb:435:11:435:14 | hash [element :a] :  | hash_flow.rb:435:11:435:18 | ...[...] :  |
-| hash_flow.rb:435:11:435:18 | ...[...] :  | hash_flow.rb:435:10:435:19 | ( ... ) |
-| hash_flow.rb:437:11:437:14 | hash [element :c] :  | hash_flow.rb:437:11:437:18 | ...[...] :  |
-| hash_flow.rb:437:11:437:18 | ...[...] :  | hash_flow.rb:437:10:437:19 | ( ... ) |
-| hash_flow.rb:438:11:438:14 | hash [element :d] :  | hash_flow.rb:438:11:438:18 | ...[...] :  |
-| hash_flow.rb:438:11:438:18 | ...[...] :  | hash_flow.rb:438:10:438:19 | ( ... ) |
-| hash_flow.rb:440:11:440:14 | hash [element :f] :  | hash_flow.rb:440:11:440:18 | ...[...] :  |
-| hash_flow.rb:440:11:440:18 | ...[...] :  | hash_flow.rb:440:10:440:19 | ( ... ) |
-| hash_flow.rb:442:11:442:15 | hash1 [element :a] :  | hash_flow.rb:442:11:442:19 | ...[...] :  |
-| hash_flow.rb:442:11:442:19 | ...[...] :  | hash_flow.rb:442:10:442:20 | ( ... ) |
-| hash_flow.rb:444:11:444:15 | hash1 [element :c] :  | hash_flow.rb:444:11:444:19 | ...[...] :  |
-| hash_flow.rb:444:11:444:19 | ...[...] :  | hash_flow.rb:444:10:444:20 | ( ... ) |
-| hash_flow.rb:445:11:445:15 | hash1 [element :d] :  | hash_flow.rb:445:11:445:19 | ...[...] :  |
-| hash_flow.rb:445:11:445:19 | ...[...] :  | hash_flow.rb:445:10:445:20 | ( ... ) |
-| hash_flow.rb:447:11:447:15 | hash1 [element :f] :  | hash_flow.rb:447:11:447:19 | ...[...] :  |
-| hash_flow.rb:447:11:447:19 | ...[...] :  | hash_flow.rb:447:10:447:20 | ( ... ) |
-| hash_flow.rb:454:15:454:25 | call to taint :  | hash_flow.rb:457:9:457:12 | hash [element :a] :  |
-| hash_flow.rb:457:9:457:12 | hash [element :a] :  | hash_flow.rb:457:9:457:22 | call to rassoc [element 1] :  |
-| hash_flow.rb:457:9:457:22 | call to rassoc [element 1] :  | hash_flow.rb:459:10:459:10 | b [element 1] :  |
-| hash_flow.rb:459:10:459:10 | b [element 1] :  | hash_flow.rb:459:10:459:13 | ...[...] |
-| hash_flow.rb:466:15:466:25 | call to taint :  | hash_flow.rb:469:9:469:12 | hash [element :a] :  |
-| hash_flow.rb:469:9:469:12 | hash [element :a] :  | hash_flow.rb:469:9:473:7 | call to reject [element :a] :  |
-| hash_flow.rb:469:9:469:12 | hash [element :a] :  | hash_flow.rb:469:29:469:33 | value :  |
-| hash_flow.rb:469:9:473:7 | call to reject [element :a] :  | hash_flow.rb:474:10:474:10 | b [element :a] :  |
-| hash_flow.rb:469:29:469:33 | value :  | hash_flow.rb:471:14:471:18 | value |
-| hash_flow.rb:474:10:474:10 | b [element :a] :  | hash_flow.rb:474:10:474:14 | ...[...] |
-| hash_flow.rb:481:15:481:25 | call to taint :  | hash_flow.rb:484:9:484:12 | hash [element :a] :  |
-| hash_flow.rb:481:15:481:25 | call to taint :  | hash_flow.rb:490:10:490:13 | hash [element :a] :  |
-| hash_flow.rb:484:9:484:12 | [post] hash [element :a] :  | hash_flow.rb:490:10:490:13 | hash [element :a] :  |
-| hash_flow.rb:484:9:484:12 | hash [element :a] :  | hash_flow.rb:484:9:484:12 | [post] hash [element :a] :  |
-| hash_flow.rb:484:9:484:12 | hash [element :a] :  | hash_flow.rb:484:9:488:7 | call to reject! [element :a] :  |
-| hash_flow.rb:484:9:484:12 | hash [element :a] :  | hash_flow.rb:484:30:484:34 | value :  |
-| hash_flow.rb:484:9:488:7 | call to reject! [element :a] :  | hash_flow.rb:489:10:489:10 | b [element :a] :  |
-| hash_flow.rb:484:30:484:34 | value :  | hash_flow.rb:486:14:486:18 | value |
-| hash_flow.rb:489:10:489:10 | b [element :a] :  | hash_flow.rb:489:10:489:14 | ...[...] |
-| hash_flow.rb:490:10:490:13 | hash [element :a] :  | hash_flow.rb:490:10:490:17 | ...[...] |
-| hash_flow.rb:497:15:497:25 | call to taint :  | hash_flow.rb:504:19:504:22 | hash [element :a] :  |
-| hash_flow.rb:499:15:499:25 | call to taint :  | hash_flow.rb:504:19:504:22 | hash [element :c] :  |
-| hash_flow.rb:504:5:504:9 | [post] hash2 [element :a] :  | hash_flow.rb:505:11:505:15 | hash2 [element :a] :  |
-| hash_flow.rb:504:5:504:9 | [post] hash2 [element :c] :  | hash_flow.rb:507:11:507:15 | hash2 [element :c] :  |
-| hash_flow.rb:504:19:504:22 | hash [element :a] :  | hash_flow.rb:504:5:504:9 | [post] hash2 [element :a] :  |
-| hash_flow.rb:504:19:504:22 | hash [element :c] :  | hash_flow.rb:504:5:504:9 | [post] hash2 [element :c] :  |
-| hash_flow.rb:505:11:505:15 | hash2 [element :a] :  | hash_flow.rb:505:11:505:19 | ...[...] :  |
-| hash_flow.rb:505:11:505:19 | ...[...] :  | hash_flow.rb:505:10:505:20 | ( ... ) |
-| hash_flow.rb:507:11:507:15 | hash2 [element :c] :  | hash_flow.rb:507:11:507:19 | ...[...] :  |
-| hash_flow.rb:507:11:507:19 | ...[...] :  | hash_flow.rb:507:10:507:20 | ( ... ) |
-| hash_flow.rb:512:15:512:25 | call to taint :  | hash_flow.rb:516:9:516:12 | hash [element :a] :  |
-| hash_flow.rb:514:15:514:25 | call to taint :  | hash_flow.rb:516:9:516:12 | hash [element :c] :  |
-| hash_flow.rb:516:9:516:12 | hash [element :a] :  | hash_flow.rb:516:9:520:7 | call to select [element :a] :  |
-| hash_flow.rb:516:9:516:12 | hash [element :a] :  | hash_flow.rb:516:30:516:34 | value :  |
-| hash_flow.rb:516:9:516:12 | hash [element :c] :  | hash_flow.rb:516:30:516:34 | value :  |
-| hash_flow.rb:516:9:520:7 | call to select [element :a] :  | hash_flow.rb:521:11:521:11 | b [element :a] :  |
-| hash_flow.rb:516:30:516:34 | value :  | hash_flow.rb:518:14:518:18 | value |
-| hash_flow.rb:521:11:521:11 | b [element :a] :  | hash_flow.rb:521:11:521:15 | ...[...] :  |
-| hash_flow.rb:521:11:521:15 | ...[...] :  | hash_flow.rb:521:10:521:16 | ( ... ) |
-| hash_flow.rb:528:15:528:25 | call to taint :  | hash_flow.rb:532:5:532:8 | hash [element :a] :  |
-| hash_flow.rb:530:15:530:25 | call to taint :  | hash_flow.rb:532:5:532:8 | hash [element :c] :  |
-| hash_flow.rb:532:5:532:8 | [post] hash [element :a] :  | hash_flow.rb:537:11:537:14 | hash [element :a] :  |
-| hash_flow.rb:532:5:532:8 | hash [element :a] :  | hash_flow.rb:532:5:532:8 | [post] hash [element :a] :  |
-| hash_flow.rb:532:5:532:8 | hash [element :a] :  | hash_flow.rb:532:27:532:31 | value :  |
-| hash_flow.rb:532:5:532:8 | hash [element :c] :  | hash_flow.rb:532:27:532:31 | value :  |
-| hash_flow.rb:532:27:532:31 | value :  | hash_flow.rb:534:14:534:18 | value |
-| hash_flow.rb:537:11:537:14 | hash [element :a] :  | hash_flow.rb:537:11:537:18 | ...[...] :  |
-| hash_flow.rb:537:11:537:18 | ...[...] :  | hash_flow.rb:537:10:537:19 | ( ... ) |
-| hash_flow.rb:544:15:544:25 | call to taint :  | hash_flow.rb:548:9:548:12 | hash [element :a] :  |
-| hash_flow.rb:546:15:546:25 | call to taint :  | hash_flow.rb:548:9:548:12 | hash [element :c] :  |
-| hash_flow.rb:548:9:548:12 | [post] hash [element :a] :  | hash_flow.rb:549:11:549:14 | hash [element :a] :  |
-| hash_flow.rb:548:9:548:12 | hash [element :a] :  | hash_flow.rb:548:9:548:12 | [post] hash [element :a] :  |
-| hash_flow.rb:548:9:548:12 | hash [element :a] :  | hash_flow.rb:548:9:548:18 | call to shift [element 1] :  |
-| hash_flow.rb:548:9:548:12 | hash [element :c] :  | hash_flow.rb:548:9:548:18 | call to shift [element 1] :  |
-| hash_flow.rb:548:9:548:18 | call to shift [element 1] :  | hash_flow.rb:551:11:551:11 | b [element 1] :  |
-| hash_flow.rb:549:11:549:14 | hash [element :a] :  | hash_flow.rb:549:11:549:18 | ...[...] :  |
-| hash_flow.rb:549:11:549:18 | ...[...] :  | hash_flow.rb:549:10:549:19 | ( ... ) |
-| hash_flow.rb:551:11:551:11 | b [element 1] :  | hash_flow.rb:551:11:551:14 | ...[...] :  |
-| hash_flow.rb:551:11:551:14 | ...[...] :  | hash_flow.rb:551:10:551:15 | ( ... ) |
-| hash_flow.rb:558:15:558:25 | call to taint :  | hash_flow.rb:562:9:562:12 | hash [element :a] :  |
-| hash_flow.rb:558:15:558:25 | call to taint :  | hash_flow.rb:567:9:567:12 | hash [element :a] :  |
-| hash_flow.rb:560:15:560:25 | call to taint :  | hash_flow.rb:567:9:567:12 | hash [element :c] :  |
-| hash_flow.rb:562:9:562:12 | hash [element :a] :  | hash_flow.rb:562:9:562:26 | call to slice [element :a] :  |
-| hash_flow.rb:562:9:562:26 | call to slice [element :a] :  | hash_flow.rb:563:11:563:11 | b [element :a] :  |
-| hash_flow.rb:563:11:563:11 | b [element :a] :  | hash_flow.rb:563:11:563:15 | ...[...] :  |
-| hash_flow.rb:563:11:563:15 | ...[...] :  | hash_flow.rb:563:10:563:16 | ( ... ) |
-| hash_flow.rb:567:9:567:12 | hash [element :a] :  | hash_flow.rb:567:9:567:25 | call to slice [element :a] :  |
-| hash_flow.rb:567:9:567:12 | hash [element :c] :  | hash_flow.rb:567:9:567:25 | call to slice [element :c] :  |
-| hash_flow.rb:567:9:567:25 | call to slice [element :a] :  | hash_flow.rb:568:11:568:11 | c [element :a] :  |
-| hash_flow.rb:567:9:567:25 | call to slice [element :c] :  | hash_flow.rb:570:11:570:11 | c [element :c] :  |
-| hash_flow.rb:568:11:568:11 | c [element :a] :  | hash_flow.rb:568:11:568:15 | ...[...] :  |
-| hash_flow.rb:568:11:568:15 | ...[...] :  | hash_flow.rb:568:10:568:16 | ( ... ) |
-| hash_flow.rb:570:11:570:11 | c [element :c] :  | hash_flow.rb:570:11:570:15 | ...[...] :  |
-| hash_flow.rb:570:11:570:15 | ...[...] :  | hash_flow.rb:570:10:570:16 | ( ... ) |
-| hash_flow.rb:577:15:577:25 | call to taint :  | hash_flow.rb:581:9:581:12 | hash [element :a] :  |
-| hash_flow.rb:579:15:579:25 | call to taint :  | hash_flow.rb:581:9:581:12 | hash [element :c] :  |
-| hash_flow.rb:581:9:581:12 | hash [element :a] :  | hash_flow.rb:581:9:581:17 | call to to_a [element, element 1] :  |
-| hash_flow.rb:581:9:581:12 | hash [element :c] :  | hash_flow.rb:581:9:581:17 | call to to_a [element, element 1] :  |
-| hash_flow.rb:581:9:581:17 | call to to_a [element, element 1] :  | hash_flow.rb:583:11:583:11 | a [element, element 1] :  |
-| hash_flow.rb:583:11:583:11 | a [element, element 1] :  | hash_flow.rb:583:11:583:14 | ...[...] [element 1] :  |
-| hash_flow.rb:583:11:583:14 | ...[...] [element 1] :  | hash_flow.rb:583:11:583:17 | ...[...] :  |
-| hash_flow.rb:583:11:583:17 | ...[...] :  | hash_flow.rb:583:10:583:18 | ( ... ) |
-| hash_flow.rb:590:15:590:25 | call to taint :  | hash_flow.rb:594:9:594:12 | hash [element :a] :  |
-| hash_flow.rb:590:15:590:25 | call to taint :  | hash_flow.rb:599:9:599:12 | hash [element :a] :  |
-| hash_flow.rb:592:15:592:25 | call to taint :  | hash_flow.rb:594:9:594:12 | hash [element :c] :  |
-| hash_flow.rb:592:15:592:25 | call to taint :  | hash_flow.rb:599:9:599:12 | hash [element :c] :  |
-| hash_flow.rb:594:9:594:12 | hash [element :a] :  | hash_flow.rb:594:9:594:17 | call to to_h [element :a] :  |
-| hash_flow.rb:594:9:594:12 | hash [element :c] :  | hash_flow.rb:594:9:594:17 | call to to_h [element :c] :  |
-| hash_flow.rb:594:9:594:17 | call to to_h [element :a] :  | hash_flow.rb:595:11:595:11 | a [element :a] :  |
-| hash_flow.rb:594:9:594:17 | call to to_h [element :c] :  | hash_flow.rb:597:11:597:11 | a [element :c] :  |
-| hash_flow.rb:595:11:595:11 | a [element :a] :  | hash_flow.rb:595:11:595:15 | ...[...] :  |
-| hash_flow.rb:595:11:595:15 | ...[...] :  | hash_flow.rb:595:10:595:16 | ( ... ) |
-| hash_flow.rb:597:11:597:11 | a [element :c] :  | hash_flow.rb:597:11:597:15 | ...[...] :  |
-| hash_flow.rb:597:11:597:15 | ...[...] :  | hash_flow.rb:597:10:597:16 | ( ... ) |
-| hash_flow.rb:599:9:599:12 | hash [element :a] :  | hash_flow.rb:599:28:599:32 | value :  |
-| hash_flow.rb:599:9:599:12 | hash [element :c] :  | hash_flow.rb:599:28:599:32 | value :  |
-| hash_flow.rb:599:9:603:7 | call to to_h [element] :  | hash_flow.rb:604:11:604:11 | b [element] :  |
-| hash_flow.rb:599:28:599:32 | value :  | hash_flow.rb:601:14:601:18 | value |
-| hash_flow.rb:602:14:602:24 | call to taint :  | hash_flow.rb:599:9:603:7 | call to to_h [element] :  |
-| hash_flow.rb:604:11:604:11 | b [element] :  | hash_flow.rb:604:11:604:15 | ...[...] :  |
-| hash_flow.rb:604:11:604:15 | ...[...] :  | hash_flow.rb:604:10:604:16 | ( ... ) |
-| hash_flow.rb:611:15:611:25 | call to taint :  | hash_flow.rb:615:9:615:12 | hash [element :a] :  |
-| hash_flow.rb:613:15:613:25 | call to taint :  | hash_flow.rb:615:9:615:12 | hash [element :c] :  |
-| hash_flow.rb:615:9:615:12 | hash [element :a] :  | hash_flow.rb:615:9:615:45 | call to transform_keys [element] :  |
-| hash_flow.rb:615:9:615:12 | hash [element :c] :  | hash_flow.rb:615:9:615:45 | call to transform_keys [element] :  |
-| hash_flow.rb:615:9:615:45 | call to transform_keys [element] :  | hash_flow.rb:616:11:616:11 | a [element] :  |
-| hash_flow.rb:615:9:615:45 | call to transform_keys [element] :  | hash_flow.rb:617:11:617:11 | a [element] :  |
-| hash_flow.rb:615:9:615:45 | call to transform_keys [element] :  | hash_flow.rb:618:11:618:11 | a [element] :  |
-| hash_flow.rb:616:11:616:11 | a [element] :  | hash_flow.rb:616:11:616:16 | ...[...] :  |
-| hash_flow.rb:616:11:616:16 | ...[...] :  | hash_flow.rb:616:10:616:17 | ( ... ) |
-| hash_flow.rb:617:11:617:11 | a [element] :  | hash_flow.rb:617:11:617:16 | ...[...] :  |
-| hash_flow.rb:617:11:617:16 | ...[...] :  | hash_flow.rb:617:10:617:17 | ( ... ) |
-| hash_flow.rb:618:11:618:11 | a [element] :  | hash_flow.rb:618:11:618:16 | ...[...] :  |
-| hash_flow.rb:618:11:618:16 | ...[...] :  | hash_flow.rb:618:10:618:17 | ( ... ) |
-| hash_flow.rb:625:15:625:25 | call to taint :  | hash_flow.rb:629:5:629:8 | hash [element :a] :  |
-| hash_flow.rb:627:15:627:25 | call to taint :  | hash_flow.rb:629:5:629:8 | hash [element :c] :  |
-| hash_flow.rb:629:5:629:8 | [post] hash [element] :  | hash_flow.rb:630:11:630:14 | hash [element] :  |
-| hash_flow.rb:629:5:629:8 | [post] hash [element] :  | hash_flow.rb:631:11:631:14 | hash [element] :  |
-| hash_flow.rb:629:5:629:8 | [post] hash [element] :  | hash_flow.rb:632:11:632:14 | hash [element] :  |
-| hash_flow.rb:629:5:629:8 | hash [element :a] :  | hash_flow.rb:629:5:629:8 | [post] hash [element] :  |
-| hash_flow.rb:629:5:629:8 | hash [element :c] :  | hash_flow.rb:629:5:629:8 | [post] hash [element] :  |
-| hash_flow.rb:630:11:630:14 | hash [element] :  | hash_flow.rb:630:11:630:19 | ...[...] :  |
-| hash_flow.rb:630:11:630:19 | ...[...] :  | hash_flow.rb:630:10:630:20 | ( ... ) |
-| hash_flow.rb:631:11:631:14 | hash [element] :  | hash_flow.rb:631:11:631:19 | ...[...] :  |
-| hash_flow.rb:631:11:631:19 | ...[...] :  | hash_flow.rb:631:10:631:20 | ( ... ) |
-| hash_flow.rb:632:11:632:14 | hash [element] :  | hash_flow.rb:632:11:632:19 | ...[...] :  |
-| hash_flow.rb:632:11:632:19 | ...[...] :  | hash_flow.rb:632:10:632:20 | ( ... ) |
-| hash_flow.rb:639:15:639:25 | call to taint :  | hash_flow.rb:643:9:643:12 | hash [element :a] :  |
-| hash_flow.rb:639:15:639:25 | call to taint :  | hash_flow.rb:647:11:647:14 | hash [element :a] :  |
-| hash_flow.rb:641:15:641:25 | call to taint :  | hash_flow.rb:643:9:643:12 | hash [element :c] :  |
-| hash_flow.rb:643:9:643:12 | hash [element :a] :  | hash_flow.rb:643:35:643:39 | value :  |
-| hash_flow.rb:643:9:643:12 | hash [element :c] :  | hash_flow.rb:643:35:643:39 | value :  |
-| hash_flow.rb:643:9:646:7 | call to transform_values [element] :  | hash_flow.rb:648:11:648:11 | b [element] :  |
-| hash_flow.rb:643:35:643:39 | value :  | hash_flow.rb:644:14:644:18 | value |
-| hash_flow.rb:645:9:645:19 | call to taint :  | hash_flow.rb:643:9:646:7 | call to transform_values [element] :  |
-| hash_flow.rb:647:11:647:14 | hash [element :a] :  | hash_flow.rb:647:11:647:18 | ...[...] :  |
-| hash_flow.rb:647:11:647:18 | ...[...] :  | hash_flow.rb:647:10:647:19 | ( ... ) |
-| hash_flow.rb:648:11:648:11 | b [element] :  | hash_flow.rb:648:11:648:15 | ...[...] :  |
-| hash_flow.rb:648:11:648:15 | ...[...] :  | hash_flow.rb:648:10:648:16 | ( ... ) |
-| hash_flow.rb:655:15:655:25 | call to taint :  | hash_flow.rb:659:5:659:8 | hash [element :a] :  |
-| hash_flow.rb:657:15:657:25 | call to taint :  | hash_flow.rb:659:5:659:8 | hash [element :c] :  |
-| hash_flow.rb:659:5:659:8 | [post] hash [element] :  | hash_flow.rb:663:11:663:14 | hash [element] :  |
-| hash_flow.rb:659:5:659:8 | hash [element :a] :  | hash_flow.rb:659:32:659:36 | value :  |
-| hash_flow.rb:659:5:659:8 | hash [element :c] :  | hash_flow.rb:659:32:659:36 | value :  |
-| hash_flow.rb:659:32:659:36 | value :  | hash_flow.rb:660:14:660:18 | value |
-| hash_flow.rb:661:9:661:19 | call to taint :  | hash_flow.rb:659:5:659:8 | [post] hash [element] :  |
-| hash_flow.rb:663:11:663:14 | hash [element] :  | hash_flow.rb:663:11:663:18 | ...[...] :  |
-| hash_flow.rb:663:11:663:18 | ...[...] :  | hash_flow.rb:663:10:663:19 | ( ... ) |
-| hash_flow.rb:670:15:670:25 | call to taint :  | hash_flow.rb:679:12:679:16 | hash1 [element :a] :  |
-| hash_flow.rb:672:15:672:25 | call to taint :  | hash_flow.rb:679:12:679:16 | hash1 [element :c] :  |
-| hash_flow.rb:675:15:675:25 | call to taint :  | hash_flow.rb:679:25:679:29 | hash2 [element :d] :  |
-| hash_flow.rb:677:15:677:25 | call to taint :  | hash_flow.rb:679:25:679:29 | hash2 [element :f] :  |
-| hash_flow.rb:679:12:679:16 | [post] hash1 [element :a] :  | hash_flow.rb:691:11:691:15 | hash1 [element :a] :  |
-| hash_flow.rb:679:12:679:16 | [post] hash1 [element :c] :  | hash_flow.rb:693:11:693:15 | hash1 [element :c] :  |
-| hash_flow.rb:679:12:679:16 | [post] hash1 [element :d] :  | hash_flow.rb:694:11:694:15 | hash1 [element :d] :  |
-| hash_flow.rb:679:12:679:16 | [post] hash1 [element :f] :  | hash_flow.rb:696:11:696:15 | hash1 [element :f] :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :a] :  | hash_flow.rb:679:12:679:16 | [post] hash1 [element :a] :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :a] :  | hash_flow.rb:679:12:683:7 | call to update [element :a] :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :a] :  | hash_flow.rb:679:41:679:49 | old_value :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :a] :  | hash_flow.rb:679:52:679:60 | new_value :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :c] :  | hash_flow.rb:679:12:679:16 | [post] hash1 [element :c] :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :c] :  | hash_flow.rb:679:12:683:7 | call to update [element :c] :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :c] :  | hash_flow.rb:679:41:679:49 | old_value :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :c] :  | hash_flow.rb:679:52:679:60 | new_value :  |
-| hash_flow.rb:679:12:683:7 | call to update [element :a] :  | hash_flow.rb:684:11:684:14 | hash [element :a] :  |
-| hash_flow.rb:679:12:683:7 | call to update [element :c] :  | hash_flow.rb:686:11:686:14 | hash [element :c] :  |
-| hash_flow.rb:679:12:683:7 | call to update [element :d] :  | hash_flow.rb:687:11:687:14 | hash [element :d] :  |
-| hash_flow.rb:679:12:683:7 | call to update [element :f] :  | hash_flow.rb:689:11:689:14 | hash [element :f] :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :d] :  | hash_flow.rb:679:12:679:16 | [post] hash1 [element :d] :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :d] :  | hash_flow.rb:679:12:683:7 | call to update [element :d] :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :d] :  | hash_flow.rb:679:41:679:49 | old_value :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :d] :  | hash_flow.rb:679:52:679:60 | new_value :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :f] :  | hash_flow.rb:679:12:679:16 | [post] hash1 [element :f] :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :f] :  | hash_flow.rb:679:12:683:7 | call to update [element :f] :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :f] :  | hash_flow.rb:679:41:679:49 | old_value :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :f] :  | hash_flow.rb:679:52:679:60 | new_value :  |
-| hash_flow.rb:679:41:679:49 | old_value :  | hash_flow.rb:681:14:681:22 | old_value |
-| hash_flow.rb:679:52:679:60 | new_value :  | hash_flow.rb:682:14:682:22 | new_value |
-| hash_flow.rb:684:11:684:14 | hash [element :a] :  | hash_flow.rb:684:11:684:18 | ...[...] :  |
-| hash_flow.rb:684:11:684:18 | ...[...] :  | hash_flow.rb:684:10:684:19 | ( ... ) |
-| hash_flow.rb:686:11:686:14 | hash [element :c] :  | hash_flow.rb:686:11:686:18 | ...[...] :  |
-| hash_flow.rb:686:11:686:18 | ...[...] :  | hash_flow.rb:686:10:686:19 | ( ... ) |
-| hash_flow.rb:687:11:687:14 | hash [element :d] :  | hash_flow.rb:687:11:687:18 | ...[...] :  |
-| hash_flow.rb:687:11:687:18 | ...[...] :  | hash_flow.rb:687:10:687:19 | ( ... ) |
-| hash_flow.rb:689:11:689:14 | hash [element :f] :  | hash_flow.rb:689:11:689:18 | ...[...] :  |
-| hash_flow.rb:689:11:689:18 | ...[...] :  | hash_flow.rb:689:10:689:19 | ( ... ) |
-| hash_flow.rb:691:11:691:15 | hash1 [element :a] :  | hash_flow.rb:691:11:691:19 | ...[...] :  |
-| hash_flow.rb:691:11:691:19 | ...[...] :  | hash_flow.rb:691:10:691:20 | ( ... ) |
-| hash_flow.rb:693:11:693:15 | hash1 [element :c] :  | hash_flow.rb:693:11:693:19 | ...[...] :  |
-| hash_flow.rb:693:11:693:19 | ...[...] :  | hash_flow.rb:693:10:693:20 | ( ... ) |
-| hash_flow.rb:694:11:694:15 | hash1 [element :d] :  | hash_flow.rb:694:11:694:19 | ...[...] :  |
-| hash_flow.rb:694:11:694:19 | ...[...] :  | hash_flow.rb:694:10:694:20 | ( ... ) |
-| hash_flow.rb:696:11:696:15 | hash1 [element :f] :  | hash_flow.rb:696:11:696:19 | ...[...] :  |
-| hash_flow.rb:696:11:696:19 | ...[...] :  | hash_flow.rb:696:10:696:20 | ( ... ) |
-| hash_flow.rb:703:15:703:25 | call to taint :  | hash_flow.rb:707:9:707:12 | hash [element :a] :  |
-| hash_flow.rb:705:15:705:25 | call to taint :  | hash_flow.rb:707:9:707:12 | hash [element :c] :  |
-| hash_flow.rb:707:9:707:12 | hash [element :a] :  | hash_flow.rb:707:9:707:19 | call to values [element] :  |
-| hash_flow.rb:707:9:707:12 | hash [element :c] :  | hash_flow.rb:707:9:707:19 | call to values [element] :  |
-| hash_flow.rb:707:9:707:19 | call to values [element] :  | hash_flow.rb:708:11:708:11 | a [element] :  |
-| hash_flow.rb:708:11:708:11 | a [element] :  | hash_flow.rb:708:11:708:14 | ...[...] :  |
-| hash_flow.rb:708:11:708:14 | ...[...] :  | hash_flow.rb:708:10:708:15 | ( ... ) |
-| hash_flow.rb:715:15:715:25 | call to taint :  | hash_flow.rb:719:9:719:12 | hash [element :a] :  |
-| hash_flow.rb:715:15:715:25 | call to taint :  | hash_flow.rb:721:9:721:12 | hash [element :a] :  |
-| hash_flow.rb:717:15:717:25 | call to taint :  | hash_flow.rb:721:9:721:12 | hash [element :c] :  |
-| hash_flow.rb:719:9:719:12 | hash [element :a] :  | hash_flow.rb:719:9:719:26 | call to values_at [element 0] :  |
-| hash_flow.rb:719:9:719:26 | call to values_at [element 0] :  | hash_flow.rb:720:10:720:10 | b [element 0] :  |
-| hash_flow.rb:720:10:720:10 | b [element 0] :  | hash_flow.rb:720:10:720:13 | ...[...] |
-| hash_flow.rb:721:9:721:12 | hash [element :a] :  | hash_flow.rb:721:9:721:31 | call to fetch_values [element] :  |
-| hash_flow.rb:721:9:721:12 | hash [element :c] :  | hash_flow.rb:721:9:721:31 | call to fetch_values [element] :  |
-| hash_flow.rb:721:9:721:31 | call to fetch_values [element] :  | hash_flow.rb:722:10:722:10 | b [element] :  |
-| hash_flow.rb:722:10:722:10 | b [element] :  | hash_flow.rb:722:10:722:13 | ...[...] |
-| hash_flow.rb:729:15:729:25 | call to taint :  | hash_flow.rb:738:16:738:20 | hash1 [element :a] :  |
-| hash_flow.rb:731:15:731:25 | call to taint :  | hash_flow.rb:738:16:738:20 | hash1 [element :c] :  |
-| hash_flow.rb:734:15:734:25 | call to taint :  | hash_flow.rb:738:44:738:48 | hash2 [element :d] :  |
-| hash_flow.rb:736:15:736:25 | call to taint :  | hash_flow.rb:738:44:738:48 | hash2 [element :f] :  |
-| hash_flow.rb:738:14:738:20 | ** ... [element :a] :  | hash_flow.rb:739:10:739:13 | hash [element :a] :  |
-| hash_flow.rb:738:14:738:20 | ** ... [element :c] :  | hash_flow.rb:741:10:741:13 | hash [element :c] :  |
-| hash_flow.rb:738:16:738:20 | hash1 [element :a] :  | hash_flow.rb:738:14:738:20 | ** ... [element :a] :  |
-| hash_flow.rb:738:16:738:20 | hash1 [element :c] :  | hash_flow.rb:738:14:738:20 | ** ... [element :c] :  |
-| hash_flow.rb:738:29:738:39 | call to taint :  | hash_flow.rb:745:10:745:13 | hash [element :g] :  |
-| hash_flow.rb:738:42:738:48 | ** ... [element :d] :  | hash_flow.rb:742:10:742:13 | hash [element :d] :  |
-| hash_flow.rb:738:42:738:48 | ** ... [element :f] :  | hash_flow.rb:744:10:744:13 | hash [element :f] :  |
-| hash_flow.rb:738:44:738:48 | hash2 [element :d] :  | hash_flow.rb:738:42:738:48 | ** ... [element :d] :  |
-| hash_flow.rb:738:44:738:48 | hash2 [element :f] :  | hash_flow.rb:738:42:738:48 | ** ... [element :f] :  |
-| hash_flow.rb:739:10:739:13 | hash [element :a] :  | hash_flow.rb:739:10:739:17 | ...[...] |
-| hash_flow.rb:741:10:741:13 | hash [element :c] :  | hash_flow.rb:741:10:741:17 | ...[...] |
-| hash_flow.rb:742:10:742:13 | hash [element :d] :  | hash_flow.rb:742:10:742:17 | ...[...] |
-| hash_flow.rb:744:10:744:13 | hash [element :f] :  | hash_flow.rb:744:10:744:17 | ...[...] |
-| hash_flow.rb:745:10:745:13 | hash [element :g] :  | hash_flow.rb:745:10:745:17 | ...[...] |
+| hash_flow.rb:72:13:72:45 | ...[...] [element a] :  | hash_flow.rb:73:10:73:14 | hash5 [element a] :  |
+| hash_flow.rb:72:18:72:34 | Pair [pair a] :  | hash_flow.rb:72:13:72:45 | ...[...] [element a] :  |
+| hash_flow.rb:72:25:72:34 | call to taint :  | hash_flow.rb:72:18:72:34 | Pair [pair a] :  |
+| hash_flow.rb:73:10:73:14 | hash5 [element a] :  | hash_flow.rb:73:10:73:19 | ...[...] |
+| hash_flow.rb:76:13:76:47 | ...[...] [element a] :  | hash_flow.rb:77:10:77:14 | hash6 [element a] :  |
+| hash_flow.rb:76:19:76:35 | Pair [pair a] :  | hash_flow.rb:76:13:76:47 | ...[...] [element a] :  |
+| hash_flow.rb:76:26:76:35 | call to taint :  | hash_flow.rb:76:19:76:35 | Pair [pair a] :  |
+| hash_flow.rb:77:10:77:14 | hash6 [element a] :  | hash_flow.rb:77:10:77:19 | ...[...] |
+| hash_flow.rb:84:13:84:42 | call to [] [element :a] :  | hash_flow.rb:85:10:85:14 | hash1 [element :a] :  |
+| hash_flow.rb:84:26:84:35 | call to taint :  | hash_flow.rb:84:13:84:42 | call to [] [element :a] :  |
+| hash_flow.rb:85:10:85:14 | hash1 [element :a] :  | hash_flow.rb:85:10:85:18 | ...[...] |
+| hash_flow.rb:93:15:93:24 | call to taint :  | hash_flow.rb:96:30:96:33 | hash [element :a] :  |
+| hash_flow.rb:96:13:96:34 | call to try_convert [element :a] :  | hash_flow.rb:97:10:97:14 | hash2 [element :a] :  |
+| hash_flow.rb:96:30:96:33 | hash [element :a] :  | hash_flow.rb:96:13:96:34 | call to try_convert [element :a] :  |
+| hash_flow.rb:97:10:97:14 | hash2 [element :a] :  | hash_flow.rb:97:10:97:18 | ...[...] |
+| hash_flow.rb:105:21:105:30 | call to taint :  | hash_flow.rb:106:10:106:10 | b |
+| hash_flow.rb:113:9:113:12 | [post] hash [element :a] :  | hash_flow.rb:114:10:114:13 | hash [element :a] :  |
+| hash_flow.rb:113:9:113:34 | call to store :  | hash_flow.rb:115:10:115:10 | b |
+| hash_flow.rb:113:24:113:33 | call to taint :  | hash_flow.rb:113:9:113:12 | [post] hash [element :a] :  |
+| hash_flow.rb:113:24:113:33 | call to taint :  | hash_flow.rb:113:9:113:34 | call to store :  |
+| hash_flow.rb:114:10:114:13 | hash [element :a] :  | hash_flow.rb:114:10:114:17 | ...[...] |
+| hash_flow.rb:118:9:118:12 | [post] hash [element] :  | hash_flow.rb:119:10:119:13 | hash [element] :  |
+| hash_flow.rb:118:9:118:12 | [post] hash [element] :  | hash_flow.rb:120:10:120:13 | hash [element] :  |
+| hash_flow.rb:118:9:118:33 | call to store :  | hash_flow.rb:121:10:121:10 | c |
+| hash_flow.rb:118:23:118:32 | call to taint :  | hash_flow.rb:118:9:118:12 | [post] hash [element] :  |
+| hash_flow.rb:118:23:118:32 | call to taint :  | hash_flow.rb:118:9:118:33 | call to store :  |
+| hash_flow.rb:119:10:119:13 | hash [element] :  | hash_flow.rb:119:10:119:17 | ...[...] |
+| hash_flow.rb:120:10:120:13 | hash [element] :  | hash_flow.rb:120:10:120:17 | ...[...] |
+| hash_flow.rb:128:15:128:24 | call to taint :  | hash_flow.rb:131:5:131:8 | hash [element :a] :  |
+| hash_flow.rb:128:15:128:24 | call to taint :  | hash_flow.rb:134:5:134:8 | hash [element :a] :  |
+| hash_flow.rb:131:5:131:8 | hash [element :a] :  | hash_flow.rb:131:18:131:29 | key_or_value :  |
+| hash_flow.rb:131:18:131:29 | key_or_value :  | hash_flow.rb:132:14:132:25 | key_or_value |
+| hash_flow.rb:134:5:134:8 | hash [element :a] :  | hash_flow.rb:134:22:134:26 | value :  |
+| hash_flow.rb:134:22:134:26 | value :  | hash_flow.rb:136:14:136:18 | value |
+| hash_flow.rb:144:15:144:25 | call to taint :  | hash_flow.rb:147:9:147:12 | hash [element :a] :  |
+| hash_flow.rb:144:15:144:25 | call to taint :  | hash_flow.rb:151:9:151:12 | hash [element :a] :  |
+| hash_flow.rb:147:9:147:12 | hash [element :a] :  | hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  |
+| hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  | hash_flow.rb:149:10:149:10 | b [element 1] :  |
+| hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  | hash_flow.rb:150:10:150:10 | b [element 1] :  |
+| hash_flow.rb:149:10:149:10 | b [element 1] :  | hash_flow.rb:149:10:149:13 | ...[...] |
+| hash_flow.rb:150:10:150:10 | b [element 1] :  | hash_flow.rb:150:10:150:13 | ...[...] |
+| hash_flow.rb:151:9:151:12 | hash [element :a] :  | hash_flow.rb:151:9:151:21 | call to assoc [element 1] :  |
+| hash_flow.rb:151:9:151:21 | call to assoc [element 1] :  | hash_flow.rb:152:10:152:10 | c [element 1] :  |
+| hash_flow.rb:152:10:152:10 | c [element 1] :  | hash_flow.rb:152:10:152:13 | ...[...] |
+| hash_flow.rb:170:15:170:25 | call to taint :  | hash_flow.rb:173:9:173:12 | hash [element :a] :  |
+| hash_flow.rb:173:9:173:12 | hash [element :a] :  | hash_flow.rb:173:9:173:20 | call to compact [element :a] :  |
+| hash_flow.rb:173:9:173:20 | call to compact [element :a] :  | hash_flow.rb:174:10:174:10 | a [element :a] :  |
+| hash_flow.rb:174:10:174:10 | a [element :a] :  | hash_flow.rb:174:10:174:14 | ...[...] |
+| hash_flow.rb:182:15:182:25 | call to taint :  | hash_flow.rb:185:9:185:12 | hash [element :a] :  |
+| hash_flow.rb:185:9:185:12 | hash [element :a] :  | hash_flow.rb:185:9:185:23 | call to delete :  |
+| hash_flow.rb:185:9:185:23 | call to delete :  | hash_flow.rb:186:10:186:10 | a |
+| hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:197:9:197:12 | hash [element :a] :  |
+| hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:202:10:202:13 | hash [element :a] :  |
+| hash_flow.rb:197:9:197:12 | [post] hash [element :a] :  | hash_flow.rb:202:10:202:13 | hash [element :a] :  |
+| hash_flow.rb:197:9:197:12 | hash [element :a] :  | hash_flow.rb:197:9:197:12 | [post] hash [element :a] :  |
+| hash_flow.rb:197:9:197:12 | hash [element :a] :  | hash_flow.rb:197:9:200:7 | call to delete_if [element :a] :  |
+| hash_flow.rb:197:9:197:12 | hash [element :a] :  | hash_flow.rb:197:33:197:37 | value :  |
+| hash_flow.rb:197:9:200:7 | call to delete_if [element :a] :  | hash_flow.rb:201:10:201:10 | a [element :a] :  |
+| hash_flow.rb:197:33:197:37 | value :  | hash_flow.rb:199:14:199:18 | value |
+| hash_flow.rb:201:10:201:10 | a [element :a] :  | hash_flow.rb:201:10:201:14 | ...[...] |
+| hash_flow.rb:202:10:202:13 | hash [element :a] :  | hash_flow.rb:202:10:202:17 | ...[...] |
+| hash_flow.rb:210:15:210:25 | call to taint :  | hash_flow.rb:217:10:217:13 | hash [element :a] :  |
+| hash_flow.rb:213:19:213:29 | call to taint :  | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] :  |
+| hash_flow.rb:217:10:217:13 | hash [element :a] :  | hash_flow.rb:217:10:217:21 | call to dig |
+| hash_flow.rb:219:10:219:13 | hash [element :c, element :d] :  | hash_flow.rb:219:10:219:24 | call to dig |
+| hash_flow.rb:227:15:227:25 | call to taint :  | hash_flow.rb:230:9:230:12 | hash [element :a] :  |
+| hash_flow.rb:230:9:230:12 | hash [element :a] :  | hash_flow.rb:230:9:233:7 | call to each [element :a] :  |
+| hash_flow.rb:230:9:230:12 | hash [element :a] :  | hash_flow.rb:230:28:230:32 | value :  |
+| hash_flow.rb:230:9:233:7 | call to each [element :a] :  | hash_flow.rb:234:10:234:10 | x [element :a] :  |
+| hash_flow.rb:230:28:230:32 | value :  | hash_flow.rb:232:14:232:18 | value |
+| hash_flow.rb:234:10:234:10 | x [element :a] :  | hash_flow.rb:234:10:234:14 | ...[...] |
+| hash_flow.rb:242:15:242:25 | call to taint :  | hash_flow.rb:245:9:245:12 | hash [element :a] :  |
+| hash_flow.rb:245:9:245:12 | hash [element :a] :  | hash_flow.rb:245:9:247:7 | call to each_key [element :a] :  |
+| hash_flow.rb:245:9:247:7 | call to each_key [element :a] :  | hash_flow.rb:248:10:248:10 | x [element :a] :  |
+| hash_flow.rb:248:10:248:10 | x [element :a] :  | hash_flow.rb:248:10:248:14 | ...[...] |
+| hash_flow.rb:256:15:256:25 | call to taint :  | hash_flow.rb:259:9:259:12 | hash [element :a] :  |
+| hash_flow.rb:259:9:259:12 | hash [element :a] :  | hash_flow.rb:259:9:262:7 | call to each_pair [element :a] :  |
+| hash_flow.rb:259:9:259:12 | hash [element :a] :  | hash_flow.rb:259:33:259:37 | value :  |
+| hash_flow.rb:259:9:262:7 | call to each_pair [element :a] :  | hash_flow.rb:263:10:263:10 | x [element :a] :  |
+| hash_flow.rb:259:33:259:37 | value :  | hash_flow.rb:261:14:261:18 | value |
+| hash_flow.rb:263:10:263:10 | x [element :a] :  | hash_flow.rb:263:10:263:14 | ...[...] |
+| hash_flow.rb:271:15:271:25 | call to taint :  | hash_flow.rb:274:9:274:12 | hash [element :a] :  |
+| hash_flow.rb:274:9:274:12 | hash [element :a] :  | hash_flow.rb:274:9:276:7 | call to each_value [element :a] :  |
+| hash_flow.rb:274:9:274:12 | hash [element :a] :  | hash_flow.rb:274:29:274:33 | value :  |
+| hash_flow.rb:274:9:276:7 | call to each_value [element :a] :  | hash_flow.rb:277:10:277:10 | x [element :a] :  |
+| hash_flow.rb:274:29:274:33 | value :  | hash_flow.rb:275:14:275:18 | value |
+| hash_flow.rb:277:10:277:10 | x [element :a] :  | hash_flow.rb:277:10:277:14 | ...[...] |
+| hash_flow.rb:287:15:287:25 | call to taint :  | hash_flow.rb:290:9:290:12 | hash [element :c] :  |
+| hash_flow.rb:290:9:290:12 | hash [element :c] :  | hash_flow.rb:290:9:290:28 | call to except [element :c] :  |
+| hash_flow.rb:290:9:290:28 | call to except [element :c] :  | hash_flow.rb:293:10:293:10 | x [element :c] :  |
+| hash_flow.rb:293:10:293:10 | x [element :c] :  | hash_flow.rb:293:10:293:14 | ...[...] |
+| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:305:9:305:12 | hash [element :a] :  |
+| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:309:9:309:12 | hash [element :a] :  |
+| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:311:9:311:12 | hash [element :a] :  |
+| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:315:9:315:12 | hash [element :a] :  |
+| hash_flow.rb:303:15:303:25 | call to taint :  | hash_flow.rb:305:9:305:12 | hash [element :c] :  |
+| hash_flow.rb:303:15:303:25 | call to taint :  | hash_flow.rb:315:9:315:12 | hash [element :c] :  |
+| hash_flow.rb:305:9:305:12 | hash [element :a] :  | hash_flow.rb:305:9:307:7 | call to fetch :  |
+| hash_flow.rb:305:9:305:12 | hash [element :c] :  | hash_flow.rb:305:9:307:7 | call to fetch :  |
+| hash_flow.rb:305:9:307:7 | call to fetch :  | hash_flow.rb:308:10:308:10 | b |
+| hash_flow.rb:305:20:305:30 | call to taint :  | hash_flow.rb:305:37:305:37 | x :  |
+| hash_flow.rb:305:37:305:37 | x :  | hash_flow.rb:306:14:306:14 | x |
+| hash_flow.rb:309:9:309:12 | hash [element :a] :  | hash_flow.rb:309:9:309:22 | call to fetch :  |
+| hash_flow.rb:309:9:309:22 | call to fetch :  | hash_flow.rb:310:10:310:10 | b |
+| hash_flow.rb:311:9:311:12 | hash [element :a] :  | hash_flow.rb:311:9:311:35 | call to fetch :  |
+| hash_flow.rb:311:9:311:35 | call to fetch :  | hash_flow.rb:312:10:312:10 | b |
+| hash_flow.rb:311:24:311:34 | call to taint :  | hash_flow.rb:311:9:311:35 | call to fetch :  |
+| hash_flow.rb:313:9:313:35 | call to fetch :  | hash_flow.rb:314:10:314:10 | b |
+| hash_flow.rb:313:24:313:34 | call to taint :  | hash_flow.rb:313:9:313:35 | call to fetch :  |
+| hash_flow.rb:315:9:315:12 | hash [element :a] :  | hash_flow.rb:315:9:315:34 | call to fetch :  |
+| hash_flow.rb:315:9:315:12 | hash [element :c] :  | hash_flow.rb:315:9:315:34 | call to fetch :  |
+| hash_flow.rb:315:9:315:34 | call to fetch :  | hash_flow.rb:316:10:316:10 | b |
+| hash_flow.rb:315:23:315:33 | call to taint :  | hash_flow.rb:315:9:315:34 | call to fetch :  |
+| hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:327:9:327:12 | hash [element :a] :  |
+| hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:332:9:332:12 | hash [element :a] :  |
+| hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:334:9:334:12 | hash [element :a] :  |
+| hash_flow.rb:325:15:325:25 | call to taint :  | hash_flow.rb:327:9:327:12 | hash [element :c] :  |
+| hash_flow.rb:325:15:325:25 | call to taint :  | hash_flow.rb:334:9:334:12 | hash [element :c] :  |
+| hash_flow.rb:327:9:327:12 | hash [element :a] :  | hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  |
+| hash_flow.rb:327:9:327:12 | hash [element :c] :  | hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  |
+| hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  | hash_flow.rb:331:10:331:10 | b [element] :  |
+| hash_flow.rb:327:27:327:37 | call to taint :  | hash_flow.rb:327:44:327:44 | x :  |
+| hash_flow.rb:327:44:327:44 | x :  | hash_flow.rb:328:14:328:14 | x |
+| hash_flow.rb:329:9:329:19 | call to taint :  | hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  |
+| hash_flow.rb:331:10:331:10 | b [element] :  | hash_flow.rb:331:10:331:13 | ...[...] |
+| hash_flow.rb:332:9:332:12 | hash [element :a] :  | hash_flow.rb:332:9:332:29 | call to fetch_values [element] :  |
+| hash_flow.rb:332:9:332:29 | call to fetch_values [element] :  | hash_flow.rb:333:10:333:10 | b [element] :  |
+| hash_flow.rb:333:10:333:10 | b [element] :  | hash_flow.rb:333:10:333:13 | ...[...] |
+| hash_flow.rb:334:9:334:12 | hash [element :a] :  | hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  |
+| hash_flow.rb:334:9:334:12 | hash [element :c] :  | hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  |
+| hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  | hash_flow.rb:335:10:335:10 | b [element] :  |
+| hash_flow.rb:335:10:335:10 | b [element] :  | hash_flow.rb:335:10:335:13 | ...[...] |
+| hash_flow.rb:342:15:342:25 | call to taint :  | hash_flow.rb:346:9:346:12 | hash [element :a] :  |
+| hash_flow.rb:344:15:344:25 | call to taint :  | hash_flow.rb:346:9:346:12 | hash [element :c] :  |
+| hash_flow.rb:346:9:346:12 | hash [element :a] :  | hash_flow.rb:346:9:350:7 | call to filter [element :a] :  |
+| hash_flow.rb:346:9:346:12 | hash [element :a] :  | hash_flow.rb:346:30:346:34 | value :  |
+| hash_flow.rb:346:9:346:12 | hash [element :c] :  | hash_flow.rb:346:30:346:34 | value :  |
+| hash_flow.rb:346:9:350:7 | call to filter [element :a] :  | hash_flow.rb:351:11:351:11 | b [element :a] :  |
+| hash_flow.rb:346:30:346:34 | value :  | hash_flow.rb:348:14:348:18 | value |
+| hash_flow.rb:351:11:351:11 | b [element :a] :  | hash_flow.rb:351:11:351:15 | ...[...] :  |
+| hash_flow.rb:351:11:351:15 | ...[...] :  | hash_flow.rb:351:10:351:16 | ( ... ) |
+| hash_flow.rb:358:15:358:25 | call to taint :  | hash_flow.rb:362:5:362:8 | hash [element :a] :  |
+| hash_flow.rb:360:15:360:25 | call to taint :  | hash_flow.rb:362:5:362:8 | hash [element :c] :  |
+| hash_flow.rb:362:5:362:8 | [post] hash [element :a] :  | hash_flow.rb:367:11:367:14 | hash [element :a] :  |
+| hash_flow.rb:362:5:362:8 | hash [element :a] :  | hash_flow.rb:362:5:362:8 | [post] hash [element :a] :  |
+| hash_flow.rb:362:5:362:8 | hash [element :a] :  | hash_flow.rb:362:27:362:31 | value :  |
+| hash_flow.rb:362:5:362:8 | hash [element :c] :  | hash_flow.rb:362:27:362:31 | value :  |
+| hash_flow.rb:362:27:362:31 | value :  | hash_flow.rb:364:14:364:18 | value |
+| hash_flow.rb:367:11:367:14 | hash [element :a] :  | hash_flow.rb:367:11:367:18 | ...[...] :  |
+| hash_flow.rb:367:11:367:18 | ...[...] :  | hash_flow.rb:367:10:367:19 | ( ... ) |
+| hash_flow.rb:374:15:374:25 | call to taint :  | hash_flow.rb:378:9:378:12 | hash [element :a] :  |
+| hash_flow.rb:376:15:376:25 | call to taint :  | hash_flow.rb:378:9:378:12 | hash [element :c] :  |
+| hash_flow.rb:378:9:378:12 | hash [element :a] :  | hash_flow.rb:378:9:378:20 | call to flatten [element] :  |
+| hash_flow.rb:378:9:378:12 | hash [element :c] :  | hash_flow.rb:378:9:378:20 | call to flatten [element] :  |
+| hash_flow.rb:378:9:378:20 | call to flatten [element] :  | hash_flow.rb:379:11:379:11 | b [element] :  |
+| hash_flow.rb:379:11:379:11 | b [element] :  | hash_flow.rb:379:11:379:14 | ...[...] :  |
+| hash_flow.rb:379:11:379:14 | ...[...] :  | hash_flow.rb:379:10:379:15 | ( ... ) |
+| hash_flow.rb:386:15:386:25 | call to taint :  | hash_flow.rb:390:9:390:12 | hash [element :a] :  |
+| hash_flow.rb:388:15:388:25 | call to taint :  | hash_flow.rb:390:9:390:12 | hash [element :c] :  |
+| hash_flow.rb:390:9:390:12 | [post] hash [element :a] :  | hash_flow.rb:395:11:395:14 | hash [element :a] :  |
+| hash_flow.rb:390:9:390:12 | hash [element :a] :  | hash_flow.rb:390:9:390:12 | [post] hash [element :a] :  |
+| hash_flow.rb:390:9:390:12 | hash [element :a] :  | hash_flow.rb:390:9:394:7 | call to keep_if [element :a] :  |
+| hash_flow.rb:390:9:390:12 | hash [element :a] :  | hash_flow.rb:390:31:390:35 | value :  |
+| hash_flow.rb:390:9:390:12 | hash [element :c] :  | hash_flow.rb:390:31:390:35 | value :  |
+| hash_flow.rb:390:9:394:7 | call to keep_if [element :a] :  | hash_flow.rb:396:11:396:11 | b [element :a] :  |
+| hash_flow.rb:390:31:390:35 | value :  | hash_flow.rb:392:14:392:18 | value |
+| hash_flow.rb:395:11:395:14 | hash [element :a] :  | hash_flow.rb:395:11:395:18 | ...[...] :  |
+| hash_flow.rb:395:11:395:18 | ...[...] :  | hash_flow.rb:395:10:395:19 | ( ... ) |
+| hash_flow.rb:396:11:396:11 | b [element :a] :  | hash_flow.rb:396:11:396:15 | ...[...] :  |
+| hash_flow.rb:396:11:396:15 | ...[...] :  | hash_flow.rb:396:10:396:16 | ( ... ) |
+| hash_flow.rb:403:15:403:25 | call to taint :  | hash_flow.rb:412:12:412:16 | hash1 [element :a] :  |
+| hash_flow.rb:405:15:405:25 | call to taint :  | hash_flow.rb:412:12:412:16 | hash1 [element :c] :  |
+| hash_flow.rb:408:15:408:25 | call to taint :  | hash_flow.rb:412:24:412:28 | hash2 [element :d] :  |
+| hash_flow.rb:410:15:410:25 | call to taint :  | hash_flow.rb:412:24:412:28 | hash2 [element :f] :  |
+| hash_flow.rb:412:12:412:16 | hash1 [element :a] :  | hash_flow.rb:412:12:416:7 | call to merge [element :a] :  |
+| hash_flow.rb:412:12:412:16 | hash1 [element :a] :  | hash_flow.rb:412:40:412:48 | old_value :  |
+| hash_flow.rb:412:12:412:16 | hash1 [element :a] :  | hash_flow.rb:412:51:412:59 | new_value :  |
+| hash_flow.rb:412:12:412:16 | hash1 [element :c] :  | hash_flow.rb:412:12:416:7 | call to merge [element :c] :  |
+| hash_flow.rb:412:12:412:16 | hash1 [element :c] :  | hash_flow.rb:412:40:412:48 | old_value :  |
+| hash_flow.rb:412:12:412:16 | hash1 [element :c] :  | hash_flow.rb:412:51:412:59 | new_value :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :a] :  | hash_flow.rb:417:11:417:14 | hash [element :a] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :c] :  | hash_flow.rb:419:11:419:14 | hash [element :c] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :d] :  | hash_flow.rb:420:11:420:14 | hash [element :d] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :f] :  | hash_flow.rb:422:11:422:14 | hash [element :f] :  |
+| hash_flow.rb:412:24:412:28 | hash2 [element :d] :  | hash_flow.rb:412:12:416:7 | call to merge [element :d] :  |
+| hash_flow.rb:412:24:412:28 | hash2 [element :d] :  | hash_flow.rb:412:40:412:48 | old_value :  |
+| hash_flow.rb:412:24:412:28 | hash2 [element :d] :  | hash_flow.rb:412:51:412:59 | new_value :  |
+| hash_flow.rb:412:24:412:28 | hash2 [element :f] :  | hash_flow.rb:412:12:416:7 | call to merge [element :f] :  |
+| hash_flow.rb:412:24:412:28 | hash2 [element :f] :  | hash_flow.rb:412:40:412:48 | old_value :  |
+| hash_flow.rb:412:24:412:28 | hash2 [element :f] :  | hash_flow.rb:412:51:412:59 | new_value :  |
+| hash_flow.rb:412:40:412:48 | old_value :  | hash_flow.rb:414:14:414:22 | old_value |
+| hash_flow.rb:412:51:412:59 | new_value :  | hash_flow.rb:415:14:415:22 | new_value |
+| hash_flow.rb:417:11:417:14 | hash [element :a] :  | hash_flow.rb:417:11:417:18 | ...[...] :  |
+| hash_flow.rb:417:11:417:18 | ...[...] :  | hash_flow.rb:417:10:417:19 | ( ... ) |
+| hash_flow.rb:419:11:419:14 | hash [element :c] :  | hash_flow.rb:419:11:419:18 | ...[...] :  |
+| hash_flow.rb:419:11:419:18 | ...[...] :  | hash_flow.rb:419:10:419:19 | ( ... ) |
+| hash_flow.rb:420:11:420:14 | hash [element :d] :  | hash_flow.rb:420:11:420:18 | ...[...] :  |
+| hash_flow.rb:420:11:420:18 | ...[...] :  | hash_flow.rb:420:10:420:19 | ( ... ) |
+| hash_flow.rb:422:11:422:14 | hash [element :f] :  | hash_flow.rb:422:11:422:18 | ...[...] :  |
+| hash_flow.rb:422:11:422:18 | ...[...] :  | hash_flow.rb:422:10:422:19 | ( ... ) |
+| hash_flow.rb:429:15:429:25 | call to taint :  | hash_flow.rb:438:12:438:16 | hash1 [element :a] :  |
+| hash_flow.rb:431:15:431:25 | call to taint :  | hash_flow.rb:438:12:438:16 | hash1 [element :c] :  |
+| hash_flow.rb:434:15:434:25 | call to taint :  | hash_flow.rb:438:25:438:29 | hash2 [element :d] :  |
+| hash_flow.rb:436:15:436:25 | call to taint :  | hash_flow.rb:438:25:438:29 | hash2 [element :f] :  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 [element :a] :  | hash_flow.rb:450:11:450:15 | hash1 [element :a] :  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 [element :c] :  | hash_flow.rb:452:11:452:15 | hash1 [element :c] :  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] :  | hash_flow.rb:453:11:453:15 | hash1 [element :d] :  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 [element :f] :  | hash_flow.rb:455:11:455:15 | hash1 [element :f] :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :a] :  | hash_flow.rb:438:12:438:16 | [post] hash1 [element :a] :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :a] :  | hash_flow.rb:438:12:442:7 | call to merge! [element :a] :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :a] :  | hash_flow.rb:438:41:438:49 | old_value :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :a] :  | hash_flow.rb:438:52:438:60 | new_value :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :c] :  | hash_flow.rb:438:12:438:16 | [post] hash1 [element :c] :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :c] :  | hash_flow.rb:438:12:442:7 | call to merge! [element :c] :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :c] :  | hash_flow.rb:438:41:438:49 | old_value :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :c] :  | hash_flow.rb:438:52:438:60 | new_value :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :a] :  | hash_flow.rb:443:11:443:14 | hash [element :a] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :c] :  | hash_flow.rb:445:11:445:14 | hash [element :c] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :d] :  | hash_flow.rb:446:11:446:14 | hash [element :d] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :f] :  | hash_flow.rb:448:11:448:14 | hash [element :f] :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :d] :  | hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :d] :  | hash_flow.rb:438:12:442:7 | call to merge! [element :d] :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :d] :  | hash_flow.rb:438:41:438:49 | old_value :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :d] :  | hash_flow.rb:438:52:438:60 | new_value :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :f] :  | hash_flow.rb:438:12:438:16 | [post] hash1 [element :f] :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :f] :  | hash_flow.rb:438:12:442:7 | call to merge! [element :f] :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :f] :  | hash_flow.rb:438:41:438:49 | old_value :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :f] :  | hash_flow.rb:438:52:438:60 | new_value :  |
+| hash_flow.rb:438:41:438:49 | old_value :  | hash_flow.rb:440:14:440:22 | old_value |
+| hash_flow.rb:438:52:438:60 | new_value :  | hash_flow.rb:441:14:441:22 | new_value |
+| hash_flow.rb:443:11:443:14 | hash [element :a] :  | hash_flow.rb:443:11:443:18 | ...[...] :  |
+| hash_flow.rb:443:11:443:18 | ...[...] :  | hash_flow.rb:443:10:443:19 | ( ... ) |
+| hash_flow.rb:445:11:445:14 | hash [element :c] :  | hash_flow.rb:445:11:445:18 | ...[...] :  |
+| hash_flow.rb:445:11:445:18 | ...[...] :  | hash_flow.rb:445:10:445:19 | ( ... ) |
+| hash_flow.rb:446:11:446:14 | hash [element :d] :  | hash_flow.rb:446:11:446:18 | ...[...] :  |
+| hash_flow.rb:446:11:446:18 | ...[...] :  | hash_flow.rb:446:10:446:19 | ( ... ) |
+| hash_flow.rb:448:11:448:14 | hash [element :f] :  | hash_flow.rb:448:11:448:18 | ...[...] :  |
+| hash_flow.rb:448:11:448:18 | ...[...] :  | hash_flow.rb:448:10:448:19 | ( ... ) |
+| hash_flow.rb:450:11:450:15 | hash1 [element :a] :  | hash_flow.rb:450:11:450:19 | ...[...] :  |
+| hash_flow.rb:450:11:450:19 | ...[...] :  | hash_flow.rb:450:10:450:20 | ( ... ) |
+| hash_flow.rb:452:11:452:15 | hash1 [element :c] :  | hash_flow.rb:452:11:452:19 | ...[...] :  |
+| hash_flow.rb:452:11:452:19 | ...[...] :  | hash_flow.rb:452:10:452:20 | ( ... ) |
+| hash_flow.rb:453:11:453:15 | hash1 [element :d] :  | hash_flow.rb:453:11:453:19 | ...[...] :  |
+| hash_flow.rb:453:11:453:19 | ...[...] :  | hash_flow.rb:453:10:453:20 | ( ... ) |
+| hash_flow.rb:455:11:455:15 | hash1 [element :f] :  | hash_flow.rb:455:11:455:19 | ...[...] :  |
+| hash_flow.rb:455:11:455:19 | ...[...] :  | hash_flow.rb:455:10:455:20 | ( ... ) |
+| hash_flow.rb:462:15:462:25 | call to taint :  | hash_flow.rb:465:9:465:12 | hash [element :a] :  |
+| hash_flow.rb:465:9:465:12 | hash [element :a] :  | hash_flow.rb:465:9:465:22 | call to rassoc [element 1] :  |
+| hash_flow.rb:465:9:465:22 | call to rassoc [element 1] :  | hash_flow.rb:467:10:467:10 | b [element 1] :  |
+| hash_flow.rb:467:10:467:10 | b [element 1] :  | hash_flow.rb:467:10:467:13 | ...[...] |
+| hash_flow.rb:474:15:474:25 | call to taint :  | hash_flow.rb:477:9:477:12 | hash [element :a] :  |
+| hash_flow.rb:477:9:477:12 | hash [element :a] :  | hash_flow.rb:477:9:481:7 | call to reject [element :a] :  |
+| hash_flow.rb:477:9:477:12 | hash [element :a] :  | hash_flow.rb:477:29:477:33 | value :  |
+| hash_flow.rb:477:9:481:7 | call to reject [element :a] :  | hash_flow.rb:482:10:482:10 | b [element :a] :  |
+| hash_flow.rb:477:29:477:33 | value :  | hash_flow.rb:479:14:479:18 | value |
+| hash_flow.rb:482:10:482:10 | b [element :a] :  | hash_flow.rb:482:10:482:14 | ...[...] |
+| hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:492:9:492:12 | hash [element :a] :  |
+| hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:498:10:498:13 | hash [element :a] :  |
+| hash_flow.rb:492:9:492:12 | [post] hash [element :a] :  | hash_flow.rb:498:10:498:13 | hash [element :a] :  |
+| hash_flow.rb:492:9:492:12 | hash [element :a] :  | hash_flow.rb:492:9:492:12 | [post] hash [element :a] :  |
+| hash_flow.rb:492:9:492:12 | hash [element :a] :  | hash_flow.rb:492:9:496:7 | call to reject! [element :a] :  |
+| hash_flow.rb:492:9:492:12 | hash [element :a] :  | hash_flow.rb:492:30:492:34 | value :  |
+| hash_flow.rb:492:9:496:7 | call to reject! [element :a] :  | hash_flow.rb:497:10:497:10 | b [element :a] :  |
+| hash_flow.rb:492:30:492:34 | value :  | hash_flow.rb:494:14:494:18 | value |
+| hash_flow.rb:497:10:497:10 | b [element :a] :  | hash_flow.rb:497:10:497:14 | ...[...] |
+| hash_flow.rb:498:10:498:13 | hash [element :a] :  | hash_flow.rb:498:10:498:17 | ...[...] |
+| hash_flow.rb:505:15:505:25 | call to taint :  | hash_flow.rb:512:19:512:22 | hash [element :a] :  |
+| hash_flow.rb:507:15:507:25 | call to taint :  | hash_flow.rb:512:19:512:22 | hash [element :c] :  |
+| hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] :  | hash_flow.rb:513:11:513:15 | hash2 [element :a] :  |
+| hash_flow.rb:512:5:512:9 | [post] hash2 [element :c] :  | hash_flow.rb:515:11:515:15 | hash2 [element :c] :  |
+| hash_flow.rb:512:19:512:22 | hash [element :a] :  | hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] :  |
+| hash_flow.rb:512:19:512:22 | hash [element :c] :  | hash_flow.rb:512:5:512:9 | [post] hash2 [element :c] :  |
+| hash_flow.rb:513:11:513:15 | hash2 [element :a] :  | hash_flow.rb:513:11:513:19 | ...[...] :  |
+| hash_flow.rb:513:11:513:19 | ...[...] :  | hash_flow.rb:513:10:513:20 | ( ... ) |
+| hash_flow.rb:515:11:515:15 | hash2 [element :c] :  | hash_flow.rb:515:11:515:19 | ...[...] :  |
+| hash_flow.rb:515:11:515:19 | ...[...] :  | hash_flow.rb:515:10:515:20 | ( ... ) |
+| hash_flow.rb:520:15:520:25 | call to taint :  | hash_flow.rb:524:9:524:12 | hash [element :a] :  |
+| hash_flow.rb:522:15:522:25 | call to taint :  | hash_flow.rb:524:9:524:12 | hash [element :c] :  |
+| hash_flow.rb:524:9:524:12 | hash [element :a] :  | hash_flow.rb:524:9:528:7 | call to select [element :a] :  |
+| hash_flow.rb:524:9:524:12 | hash [element :a] :  | hash_flow.rb:524:30:524:34 | value :  |
+| hash_flow.rb:524:9:524:12 | hash [element :c] :  | hash_flow.rb:524:30:524:34 | value :  |
+| hash_flow.rb:524:9:528:7 | call to select [element :a] :  | hash_flow.rb:529:11:529:11 | b [element :a] :  |
+| hash_flow.rb:524:30:524:34 | value :  | hash_flow.rb:526:14:526:18 | value |
+| hash_flow.rb:529:11:529:11 | b [element :a] :  | hash_flow.rb:529:11:529:15 | ...[...] :  |
+| hash_flow.rb:529:11:529:15 | ...[...] :  | hash_flow.rb:529:10:529:16 | ( ... ) |
+| hash_flow.rb:536:15:536:25 | call to taint :  | hash_flow.rb:540:5:540:8 | hash [element :a] :  |
+| hash_flow.rb:538:15:538:25 | call to taint :  | hash_flow.rb:540:5:540:8 | hash [element :c] :  |
+| hash_flow.rb:540:5:540:8 | [post] hash [element :a] :  | hash_flow.rb:545:11:545:14 | hash [element :a] :  |
+| hash_flow.rb:540:5:540:8 | hash [element :a] :  | hash_flow.rb:540:5:540:8 | [post] hash [element :a] :  |
+| hash_flow.rb:540:5:540:8 | hash [element :a] :  | hash_flow.rb:540:27:540:31 | value :  |
+| hash_flow.rb:540:5:540:8 | hash [element :c] :  | hash_flow.rb:540:27:540:31 | value :  |
+| hash_flow.rb:540:27:540:31 | value :  | hash_flow.rb:542:14:542:18 | value |
+| hash_flow.rb:545:11:545:14 | hash [element :a] :  | hash_flow.rb:545:11:545:18 | ...[...] :  |
+| hash_flow.rb:545:11:545:18 | ...[...] :  | hash_flow.rb:545:10:545:19 | ( ... ) |
+| hash_flow.rb:552:15:552:25 | call to taint :  | hash_flow.rb:556:9:556:12 | hash [element :a] :  |
+| hash_flow.rb:554:15:554:25 | call to taint :  | hash_flow.rb:556:9:556:12 | hash [element :c] :  |
+| hash_flow.rb:556:9:556:12 | [post] hash [element :a] :  | hash_flow.rb:557:11:557:14 | hash [element :a] :  |
+| hash_flow.rb:556:9:556:12 | hash [element :a] :  | hash_flow.rb:556:9:556:12 | [post] hash [element :a] :  |
+| hash_flow.rb:556:9:556:12 | hash [element :a] :  | hash_flow.rb:556:9:556:18 | call to shift [element 1] :  |
+| hash_flow.rb:556:9:556:12 | hash [element :c] :  | hash_flow.rb:556:9:556:18 | call to shift [element 1] :  |
+| hash_flow.rb:556:9:556:18 | call to shift [element 1] :  | hash_flow.rb:559:11:559:11 | b [element 1] :  |
+| hash_flow.rb:557:11:557:14 | hash [element :a] :  | hash_flow.rb:557:11:557:18 | ...[...] :  |
+| hash_flow.rb:557:11:557:18 | ...[...] :  | hash_flow.rb:557:10:557:19 | ( ... ) |
+| hash_flow.rb:559:11:559:11 | b [element 1] :  | hash_flow.rb:559:11:559:14 | ...[...] :  |
+| hash_flow.rb:559:11:559:14 | ...[...] :  | hash_flow.rb:559:10:559:15 | ( ... ) |
+| hash_flow.rb:566:15:566:25 | call to taint :  | hash_flow.rb:570:9:570:12 | hash [element :a] :  |
+| hash_flow.rb:566:15:566:25 | call to taint :  | hash_flow.rb:575:9:575:12 | hash [element :a] :  |
+| hash_flow.rb:568:15:568:25 | call to taint :  | hash_flow.rb:575:9:575:12 | hash [element :c] :  |
+| hash_flow.rb:570:9:570:12 | hash [element :a] :  | hash_flow.rb:570:9:570:26 | call to slice [element :a] :  |
+| hash_flow.rb:570:9:570:26 | call to slice [element :a] :  | hash_flow.rb:571:11:571:11 | b [element :a] :  |
+| hash_flow.rb:571:11:571:11 | b [element :a] :  | hash_flow.rb:571:11:571:15 | ...[...] :  |
+| hash_flow.rb:571:11:571:15 | ...[...] :  | hash_flow.rb:571:10:571:16 | ( ... ) |
+| hash_flow.rb:575:9:575:12 | hash [element :a] :  | hash_flow.rb:575:9:575:25 | call to slice [element :a] :  |
+| hash_flow.rb:575:9:575:12 | hash [element :c] :  | hash_flow.rb:575:9:575:25 | call to slice [element :c] :  |
+| hash_flow.rb:575:9:575:25 | call to slice [element :a] :  | hash_flow.rb:576:11:576:11 | c [element :a] :  |
+| hash_flow.rb:575:9:575:25 | call to slice [element :c] :  | hash_flow.rb:578:11:578:11 | c [element :c] :  |
+| hash_flow.rb:576:11:576:11 | c [element :a] :  | hash_flow.rb:576:11:576:15 | ...[...] :  |
+| hash_flow.rb:576:11:576:15 | ...[...] :  | hash_flow.rb:576:10:576:16 | ( ... ) |
+| hash_flow.rb:578:11:578:11 | c [element :c] :  | hash_flow.rb:578:11:578:15 | ...[...] :  |
+| hash_flow.rb:578:11:578:15 | ...[...] :  | hash_flow.rb:578:10:578:16 | ( ... ) |
+| hash_flow.rb:585:15:585:25 | call to taint :  | hash_flow.rb:589:9:589:12 | hash [element :a] :  |
+| hash_flow.rb:587:15:587:25 | call to taint :  | hash_flow.rb:589:9:589:12 | hash [element :c] :  |
+| hash_flow.rb:589:9:589:12 | hash [element :a] :  | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  |
+| hash_flow.rb:589:9:589:12 | hash [element :c] :  | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  |
+| hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  | hash_flow.rb:591:11:591:11 | a [element, element 1] :  |
+| hash_flow.rb:591:11:591:11 | a [element, element 1] :  | hash_flow.rb:591:11:591:14 | ...[...] [element 1] :  |
+| hash_flow.rb:591:11:591:14 | ...[...] [element 1] :  | hash_flow.rb:591:11:591:17 | ...[...] :  |
+| hash_flow.rb:591:11:591:17 | ...[...] :  | hash_flow.rb:591:10:591:18 | ( ... ) |
+| hash_flow.rb:598:15:598:25 | call to taint :  | hash_flow.rb:602:9:602:12 | hash [element :a] :  |
+| hash_flow.rb:598:15:598:25 | call to taint :  | hash_flow.rb:607:9:607:12 | hash [element :a] :  |
+| hash_flow.rb:600:15:600:25 | call to taint :  | hash_flow.rb:602:9:602:12 | hash [element :c] :  |
+| hash_flow.rb:600:15:600:25 | call to taint :  | hash_flow.rb:607:9:607:12 | hash [element :c] :  |
+| hash_flow.rb:602:9:602:12 | hash [element :a] :  | hash_flow.rb:602:9:602:17 | call to to_h [element :a] :  |
+| hash_flow.rb:602:9:602:12 | hash [element :c] :  | hash_flow.rb:602:9:602:17 | call to to_h [element :c] :  |
+| hash_flow.rb:602:9:602:17 | call to to_h [element :a] :  | hash_flow.rb:603:11:603:11 | a [element :a] :  |
+| hash_flow.rb:602:9:602:17 | call to to_h [element :c] :  | hash_flow.rb:605:11:605:11 | a [element :c] :  |
+| hash_flow.rb:603:11:603:11 | a [element :a] :  | hash_flow.rb:603:11:603:15 | ...[...] :  |
+| hash_flow.rb:603:11:603:15 | ...[...] :  | hash_flow.rb:603:10:603:16 | ( ... ) |
+| hash_flow.rb:605:11:605:11 | a [element :c] :  | hash_flow.rb:605:11:605:15 | ...[...] :  |
+| hash_flow.rb:605:11:605:15 | ...[...] :  | hash_flow.rb:605:10:605:16 | ( ... ) |
+| hash_flow.rb:607:9:607:12 | hash [element :a] :  | hash_flow.rb:607:28:607:32 | value :  |
+| hash_flow.rb:607:9:607:12 | hash [element :c] :  | hash_flow.rb:607:28:607:32 | value :  |
+| hash_flow.rb:607:9:611:7 | call to to_h [element] :  | hash_flow.rb:612:11:612:11 | b [element] :  |
+| hash_flow.rb:607:28:607:32 | value :  | hash_flow.rb:609:14:609:18 | value |
+| hash_flow.rb:610:14:610:24 | call to taint :  | hash_flow.rb:607:9:611:7 | call to to_h [element] :  |
+| hash_flow.rb:612:11:612:11 | b [element] :  | hash_flow.rb:612:11:612:15 | ...[...] :  |
+| hash_flow.rb:612:11:612:15 | ...[...] :  | hash_flow.rb:612:10:612:16 | ( ... ) |
+| hash_flow.rb:619:15:619:25 | call to taint :  | hash_flow.rb:623:9:623:12 | hash [element :a] :  |
+| hash_flow.rb:621:15:621:25 | call to taint :  | hash_flow.rb:623:9:623:12 | hash [element :c] :  |
+| hash_flow.rb:623:9:623:12 | hash [element :a] :  | hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  |
+| hash_flow.rb:623:9:623:12 | hash [element :c] :  | hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  |
+| hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | hash_flow.rb:624:11:624:11 | a [element] :  |
+| hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | hash_flow.rb:625:11:625:11 | a [element] :  |
+| hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | hash_flow.rb:626:11:626:11 | a [element] :  |
+| hash_flow.rb:624:11:624:11 | a [element] :  | hash_flow.rb:624:11:624:16 | ...[...] :  |
+| hash_flow.rb:624:11:624:16 | ...[...] :  | hash_flow.rb:624:10:624:17 | ( ... ) |
+| hash_flow.rb:625:11:625:11 | a [element] :  | hash_flow.rb:625:11:625:16 | ...[...] :  |
+| hash_flow.rb:625:11:625:16 | ...[...] :  | hash_flow.rb:625:10:625:17 | ( ... ) |
+| hash_flow.rb:626:11:626:11 | a [element] :  | hash_flow.rb:626:11:626:16 | ...[...] :  |
+| hash_flow.rb:626:11:626:16 | ...[...] :  | hash_flow.rb:626:10:626:17 | ( ... ) |
+| hash_flow.rb:633:15:633:25 | call to taint :  | hash_flow.rb:637:5:637:8 | hash [element :a] :  |
+| hash_flow.rb:635:15:635:25 | call to taint :  | hash_flow.rb:637:5:637:8 | hash [element :c] :  |
+| hash_flow.rb:637:5:637:8 | [post] hash [element] :  | hash_flow.rb:638:11:638:14 | hash [element] :  |
+| hash_flow.rb:637:5:637:8 | [post] hash [element] :  | hash_flow.rb:639:11:639:14 | hash [element] :  |
+| hash_flow.rb:637:5:637:8 | [post] hash [element] :  | hash_flow.rb:640:11:640:14 | hash [element] :  |
+| hash_flow.rb:637:5:637:8 | hash [element :a] :  | hash_flow.rb:637:5:637:8 | [post] hash [element] :  |
+| hash_flow.rb:637:5:637:8 | hash [element :c] :  | hash_flow.rb:637:5:637:8 | [post] hash [element] :  |
+| hash_flow.rb:638:11:638:14 | hash [element] :  | hash_flow.rb:638:11:638:19 | ...[...] :  |
+| hash_flow.rb:638:11:638:19 | ...[...] :  | hash_flow.rb:638:10:638:20 | ( ... ) |
+| hash_flow.rb:639:11:639:14 | hash [element] :  | hash_flow.rb:639:11:639:19 | ...[...] :  |
+| hash_flow.rb:639:11:639:19 | ...[...] :  | hash_flow.rb:639:10:639:20 | ( ... ) |
+| hash_flow.rb:640:11:640:14 | hash [element] :  | hash_flow.rb:640:11:640:19 | ...[...] :  |
+| hash_flow.rb:640:11:640:19 | ...[...] :  | hash_flow.rb:640:10:640:20 | ( ... ) |
+| hash_flow.rb:647:15:647:25 | call to taint :  | hash_flow.rb:651:9:651:12 | hash [element :a] :  |
+| hash_flow.rb:647:15:647:25 | call to taint :  | hash_flow.rb:655:11:655:14 | hash [element :a] :  |
+| hash_flow.rb:649:15:649:25 | call to taint :  | hash_flow.rb:651:9:651:12 | hash [element :c] :  |
+| hash_flow.rb:651:9:651:12 | hash [element :a] :  | hash_flow.rb:651:35:651:39 | value :  |
+| hash_flow.rb:651:9:651:12 | hash [element :c] :  | hash_flow.rb:651:35:651:39 | value :  |
+| hash_flow.rb:651:9:654:7 | call to transform_values [element] :  | hash_flow.rb:656:11:656:11 | b [element] :  |
+| hash_flow.rb:651:35:651:39 | value :  | hash_flow.rb:652:14:652:18 | value |
+| hash_flow.rb:653:9:653:19 | call to taint :  | hash_flow.rb:651:9:654:7 | call to transform_values [element] :  |
+| hash_flow.rb:655:11:655:14 | hash [element :a] :  | hash_flow.rb:655:11:655:18 | ...[...] :  |
+| hash_flow.rb:655:11:655:18 | ...[...] :  | hash_flow.rb:655:10:655:19 | ( ... ) |
+| hash_flow.rb:656:11:656:11 | b [element] :  | hash_flow.rb:656:11:656:15 | ...[...] :  |
+| hash_flow.rb:656:11:656:15 | ...[...] :  | hash_flow.rb:656:10:656:16 | ( ... ) |
+| hash_flow.rb:663:15:663:25 | call to taint :  | hash_flow.rb:667:5:667:8 | hash [element :a] :  |
+| hash_flow.rb:665:15:665:25 | call to taint :  | hash_flow.rb:667:5:667:8 | hash [element :c] :  |
+| hash_flow.rb:667:5:667:8 | [post] hash [element] :  | hash_flow.rb:671:11:671:14 | hash [element] :  |
+| hash_flow.rb:667:5:667:8 | hash [element :a] :  | hash_flow.rb:667:32:667:36 | value :  |
+| hash_flow.rb:667:5:667:8 | hash [element :c] :  | hash_flow.rb:667:32:667:36 | value :  |
+| hash_flow.rb:667:32:667:36 | value :  | hash_flow.rb:668:14:668:18 | value |
+| hash_flow.rb:669:9:669:19 | call to taint :  | hash_flow.rb:667:5:667:8 | [post] hash [element] :  |
+| hash_flow.rb:671:11:671:14 | hash [element] :  | hash_flow.rb:671:11:671:18 | ...[...] :  |
+| hash_flow.rb:671:11:671:18 | ...[...] :  | hash_flow.rb:671:10:671:19 | ( ... ) |
+| hash_flow.rb:678:15:678:25 | call to taint :  | hash_flow.rb:687:12:687:16 | hash1 [element :a] :  |
+| hash_flow.rb:680:15:680:25 | call to taint :  | hash_flow.rb:687:12:687:16 | hash1 [element :c] :  |
+| hash_flow.rb:683:15:683:25 | call to taint :  | hash_flow.rb:687:25:687:29 | hash2 [element :d] :  |
+| hash_flow.rb:685:15:685:25 | call to taint :  | hash_flow.rb:687:25:687:29 | hash2 [element :f] :  |
+| hash_flow.rb:687:12:687:16 | [post] hash1 [element :a] :  | hash_flow.rb:699:11:699:15 | hash1 [element :a] :  |
+| hash_flow.rb:687:12:687:16 | [post] hash1 [element :c] :  | hash_flow.rb:701:11:701:15 | hash1 [element :c] :  |
+| hash_flow.rb:687:12:687:16 | [post] hash1 [element :d] :  | hash_flow.rb:702:11:702:15 | hash1 [element :d] :  |
+| hash_flow.rb:687:12:687:16 | [post] hash1 [element :f] :  | hash_flow.rb:704:11:704:15 | hash1 [element :f] :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :a] :  | hash_flow.rb:687:12:687:16 | [post] hash1 [element :a] :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :a] :  | hash_flow.rb:687:12:691:7 | call to update [element :a] :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :a] :  | hash_flow.rb:687:41:687:49 | old_value :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :a] :  | hash_flow.rb:687:52:687:60 | new_value :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :c] :  | hash_flow.rb:687:12:687:16 | [post] hash1 [element :c] :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :c] :  | hash_flow.rb:687:12:691:7 | call to update [element :c] :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :c] :  | hash_flow.rb:687:41:687:49 | old_value :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :c] :  | hash_flow.rb:687:52:687:60 | new_value :  |
+| hash_flow.rb:687:12:691:7 | call to update [element :a] :  | hash_flow.rb:692:11:692:14 | hash [element :a] :  |
+| hash_flow.rb:687:12:691:7 | call to update [element :c] :  | hash_flow.rb:694:11:694:14 | hash [element :c] :  |
+| hash_flow.rb:687:12:691:7 | call to update [element :d] :  | hash_flow.rb:695:11:695:14 | hash [element :d] :  |
+| hash_flow.rb:687:12:691:7 | call to update [element :f] :  | hash_flow.rb:697:11:697:14 | hash [element :f] :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :d] :  | hash_flow.rb:687:12:687:16 | [post] hash1 [element :d] :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :d] :  | hash_flow.rb:687:12:691:7 | call to update [element :d] :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :d] :  | hash_flow.rb:687:41:687:49 | old_value :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :d] :  | hash_flow.rb:687:52:687:60 | new_value :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :f] :  | hash_flow.rb:687:12:687:16 | [post] hash1 [element :f] :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :f] :  | hash_flow.rb:687:12:691:7 | call to update [element :f] :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :f] :  | hash_flow.rb:687:41:687:49 | old_value :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :f] :  | hash_flow.rb:687:52:687:60 | new_value :  |
+| hash_flow.rb:687:41:687:49 | old_value :  | hash_flow.rb:689:14:689:22 | old_value |
+| hash_flow.rb:687:52:687:60 | new_value :  | hash_flow.rb:690:14:690:22 | new_value |
+| hash_flow.rb:692:11:692:14 | hash [element :a] :  | hash_flow.rb:692:11:692:18 | ...[...] :  |
+| hash_flow.rb:692:11:692:18 | ...[...] :  | hash_flow.rb:692:10:692:19 | ( ... ) |
+| hash_flow.rb:694:11:694:14 | hash [element :c] :  | hash_flow.rb:694:11:694:18 | ...[...] :  |
+| hash_flow.rb:694:11:694:18 | ...[...] :  | hash_flow.rb:694:10:694:19 | ( ... ) |
+| hash_flow.rb:695:11:695:14 | hash [element :d] :  | hash_flow.rb:695:11:695:18 | ...[...] :  |
+| hash_flow.rb:695:11:695:18 | ...[...] :  | hash_flow.rb:695:10:695:19 | ( ... ) |
+| hash_flow.rb:697:11:697:14 | hash [element :f] :  | hash_flow.rb:697:11:697:18 | ...[...] :  |
+| hash_flow.rb:697:11:697:18 | ...[...] :  | hash_flow.rb:697:10:697:19 | ( ... ) |
+| hash_flow.rb:699:11:699:15 | hash1 [element :a] :  | hash_flow.rb:699:11:699:19 | ...[...] :  |
+| hash_flow.rb:699:11:699:19 | ...[...] :  | hash_flow.rb:699:10:699:20 | ( ... ) |
+| hash_flow.rb:701:11:701:15 | hash1 [element :c] :  | hash_flow.rb:701:11:701:19 | ...[...] :  |
+| hash_flow.rb:701:11:701:19 | ...[...] :  | hash_flow.rb:701:10:701:20 | ( ... ) |
+| hash_flow.rb:702:11:702:15 | hash1 [element :d] :  | hash_flow.rb:702:11:702:19 | ...[...] :  |
+| hash_flow.rb:702:11:702:19 | ...[...] :  | hash_flow.rb:702:10:702:20 | ( ... ) |
+| hash_flow.rb:704:11:704:15 | hash1 [element :f] :  | hash_flow.rb:704:11:704:19 | ...[...] :  |
+| hash_flow.rb:704:11:704:19 | ...[...] :  | hash_flow.rb:704:10:704:20 | ( ... ) |
+| hash_flow.rb:711:15:711:25 | call to taint :  | hash_flow.rb:715:9:715:12 | hash [element :a] :  |
+| hash_flow.rb:713:15:713:25 | call to taint :  | hash_flow.rb:715:9:715:12 | hash [element :c] :  |
+| hash_flow.rb:715:9:715:12 | hash [element :a] :  | hash_flow.rb:715:9:715:19 | call to values [element] :  |
+| hash_flow.rb:715:9:715:12 | hash [element :c] :  | hash_flow.rb:715:9:715:19 | call to values [element] :  |
+| hash_flow.rb:715:9:715:19 | call to values [element] :  | hash_flow.rb:716:11:716:11 | a [element] :  |
+| hash_flow.rb:716:11:716:11 | a [element] :  | hash_flow.rb:716:11:716:14 | ...[...] :  |
+| hash_flow.rb:716:11:716:14 | ...[...] :  | hash_flow.rb:716:10:716:15 | ( ... ) |
+| hash_flow.rb:723:15:723:25 | call to taint :  | hash_flow.rb:727:9:727:12 | hash [element :a] :  |
+| hash_flow.rb:723:15:723:25 | call to taint :  | hash_flow.rb:729:9:729:12 | hash [element :a] :  |
+| hash_flow.rb:725:15:725:25 | call to taint :  | hash_flow.rb:729:9:729:12 | hash [element :c] :  |
+| hash_flow.rb:727:9:727:12 | hash [element :a] :  | hash_flow.rb:727:9:727:26 | call to values_at [element 0] :  |
+| hash_flow.rb:727:9:727:26 | call to values_at [element 0] :  | hash_flow.rb:728:10:728:10 | b [element 0] :  |
+| hash_flow.rb:728:10:728:10 | b [element 0] :  | hash_flow.rb:728:10:728:13 | ...[...] |
+| hash_flow.rb:729:9:729:12 | hash [element :a] :  | hash_flow.rb:729:9:729:31 | call to fetch_values [element] :  |
+| hash_flow.rb:729:9:729:12 | hash [element :c] :  | hash_flow.rb:729:9:729:31 | call to fetch_values [element] :  |
+| hash_flow.rb:729:9:729:31 | call to fetch_values [element] :  | hash_flow.rb:730:10:730:10 | b [element] :  |
+| hash_flow.rb:730:10:730:10 | b [element] :  | hash_flow.rb:730:10:730:13 | ...[...] |
+| hash_flow.rb:737:15:737:25 | call to taint :  | hash_flow.rb:746:16:746:20 | hash1 [element :a] :  |
+| hash_flow.rb:739:15:739:25 | call to taint :  | hash_flow.rb:746:16:746:20 | hash1 [element :c] :  |
+| hash_flow.rb:742:15:742:25 | call to taint :  | hash_flow.rb:746:44:746:48 | hash2 [element :d] :  |
+| hash_flow.rb:744:15:744:25 | call to taint :  | hash_flow.rb:746:44:746:48 | hash2 [element :f] :  |
+| hash_flow.rb:746:14:746:20 | ** ... [element :a] :  | hash_flow.rb:747:10:747:13 | hash [element :a] :  |
+| hash_flow.rb:746:14:746:20 | ** ... [element :c] :  | hash_flow.rb:749:10:749:13 | hash [element :c] :  |
+| hash_flow.rb:746:16:746:20 | hash1 [element :a] :  | hash_flow.rb:746:14:746:20 | ** ... [element :a] :  |
+| hash_flow.rb:746:16:746:20 | hash1 [element :c] :  | hash_flow.rb:746:14:746:20 | ** ... [element :c] :  |
+| hash_flow.rb:746:29:746:39 | call to taint :  | hash_flow.rb:753:10:753:13 | hash [element :g] :  |
+| hash_flow.rb:746:42:746:48 | ** ... [element :d] :  | hash_flow.rb:750:10:750:13 | hash [element :d] :  |
+| hash_flow.rb:746:42:746:48 | ** ... [element :f] :  | hash_flow.rb:752:10:752:13 | hash [element :f] :  |
+| hash_flow.rb:746:44:746:48 | hash2 [element :d] :  | hash_flow.rb:746:42:746:48 | ** ... [element :d] :  |
+| hash_flow.rb:746:44:746:48 | hash2 [element :f] :  | hash_flow.rb:746:42:746:48 | ** ... [element :f] :  |
+| hash_flow.rb:747:10:747:13 | hash [element :a] :  | hash_flow.rb:747:10:747:17 | ...[...] |
+| hash_flow.rb:749:10:749:13 | hash [element :c] :  | hash_flow.rb:749:10:749:17 | ...[...] |
+| hash_flow.rb:750:10:750:13 | hash [element :d] :  | hash_flow.rb:750:10:750:17 | ...[...] |
+| hash_flow.rb:752:10:752:13 | hash [element :f] :  | hash_flow.rb:752:10:752:17 | ...[...] |
+| hash_flow.rb:753:10:753:13 | hash [element :g] :  | hash_flow.rb:753:10:753:17 | ...[...] |
 nodes
 | hash_flow.rb:11:15:11:24 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:13:12:13:21 | call to taint :  | semmle.label | call to taint :  |
@@ -590,515 +598,525 @@ nodes
 | hash_flow.rb:68:22:68:31 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:69:10:69:14 | hash4 [element :a] :  | semmle.label | hash4 [element :a] :  |
 | hash_flow.rb:69:10:69:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:76:13:76:42 | call to [] [element :a] :  | semmle.label | call to [] [element :a] :  |
+| hash_flow.rb:72:13:72:45 | ...[...] [element a] :  | semmle.label | ...[...] [element a] :  |
+| hash_flow.rb:72:18:72:34 | Pair [pair a] :  | semmle.label | Pair [pair a] :  |
+| hash_flow.rb:72:25:72:34 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:73:10:73:14 | hash5 [element a] :  | semmle.label | hash5 [element a] :  |
+| hash_flow.rb:73:10:73:19 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:76:13:76:47 | ...[...] [element a] :  | semmle.label | ...[...] [element a] :  |
+| hash_flow.rb:76:19:76:35 | Pair [pair a] :  | semmle.label | Pair [pair a] :  |
 | hash_flow.rb:76:26:76:35 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:77:10:77:14 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
-| hash_flow.rb:77:10:77:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:85:15:85:24 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:88:13:88:34 | call to try_convert [element :a] :  | semmle.label | call to try_convert [element :a] :  |
-| hash_flow.rb:88:30:88:33 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:89:10:89:14 | hash2 [element :a] :  | semmle.label | hash2 [element :a] :  |
-| hash_flow.rb:89:10:89:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:97:21:97:30 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:98:10:98:10 | b | semmle.label | b |
-| hash_flow.rb:105:9:105:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
-| hash_flow.rb:105:9:105:34 | call to store :  | semmle.label | call to store :  |
-| hash_flow.rb:105:24:105:33 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:106:10:106:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:106:10:106:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:107:10:107:10 | b | semmle.label | b |
-| hash_flow.rb:110:9:110:12 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
-| hash_flow.rb:110:9:110:33 | call to store :  | semmle.label | call to store :  |
-| hash_flow.rb:110:23:110:32 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:111:10:111:13 | hash [element] :  | semmle.label | hash [element] :  |
-| hash_flow.rb:111:10:111:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:112:10:112:13 | hash [element] :  | semmle.label | hash [element] :  |
-| hash_flow.rb:112:10:112:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:113:10:113:10 | c | semmle.label | c |
-| hash_flow.rb:120:15:120:24 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:123:5:123:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:123:18:123:29 | key_or_value :  | semmle.label | key_or_value :  |
-| hash_flow.rb:124:14:124:25 | key_or_value | semmle.label | key_or_value |
-| hash_flow.rb:126:5:126:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:126:22:126:26 | value :  | semmle.label | value :  |
-| hash_flow.rb:128:14:128:18 | value | semmle.label | value |
-| hash_flow.rb:136:15:136:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:139:9:139:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:139:9:139:22 | call to assoc [element 1] :  | semmle.label | call to assoc [element 1] :  |
-| hash_flow.rb:141:10:141:10 | b [element 1] :  | semmle.label | b [element 1] :  |
-| hash_flow.rb:141:10:141:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:142:10:142:10 | b [element 1] :  | semmle.label | b [element 1] :  |
-| hash_flow.rb:142:10:142:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:143:9:143:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:143:9:143:21 | call to assoc [element 1] :  | semmle.label | call to assoc [element 1] :  |
-| hash_flow.rb:144:10:144:10 | c [element 1] :  | semmle.label | c [element 1] :  |
-| hash_flow.rb:144:10:144:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:162:15:162:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:165:9:165:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:165:9:165:20 | call to compact [element :a] :  | semmle.label | call to compact [element :a] :  |
-| hash_flow.rb:166:10:166:10 | a [element :a] :  | semmle.label | a [element :a] :  |
-| hash_flow.rb:166:10:166:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:174:15:174:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:177:9:177:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:177:9:177:23 | call to delete :  | semmle.label | call to delete :  |
-| hash_flow.rb:178:10:178:10 | a | semmle.label | a |
-| hash_flow.rb:186:15:186:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:189:9:189:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
-| hash_flow.rb:189:9:189:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:189:9:192:7 | call to delete_if [element :a] :  | semmle.label | call to delete_if [element :a] :  |
-| hash_flow.rb:189:33:189:37 | value :  | semmle.label | value :  |
-| hash_flow.rb:191:14:191:18 | value | semmle.label | value |
-| hash_flow.rb:193:10:193:10 | a [element :a] :  | semmle.label | a [element :a] :  |
-| hash_flow.rb:193:10:193:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:194:10:194:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:194:10:194:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:202:15:202:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:205:19:205:29 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:209:10:209:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:209:10:209:21 | call to dig | semmle.label | call to dig |
-| hash_flow.rb:211:10:211:13 | hash [element :c, element :d] :  | semmle.label | hash [element :c, element :d] :  |
-| hash_flow.rb:211:10:211:24 | call to dig | semmle.label | call to dig |
-| hash_flow.rb:219:15:219:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:222:9:222:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:222:9:225:7 | call to each [element :a] :  | semmle.label | call to each [element :a] :  |
-| hash_flow.rb:222:28:222:32 | value :  | semmle.label | value :  |
-| hash_flow.rb:224:14:224:18 | value | semmle.label | value |
-| hash_flow.rb:226:10:226:10 | x [element :a] :  | semmle.label | x [element :a] :  |
-| hash_flow.rb:226:10:226:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:234:15:234:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:237:9:237:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:237:9:239:7 | call to each_key [element :a] :  | semmle.label | call to each_key [element :a] :  |
-| hash_flow.rb:240:10:240:10 | x [element :a] :  | semmle.label | x [element :a] :  |
-| hash_flow.rb:240:10:240:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:248:15:248:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:251:9:251:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:251:9:254:7 | call to each_pair [element :a] :  | semmle.label | call to each_pair [element :a] :  |
-| hash_flow.rb:251:33:251:37 | value :  | semmle.label | value :  |
-| hash_flow.rb:253:14:253:18 | value | semmle.label | value |
-| hash_flow.rb:255:10:255:10 | x [element :a] :  | semmle.label | x [element :a] :  |
-| hash_flow.rb:255:10:255:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:263:15:263:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:266:9:266:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:266:9:268:7 | call to each_value [element :a] :  | semmle.label | call to each_value [element :a] :  |
-| hash_flow.rb:266:29:266:33 | value :  | semmle.label | value :  |
-| hash_flow.rb:267:14:267:18 | value | semmle.label | value |
-| hash_flow.rb:269:10:269:10 | x [element :a] :  | semmle.label | x [element :a] :  |
-| hash_flow.rb:269:10:269:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:279:15:279:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:282:9:282:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:282:9:282:28 | call to except [element :c] :  | semmle.label | call to except [element :c] :  |
-| hash_flow.rb:285:10:285:10 | x [element :c] :  | semmle.label | x [element :c] :  |
-| hash_flow.rb:285:10:285:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:293:15:293:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:295:15:295:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:297:9:297:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:297:9:297:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:297:9:299:7 | call to fetch :  | semmle.label | call to fetch :  |
-| hash_flow.rb:297:20:297:30 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:297:37:297:37 | x :  | semmle.label | x :  |
-| hash_flow.rb:298:14:298:14 | x | semmle.label | x |
-| hash_flow.rb:300:10:300:10 | b | semmle.label | b |
-| hash_flow.rb:301:9:301:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:301:9:301:22 | call to fetch :  | semmle.label | call to fetch :  |
-| hash_flow.rb:302:10:302:10 | b | semmle.label | b |
-| hash_flow.rb:303:9:303:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:303:9:303:35 | call to fetch :  | semmle.label | call to fetch :  |
-| hash_flow.rb:303:24:303:34 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:304:10:304:10 | b | semmle.label | b |
-| hash_flow.rb:305:9:305:35 | call to fetch :  | semmle.label | call to fetch :  |
-| hash_flow.rb:305:24:305:34 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:306:10:306:10 | b | semmle.label | b |
-| hash_flow.rb:307:9:307:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:307:9:307:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:307:9:307:34 | call to fetch :  | semmle.label | call to fetch :  |
-| hash_flow.rb:307:23:307:33 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:77:10:77:14 | hash6 [element a] :  | semmle.label | hash6 [element a] :  |
+| hash_flow.rb:77:10:77:19 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:84:13:84:42 | call to [] [element :a] :  | semmle.label | call to [] [element :a] :  |
+| hash_flow.rb:84:26:84:35 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:85:10:85:14 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:85:10:85:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:93:15:93:24 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:96:13:96:34 | call to try_convert [element :a] :  | semmle.label | call to try_convert [element :a] :  |
+| hash_flow.rb:96:30:96:33 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:97:10:97:14 | hash2 [element :a] :  | semmle.label | hash2 [element :a] :  |
+| hash_flow.rb:97:10:97:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:105:21:105:30 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:106:10:106:10 | b | semmle.label | b |
+| hash_flow.rb:113:9:113:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
+| hash_flow.rb:113:9:113:34 | call to store :  | semmle.label | call to store :  |
+| hash_flow.rb:113:24:113:33 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:114:10:114:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:114:10:114:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:115:10:115:10 | b | semmle.label | b |
+| hash_flow.rb:118:9:118:12 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
+| hash_flow.rb:118:9:118:33 | call to store :  | semmle.label | call to store :  |
+| hash_flow.rb:118:23:118:32 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:119:10:119:13 | hash [element] :  | semmle.label | hash [element] :  |
+| hash_flow.rb:119:10:119:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:120:10:120:13 | hash [element] :  | semmle.label | hash [element] :  |
+| hash_flow.rb:120:10:120:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:121:10:121:10 | c | semmle.label | c |
+| hash_flow.rb:128:15:128:24 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:131:5:131:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:131:18:131:29 | key_or_value :  | semmle.label | key_or_value :  |
+| hash_flow.rb:132:14:132:25 | key_or_value | semmle.label | key_or_value |
+| hash_flow.rb:134:5:134:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:134:22:134:26 | value :  | semmle.label | value :  |
+| hash_flow.rb:136:14:136:18 | value | semmle.label | value |
+| hash_flow.rb:144:15:144:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:147:9:147:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  | semmle.label | call to assoc [element 1] :  |
+| hash_flow.rb:149:10:149:10 | b [element 1] :  | semmle.label | b [element 1] :  |
+| hash_flow.rb:149:10:149:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:150:10:150:10 | b [element 1] :  | semmle.label | b [element 1] :  |
+| hash_flow.rb:150:10:150:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:151:9:151:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:151:9:151:21 | call to assoc [element 1] :  | semmle.label | call to assoc [element 1] :  |
+| hash_flow.rb:152:10:152:10 | c [element 1] :  | semmle.label | c [element 1] :  |
+| hash_flow.rb:152:10:152:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:170:15:170:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:173:9:173:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:173:9:173:20 | call to compact [element :a] :  | semmle.label | call to compact [element :a] :  |
+| hash_flow.rb:174:10:174:10 | a [element :a] :  | semmle.label | a [element :a] :  |
+| hash_flow.rb:174:10:174:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:182:15:182:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:185:9:185:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:185:9:185:23 | call to delete :  | semmle.label | call to delete :  |
+| hash_flow.rb:186:10:186:10 | a | semmle.label | a |
+| hash_flow.rb:194:15:194:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:197:9:197:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
+| hash_flow.rb:197:9:197:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:197:9:200:7 | call to delete_if [element :a] :  | semmle.label | call to delete_if [element :a] :  |
+| hash_flow.rb:197:33:197:37 | value :  | semmle.label | value :  |
+| hash_flow.rb:199:14:199:18 | value | semmle.label | value |
+| hash_flow.rb:201:10:201:10 | a [element :a] :  | semmle.label | a [element :a] :  |
+| hash_flow.rb:201:10:201:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:202:10:202:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:202:10:202:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:210:15:210:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:213:19:213:29 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:217:10:217:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:217:10:217:21 | call to dig | semmle.label | call to dig |
+| hash_flow.rb:219:10:219:13 | hash [element :c, element :d] :  | semmle.label | hash [element :c, element :d] :  |
+| hash_flow.rb:219:10:219:24 | call to dig | semmle.label | call to dig |
+| hash_flow.rb:227:15:227:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:230:9:230:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:230:9:233:7 | call to each [element :a] :  | semmle.label | call to each [element :a] :  |
+| hash_flow.rb:230:28:230:32 | value :  | semmle.label | value :  |
+| hash_flow.rb:232:14:232:18 | value | semmle.label | value |
+| hash_flow.rb:234:10:234:10 | x [element :a] :  | semmle.label | x [element :a] :  |
+| hash_flow.rb:234:10:234:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:242:15:242:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:245:9:245:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:245:9:247:7 | call to each_key [element :a] :  | semmle.label | call to each_key [element :a] :  |
+| hash_flow.rb:248:10:248:10 | x [element :a] :  | semmle.label | x [element :a] :  |
+| hash_flow.rb:248:10:248:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:256:15:256:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:259:9:259:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:259:9:262:7 | call to each_pair [element :a] :  | semmle.label | call to each_pair [element :a] :  |
+| hash_flow.rb:259:33:259:37 | value :  | semmle.label | value :  |
+| hash_flow.rb:261:14:261:18 | value | semmle.label | value |
+| hash_flow.rb:263:10:263:10 | x [element :a] :  | semmle.label | x [element :a] :  |
+| hash_flow.rb:263:10:263:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:271:15:271:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:274:9:274:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:274:9:276:7 | call to each_value [element :a] :  | semmle.label | call to each_value [element :a] :  |
+| hash_flow.rb:274:29:274:33 | value :  | semmle.label | value :  |
+| hash_flow.rb:275:14:275:18 | value | semmle.label | value |
+| hash_flow.rb:277:10:277:10 | x [element :a] :  | semmle.label | x [element :a] :  |
+| hash_flow.rb:277:10:277:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:287:15:287:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:290:9:290:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:290:9:290:28 | call to except [element :c] :  | semmle.label | call to except [element :c] :  |
+| hash_flow.rb:293:10:293:10 | x [element :c] :  | semmle.label | x [element :c] :  |
+| hash_flow.rb:293:10:293:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:301:15:301:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:303:15:303:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:305:9:305:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:305:9:305:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:305:9:307:7 | call to fetch :  | semmle.label | call to fetch :  |
+| hash_flow.rb:305:20:305:30 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:305:37:305:37 | x :  | semmle.label | x :  |
+| hash_flow.rb:306:14:306:14 | x | semmle.label | x |
 | hash_flow.rb:308:10:308:10 | b | semmle.label | b |
-| hash_flow.rb:315:15:315:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:317:15:317:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:319:9:319:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:319:9:319:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:319:9:322:7 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
-| hash_flow.rb:319:27:319:37 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:319:44:319:44 | x :  | semmle.label | x :  |
-| hash_flow.rb:320:14:320:14 | x | semmle.label | x |
-| hash_flow.rb:321:9:321:19 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:323:10:323:10 | b [element] :  | semmle.label | b [element] :  |
-| hash_flow.rb:323:10:323:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:324:9:324:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:324:9:324:29 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
-| hash_flow.rb:325:10:325:10 | b [element] :  | semmle.label | b [element] :  |
-| hash_flow.rb:325:10:325:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:326:9:326:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:326:9:326:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:326:9:326:31 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
-| hash_flow.rb:327:10:327:10 | b [element] :  | semmle.label | b [element] :  |
-| hash_flow.rb:327:10:327:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:334:15:334:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:336:15:336:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:338:9:338:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:338:9:338:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:338:9:342:7 | call to filter [element :a] :  | semmle.label | call to filter [element :a] :  |
-| hash_flow.rb:338:30:338:34 | value :  | semmle.label | value :  |
-| hash_flow.rb:340:14:340:18 | value | semmle.label | value |
-| hash_flow.rb:343:10:343:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:343:11:343:11 | b [element :a] :  | semmle.label | b [element :a] :  |
-| hash_flow.rb:343:11:343:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:350:15:350:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:352:15:352:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:354:5:354:8 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
-| hash_flow.rb:354:5:354:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:354:5:354:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:354:27:354:31 | value :  | semmle.label | value :  |
-| hash_flow.rb:356:14:356:18 | value | semmle.label | value |
-| hash_flow.rb:359:10:359:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:359:11:359:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:359:11:359:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:366:15:366:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:368:15:368:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:370:9:370:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:370:9:370:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:370:9:370:20 | call to flatten [element] :  | semmle.label | call to flatten [element] :  |
-| hash_flow.rb:371:10:371:15 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:371:11:371:11 | b [element] :  | semmle.label | b [element] :  |
-| hash_flow.rb:371:11:371:14 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:378:15:378:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:380:15:380:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:382:9:382:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
-| hash_flow.rb:382:9:382:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:382:9:382:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:382:9:386:7 | call to keep_if [element :a] :  | semmle.label | call to keep_if [element :a] :  |
-| hash_flow.rb:382:31:382:35 | value :  | semmle.label | value :  |
-| hash_flow.rb:384:14:384:18 | value | semmle.label | value |
-| hash_flow.rb:387:10:387:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:387:11:387:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:387:11:387:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:388:10:388:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:388:11:388:11 | b [element :a] :  | semmle.label | b [element :a] :  |
-| hash_flow.rb:388:11:388:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:395:15:395:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:397:15:397:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:400:15:400:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:402:15:402:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:404:12:404:16 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
-| hash_flow.rb:404:12:404:16 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
-| hash_flow.rb:404:12:408:7 | call to merge [element :a] :  | semmle.label | call to merge [element :a] :  |
-| hash_flow.rb:404:12:408:7 | call to merge [element :c] :  | semmle.label | call to merge [element :c] :  |
-| hash_flow.rb:404:12:408:7 | call to merge [element :d] :  | semmle.label | call to merge [element :d] :  |
-| hash_flow.rb:404:12:408:7 | call to merge [element :f] :  | semmle.label | call to merge [element :f] :  |
-| hash_flow.rb:404:24:404:28 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
-| hash_flow.rb:404:24:404:28 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
-| hash_flow.rb:404:40:404:48 | old_value :  | semmle.label | old_value :  |
-| hash_flow.rb:404:51:404:59 | new_value :  | semmle.label | new_value :  |
-| hash_flow.rb:406:14:406:22 | old_value | semmle.label | old_value |
-| hash_flow.rb:407:14:407:22 | new_value | semmle.label | new_value |
-| hash_flow.rb:409:10:409:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:409:11:409:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:409:11:409:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:411:10:411:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:411:11:411:14 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:411:11:411:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:412:10:412:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:412:11:412:14 | hash [element :d] :  | semmle.label | hash [element :d] :  |
-| hash_flow.rb:412:11:412:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:414:10:414:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:414:11:414:14 | hash [element :f] :  | semmle.label | hash [element :f] :  |
-| hash_flow.rb:414:11:414:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:421:15:421:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:423:15:423:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:426:15:426:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:428:15:428:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:430:12:430:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
-| hash_flow.rb:430:12:430:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
-| hash_flow.rb:430:12:430:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
-| hash_flow.rb:430:12:430:16 | [post] hash1 [element :f] :  | semmle.label | [post] hash1 [element :f] :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
-| hash_flow.rb:430:12:430:16 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
-| hash_flow.rb:430:12:434:7 | call to merge! [element :a] :  | semmle.label | call to merge! [element :a] :  |
-| hash_flow.rb:430:12:434:7 | call to merge! [element :c] :  | semmle.label | call to merge! [element :c] :  |
-| hash_flow.rb:430:12:434:7 | call to merge! [element :d] :  | semmle.label | call to merge! [element :d] :  |
-| hash_flow.rb:430:12:434:7 | call to merge! [element :f] :  | semmle.label | call to merge! [element :f] :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
-| hash_flow.rb:430:25:430:29 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
-| hash_flow.rb:430:41:430:49 | old_value :  | semmle.label | old_value :  |
-| hash_flow.rb:430:52:430:60 | new_value :  | semmle.label | new_value :  |
-| hash_flow.rb:432:14:432:22 | old_value | semmle.label | old_value |
-| hash_flow.rb:433:14:433:22 | new_value | semmle.label | new_value |
-| hash_flow.rb:435:10:435:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:435:11:435:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:435:11:435:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:437:10:437:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:437:11:437:14 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:437:11:437:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:438:10:438:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:438:11:438:14 | hash [element :d] :  | semmle.label | hash [element :d] :  |
-| hash_flow.rb:438:11:438:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:440:10:440:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:440:11:440:14 | hash [element :f] :  | semmle.label | hash [element :f] :  |
-| hash_flow.rb:440:11:440:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:442:10:442:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:442:11:442:15 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
-| hash_flow.rb:442:11:442:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:444:10:444:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:444:11:444:15 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
-| hash_flow.rb:444:11:444:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:445:10:445:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:445:11:445:15 | hash1 [element :d] :  | semmle.label | hash1 [element :d] :  |
-| hash_flow.rb:445:11:445:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:447:10:447:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:447:11:447:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
-| hash_flow.rb:447:11:447:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:454:15:454:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:457:9:457:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:457:9:457:22 | call to rassoc [element 1] :  | semmle.label | call to rassoc [element 1] :  |
-| hash_flow.rb:459:10:459:10 | b [element 1] :  | semmle.label | b [element 1] :  |
-| hash_flow.rb:459:10:459:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:466:15:466:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:469:9:469:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:469:9:473:7 | call to reject [element :a] :  | semmle.label | call to reject [element :a] :  |
-| hash_flow.rb:469:29:469:33 | value :  | semmle.label | value :  |
-| hash_flow.rb:471:14:471:18 | value | semmle.label | value |
-| hash_flow.rb:474:10:474:10 | b [element :a] :  | semmle.label | b [element :a] :  |
-| hash_flow.rb:474:10:474:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:481:15:481:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:484:9:484:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
-| hash_flow.rb:484:9:484:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:484:9:488:7 | call to reject! [element :a] :  | semmle.label | call to reject! [element :a] :  |
-| hash_flow.rb:484:30:484:34 | value :  | semmle.label | value :  |
-| hash_flow.rb:486:14:486:18 | value | semmle.label | value |
-| hash_flow.rb:489:10:489:10 | b [element :a] :  | semmle.label | b [element :a] :  |
-| hash_flow.rb:489:10:489:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:490:10:490:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:490:10:490:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:497:15:497:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:499:15:499:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:504:5:504:9 | [post] hash2 [element :a] :  | semmle.label | [post] hash2 [element :a] :  |
-| hash_flow.rb:504:5:504:9 | [post] hash2 [element :c] :  | semmle.label | [post] hash2 [element :c] :  |
-| hash_flow.rb:504:19:504:22 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:504:19:504:22 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:505:10:505:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:505:11:505:15 | hash2 [element :a] :  | semmle.label | hash2 [element :a] :  |
-| hash_flow.rb:505:11:505:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:507:10:507:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:507:11:507:15 | hash2 [element :c] :  | semmle.label | hash2 [element :c] :  |
-| hash_flow.rb:507:11:507:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:512:15:512:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:514:15:514:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:516:9:516:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:516:9:516:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:516:9:520:7 | call to select [element :a] :  | semmle.label | call to select [element :a] :  |
-| hash_flow.rb:516:30:516:34 | value :  | semmle.label | value :  |
-| hash_flow.rb:518:14:518:18 | value | semmle.label | value |
-| hash_flow.rb:521:10:521:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:521:11:521:11 | b [element :a] :  | semmle.label | b [element :a] :  |
-| hash_flow.rb:521:11:521:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:528:15:528:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:530:15:530:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:532:5:532:8 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
-| hash_flow.rb:532:5:532:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:532:5:532:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:532:27:532:31 | value :  | semmle.label | value :  |
-| hash_flow.rb:534:14:534:18 | value | semmle.label | value |
-| hash_flow.rb:537:10:537:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:537:11:537:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:537:11:537:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:544:15:544:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:546:15:546:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:548:9:548:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
-| hash_flow.rb:548:9:548:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:548:9:548:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:548:9:548:18 | call to shift [element 1] :  | semmle.label | call to shift [element 1] :  |
-| hash_flow.rb:549:10:549:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:549:11:549:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:549:11:549:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:551:10:551:15 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:551:11:551:11 | b [element 1] :  | semmle.label | b [element 1] :  |
-| hash_flow.rb:551:11:551:14 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:558:15:558:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:560:15:560:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:562:9:562:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:562:9:562:26 | call to slice [element :a] :  | semmle.label | call to slice [element :a] :  |
-| hash_flow.rb:563:10:563:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:563:11:563:11 | b [element :a] :  | semmle.label | b [element :a] :  |
-| hash_flow.rb:563:11:563:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:567:9:567:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:567:9:567:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:567:9:567:25 | call to slice [element :a] :  | semmle.label | call to slice [element :a] :  |
-| hash_flow.rb:567:9:567:25 | call to slice [element :c] :  | semmle.label | call to slice [element :c] :  |
-| hash_flow.rb:568:10:568:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:568:11:568:11 | c [element :a] :  | semmle.label | c [element :a] :  |
-| hash_flow.rb:568:11:568:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:570:10:570:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:570:11:570:11 | c [element :c] :  | semmle.label | c [element :c] :  |
-| hash_flow.rb:570:11:570:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:577:15:577:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:579:15:579:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:581:9:581:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:581:9:581:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:581:9:581:17 | call to to_a [element, element 1] :  | semmle.label | call to to_a [element, element 1] :  |
-| hash_flow.rb:583:10:583:18 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:583:11:583:11 | a [element, element 1] :  | semmle.label | a [element, element 1] :  |
-| hash_flow.rb:583:11:583:14 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
-| hash_flow.rb:583:11:583:17 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:590:15:590:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:592:15:592:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:594:9:594:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:594:9:594:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:594:9:594:17 | call to to_h [element :a] :  | semmle.label | call to to_h [element :a] :  |
-| hash_flow.rb:594:9:594:17 | call to to_h [element :c] :  | semmle.label | call to to_h [element :c] :  |
-| hash_flow.rb:595:10:595:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:595:11:595:11 | a [element :a] :  | semmle.label | a [element :a] :  |
-| hash_flow.rb:595:11:595:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:597:10:597:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:597:11:597:11 | a [element :c] :  | semmle.label | a [element :c] :  |
-| hash_flow.rb:597:11:597:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:599:9:599:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:599:9:599:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:599:9:603:7 | call to to_h [element] :  | semmle.label | call to to_h [element] :  |
-| hash_flow.rb:599:28:599:32 | value :  | semmle.label | value :  |
-| hash_flow.rb:601:14:601:18 | value | semmle.label | value |
-| hash_flow.rb:602:14:602:24 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:604:10:604:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:604:11:604:11 | b [element] :  | semmle.label | b [element] :  |
-| hash_flow.rb:604:11:604:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:611:15:611:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:613:15:613:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:615:9:615:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:615:9:615:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:615:9:615:45 | call to transform_keys [element] :  | semmle.label | call to transform_keys [element] :  |
-| hash_flow.rb:616:10:616:17 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:616:11:616:11 | a [element] :  | semmle.label | a [element] :  |
-| hash_flow.rb:616:11:616:16 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:617:10:617:17 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:617:11:617:11 | a [element] :  | semmle.label | a [element] :  |
-| hash_flow.rb:617:11:617:16 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:618:10:618:17 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:618:11:618:11 | a [element] :  | semmle.label | a [element] :  |
-| hash_flow.rb:618:11:618:16 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:625:15:625:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:627:15:627:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:629:5:629:8 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
-| hash_flow.rb:629:5:629:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:629:5:629:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:630:10:630:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:630:11:630:14 | hash [element] :  | semmle.label | hash [element] :  |
-| hash_flow.rb:630:11:630:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:631:10:631:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:631:11:631:14 | hash [element] :  | semmle.label | hash [element] :  |
-| hash_flow.rb:631:11:631:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:632:10:632:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:632:11:632:14 | hash [element] :  | semmle.label | hash [element] :  |
-| hash_flow.rb:632:11:632:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:639:15:639:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:641:15:641:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:643:9:643:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:643:9:643:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:643:9:646:7 | call to transform_values [element] :  | semmle.label | call to transform_values [element] :  |
-| hash_flow.rb:643:35:643:39 | value :  | semmle.label | value :  |
-| hash_flow.rb:644:14:644:18 | value | semmle.label | value |
-| hash_flow.rb:645:9:645:19 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:647:10:647:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:647:11:647:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:647:11:647:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:648:10:648:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:648:11:648:11 | b [element] :  | semmle.label | b [element] :  |
-| hash_flow.rb:648:11:648:15 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:655:15:655:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:657:15:657:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:659:5:659:8 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
-| hash_flow.rb:659:5:659:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:659:5:659:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:659:32:659:36 | value :  | semmle.label | value :  |
-| hash_flow.rb:660:14:660:18 | value | semmle.label | value |
-| hash_flow.rb:661:9:661:19 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:663:10:663:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:663:11:663:14 | hash [element] :  | semmle.label | hash [element] :  |
-| hash_flow.rb:663:11:663:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:670:15:670:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:672:15:672:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:675:15:675:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:677:15:677:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:679:12:679:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
-| hash_flow.rb:679:12:679:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
-| hash_flow.rb:679:12:679:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
-| hash_flow.rb:679:12:679:16 | [post] hash1 [element :f] :  | semmle.label | [post] hash1 [element :f] :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
-| hash_flow.rb:679:12:679:16 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
-| hash_flow.rb:679:12:683:7 | call to update [element :a] :  | semmle.label | call to update [element :a] :  |
-| hash_flow.rb:679:12:683:7 | call to update [element :c] :  | semmle.label | call to update [element :c] :  |
-| hash_flow.rb:679:12:683:7 | call to update [element :d] :  | semmle.label | call to update [element :d] :  |
-| hash_flow.rb:679:12:683:7 | call to update [element :f] :  | semmle.label | call to update [element :f] :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
-| hash_flow.rb:679:25:679:29 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
-| hash_flow.rb:679:41:679:49 | old_value :  | semmle.label | old_value :  |
-| hash_flow.rb:679:52:679:60 | new_value :  | semmle.label | new_value :  |
-| hash_flow.rb:681:14:681:22 | old_value | semmle.label | old_value |
-| hash_flow.rb:682:14:682:22 | new_value | semmle.label | new_value |
-| hash_flow.rb:684:10:684:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:684:11:684:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:684:11:684:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:686:10:686:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:686:11:686:14 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:686:11:686:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:687:10:687:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:687:11:687:14 | hash [element :d] :  | semmle.label | hash [element :d] :  |
-| hash_flow.rb:687:11:687:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:689:10:689:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:689:11:689:14 | hash [element :f] :  | semmle.label | hash [element :f] :  |
-| hash_flow.rb:689:11:689:18 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:691:10:691:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:691:11:691:15 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
-| hash_flow.rb:691:11:691:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:693:10:693:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:693:11:693:15 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
-| hash_flow.rb:693:11:693:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:694:10:694:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:694:11:694:15 | hash1 [element :d] :  | semmle.label | hash1 [element :d] :  |
-| hash_flow.rb:694:11:694:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:696:10:696:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:696:11:696:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
-| hash_flow.rb:696:11:696:19 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:703:15:703:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:705:15:705:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:707:9:707:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:707:9:707:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:707:9:707:19 | call to values [element] :  | semmle.label | call to values [element] :  |
-| hash_flow.rb:708:10:708:15 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:708:11:708:11 | a [element] :  | semmle.label | a [element] :  |
-| hash_flow.rb:708:11:708:14 | ...[...] :  | semmle.label | ...[...] :  |
-| hash_flow.rb:715:15:715:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:717:15:717:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:719:9:719:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:719:9:719:26 | call to values_at [element 0] :  | semmle.label | call to values_at [element 0] :  |
-| hash_flow.rb:720:10:720:10 | b [element 0] :  | semmle.label | b [element 0] :  |
-| hash_flow.rb:720:10:720:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:721:9:721:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:721:9:721:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:721:9:721:31 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
-| hash_flow.rb:722:10:722:10 | b [element] :  | semmle.label | b [element] :  |
-| hash_flow.rb:722:10:722:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:729:15:729:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:731:15:731:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:734:15:734:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:736:15:736:25 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:738:14:738:20 | ** ... [element :a] :  | semmle.label | ** ... [element :a] :  |
-| hash_flow.rb:738:14:738:20 | ** ... [element :c] :  | semmle.label | ** ... [element :c] :  |
-| hash_flow.rb:738:16:738:20 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
-| hash_flow.rb:738:16:738:20 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
-| hash_flow.rb:738:29:738:39 | call to taint :  | semmle.label | call to taint :  |
-| hash_flow.rb:738:42:738:48 | ** ... [element :d] :  | semmle.label | ** ... [element :d] :  |
-| hash_flow.rb:738:42:738:48 | ** ... [element :f] :  | semmle.label | ** ... [element :f] :  |
-| hash_flow.rb:738:44:738:48 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
-| hash_flow.rb:738:44:738:48 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
-| hash_flow.rb:739:10:739:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
-| hash_flow.rb:739:10:739:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:741:10:741:13 | hash [element :c] :  | semmle.label | hash [element :c] :  |
-| hash_flow.rb:741:10:741:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:742:10:742:13 | hash [element :d] :  | semmle.label | hash [element :d] :  |
-| hash_flow.rb:742:10:742:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:744:10:744:13 | hash [element :f] :  | semmle.label | hash [element :f] :  |
-| hash_flow.rb:744:10:744:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:745:10:745:13 | hash [element :g] :  | semmle.label | hash [element :g] :  |
-| hash_flow.rb:745:10:745:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:309:9:309:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:309:9:309:22 | call to fetch :  | semmle.label | call to fetch :  |
+| hash_flow.rb:310:10:310:10 | b | semmle.label | b |
+| hash_flow.rb:311:9:311:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:311:9:311:35 | call to fetch :  | semmle.label | call to fetch :  |
+| hash_flow.rb:311:24:311:34 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:312:10:312:10 | b | semmle.label | b |
+| hash_flow.rb:313:9:313:35 | call to fetch :  | semmle.label | call to fetch :  |
+| hash_flow.rb:313:24:313:34 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:314:10:314:10 | b | semmle.label | b |
+| hash_flow.rb:315:9:315:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:315:9:315:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:315:9:315:34 | call to fetch :  | semmle.label | call to fetch :  |
+| hash_flow.rb:315:23:315:33 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:316:10:316:10 | b | semmle.label | b |
+| hash_flow.rb:323:15:323:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:325:15:325:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:327:9:327:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:327:9:327:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
+| hash_flow.rb:327:27:327:37 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:327:44:327:44 | x :  | semmle.label | x :  |
+| hash_flow.rb:328:14:328:14 | x | semmle.label | x |
+| hash_flow.rb:329:9:329:19 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:331:10:331:10 | b [element] :  | semmle.label | b [element] :  |
+| hash_flow.rb:331:10:331:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:332:9:332:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:332:9:332:29 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
+| hash_flow.rb:333:10:333:10 | b [element] :  | semmle.label | b [element] :  |
+| hash_flow.rb:333:10:333:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:334:9:334:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:334:9:334:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
+| hash_flow.rb:335:10:335:10 | b [element] :  | semmle.label | b [element] :  |
+| hash_flow.rb:335:10:335:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:342:15:342:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:344:15:344:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:346:9:346:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:346:9:346:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:346:9:350:7 | call to filter [element :a] :  | semmle.label | call to filter [element :a] :  |
+| hash_flow.rb:346:30:346:34 | value :  | semmle.label | value :  |
+| hash_flow.rb:348:14:348:18 | value | semmle.label | value |
+| hash_flow.rb:351:10:351:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:351:11:351:11 | b [element :a] :  | semmle.label | b [element :a] :  |
+| hash_flow.rb:351:11:351:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:358:15:358:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:360:15:360:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:362:5:362:8 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
+| hash_flow.rb:362:5:362:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:362:5:362:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:362:27:362:31 | value :  | semmle.label | value :  |
+| hash_flow.rb:364:14:364:18 | value | semmle.label | value |
+| hash_flow.rb:367:10:367:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:367:11:367:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:367:11:367:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:374:15:374:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:376:15:376:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:378:9:378:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:378:9:378:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:378:9:378:20 | call to flatten [element] :  | semmle.label | call to flatten [element] :  |
+| hash_flow.rb:379:10:379:15 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:379:11:379:11 | b [element] :  | semmle.label | b [element] :  |
+| hash_flow.rb:379:11:379:14 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:386:15:386:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:388:15:388:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:390:9:390:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
+| hash_flow.rb:390:9:390:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:390:9:390:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:390:9:394:7 | call to keep_if [element :a] :  | semmle.label | call to keep_if [element :a] :  |
+| hash_flow.rb:390:31:390:35 | value :  | semmle.label | value :  |
+| hash_flow.rb:392:14:392:18 | value | semmle.label | value |
+| hash_flow.rb:395:10:395:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:395:11:395:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:395:11:395:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:396:10:396:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:396:11:396:11 | b [element :a] :  | semmle.label | b [element :a] :  |
+| hash_flow.rb:396:11:396:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:403:15:403:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:405:15:405:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:408:15:408:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:410:15:410:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:412:12:412:16 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:412:12:412:16 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :a] :  | semmle.label | call to merge [element :a] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :c] :  | semmle.label | call to merge [element :c] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :d] :  | semmle.label | call to merge [element :d] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :f] :  | semmle.label | call to merge [element :f] :  |
+| hash_flow.rb:412:24:412:28 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:412:24:412:28 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
+| hash_flow.rb:412:40:412:48 | old_value :  | semmle.label | old_value :  |
+| hash_flow.rb:412:51:412:59 | new_value :  | semmle.label | new_value :  |
+| hash_flow.rb:414:14:414:22 | old_value | semmle.label | old_value |
+| hash_flow.rb:415:14:415:22 | new_value | semmle.label | new_value |
+| hash_flow.rb:417:10:417:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:417:11:417:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:417:11:417:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:419:10:419:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:419:11:419:14 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:419:11:419:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:420:10:420:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:420:11:420:14 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:420:11:420:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:422:10:422:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:422:11:422:14 | hash [element :f] :  | semmle.label | hash [element :f] :  |
+| hash_flow.rb:422:11:422:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:429:15:429:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:431:15:431:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:434:15:434:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:436:15:436:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 [element :f] :  | semmle.label | [post] hash1 [element :f] :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:438:12:438:16 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :a] :  | semmle.label | call to merge! [element :a] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :c] :  | semmle.label | call to merge! [element :c] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :d] :  | semmle.label | call to merge! [element :d] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :f] :  | semmle.label | call to merge! [element :f] :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:438:25:438:29 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
+| hash_flow.rb:438:41:438:49 | old_value :  | semmle.label | old_value :  |
+| hash_flow.rb:438:52:438:60 | new_value :  | semmle.label | new_value :  |
+| hash_flow.rb:440:14:440:22 | old_value | semmle.label | old_value |
+| hash_flow.rb:441:14:441:22 | new_value | semmle.label | new_value |
+| hash_flow.rb:443:10:443:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:443:11:443:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:443:11:443:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:445:10:445:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:445:11:445:14 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:445:11:445:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:446:10:446:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:446:11:446:14 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:446:11:446:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:448:10:448:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:448:11:448:14 | hash [element :f] :  | semmle.label | hash [element :f] :  |
+| hash_flow.rb:448:11:448:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:450:10:450:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:450:11:450:15 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:450:11:450:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:452:10:452:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:452:11:452:15 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
+| hash_flow.rb:452:11:452:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:453:10:453:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:453:11:453:15 | hash1 [element :d] :  | semmle.label | hash1 [element :d] :  |
+| hash_flow.rb:453:11:453:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:455:10:455:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:455:11:455:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
+| hash_flow.rb:455:11:455:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:462:15:462:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:465:9:465:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:465:9:465:22 | call to rassoc [element 1] :  | semmle.label | call to rassoc [element 1] :  |
+| hash_flow.rb:467:10:467:10 | b [element 1] :  | semmle.label | b [element 1] :  |
+| hash_flow.rb:467:10:467:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:474:15:474:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:477:9:477:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:477:9:481:7 | call to reject [element :a] :  | semmle.label | call to reject [element :a] :  |
+| hash_flow.rb:477:29:477:33 | value :  | semmle.label | value :  |
+| hash_flow.rb:479:14:479:18 | value | semmle.label | value |
+| hash_flow.rb:482:10:482:10 | b [element :a] :  | semmle.label | b [element :a] :  |
+| hash_flow.rb:482:10:482:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:489:15:489:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:492:9:492:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
+| hash_flow.rb:492:9:492:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:492:9:496:7 | call to reject! [element :a] :  | semmle.label | call to reject! [element :a] :  |
+| hash_flow.rb:492:30:492:34 | value :  | semmle.label | value :  |
+| hash_flow.rb:494:14:494:18 | value | semmle.label | value |
+| hash_flow.rb:497:10:497:10 | b [element :a] :  | semmle.label | b [element :a] :  |
+| hash_flow.rb:497:10:497:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:498:10:498:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:498:10:498:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:505:15:505:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:507:15:507:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] :  | semmle.label | [post] hash2 [element :a] :  |
+| hash_flow.rb:512:5:512:9 | [post] hash2 [element :c] :  | semmle.label | [post] hash2 [element :c] :  |
+| hash_flow.rb:512:19:512:22 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:512:19:512:22 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:513:10:513:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:513:11:513:15 | hash2 [element :a] :  | semmle.label | hash2 [element :a] :  |
+| hash_flow.rb:513:11:513:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:515:10:515:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:515:11:515:15 | hash2 [element :c] :  | semmle.label | hash2 [element :c] :  |
+| hash_flow.rb:515:11:515:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:520:15:520:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:522:15:522:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:524:9:524:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:524:9:524:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:524:9:528:7 | call to select [element :a] :  | semmle.label | call to select [element :a] :  |
+| hash_flow.rb:524:30:524:34 | value :  | semmle.label | value :  |
+| hash_flow.rb:526:14:526:18 | value | semmle.label | value |
+| hash_flow.rb:529:10:529:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:529:11:529:11 | b [element :a] :  | semmle.label | b [element :a] :  |
+| hash_flow.rb:529:11:529:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:536:15:536:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:538:15:538:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:540:5:540:8 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
+| hash_flow.rb:540:5:540:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:540:5:540:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:540:27:540:31 | value :  | semmle.label | value :  |
+| hash_flow.rb:542:14:542:18 | value | semmle.label | value |
+| hash_flow.rb:545:10:545:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:545:11:545:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:545:11:545:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:552:15:552:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:554:15:554:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:556:9:556:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
+| hash_flow.rb:556:9:556:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:556:9:556:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:556:9:556:18 | call to shift [element 1] :  | semmle.label | call to shift [element 1] :  |
+| hash_flow.rb:557:10:557:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:557:11:557:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:557:11:557:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:559:10:559:15 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:559:11:559:11 | b [element 1] :  | semmle.label | b [element 1] :  |
+| hash_flow.rb:559:11:559:14 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:566:15:566:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:568:15:568:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:570:9:570:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:570:9:570:26 | call to slice [element :a] :  | semmle.label | call to slice [element :a] :  |
+| hash_flow.rb:571:10:571:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:571:11:571:11 | b [element :a] :  | semmle.label | b [element :a] :  |
+| hash_flow.rb:571:11:571:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:575:9:575:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:575:9:575:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:575:9:575:25 | call to slice [element :a] :  | semmle.label | call to slice [element :a] :  |
+| hash_flow.rb:575:9:575:25 | call to slice [element :c] :  | semmle.label | call to slice [element :c] :  |
+| hash_flow.rb:576:10:576:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:576:11:576:11 | c [element :a] :  | semmle.label | c [element :a] :  |
+| hash_flow.rb:576:11:576:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:578:10:578:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:578:11:578:11 | c [element :c] :  | semmle.label | c [element :c] :  |
+| hash_flow.rb:578:11:578:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:585:15:585:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:587:15:587:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:589:9:589:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:589:9:589:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  | semmle.label | call to to_a [element, element 1] :  |
+| hash_flow.rb:591:10:591:18 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:591:11:591:11 | a [element, element 1] :  | semmle.label | a [element, element 1] :  |
+| hash_flow.rb:591:11:591:14 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
+| hash_flow.rb:591:11:591:17 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:598:15:598:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:600:15:600:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:602:9:602:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:602:9:602:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:602:9:602:17 | call to to_h [element :a] :  | semmle.label | call to to_h [element :a] :  |
+| hash_flow.rb:602:9:602:17 | call to to_h [element :c] :  | semmle.label | call to to_h [element :c] :  |
+| hash_flow.rb:603:10:603:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:603:11:603:11 | a [element :a] :  | semmle.label | a [element :a] :  |
+| hash_flow.rb:603:11:603:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:605:10:605:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:605:11:605:11 | a [element :c] :  | semmle.label | a [element :c] :  |
+| hash_flow.rb:605:11:605:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:607:9:607:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:607:9:607:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:607:9:611:7 | call to to_h [element] :  | semmle.label | call to to_h [element] :  |
+| hash_flow.rb:607:28:607:32 | value :  | semmle.label | value :  |
+| hash_flow.rb:609:14:609:18 | value | semmle.label | value |
+| hash_flow.rb:610:14:610:24 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:612:10:612:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:612:11:612:11 | b [element] :  | semmle.label | b [element] :  |
+| hash_flow.rb:612:11:612:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:619:15:619:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:621:15:621:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:623:9:623:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:623:9:623:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | semmle.label | call to transform_keys [element] :  |
+| hash_flow.rb:624:10:624:17 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:624:11:624:11 | a [element] :  | semmle.label | a [element] :  |
+| hash_flow.rb:624:11:624:16 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:625:10:625:17 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:625:11:625:11 | a [element] :  | semmle.label | a [element] :  |
+| hash_flow.rb:625:11:625:16 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:626:10:626:17 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:626:11:626:11 | a [element] :  | semmle.label | a [element] :  |
+| hash_flow.rb:626:11:626:16 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:633:15:633:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:635:15:635:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:637:5:637:8 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
+| hash_flow.rb:637:5:637:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:637:5:637:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:638:10:638:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:638:11:638:14 | hash [element] :  | semmle.label | hash [element] :  |
+| hash_flow.rb:638:11:638:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:639:10:639:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:639:11:639:14 | hash [element] :  | semmle.label | hash [element] :  |
+| hash_flow.rb:639:11:639:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:640:10:640:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:640:11:640:14 | hash [element] :  | semmle.label | hash [element] :  |
+| hash_flow.rb:640:11:640:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:647:15:647:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:649:15:649:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:651:9:651:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:651:9:651:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:651:9:654:7 | call to transform_values [element] :  | semmle.label | call to transform_values [element] :  |
+| hash_flow.rb:651:35:651:39 | value :  | semmle.label | value :  |
+| hash_flow.rb:652:14:652:18 | value | semmle.label | value |
+| hash_flow.rb:653:9:653:19 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:655:10:655:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:655:11:655:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:655:11:655:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:656:10:656:16 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:656:11:656:11 | b [element] :  | semmle.label | b [element] :  |
+| hash_flow.rb:656:11:656:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:663:15:663:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:665:15:665:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:667:5:667:8 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
+| hash_flow.rb:667:5:667:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:667:5:667:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:667:32:667:36 | value :  | semmle.label | value :  |
+| hash_flow.rb:668:14:668:18 | value | semmle.label | value |
+| hash_flow.rb:669:9:669:19 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:671:10:671:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:671:11:671:14 | hash [element] :  | semmle.label | hash [element] :  |
+| hash_flow.rb:671:11:671:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:678:15:678:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:680:15:680:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:683:15:683:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:685:15:685:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:687:12:687:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
+| hash_flow.rb:687:12:687:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
+| hash_flow.rb:687:12:687:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
+| hash_flow.rb:687:12:687:16 | [post] hash1 [element :f] :  | semmle.label | [post] hash1 [element :f] :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:687:12:687:16 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
+| hash_flow.rb:687:12:691:7 | call to update [element :a] :  | semmle.label | call to update [element :a] :  |
+| hash_flow.rb:687:12:691:7 | call to update [element :c] :  | semmle.label | call to update [element :c] :  |
+| hash_flow.rb:687:12:691:7 | call to update [element :d] :  | semmle.label | call to update [element :d] :  |
+| hash_flow.rb:687:12:691:7 | call to update [element :f] :  | semmle.label | call to update [element :f] :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:687:25:687:29 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
+| hash_flow.rb:687:41:687:49 | old_value :  | semmle.label | old_value :  |
+| hash_flow.rb:687:52:687:60 | new_value :  | semmle.label | new_value :  |
+| hash_flow.rb:689:14:689:22 | old_value | semmle.label | old_value |
+| hash_flow.rb:690:14:690:22 | new_value | semmle.label | new_value |
+| hash_flow.rb:692:10:692:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:692:11:692:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:692:11:692:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:694:10:694:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:694:11:694:14 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:694:11:694:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:695:10:695:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:695:11:695:14 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:695:11:695:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:697:10:697:19 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:697:11:697:14 | hash [element :f] :  | semmle.label | hash [element :f] :  |
+| hash_flow.rb:697:11:697:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:699:10:699:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:699:11:699:15 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:699:11:699:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:701:10:701:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:701:11:701:15 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
+| hash_flow.rb:701:11:701:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:702:10:702:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:702:11:702:15 | hash1 [element :d] :  | semmle.label | hash1 [element :d] :  |
+| hash_flow.rb:702:11:702:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:704:10:704:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:704:11:704:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
+| hash_flow.rb:704:11:704:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:711:15:711:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:713:15:713:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:715:9:715:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:715:9:715:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:715:9:715:19 | call to values [element] :  | semmle.label | call to values [element] :  |
+| hash_flow.rb:716:10:716:15 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:716:11:716:11 | a [element] :  | semmle.label | a [element] :  |
+| hash_flow.rb:716:11:716:14 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:723:15:723:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:725:15:725:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:727:9:727:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:727:9:727:26 | call to values_at [element 0] :  | semmle.label | call to values_at [element 0] :  |
+| hash_flow.rb:728:10:728:10 | b [element 0] :  | semmle.label | b [element 0] :  |
+| hash_flow.rb:728:10:728:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:729:9:729:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:729:9:729:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:729:9:729:31 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
+| hash_flow.rb:730:10:730:10 | b [element] :  | semmle.label | b [element] :  |
+| hash_flow.rb:730:10:730:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:737:15:737:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:739:15:739:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:742:15:742:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:744:15:744:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:746:14:746:20 | ** ... [element :a] :  | semmle.label | ** ... [element :a] :  |
+| hash_flow.rb:746:14:746:20 | ** ... [element :c] :  | semmle.label | ** ... [element :c] :  |
+| hash_flow.rb:746:16:746:20 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:746:16:746:20 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
+| hash_flow.rb:746:29:746:39 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:746:42:746:48 | ** ... [element :d] :  | semmle.label | ** ... [element :d] :  |
+| hash_flow.rb:746:42:746:48 | ** ... [element :f] :  | semmle.label | ** ... [element :f] :  |
+| hash_flow.rb:746:44:746:48 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:746:44:746:48 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
+| hash_flow.rb:747:10:747:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:747:10:747:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:749:10:749:13 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:749:10:749:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:750:10:750:13 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:750:10:750:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:752:10:752:13 | hash [element :f] :  | semmle.label | hash [element :f] :  |
+| hash_flow.rb:752:10:752:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:753:10:753:13 | hash [element :g] :  | semmle.label | hash [element :g] :  |
+| hash_flow.rb:753:10:753:17 | ...[...] | semmle.label | ...[...] |
 subpaths
 #select
 | hash_flow.rb:22:10:22:17 | ...[...] | hash_flow.rb:11:15:11:24 | call to taint :  | hash_flow.rb:22:10:22:17 | ...[...] | $@ | hash_flow.rb:11:15:11:24 | call to taint :  | call to taint :  |
@@ -1114,160 +1132,162 @@ subpaths
 | hash_flow.rb:65:10:65:18 | ...[...] | hash_flow.rb:64:24:64:33 | call to taint :  | hash_flow.rb:65:10:65:18 | ...[...] | $@ | hash_flow.rb:64:24:64:33 | call to taint :  | call to taint :  |
 | hash_flow.rb:66:10:66:18 | ...[...] | hash_flow.rb:64:24:64:33 | call to taint :  | hash_flow.rb:66:10:66:18 | ...[...] | $@ | hash_flow.rb:64:24:64:33 | call to taint :  | call to taint :  |
 | hash_flow.rb:69:10:69:18 | ...[...] | hash_flow.rb:68:22:68:31 | call to taint :  | hash_flow.rb:69:10:69:18 | ...[...] | $@ | hash_flow.rb:68:22:68:31 | call to taint :  | call to taint :  |
-| hash_flow.rb:77:10:77:18 | ...[...] | hash_flow.rb:76:26:76:35 | call to taint :  | hash_flow.rb:77:10:77:18 | ...[...] | $@ | hash_flow.rb:76:26:76:35 | call to taint :  | call to taint :  |
-| hash_flow.rb:89:10:89:18 | ...[...] | hash_flow.rb:85:15:85:24 | call to taint :  | hash_flow.rb:89:10:89:18 | ...[...] | $@ | hash_flow.rb:85:15:85:24 | call to taint :  | call to taint :  |
-| hash_flow.rb:98:10:98:10 | b | hash_flow.rb:97:21:97:30 | call to taint :  | hash_flow.rb:98:10:98:10 | b | $@ | hash_flow.rb:97:21:97:30 | call to taint :  | call to taint :  |
-| hash_flow.rb:106:10:106:17 | ...[...] | hash_flow.rb:105:24:105:33 | call to taint :  | hash_flow.rb:106:10:106:17 | ...[...] | $@ | hash_flow.rb:105:24:105:33 | call to taint :  | call to taint :  |
-| hash_flow.rb:107:10:107:10 | b | hash_flow.rb:105:24:105:33 | call to taint :  | hash_flow.rb:107:10:107:10 | b | $@ | hash_flow.rb:105:24:105:33 | call to taint :  | call to taint :  |
-| hash_flow.rb:111:10:111:17 | ...[...] | hash_flow.rb:110:23:110:32 | call to taint :  | hash_flow.rb:111:10:111:17 | ...[...] | $@ | hash_flow.rb:110:23:110:32 | call to taint :  | call to taint :  |
-| hash_flow.rb:112:10:112:17 | ...[...] | hash_flow.rb:110:23:110:32 | call to taint :  | hash_flow.rb:112:10:112:17 | ...[...] | $@ | hash_flow.rb:110:23:110:32 | call to taint :  | call to taint :  |
-| hash_flow.rb:113:10:113:10 | c | hash_flow.rb:110:23:110:32 | call to taint :  | hash_flow.rb:113:10:113:10 | c | $@ | hash_flow.rb:110:23:110:32 | call to taint :  | call to taint :  |
-| hash_flow.rb:124:14:124:25 | key_or_value | hash_flow.rb:120:15:120:24 | call to taint :  | hash_flow.rb:124:14:124:25 | key_or_value | $@ | hash_flow.rb:120:15:120:24 | call to taint :  | call to taint :  |
-| hash_flow.rb:128:14:128:18 | value | hash_flow.rb:120:15:120:24 | call to taint :  | hash_flow.rb:128:14:128:18 | value | $@ | hash_flow.rb:120:15:120:24 | call to taint :  | call to taint :  |
-| hash_flow.rb:141:10:141:13 | ...[...] | hash_flow.rb:136:15:136:25 | call to taint :  | hash_flow.rb:141:10:141:13 | ...[...] | $@ | hash_flow.rb:136:15:136:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:142:10:142:13 | ...[...] | hash_flow.rb:136:15:136:25 | call to taint :  | hash_flow.rb:142:10:142:13 | ...[...] | $@ | hash_flow.rb:136:15:136:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:144:10:144:13 | ...[...] | hash_flow.rb:136:15:136:25 | call to taint :  | hash_flow.rb:144:10:144:13 | ...[...] | $@ | hash_flow.rb:136:15:136:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:166:10:166:14 | ...[...] | hash_flow.rb:162:15:162:25 | call to taint :  | hash_flow.rb:166:10:166:14 | ...[...] | $@ | hash_flow.rb:162:15:162:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:178:10:178:10 | a | hash_flow.rb:174:15:174:25 | call to taint :  | hash_flow.rb:178:10:178:10 | a | $@ | hash_flow.rb:174:15:174:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:191:14:191:18 | value | hash_flow.rb:186:15:186:25 | call to taint :  | hash_flow.rb:191:14:191:18 | value | $@ | hash_flow.rb:186:15:186:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:193:10:193:14 | ...[...] | hash_flow.rb:186:15:186:25 | call to taint :  | hash_flow.rb:193:10:193:14 | ...[...] | $@ | hash_flow.rb:186:15:186:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:194:10:194:17 | ...[...] | hash_flow.rb:186:15:186:25 | call to taint :  | hash_flow.rb:194:10:194:17 | ...[...] | $@ | hash_flow.rb:186:15:186:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:209:10:209:21 | call to dig | hash_flow.rb:202:15:202:25 | call to taint :  | hash_flow.rb:209:10:209:21 | call to dig | $@ | hash_flow.rb:202:15:202:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:211:10:211:24 | call to dig | hash_flow.rb:205:19:205:29 | call to taint :  | hash_flow.rb:211:10:211:24 | call to dig | $@ | hash_flow.rb:205:19:205:29 | call to taint :  | call to taint :  |
-| hash_flow.rb:224:14:224:18 | value | hash_flow.rb:219:15:219:25 | call to taint :  | hash_flow.rb:224:14:224:18 | value | $@ | hash_flow.rb:219:15:219:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:226:10:226:14 | ...[...] | hash_flow.rb:219:15:219:25 | call to taint :  | hash_flow.rb:226:10:226:14 | ...[...] | $@ | hash_flow.rb:219:15:219:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:240:10:240:14 | ...[...] | hash_flow.rb:234:15:234:25 | call to taint :  | hash_flow.rb:240:10:240:14 | ...[...] | $@ | hash_flow.rb:234:15:234:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:253:14:253:18 | value | hash_flow.rb:248:15:248:25 | call to taint :  | hash_flow.rb:253:14:253:18 | value | $@ | hash_flow.rb:248:15:248:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:255:10:255:14 | ...[...] | hash_flow.rb:248:15:248:25 | call to taint :  | hash_flow.rb:255:10:255:14 | ...[...] | $@ | hash_flow.rb:248:15:248:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:267:14:267:18 | value | hash_flow.rb:263:15:263:25 | call to taint :  | hash_flow.rb:267:14:267:18 | value | $@ | hash_flow.rb:263:15:263:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:269:10:269:14 | ...[...] | hash_flow.rb:263:15:263:25 | call to taint :  | hash_flow.rb:269:10:269:14 | ...[...] | $@ | hash_flow.rb:263:15:263:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:285:10:285:14 | ...[...] | hash_flow.rb:279:15:279:25 | call to taint :  | hash_flow.rb:285:10:285:14 | ...[...] | $@ | hash_flow.rb:279:15:279:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:298:14:298:14 | x | hash_flow.rb:297:20:297:30 | call to taint :  | hash_flow.rb:298:14:298:14 | x | $@ | hash_flow.rb:297:20:297:30 | call to taint :  | call to taint :  |
-| hash_flow.rb:300:10:300:10 | b | hash_flow.rb:293:15:293:25 | call to taint :  | hash_flow.rb:300:10:300:10 | b | $@ | hash_flow.rb:293:15:293:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:300:10:300:10 | b | hash_flow.rb:295:15:295:25 | call to taint :  | hash_flow.rb:300:10:300:10 | b | $@ | hash_flow.rb:295:15:295:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:302:10:302:10 | b | hash_flow.rb:293:15:293:25 | call to taint :  | hash_flow.rb:302:10:302:10 | b | $@ | hash_flow.rb:293:15:293:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:304:10:304:10 | b | hash_flow.rb:293:15:293:25 | call to taint :  | hash_flow.rb:304:10:304:10 | b | $@ | hash_flow.rb:293:15:293:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:304:10:304:10 | b | hash_flow.rb:303:24:303:34 | call to taint :  | hash_flow.rb:304:10:304:10 | b | $@ | hash_flow.rb:303:24:303:34 | call to taint :  | call to taint :  |
-| hash_flow.rb:306:10:306:10 | b | hash_flow.rb:305:24:305:34 | call to taint :  | hash_flow.rb:306:10:306:10 | b | $@ | hash_flow.rb:305:24:305:34 | call to taint :  | call to taint :  |
-| hash_flow.rb:308:10:308:10 | b | hash_flow.rb:293:15:293:25 | call to taint :  | hash_flow.rb:308:10:308:10 | b | $@ | hash_flow.rb:293:15:293:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:308:10:308:10 | b | hash_flow.rb:295:15:295:25 | call to taint :  | hash_flow.rb:308:10:308:10 | b | $@ | hash_flow.rb:295:15:295:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:308:10:308:10 | b | hash_flow.rb:307:23:307:33 | call to taint :  | hash_flow.rb:308:10:308:10 | b | $@ | hash_flow.rb:307:23:307:33 | call to taint :  | call to taint :  |
-| hash_flow.rb:320:14:320:14 | x | hash_flow.rb:319:27:319:37 | call to taint :  | hash_flow.rb:320:14:320:14 | x | $@ | hash_flow.rb:319:27:319:37 | call to taint :  | call to taint :  |
-| hash_flow.rb:323:10:323:13 | ...[...] | hash_flow.rb:315:15:315:25 | call to taint :  | hash_flow.rb:323:10:323:13 | ...[...] | $@ | hash_flow.rb:315:15:315:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:323:10:323:13 | ...[...] | hash_flow.rb:317:15:317:25 | call to taint :  | hash_flow.rb:323:10:323:13 | ...[...] | $@ | hash_flow.rb:317:15:317:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:323:10:323:13 | ...[...] | hash_flow.rb:321:9:321:19 | call to taint :  | hash_flow.rb:323:10:323:13 | ...[...] | $@ | hash_flow.rb:321:9:321:19 | call to taint :  | call to taint :  |
-| hash_flow.rb:325:10:325:13 | ...[...] | hash_flow.rb:315:15:315:25 | call to taint :  | hash_flow.rb:325:10:325:13 | ...[...] | $@ | hash_flow.rb:315:15:315:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:327:10:327:13 | ...[...] | hash_flow.rb:315:15:315:25 | call to taint :  | hash_flow.rb:327:10:327:13 | ...[...] | $@ | hash_flow.rb:315:15:315:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:327:10:327:13 | ...[...] | hash_flow.rb:317:15:317:25 | call to taint :  | hash_flow.rb:327:10:327:13 | ...[...] | $@ | hash_flow.rb:317:15:317:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:340:14:340:18 | value | hash_flow.rb:334:15:334:25 | call to taint :  | hash_flow.rb:340:14:340:18 | value | $@ | hash_flow.rb:334:15:334:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:340:14:340:18 | value | hash_flow.rb:336:15:336:25 | call to taint :  | hash_flow.rb:340:14:340:18 | value | $@ | hash_flow.rb:336:15:336:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:343:10:343:16 | ( ... ) | hash_flow.rb:334:15:334:25 | call to taint :  | hash_flow.rb:343:10:343:16 | ( ... ) | $@ | hash_flow.rb:334:15:334:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:356:14:356:18 | value | hash_flow.rb:350:15:350:25 | call to taint :  | hash_flow.rb:356:14:356:18 | value | $@ | hash_flow.rb:350:15:350:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:356:14:356:18 | value | hash_flow.rb:352:15:352:25 | call to taint :  | hash_flow.rb:356:14:356:18 | value | $@ | hash_flow.rb:352:15:352:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:359:10:359:19 | ( ... ) | hash_flow.rb:350:15:350:25 | call to taint :  | hash_flow.rb:359:10:359:19 | ( ... ) | $@ | hash_flow.rb:350:15:350:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:371:10:371:15 | ( ... ) | hash_flow.rb:366:15:366:25 | call to taint :  | hash_flow.rb:371:10:371:15 | ( ... ) | $@ | hash_flow.rb:366:15:366:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:371:10:371:15 | ( ... ) | hash_flow.rb:368:15:368:25 | call to taint :  | hash_flow.rb:371:10:371:15 | ( ... ) | $@ | hash_flow.rb:368:15:368:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:384:14:384:18 | value | hash_flow.rb:378:15:378:25 | call to taint :  | hash_flow.rb:384:14:384:18 | value | $@ | hash_flow.rb:378:15:378:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:384:14:384:18 | value | hash_flow.rb:380:15:380:25 | call to taint :  | hash_flow.rb:384:14:384:18 | value | $@ | hash_flow.rb:380:15:380:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:387:10:387:19 | ( ... ) | hash_flow.rb:378:15:378:25 | call to taint :  | hash_flow.rb:387:10:387:19 | ( ... ) | $@ | hash_flow.rb:378:15:378:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:388:10:388:16 | ( ... ) | hash_flow.rb:378:15:378:25 | call to taint :  | hash_flow.rb:388:10:388:16 | ( ... ) | $@ | hash_flow.rb:378:15:378:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:406:14:406:22 | old_value | hash_flow.rb:395:15:395:25 | call to taint :  | hash_flow.rb:406:14:406:22 | old_value | $@ | hash_flow.rb:395:15:395:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:406:14:406:22 | old_value | hash_flow.rb:397:15:397:25 | call to taint :  | hash_flow.rb:406:14:406:22 | old_value | $@ | hash_flow.rb:397:15:397:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:406:14:406:22 | old_value | hash_flow.rb:400:15:400:25 | call to taint :  | hash_flow.rb:406:14:406:22 | old_value | $@ | hash_flow.rb:400:15:400:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:406:14:406:22 | old_value | hash_flow.rb:402:15:402:25 | call to taint :  | hash_flow.rb:406:14:406:22 | old_value | $@ | hash_flow.rb:402:15:402:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:407:14:407:22 | new_value | hash_flow.rb:395:15:395:25 | call to taint :  | hash_flow.rb:407:14:407:22 | new_value | $@ | hash_flow.rb:395:15:395:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:407:14:407:22 | new_value | hash_flow.rb:397:15:397:25 | call to taint :  | hash_flow.rb:407:14:407:22 | new_value | $@ | hash_flow.rb:397:15:397:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:407:14:407:22 | new_value | hash_flow.rb:400:15:400:25 | call to taint :  | hash_flow.rb:407:14:407:22 | new_value | $@ | hash_flow.rb:400:15:400:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:407:14:407:22 | new_value | hash_flow.rb:402:15:402:25 | call to taint :  | hash_flow.rb:407:14:407:22 | new_value | $@ | hash_flow.rb:402:15:402:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:409:10:409:19 | ( ... ) | hash_flow.rb:395:15:395:25 | call to taint :  | hash_flow.rb:409:10:409:19 | ( ... ) | $@ | hash_flow.rb:395:15:395:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:411:10:411:19 | ( ... ) | hash_flow.rb:397:15:397:25 | call to taint :  | hash_flow.rb:411:10:411:19 | ( ... ) | $@ | hash_flow.rb:397:15:397:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:412:10:412:19 | ( ... ) | hash_flow.rb:400:15:400:25 | call to taint :  | hash_flow.rb:412:10:412:19 | ( ... ) | $@ | hash_flow.rb:400:15:400:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:414:10:414:19 | ( ... ) | hash_flow.rb:402:15:402:25 | call to taint :  | hash_flow.rb:414:10:414:19 | ( ... ) | $@ | hash_flow.rb:402:15:402:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:432:14:432:22 | old_value | hash_flow.rb:421:15:421:25 | call to taint :  | hash_flow.rb:432:14:432:22 | old_value | $@ | hash_flow.rb:421:15:421:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:432:14:432:22 | old_value | hash_flow.rb:423:15:423:25 | call to taint :  | hash_flow.rb:432:14:432:22 | old_value | $@ | hash_flow.rb:423:15:423:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:432:14:432:22 | old_value | hash_flow.rb:426:15:426:25 | call to taint :  | hash_flow.rb:432:14:432:22 | old_value | $@ | hash_flow.rb:426:15:426:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:432:14:432:22 | old_value | hash_flow.rb:428:15:428:25 | call to taint :  | hash_flow.rb:432:14:432:22 | old_value | $@ | hash_flow.rb:428:15:428:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:433:14:433:22 | new_value | hash_flow.rb:421:15:421:25 | call to taint :  | hash_flow.rb:433:14:433:22 | new_value | $@ | hash_flow.rb:421:15:421:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:433:14:433:22 | new_value | hash_flow.rb:423:15:423:25 | call to taint :  | hash_flow.rb:433:14:433:22 | new_value | $@ | hash_flow.rb:423:15:423:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:433:14:433:22 | new_value | hash_flow.rb:426:15:426:25 | call to taint :  | hash_flow.rb:433:14:433:22 | new_value | $@ | hash_flow.rb:426:15:426:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:433:14:433:22 | new_value | hash_flow.rb:428:15:428:25 | call to taint :  | hash_flow.rb:433:14:433:22 | new_value | $@ | hash_flow.rb:428:15:428:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:435:10:435:19 | ( ... ) | hash_flow.rb:421:15:421:25 | call to taint :  | hash_flow.rb:435:10:435:19 | ( ... ) | $@ | hash_flow.rb:421:15:421:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:437:10:437:19 | ( ... ) | hash_flow.rb:423:15:423:25 | call to taint :  | hash_flow.rb:437:10:437:19 | ( ... ) | $@ | hash_flow.rb:423:15:423:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:438:10:438:19 | ( ... ) | hash_flow.rb:426:15:426:25 | call to taint :  | hash_flow.rb:438:10:438:19 | ( ... ) | $@ | hash_flow.rb:426:15:426:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:440:10:440:19 | ( ... ) | hash_flow.rb:428:15:428:25 | call to taint :  | hash_flow.rb:440:10:440:19 | ( ... ) | $@ | hash_flow.rb:428:15:428:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:442:10:442:20 | ( ... ) | hash_flow.rb:421:15:421:25 | call to taint :  | hash_flow.rb:442:10:442:20 | ( ... ) | $@ | hash_flow.rb:421:15:421:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:444:10:444:20 | ( ... ) | hash_flow.rb:423:15:423:25 | call to taint :  | hash_flow.rb:444:10:444:20 | ( ... ) | $@ | hash_flow.rb:423:15:423:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:445:10:445:20 | ( ... ) | hash_flow.rb:426:15:426:25 | call to taint :  | hash_flow.rb:445:10:445:20 | ( ... ) | $@ | hash_flow.rb:426:15:426:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:447:10:447:20 | ( ... ) | hash_flow.rb:428:15:428:25 | call to taint :  | hash_flow.rb:447:10:447:20 | ( ... ) | $@ | hash_flow.rb:428:15:428:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:459:10:459:13 | ...[...] | hash_flow.rb:454:15:454:25 | call to taint :  | hash_flow.rb:459:10:459:13 | ...[...] | $@ | hash_flow.rb:454:15:454:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:471:14:471:18 | value | hash_flow.rb:466:15:466:25 | call to taint :  | hash_flow.rb:471:14:471:18 | value | $@ | hash_flow.rb:466:15:466:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:474:10:474:14 | ...[...] | hash_flow.rb:466:15:466:25 | call to taint :  | hash_flow.rb:474:10:474:14 | ...[...] | $@ | hash_flow.rb:466:15:466:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:486:14:486:18 | value | hash_flow.rb:481:15:481:25 | call to taint :  | hash_flow.rb:486:14:486:18 | value | $@ | hash_flow.rb:481:15:481:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:489:10:489:14 | ...[...] | hash_flow.rb:481:15:481:25 | call to taint :  | hash_flow.rb:489:10:489:14 | ...[...] | $@ | hash_flow.rb:481:15:481:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:490:10:490:17 | ...[...] | hash_flow.rb:481:15:481:25 | call to taint :  | hash_flow.rb:490:10:490:17 | ...[...] | $@ | hash_flow.rb:481:15:481:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:505:10:505:20 | ( ... ) | hash_flow.rb:497:15:497:25 | call to taint :  | hash_flow.rb:505:10:505:20 | ( ... ) | $@ | hash_flow.rb:497:15:497:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:507:10:507:20 | ( ... ) | hash_flow.rb:499:15:499:25 | call to taint :  | hash_flow.rb:507:10:507:20 | ( ... ) | $@ | hash_flow.rb:499:15:499:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:518:14:518:18 | value | hash_flow.rb:512:15:512:25 | call to taint :  | hash_flow.rb:518:14:518:18 | value | $@ | hash_flow.rb:512:15:512:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:518:14:518:18 | value | hash_flow.rb:514:15:514:25 | call to taint :  | hash_flow.rb:518:14:518:18 | value | $@ | hash_flow.rb:514:15:514:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:521:10:521:16 | ( ... ) | hash_flow.rb:512:15:512:25 | call to taint :  | hash_flow.rb:521:10:521:16 | ( ... ) | $@ | hash_flow.rb:512:15:512:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:534:14:534:18 | value | hash_flow.rb:528:15:528:25 | call to taint :  | hash_flow.rb:534:14:534:18 | value | $@ | hash_flow.rb:528:15:528:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:534:14:534:18 | value | hash_flow.rb:530:15:530:25 | call to taint :  | hash_flow.rb:534:14:534:18 | value | $@ | hash_flow.rb:530:15:530:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:537:10:537:19 | ( ... ) | hash_flow.rb:528:15:528:25 | call to taint :  | hash_flow.rb:537:10:537:19 | ( ... ) | $@ | hash_flow.rb:528:15:528:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:549:10:549:19 | ( ... ) | hash_flow.rb:544:15:544:25 | call to taint :  | hash_flow.rb:549:10:549:19 | ( ... ) | $@ | hash_flow.rb:544:15:544:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:551:10:551:15 | ( ... ) | hash_flow.rb:544:15:544:25 | call to taint :  | hash_flow.rb:551:10:551:15 | ( ... ) | $@ | hash_flow.rb:544:15:544:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:551:10:551:15 | ( ... ) | hash_flow.rb:546:15:546:25 | call to taint :  | hash_flow.rb:551:10:551:15 | ( ... ) | $@ | hash_flow.rb:546:15:546:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:563:10:563:16 | ( ... ) | hash_flow.rb:558:15:558:25 | call to taint :  | hash_flow.rb:563:10:563:16 | ( ... ) | $@ | hash_flow.rb:558:15:558:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:568:10:568:16 | ( ... ) | hash_flow.rb:558:15:558:25 | call to taint :  | hash_flow.rb:568:10:568:16 | ( ... ) | $@ | hash_flow.rb:558:15:558:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:570:10:570:16 | ( ... ) | hash_flow.rb:560:15:560:25 | call to taint :  | hash_flow.rb:570:10:570:16 | ( ... ) | $@ | hash_flow.rb:560:15:560:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:583:10:583:18 | ( ... ) | hash_flow.rb:577:15:577:25 | call to taint :  | hash_flow.rb:583:10:583:18 | ( ... ) | $@ | hash_flow.rb:577:15:577:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:583:10:583:18 | ( ... ) | hash_flow.rb:579:15:579:25 | call to taint :  | hash_flow.rb:583:10:583:18 | ( ... ) | $@ | hash_flow.rb:579:15:579:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:595:10:595:16 | ( ... ) | hash_flow.rb:590:15:590:25 | call to taint :  | hash_flow.rb:595:10:595:16 | ( ... ) | $@ | hash_flow.rb:590:15:590:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:597:10:597:16 | ( ... ) | hash_flow.rb:592:15:592:25 | call to taint :  | hash_flow.rb:597:10:597:16 | ( ... ) | $@ | hash_flow.rb:592:15:592:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:601:14:601:18 | value | hash_flow.rb:590:15:590:25 | call to taint :  | hash_flow.rb:601:14:601:18 | value | $@ | hash_flow.rb:590:15:590:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:601:14:601:18 | value | hash_flow.rb:592:15:592:25 | call to taint :  | hash_flow.rb:601:14:601:18 | value | $@ | hash_flow.rb:592:15:592:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:604:10:604:16 | ( ... ) | hash_flow.rb:602:14:602:24 | call to taint :  | hash_flow.rb:604:10:604:16 | ( ... ) | $@ | hash_flow.rb:602:14:602:24 | call to taint :  | call to taint :  |
-| hash_flow.rb:616:10:616:17 | ( ... ) | hash_flow.rb:611:15:611:25 | call to taint :  | hash_flow.rb:616:10:616:17 | ( ... ) | $@ | hash_flow.rb:611:15:611:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:616:10:616:17 | ( ... ) | hash_flow.rb:613:15:613:25 | call to taint :  | hash_flow.rb:616:10:616:17 | ( ... ) | $@ | hash_flow.rb:613:15:613:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:617:10:617:17 | ( ... ) | hash_flow.rb:611:15:611:25 | call to taint :  | hash_flow.rb:617:10:617:17 | ( ... ) | $@ | hash_flow.rb:611:15:611:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:617:10:617:17 | ( ... ) | hash_flow.rb:613:15:613:25 | call to taint :  | hash_flow.rb:617:10:617:17 | ( ... ) | $@ | hash_flow.rb:613:15:613:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:618:10:618:17 | ( ... ) | hash_flow.rb:611:15:611:25 | call to taint :  | hash_flow.rb:618:10:618:17 | ( ... ) | $@ | hash_flow.rb:611:15:611:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:618:10:618:17 | ( ... ) | hash_flow.rb:613:15:613:25 | call to taint :  | hash_flow.rb:618:10:618:17 | ( ... ) | $@ | hash_flow.rb:613:15:613:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:630:10:630:20 | ( ... ) | hash_flow.rb:625:15:625:25 | call to taint :  | hash_flow.rb:630:10:630:20 | ( ... ) | $@ | hash_flow.rb:625:15:625:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:630:10:630:20 | ( ... ) | hash_flow.rb:627:15:627:25 | call to taint :  | hash_flow.rb:630:10:630:20 | ( ... ) | $@ | hash_flow.rb:627:15:627:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:631:10:631:20 | ( ... ) | hash_flow.rb:625:15:625:25 | call to taint :  | hash_flow.rb:631:10:631:20 | ( ... ) | $@ | hash_flow.rb:625:15:625:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:631:10:631:20 | ( ... ) | hash_flow.rb:627:15:627:25 | call to taint :  | hash_flow.rb:631:10:631:20 | ( ... ) | $@ | hash_flow.rb:627:15:627:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:632:10:632:20 | ( ... ) | hash_flow.rb:625:15:625:25 | call to taint :  | hash_flow.rb:632:10:632:20 | ( ... ) | $@ | hash_flow.rb:625:15:625:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:632:10:632:20 | ( ... ) | hash_flow.rb:627:15:627:25 | call to taint :  | hash_flow.rb:632:10:632:20 | ( ... ) | $@ | hash_flow.rb:627:15:627:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:644:14:644:18 | value | hash_flow.rb:639:15:639:25 | call to taint :  | hash_flow.rb:644:14:644:18 | value | $@ | hash_flow.rb:639:15:639:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:644:14:644:18 | value | hash_flow.rb:641:15:641:25 | call to taint :  | hash_flow.rb:644:14:644:18 | value | $@ | hash_flow.rb:641:15:641:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:647:10:647:19 | ( ... ) | hash_flow.rb:639:15:639:25 | call to taint :  | hash_flow.rb:647:10:647:19 | ( ... ) | $@ | hash_flow.rb:639:15:639:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:648:10:648:16 | ( ... ) | hash_flow.rb:645:9:645:19 | call to taint :  | hash_flow.rb:648:10:648:16 | ( ... ) | $@ | hash_flow.rb:645:9:645:19 | call to taint :  | call to taint :  |
-| hash_flow.rb:660:14:660:18 | value | hash_flow.rb:655:15:655:25 | call to taint :  | hash_flow.rb:660:14:660:18 | value | $@ | hash_flow.rb:655:15:655:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:660:14:660:18 | value | hash_flow.rb:657:15:657:25 | call to taint :  | hash_flow.rb:660:14:660:18 | value | $@ | hash_flow.rb:657:15:657:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:663:10:663:19 | ( ... ) | hash_flow.rb:661:9:661:19 | call to taint :  | hash_flow.rb:663:10:663:19 | ( ... ) | $@ | hash_flow.rb:661:9:661:19 | call to taint :  | call to taint :  |
-| hash_flow.rb:681:14:681:22 | old_value | hash_flow.rb:670:15:670:25 | call to taint :  | hash_flow.rb:681:14:681:22 | old_value | $@ | hash_flow.rb:670:15:670:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:681:14:681:22 | old_value | hash_flow.rb:672:15:672:25 | call to taint :  | hash_flow.rb:681:14:681:22 | old_value | $@ | hash_flow.rb:672:15:672:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:681:14:681:22 | old_value | hash_flow.rb:675:15:675:25 | call to taint :  | hash_flow.rb:681:14:681:22 | old_value | $@ | hash_flow.rb:675:15:675:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:681:14:681:22 | old_value | hash_flow.rb:677:15:677:25 | call to taint :  | hash_flow.rb:681:14:681:22 | old_value | $@ | hash_flow.rb:677:15:677:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:682:14:682:22 | new_value | hash_flow.rb:670:15:670:25 | call to taint :  | hash_flow.rb:682:14:682:22 | new_value | $@ | hash_flow.rb:670:15:670:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:682:14:682:22 | new_value | hash_flow.rb:672:15:672:25 | call to taint :  | hash_flow.rb:682:14:682:22 | new_value | $@ | hash_flow.rb:672:15:672:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:682:14:682:22 | new_value | hash_flow.rb:675:15:675:25 | call to taint :  | hash_flow.rb:682:14:682:22 | new_value | $@ | hash_flow.rb:675:15:675:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:682:14:682:22 | new_value | hash_flow.rb:677:15:677:25 | call to taint :  | hash_flow.rb:682:14:682:22 | new_value | $@ | hash_flow.rb:677:15:677:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:684:10:684:19 | ( ... ) | hash_flow.rb:670:15:670:25 | call to taint :  | hash_flow.rb:684:10:684:19 | ( ... ) | $@ | hash_flow.rb:670:15:670:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:686:10:686:19 | ( ... ) | hash_flow.rb:672:15:672:25 | call to taint :  | hash_flow.rb:686:10:686:19 | ( ... ) | $@ | hash_flow.rb:672:15:672:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:687:10:687:19 | ( ... ) | hash_flow.rb:675:15:675:25 | call to taint :  | hash_flow.rb:687:10:687:19 | ( ... ) | $@ | hash_flow.rb:675:15:675:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:689:10:689:19 | ( ... ) | hash_flow.rb:677:15:677:25 | call to taint :  | hash_flow.rb:689:10:689:19 | ( ... ) | $@ | hash_flow.rb:677:15:677:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:691:10:691:20 | ( ... ) | hash_flow.rb:670:15:670:25 | call to taint :  | hash_flow.rb:691:10:691:20 | ( ... ) | $@ | hash_flow.rb:670:15:670:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:693:10:693:20 | ( ... ) | hash_flow.rb:672:15:672:25 | call to taint :  | hash_flow.rb:693:10:693:20 | ( ... ) | $@ | hash_flow.rb:672:15:672:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:694:10:694:20 | ( ... ) | hash_flow.rb:675:15:675:25 | call to taint :  | hash_flow.rb:694:10:694:20 | ( ... ) | $@ | hash_flow.rb:675:15:675:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:696:10:696:20 | ( ... ) | hash_flow.rb:677:15:677:25 | call to taint :  | hash_flow.rb:696:10:696:20 | ( ... ) | $@ | hash_flow.rb:677:15:677:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:708:10:708:15 | ( ... ) | hash_flow.rb:703:15:703:25 | call to taint :  | hash_flow.rb:708:10:708:15 | ( ... ) | $@ | hash_flow.rb:703:15:703:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:708:10:708:15 | ( ... ) | hash_flow.rb:705:15:705:25 | call to taint :  | hash_flow.rb:708:10:708:15 | ( ... ) | $@ | hash_flow.rb:705:15:705:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:720:10:720:13 | ...[...] | hash_flow.rb:715:15:715:25 | call to taint :  | hash_flow.rb:720:10:720:13 | ...[...] | $@ | hash_flow.rb:715:15:715:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:722:10:722:13 | ...[...] | hash_flow.rb:715:15:715:25 | call to taint :  | hash_flow.rb:722:10:722:13 | ...[...] | $@ | hash_flow.rb:715:15:715:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:722:10:722:13 | ...[...] | hash_flow.rb:717:15:717:25 | call to taint :  | hash_flow.rb:722:10:722:13 | ...[...] | $@ | hash_flow.rb:717:15:717:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:739:10:739:17 | ...[...] | hash_flow.rb:729:15:729:25 | call to taint :  | hash_flow.rb:739:10:739:17 | ...[...] | $@ | hash_flow.rb:729:15:729:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:741:10:741:17 | ...[...] | hash_flow.rb:731:15:731:25 | call to taint :  | hash_flow.rb:741:10:741:17 | ...[...] | $@ | hash_flow.rb:731:15:731:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:742:10:742:17 | ...[...] | hash_flow.rb:734:15:734:25 | call to taint :  | hash_flow.rb:742:10:742:17 | ...[...] | $@ | hash_flow.rb:734:15:734:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:744:10:744:17 | ...[...] | hash_flow.rb:736:15:736:25 | call to taint :  | hash_flow.rb:744:10:744:17 | ...[...] | $@ | hash_flow.rb:736:15:736:25 | call to taint :  | call to taint :  |
-| hash_flow.rb:745:10:745:17 | ...[...] | hash_flow.rb:738:29:738:39 | call to taint :  | hash_flow.rb:745:10:745:17 | ...[...] | $@ | hash_flow.rb:738:29:738:39 | call to taint :  | call to taint :  |
+| hash_flow.rb:73:10:73:19 | ...[...] | hash_flow.rb:72:25:72:34 | call to taint :  | hash_flow.rb:73:10:73:19 | ...[...] | $@ | hash_flow.rb:72:25:72:34 | call to taint :  | call to taint :  |
+| hash_flow.rb:77:10:77:19 | ...[...] | hash_flow.rb:76:26:76:35 | call to taint :  | hash_flow.rb:77:10:77:19 | ...[...] | $@ | hash_flow.rb:76:26:76:35 | call to taint :  | call to taint :  |
+| hash_flow.rb:85:10:85:18 | ...[...] | hash_flow.rb:84:26:84:35 | call to taint :  | hash_flow.rb:85:10:85:18 | ...[...] | $@ | hash_flow.rb:84:26:84:35 | call to taint :  | call to taint :  |
+| hash_flow.rb:97:10:97:18 | ...[...] | hash_flow.rb:93:15:93:24 | call to taint :  | hash_flow.rb:97:10:97:18 | ...[...] | $@ | hash_flow.rb:93:15:93:24 | call to taint :  | call to taint :  |
+| hash_flow.rb:106:10:106:10 | b | hash_flow.rb:105:21:105:30 | call to taint :  | hash_flow.rb:106:10:106:10 | b | $@ | hash_flow.rb:105:21:105:30 | call to taint :  | call to taint :  |
+| hash_flow.rb:114:10:114:17 | ...[...] | hash_flow.rb:113:24:113:33 | call to taint :  | hash_flow.rb:114:10:114:17 | ...[...] | $@ | hash_flow.rb:113:24:113:33 | call to taint :  | call to taint :  |
+| hash_flow.rb:115:10:115:10 | b | hash_flow.rb:113:24:113:33 | call to taint :  | hash_flow.rb:115:10:115:10 | b | $@ | hash_flow.rb:113:24:113:33 | call to taint :  | call to taint :  |
+| hash_flow.rb:119:10:119:17 | ...[...] | hash_flow.rb:118:23:118:32 | call to taint :  | hash_flow.rb:119:10:119:17 | ...[...] | $@ | hash_flow.rb:118:23:118:32 | call to taint :  | call to taint :  |
+| hash_flow.rb:120:10:120:17 | ...[...] | hash_flow.rb:118:23:118:32 | call to taint :  | hash_flow.rb:120:10:120:17 | ...[...] | $@ | hash_flow.rb:118:23:118:32 | call to taint :  | call to taint :  |
+| hash_flow.rb:121:10:121:10 | c | hash_flow.rb:118:23:118:32 | call to taint :  | hash_flow.rb:121:10:121:10 | c | $@ | hash_flow.rb:118:23:118:32 | call to taint :  | call to taint :  |
+| hash_flow.rb:132:14:132:25 | key_or_value | hash_flow.rb:128:15:128:24 | call to taint :  | hash_flow.rb:132:14:132:25 | key_or_value | $@ | hash_flow.rb:128:15:128:24 | call to taint :  | call to taint :  |
+| hash_flow.rb:136:14:136:18 | value | hash_flow.rb:128:15:128:24 | call to taint :  | hash_flow.rb:136:14:136:18 | value | $@ | hash_flow.rb:128:15:128:24 | call to taint :  | call to taint :  |
+| hash_flow.rb:149:10:149:13 | ...[...] | hash_flow.rb:144:15:144:25 | call to taint :  | hash_flow.rb:149:10:149:13 | ...[...] | $@ | hash_flow.rb:144:15:144:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:150:10:150:13 | ...[...] | hash_flow.rb:144:15:144:25 | call to taint :  | hash_flow.rb:150:10:150:13 | ...[...] | $@ | hash_flow.rb:144:15:144:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:152:10:152:13 | ...[...] | hash_flow.rb:144:15:144:25 | call to taint :  | hash_flow.rb:152:10:152:13 | ...[...] | $@ | hash_flow.rb:144:15:144:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:174:10:174:14 | ...[...] | hash_flow.rb:170:15:170:25 | call to taint :  | hash_flow.rb:174:10:174:14 | ...[...] | $@ | hash_flow.rb:170:15:170:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:186:10:186:10 | a | hash_flow.rb:182:15:182:25 | call to taint :  | hash_flow.rb:186:10:186:10 | a | $@ | hash_flow.rb:182:15:182:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:199:14:199:18 | value | hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:199:14:199:18 | value | $@ | hash_flow.rb:194:15:194:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:201:10:201:14 | ...[...] | hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:201:10:201:14 | ...[...] | $@ | hash_flow.rb:194:15:194:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:202:10:202:17 | ...[...] | hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:202:10:202:17 | ...[...] | $@ | hash_flow.rb:194:15:194:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:217:10:217:21 | call to dig | hash_flow.rb:210:15:210:25 | call to taint :  | hash_flow.rb:217:10:217:21 | call to dig | $@ | hash_flow.rb:210:15:210:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:219:10:219:24 | call to dig | hash_flow.rb:213:19:213:29 | call to taint :  | hash_flow.rb:219:10:219:24 | call to dig | $@ | hash_flow.rb:213:19:213:29 | call to taint :  | call to taint :  |
+| hash_flow.rb:232:14:232:18 | value | hash_flow.rb:227:15:227:25 | call to taint :  | hash_flow.rb:232:14:232:18 | value | $@ | hash_flow.rb:227:15:227:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:234:10:234:14 | ...[...] | hash_flow.rb:227:15:227:25 | call to taint :  | hash_flow.rb:234:10:234:14 | ...[...] | $@ | hash_flow.rb:227:15:227:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:248:10:248:14 | ...[...] | hash_flow.rb:242:15:242:25 | call to taint :  | hash_flow.rb:248:10:248:14 | ...[...] | $@ | hash_flow.rb:242:15:242:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:261:14:261:18 | value | hash_flow.rb:256:15:256:25 | call to taint :  | hash_flow.rb:261:14:261:18 | value | $@ | hash_flow.rb:256:15:256:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:263:10:263:14 | ...[...] | hash_flow.rb:256:15:256:25 | call to taint :  | hash_flow.rb:263:10:263:14 | ...[...] | $@ | hash_flow.rb:256:15:256:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:275:14:275:18 | value | hash_flow.rb:271:15:271:25 | call to taint :  | hash_flow.rb:275:14:275:18 | value | $@ | hash_flow.rb:271:15:271:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:277:10:277:14 | ...[...] | hash_flow.rb:271:15:271:25 | call to taint :  | hash_flow.rb:277:10:277:14 | ...[...] | $@ | hash_flow.rb:271:15:271:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:293:10:293:14 | ...[...] | hash_flow.rb:287:15:287:25 | call to taint :  | hash_flow.rb:293:10:293:14 | ...[...] | $@ | hash_flow.rb:287:15:287:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:306:14:306:14 | x | hash_flow.rb:305:20:305:30 | call to taint :  | hash_flow.rb:306:14:306:14 | x | $@ | hash_flow.rb:305:20:305:30 | call to taint :  | call to taint :  |
+| hash_flow.rb:308:10:308:10 | b | hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:308:10:308:10 | b | $@ | hash_flow.rb:301:15:301:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:308:10:308:10 | b | hash_flow.rb:303:15:303:25 | call to taint :  | hash_flow.rb:308:10:308:10 | b | $@ | hash_flow.rb:303:15:303:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:310:10:310:10 | b | hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:310:10:310:10 | b | $@ | hash_flow.rb:301:15:301:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:312:10:312:10 | b | hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:312:10:312:10 | b | $@ | hash_flow.rb:301:15:301:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:312:10:312:10 | b | hash_flow.rb:311:24:311:34 | call to taint :  | hash_flow.rb:312:10:312:10 | b | $@ | hash_flow.rb:311:24:311:34 | call to taint :  | call to taint :  |
+| hash_flow.rb:314:10:314:10 | b | hash_flow.rb:313:24:313:34 | call to taint :  | hash_flow.rb:314:10:314:10 | b | $@ | hash_flow.rb:313:24:313:34 | call to taint :  | call to taint :  |
+| hash_flow.rb:316:10:316:10 | b | hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:316:10:316:10 | b | $@ | hash_flow.rb:301:15:301:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:316:10:316:10 | b | hash_flow.rb:303:15:303:25 | call to taint :  | hash_flow.rb:316:10:316:10 | b | $@ | hash_flow.rb:303:15:303:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:316:10:316:10 | b | hash_flow.rb:315:23:315:33 | call to taint :  | hash_flow.rb:316:10:316:10 | b | $@ | hash_flow.rb:315:23:315:33 | call to taint :  | call to taint :  |
+| hash_flow.rb:328:14:328:14 | x | hash_flow.rb:327:27:327:37 | call to taint :  | hash_flow.rb:328:14:328:14 | x | $@ | hash_flow.rb:327:27:327:37 | call to taint :  | call to taint :  |
+| hash_flow.rb:331:10:331:13 | ...[...] | hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:331:10:331:13 | ...[...] | $@ | hash_flow.rb:323:15:323:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:331:10:331:13 | ...[...] | hash_flow.rb:325:15:325:25 | call to taint :  | hash_flow.rb:331:10:331:13 | ...[...] | $@ | hash_flow.rb:325:15:325:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:331:10:331:13 | ...[...] | hash_flow.rb:329:9:329:19 | call to taint :  | hash_flow.rb:331:10:331:13 | ...[...] | $@ | hash_flow.rb:329:9:329:19 | call to taint :  | call to taint :  |
+| hash_flow.rb:333:10:333:13 | ...[...] | hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:333:10:333:13 | ...[...] | $@ | hash_flow.rb:323:15:323:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:335:10:335:13 | ...[...] | hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:335:10:335:13 | ...[...] | $@ | hash_flow.rb:323:15:323:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:335:10:335:13 | ...[...] | hash_flow.rb:325:15:325:25 | call to taint :  | hash_flow.rb:335:10:335:13 | ...[...] | $@ | hash_flow.rb:325:15:325:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:348:14:348:18 | value | hash_flow.rb:342:15:342:25 | call to taint :  | hash_flow.rb:348:14:348:18 | value | $@ | hash_flow.rb:342:15:342:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:348:14:348:18 | value | hash_flow.rb:344:15:344:25 | call to taint :  | hash_flow.rb:348:14:348:18 | value | $@ | hash_flow.rb:344:15:344:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:351:10:351:16 | ( ... ) | hash_flow.rb:342:15:342:25 | call to taint :  | hash_flow.rb:351:10:351:16 | ( ... ) | $@ | hash_flow.rb:342:15:342:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:364:14:364:18 | value | hash_flow.rb:358:15:358:25 | call to taint :  | hash_flow.rb:364:14:364:18 | value | $@ | hash_flow.rb:358:15:358:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:364:14:364:18 | value | hash_flow.rb:360:15:360:25 | call to taint :  | hash_flow.rb:364:14:364:18 | value | $@ | hash_flow.rb:360:15:360:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:367:10:367:19 | ( ... ) | hash_flow.rb:358:15:358:25 | call to taint :  | hash_flow.rb:367:10:367:19 | ( ... ) | $@ | hash_flow.rb:358:15:358:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:379:10:379:15 | ( ... ) | hash_flow.rb:374:15:374:25 | call to taint :  | hash_flow.rb:379:10:379:15 | ( ... ) | $@ | hash_flow.rb:374:15:374:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:379:10:379:15 | ( ... ) | hash_flow.rb:376:15:376:25 | call to taint :  | hash_flow.rb:379:10:379:15 | ( ... ) | $@ | hash_flow.rb:376:15:376:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:392:14:392:18 | value | hash_flow.rb:386:15:386:25 | call to taint :  | hash_flow.rb:392:14:392:18 | value | $@ | hash_flow.rb:386:15:386:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:392:14:392:18 | value | hash_flow.rb:388:15:388:25 | call to taint :  | hash_flow.rb:392:14:392:18 | value | $@ | hash_flow.rb:388:15:388:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:395:10:395:19 | ( ... ) | hash_flow.rb:386:15:386:25 | call to taint :  | hash_flow.rb:395:10:395:19 | ( ... ) | $@ | hash_flow.rb:386:15:386:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:396:10:396:16 | ( ... ) | hash_flow.rb:386:15:386:25 | call to taint :  | hash_flow.rb:396:10:396:16 | ( ... ) | $@ | hash_flow.rb:386:15:386:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:414:14:414:22 | old_value | hash_flow.rb:403:15:403:25 | call to taint :  | hash_flow.rb:414:14:414:22 | old_value | $@ | hash_flow.rb:403:15:403:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:414:14:414:22 | old_value | hash_flow.rb:405:15:405:25 | call to taint :  | hash_flow.rb:414:14:414:22 | old_value | $@ | hash_flow.rb:405:15:405:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:414:14:414:22 | old_value | hash_flow.rb:408:15:408:25 | call to taint :  | hash_flow.rb:414:14:414:22 | old_value | $@ | hash_flow.rb:408:15:408:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:414:14:414:22 | old_value | hash_flow.rb:410:15:410:25 | call to taint :  | hash_flow.rb:414:14:414:22 | old_value | $@ | hash_flow.rb:410:15:410:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:415:14:415:22 | new_value | hash_flow.rb:403:15:403:25 | call to taint :  | hash_flow.rb:415:14:415:22 | new_value | $@ | hash_flow.rb:403:15:403:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:415:14:415:22 | new_value | hash_flow.rb:405:15:405:25 | call to taint :  | hash_flow.rb:415:14:415:22 | new_value | $@ | hash_flow.rb:405:15:405:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:415:14:415:22 | new_value | hash_flow.rb:408:15:408:25 | call to taint :  | hash_flow.rb:415:14:415:22 | new_value | $@ | hash_flow.rb:408:15:408:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:415:14:415:22 | new_value | hash_flow.rb:410:15:410:25 | call to taint :  | hash_flow.rb:415:14:415:22 | new_value | $@ | hash_flow.rb:410:15:410:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:417:10:417:19 | ( ... ) | hash_flow.rb:403:15:403:25 | call to taint :  | hash_flow.rb:417:10:417:19 | ( ... ) | $@ | hash_flow.rb:403:15:403:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:419:10:419:19 | ( ... ) | hash_flow.rb:405:15:405:25 | call to taint :  | hash_flow.rb:419:10:419:19 | ( ... ) | $@ | hash_flow.rb:405:15:405:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:420:10:420:19 | ( ... ) | hash_flow.rb:408:15:408:25 | call to taint :  | hash_flow.rb:420:10:420:19 | ( ... ) | $@ | hash_flow.rb:408:15:408:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:422:10:422:19 | ( ... ) | hash_flow.rb:410:15:410:25 | call to taint :  | hash_flow.rb:422:10:422:19 | ( ... ) | $@ | hash_flow.rb:410:15:410:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:440:14:440:22 | old_value | hash_flow.rb:429:15:429:25 | call to taint :  | hash_flow.rb:440:14:440:22 | old_value | $@ | hash_flow.rb:429:15:429:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:440:14:440:22 | old_value | hash_flow.rb:431:15:431:25 | call to taint :  | hash_flow.rb:440:14:440:22 | old_value | $@ | hash_flow.rb:431:15:431:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:440:14:440:22 | old_value | hash_flow.rb:434:15:434:25 | call to taint :  | hash_flow.rb:440:14:440:22 | old_value | $@ | hash_flow.rb:434:15:434:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:440:14:440:22 | old_value | hash_flow.rb:436:15:436:25 | call to taint :  | hash_flow.rb:440:14:440:22 | old_value | $@ | hash_flow.rb:436:15:436:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:441:14:441:22 | new_value | hash_flow.rb:429:15:429:25 | call to taint :  | hash_flow.rb:441:14:441:22 | new_value | $@ | hash_flow.rb:429:15:429:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:441:14:441:22 | new_value | hash_flow.rb:431:15:431:25 | call to taint :  | hash_flow.rb:441:14:441:22 | new_value | $@ | hash_flow.rb:431:15:431:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:441:14:441:22 | new_value | hash_flow.rb:434:15:434:25 | call to taint :  | hash_flow.rb:441:14:441:22 | new_value | $@ | hash_flow.rb:434:15:434:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:441:14:441:22 | new_value | hash_flow.rb:436:15:436:25 | call to taint :  | hash_flow.rb:441:14:441:22 | new_value | $@ | hash_flow.rb:436:15:436:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:443:10:443:19 | ( ... ) | hash_flow.rb:429:15:429:25 | call to taint :  | hash_flow.rb:443:10:443:19 | ( ... ) | $@ | hash_flow.rb:429:15:429:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:445:10:445:19 | ( ... ) | hash_flow.rb:431:15:431:25 | call to taint :  | hash_flow.rb:445:10:445:19 | ( ... ) | $@ | hash_flow.rb:431:15:431:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:446:10:446:19 | ( ... ) | hash_flow.rb:434:15:434:25 | call to taint :  | hash_flow.rb:446:10:446:19 | ( ... ) | $@ | hash_flow.rb:434:15:434:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:448:10:448:19 | ( ... ) | hash_flow.rb:436:15:436:25 | call to taint :  | hash_flow.rb:448:10:448:19 | ( ... ) | $@ | hash_flow.rb:436:15:436:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:450:10:450:20 | ( ... ) | hash_flow.rb:429:15:429:25 | call to taint :  | hash_flow.rb:450:10:450:20 | ( ... ) | $@ | hash_flow.rb:429:15:429:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:452:10:452:20 | ( ... ) | hash_flow.rb:431:15:431:25 | call to taint :  | hash_flow.rb:452:10:452:20 | ( ... ) | $@ | hash_flow.rb:431:15:431:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:453:10:453:20 | ( ... ) | hash_flow.rb:434:15:434:25 | call to taint :  | hash_flow.rb:453:10:453:20 | ( ... ) | $@ | hash_flow.rb:434:15:434:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:455:10:455:20 | ( ... ) | hash_flow.rb:436:15:436:25 | call to taint :  | hash_flow.rb:455:10:455:20 | ( ... ) | $@ | hash_flow.rb:436:15:436:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:467:10:467:13 | ...[...] | hash_flow.rb:462:15:462:25 | call to taint :  | hash_flow.rb:467:10:467:13 | ...[...] | $@ | hash_flow.rb:462:15:462:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:479:14:479:18 | value | hash_flow.rb:474:15:474:25 | call to taint :  | hash_flow.rb:479:14:479:18 | value | $@ | hash_flow.rb:474:15:474:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:482:10:482:14 | ...[...] | hash_flow.rb:474:15:474:25 | call to taint :  | hash_flow.rb:482:10:482:14 | ...[...] | $@ | hash_flow.rb:474:15:474:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:494:14:494:18 | value | hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:494:14:494:18 | value | $@ | hash_flow.rb:489:15:489:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:497:10:497:14 | ...[...] | hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:497:10:497:14 | ...[...] | $@ | hash_flow.rb:489:15:489:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:498:10:498:17 | ...[...] | hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:498:10:498:17 | ...[...] | $@ | hash_flow.rb:489:15:489:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:513:10:513:20 | ( ... ) | hash_flow.rb:505:15:505:25 | call to taint :  | hash_flow.rb:513:10:513:20 | ( ... ) | $@ | hash_flow.rb:505:15:505:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:515:10:515:20 | ( ... ) | hash_flow.rb:507:15:507:25 | call to taint :  | hash_flow.rb:515:10:515:20 | ( ... ) | $@ | hash_flow.rb:507:15:507:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:526:14:526:18 | value | hash_flow.rb:520:15:520:25 | call to taint :  | hash_flow.rb:526:14:526:18 | value | $@ | hash_flow.rb:520:15:520:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:526:14:526:18 | value | hash_flow.rb:522:15:522:25 | call to taint :  | hash_flow.rb:526:14:526:18 | value | $@ | hash_flow.rb:522:15:522:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:529:10:529:16 | ( ... ) | hash_flow.rb:520:15:520:25 | call to taint :  | hash_flow.rb:529:10:529:16 | ( ... ) | $@ | hash_flow.rb:520:15:520:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:542:14:542:18 | value | hash_flow.rb:536:15:536:25 | call to taint :  | hash_flow.rb:542:14:542:18 | value | $@ | hash_flow.rb:536:15:536:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:542:14:542:18 | value | hash_flow.rb:538:15:538:25 | call to taint :  | hash_flow.rb:542:14:542:18 | value | $@ | hash_flow.rb:538:15:538:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:545:10:545:19 | ( ... ) | hash_flow.rb:536:15:536:25 | call to taint :  | hash_flow.rb:545:10:545:19 | ( ... ) | $@ | hash_flow.rb:536:15:536:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:557:10:557:19 | ( ... ) | hash_flow.rb:552:15:552:25 | call to taint :  | hash_flow.rb:557:10:557:19 | ( ... ) | $@ | hash_flow.rb:552:15:552:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:559:10:559:15 | ( ... ) | hash_flow.rb:552:15:552:25 | call to taint :  | hash_flow.rb:559:10:559:15 | ( ... ) | $@ | hash_flow.rb:552:15:552:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:559:10:559:15 | ( ... ) | hash_flow.rb:554:15:554:25 | call to taint :  | hash_flow.rb:559:10:559:15 | ( ... ) | $@ | hash_flow.rb:554:15:554:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:571:10:571:16 | ( ... ) | hash_flow.rb:566:15:566:25 | call to taint :  | hash_flow.rb:571:10:571:16 | ( ... ) | $@ | hash_flow.rb:566:15:566:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:576:10:576:16 | ( ... ) | hash_flow.rb:566:15:566:25 | call to taint :  | hash_flow.rb:576:10:576:16 | ( ... ) | $@ | hash_flow.rb:566:15:566:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:578:10:578:16 | ( ... ) | hash_flow.rb:568:15:568:25 | call to taint :  | hash_flow.rb:578:10:578:16 | ( ... ) | $@ | hash_flow.rb:568:15:568:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:591:10:591:18 | ( ... ) | hash_flow.rb:585:15:585:25 | call to taint :  | hash_flow.rb:591:10:591:18 | ( ... ) | $@ | hash_flow.rb:585:15:585:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:591:10:591:18 | ( ... ) | hash_flow.rb:587:15:587:25 | call to taint :  | hash_flow.rb:591:10:591:18 | ( ... ) | $@ | hash_flow.rb:587:15:587:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:603:10:603:16 | ( ... ) | hash_flow.rb:598:15:598:25 | call to taint :  | hash_flow.rb:603:10:603:16 | ( ... ) | $@ | hash_flow.rb:598:15:598:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:605:10:605:16 | ( ... ) | hash_flow.rb:600:15:600:25 | call to taint :  | hash_flow.rb:605:10:605:16 | ( ... ) | $@ | hash_flow.rb:600:15:600:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:609:14:609:18 | value | hash_flow.rb:598:15:598:25 | call to taint :  | hash_flow.rb:609:14:609:18 | value | $@ | hash_flow.rb:598:15:598:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:609:14:609:18 | value | hash_flow.rb:600:15:600:25 | call to taint :  | hash_flow.rb:609:14:609:18 | value | $@ | hash_flow.rb:600:15:600:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:612:10:612:16 | ( ... ) | hash_flow.rb:610:14:610:24 | call to taint :  | hash_flow.rb:612:10:612:16 | ( ... ) | $@ | hash_flow.rb:610:14:610:24 | call to taint :  | call to taint :  |
+| hash_flow.rb:624:10:624:17 | ( ... ) | hash_flow.rb:619:15:619:25 | call to taint :  | hash_flow.rb:624:10:624:17 | ( ... ) | $@ | hash_flow.rb:619:15:619:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:624:10:624:17 | ( ... ) | hash_flow.rb:621:15:621:25 | call to taint :  | hash_flow.rb:624:10:624:17 | ( ... ) | $@ | hash_flow.rb:621:15:621:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:625:10:625:17 | ( ... ) | hash_flow.rb:619:15:619:25 | call to taint :  | hash_flow.rb:625:10:625:17 | ( ... ) | $@ | hash_flow.rb:619:15:619:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:625:10:625:17 | ( ... ) | hash_flow.rb:621:15:621:25 | call to taint :  | hash_flow.rb:625:10:625:17 | ( ... ) | $@ | hash_flow.rb:621:15:621:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:626:10:626:17 | ( ... ) | hash_flow.rb:619:15:619:25 | call to taint :  | hash_flow.rb:626:10:626:17 | ( ... ) | $@ | hash_flow.rb:619:15:619:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:626:10:626:17 | ( ... ) | hash_flow.rb:621:15:621:25 | call to taint :  | hash_flow.rb:626:10:626:17 | ( ... ) | $@ | hash_flow.rb:621:15:621:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:638:10:638:20 | ( ... ) | hash_flow.rb:633:15:633:25 | call to taint :  | hash_flow.rb:638:10:638:20 | ( ... ) | $@ | hash_flow.rb:633:15:633:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:638:10:638:20 | ( ... ) | hash_flow.rb:635:15:635:25 | call to taint :  | hash_flow.rb:638:10:638:20 | ( ... ) | $@ | hash_flow.rb:635:15:635:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:639:10:639:20 | ( ... ) | hash_flow.rb:633:15:633:25 | call to taint :  | hash_flow.rb:639:10:639:20 | ( ... ) | $@ | hash_flow.rb:633:15:633:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:639:10:639:20 | ( ... ) | hash_flow.rb:635:15:635:25 | call to taint :  | hash_flow.rb:639:10:639:20 | ( ... ) | $@ | hash_flow.rb:635:15:635:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:640:10:640:20 | ( ... ) | hash_flow.rb:633:15:633:25 | call to taint :  | hash_flow.rb:640:10:640:20 | ( ... ) | $@ | hash_flow.rb:633:15:633:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:640:10:640:20 | ( ... ) | hash_flow.rb:635:15:635:25 | call to taint :  | hash_flow.rb:640:10:640:20 | ( ... ) | $@ | hash_flow.rb:635:15:635:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:652:14:652:18 | value | hash_flow.rb:647:15:647:25 | call to taint :  | hash_flow.rb:652:14:652:18 | value | $@ | hash_flow.rb:647:15:647:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:652:14:652:18 | value | hash_flow.rb:649:15:649:25 | call to taint :  | hash_flow.rb:652:14:652:18 | value | $@ | hash_flow.rb:649:15:649:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:655:10:655:19 | ( ... ) | hash_flow.rb:647:15:647:25 | call to taint :  | hash_flow.rb:655:10:655:19 | ( ... ) | $@ | hash_flow.rb:647:15:647:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:656:10:656:16 | ( ... ) | hash_flow.rb:653:9:653:19 | call to taint :  | hash_flow.rb:656:10:656:16 | ( ... ) | $@ | hash_flow.rb:653:9:653:19 | call to taint :  | call to taint :  |
+| hash_flow.rb:668:14:668:18 | value | hash_flow.rb:663:15:663:25 | call to taint :  | hash_flow.rb:668:14:668:18 | value | $@ | hash_flow.rb:663:15:663:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:668:14:668:18 | value | hash_flow.rb:665:15:665:25 | call to taint :  | hash_flow.rb:668:14:668:18 | value | $@ | hash_flow.rb:665:15:665:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:671:10:671:19 | ( ... ) | hash_flow.rb:669:9:669:19 | call to taint :  | hash_flow.rb:671:10:671:19 | ( ... ) | $@ | hash_flow.rb:669:9:669:19 | call to taint :  | call to taint :  |
+| hash_flow.rb:689:14:689:22 | old_value | hash_flow.rb:678:15:678:25 | call to taint :  | hash_flow.rb:689:14:689:22 | old_value | $@ | hash_flow.rb:678:15:678:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:689:14:689:22 | old_value | hash_flow.rb:680:15:680:25 | call to taint :  | hash_flow.rb:689:14:689:22 | old_value | $@ | hash_flow.rb:680:15:680:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:689:14:689:22 | old_value | hash_flow.rb:683:15:683:25 | call to taint :  | hash_flow.rb:689:14:689:22 | old_value | $@ | hash_flow.rb:683:15:683:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:689:14:689:22 | old_value | hash_flow.rb:685:15:685:25 | call to taint :  | hash_flow.rb:689:14:689:22 | old_value | $@ | hash_flow.rb:685:15:685:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:690:14:690:22 | new_value | hash_flow.rb:678:15:678:25 | call to taint :  | hash_flow.rb:690:14:690:22 | new_value | $@ | hash_flow.rb:678:15:678:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:690:14:690:22 | new_value | hash_flow.rb:680:15:680:25 | call to taint :  | hash_flow.rb:690:14:690:22 | new_value | $@ | hash_flow.rb:680:15:680:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:690:14:690:22 | new_value | hash_flow.rb:683:15:683:25 | call to taint :  | hash_flow.rb:690:14:690:22 | new_value | $@ | hash_flow.rb:683:15:683:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:690:14:690:22 | new_value | hash_flow.rb:685:15:685:25 | call to taint :  | hash_flow.rb:690:14:690:22 | new_value | $@ | hash_flow.rb:685:15:685:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:692:10:692:19 | ( ... ) | hash_flow.rb:678:15:678:25 | call to taint :  | hash_flow.rb:692:10:692:19 | ( ... ) | $@ | hash_flow.rb:678:15:678:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:694:10:694:19 | ( ... ) | hash_flow.rb:680:15:680:25 | call to taint :  | hash_flow.rb:694:10:694:19 | ( ... ) | $@ | hash_flow.rb:680:15:680:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:695:10:695:19 | ( ... ) | hash_flow.rb:683:15:683:25 | call to taint :  | hash_flow.rb:695:10:695:19 | ( ... ) | $@ | hash_flow.rb:683:15:683:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:697:10:697:19 | ( ... ) | hash_flow.rb:685:15:685:25 | call to taint :  | hash_flow.rb:697:10:697:19 | ( ... ) | $@ | hash_flow.rb:685:15:685:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:699:10:699:20 | ( ... ) | hash_flow.rb:678:15:678:25 | call to taint :  | hash_flow.rb:699:10:699:20 | ( ... ) | $@ | hash_flow.rb:678:15:678:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:701:10:701:20 | ( ... ) | hash_flow.rb:680:15:680:25 | call to taint :  | hash_flow.rb:701:10:701:20 | ( ... ) | $@ | hash_flow.rb:680:15:680:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:702:10:702:20 | ( ... ) | hash_flow.rb:683:15:683:25 | call to taint :  | hash_flow.rb:702:10:702:20 | ( ... ) | $@ | hash_flow.rb:683:15:683:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:704:10:704:20 | ( ... ) | hash_flow.rb:685:15:685:25 | call to taint :  | hash_flow.rb:704:10:704:20 | ( ... ) | $@ | hash_flow.rb:685:15:685:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:716:10:716:15 | ( ... ) | hash_flow.rb:711:15:711:25 | call to taint :  | hash_flow.rb:716:10:716:15 | ( ... ) | $@ | hash_flow.rb:711:15:711:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:716:10:716:15 | ( ... ) | hash_flow.rb:713:15:713:25 | call to taint :  | hash_flow.rb:716:10:716:15 | ( ... ) | $@ | hash_flow.rb:713:15:713:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:728:10:728:13 | ...[...] | hash_flow.rb:723:15:723:25 | call to taint :  | hash_flow.rb:728:10:728:13 | ...[...] | $@ | hash_flow.rb:723:15:723:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:730:10:730:13 | ...[...] | hash_flow.rb:723:15:723:25 | call to taint :  | hash_flow.rb:730:10:730:13 | ...[...] | $@ | hash_flow.rb:723:15:723:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:730:10:730:13 | ...[...] | hash_flow.rb:725:15:725:25 | call to taint :  | hash_flow.rb:730:10:730:13 | ...[...] | $@ | hash_flow.rb:725:15:725:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:747:10:747:17 | ...[...] | hash_flow.rb:737:15:737:25 | call to taint :  | hash_flow.rb:747:10:747:17 | ...[...] | $@ | hash_flow.rb:737:15:737:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:749:10:749:17 | ...[...] | hash_flow.rb:739:15:739:25 | call to taint :  | hash_flow.rb:749:10:749:17 | ...[...] | $@ | hash_flow.rb:739:15:739:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:750:10:750:17 | ...[...] | hash_flow.rb:742:15:742:25 | call to taint :  | hash_flow.rb:750:10:750:17 | ...[...] | $@ | hash_flow.rb:742:15:742:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:752:10:752:17 | ...[...] | hash_flow.rb:744:15:744:25 | call to taint :  | hash_flow.rb:752:10:752:17 | ...[...] | $@ | hash_flow.rb:744:15:744:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:753:10:753:17 | ...[...] | hash_flow.rb:746:29:746:39 | call to taint :  | hash_flow.rb:753:10:753:17 | ...[...] | $@ | hash_flow.rb:746:29:746:39 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash_flow.rb
@@ -68,6 +68,14 @@ def m3()
     hash4 = Hash[:a, taint(3.4), :b, 1]
     sink(hash4[:a]) # $ hasValueFlow=3.4
     sink(hash4[:b])
+
+    hash5 = Hash["a" => taint(3.5), "b" => 1]
+    sink(hash5["a"]) # $ hasValueFlow=3.5
+    sink(hash5["b"])
+
+    hash6 = Hash[{"a" => taint(3.6), "b" => 1}]
+    sink(hash6["a"]) # $ hasValueFlow=3.6
+    sink(hash6["b"])
 end
 
 m3()


### PR DESCRIPTION
The existing summaries could be simplified using the models-as-data token `Argument[hash-splat]`, which refers to both keyword arguments wrapped in an implicit hash, as well as explicit hash splat arguments.