### PR TITLE
Fix path of `fetch-codeql`

### DIFF
--- a/.github/workflows/csv-coverage-timeseries.yml
+++ b/.github/workflows/csv-coverage-timeseries.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Download CodeQL CLI
-        uses: ./.github/actions/fetch-codeql
+        uses: ./script/.github/actions/fetch-codeql
       - name: Build modeled package list
         run: |
           python script/misc/scripts/library-coverage/generate-timeseries.py codeqlModels

--- a/.github/workflows/csv-coverage-update.yml
+++ b/.github/workflows/csv-coverage-update.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Download CodeQL CLI
-        uses: ./.github/actions/fetch-codeql
+        uses: ./ql/.github/actions/fetch-codeql
       - name: Generate coverage files
         run: |
           python ql/misc/scripts/library-coverage/generate-report.py ci ql ql

--- a/.github/workflows/csv-coverage.yml
+++ b/.github/workflows/csv-coverage.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Download CodeQL CLI
-        uses: ./.github/actions/fetch-codeql
+        uses: ./script/.github/actions/fetch-codeql
       - name: Build modeled package list
         run: |
           python script/misc/scripts/library-coverage/generate-report.py ci codeqlModels script


### PR DESCRIPTION
This PR fixes the path of `.github/actions/fetch-codeql` where the CodeQL `actions/checkout@v3` is using a custom `path`.