### PR TITLE
Swift: Fix flow summaries for methods

### DIFF
--- a/swift/ql/lib/codeql/swift/controlflow/CfgNodes.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/CfgNodes.qll
@@ -125,6 +125,8 @@ class ApplyExprCfgNode extends ExprCfgNode {
   }
 
   AbstractFunctionDecl getStaticTarget() { result = e.getStaticTarget() }
+
+  Expr getFunction() { result = e.getFunction() }
 }
 
 class CallExprCfgNode extends ApplyExprCfgNode {

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -11,6 +11,7 @@ private import FlowSummaryImpl::Private
 private import FlowSummaryImpl::Public
 private import codeql.swift.dataflow.ExternalFlow
 private import codeql.swift.dataflow.FlowSummary as FlowSummary
+private import codeql.swift.controlflow.CfgNodes
 
 class SummarizedCallableBase = AbstractFunctionDecl;
 
@@ -153,7 +154,9 @@ class InterpretNode extends TInterpretNode {
   DataFlowCallable asCallable() { result.getUnderlyingCallable() = this.asElement() }
 
   /** Gets the target of this call, if any. */
-  AbstractFunctionDecl getCallTarget() { result = this.asCall().asCall().getStaticTarget() }
+  AbstractFunctionDecl getCallTarget() {
+    result = this.asCall().asCall().getFunction().(ApplyExpr).getStaticTarget()
+  }
 
   /** Gets a textual representation of this node. */
   string toString() {

--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
@@ -17,24 +17,6 @@ import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.TaintTracking
 import codeql.swift.dataflow.FlowSources
 import DataFlow::PathGraph
-import codeql.swift.frameworks.StandardLibrary.String
-
-/**
- * A taint source that is `String(contentsOf:)`.
- * TODO: this shouldn't be needed when `StringSource` in `String.qll` is working.
- */
-class StringContentsOfUrlSource extends RemoteFlowSource {
-  StringContentsOfUrlSource() {
-    exists(CallExpr call, AbstractFunctionDecl f |
-      call.getFunction().(ApplyExpr).getStaticTarget() = f and
-      f.getName() = "init(contentsOf:)" and
-      f.getParam(0).getType().getName() = "URL" and
-      this.asExpr() = call
-    )
-  }
-
-  override string getSourceType() { result = "" }
-}
 
 /**
  * A sink that is a candidate result for this query, such as certain arguments


### PR DESCRIPTION
The `getCallTarget` predicate in our flow summary instantiation was suffering from the same problem as the one I described [here](https://github.com/github/codeql/pull/9673#discussion_r905171464): The call to `init(contentsOf:)` is really two calls (one providing the qualifier, and another one providing the `contentsOf` argument. Prior to this PR, the `getCallTarget` predicate was giving us the function that provided the qualifier.

cc @geoffw0.

Note: Once we merge https://github.com/github/codeql/pull/9891 this class of issues will be gone (since we can provide a much better API for function calls then)