### PR TITLE
Swift: CFG for `any!`

### DIFF
--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
@@ -1676,8 +1676,8 @@ module Exprs {
     }
   }
 
-  private class TryTree extends AstStandardPostOrderTree {
-    override TryExpr ast;
+  private class AnyTryTree extends AstStandardPostOrderTree {
+    override AnyTryExpr ast;
 
     override ControlFlowElement getChildElement(int i) {
       i = 0 and

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -200,6 +200,7 @@ cfg.swift:
 #-----|  -> Did not throw.
 
 #   29| call to print(_:separator:terminator:)
+#-----|  -> mightThrow(x:)
 
 #   29| default separator
 #-----|  -> default terminator
@@ -217,6 +218,43 @@ cfg.swift:
 #-----|  -> default separator
 
 #   29| [...]
+#-----|  -> [...]
+
+#   30| try! ...
+#-----|  -> print(_:separator:terminator:)
+
+#   30| mightThrow(x:)
+#-----|  -> 0
+
+#   30| call to mightThrow(x:)
+#-----|  -> try! ...
+#-----| exception -> case ...
+
+#   30| 0
+#-----|  -> call to mightThrow(x:)
+
+#   31| print(_:separator:terminator:)
+#-----|  -> Still did not throw.
+
+#   31| call to print(_:separator:terminator:)
+#-----|  -> 0
+
+#   31| default separator
+#-----|  -> default terminator
+
+#   31| default terminator
+#-----|  -> call to print(_:separator:terminator:)
+
+#   31| (Any) ...
+#-----|  -> [...]
+
+#   31| Still did not throw.
+#-----|  -> (Any) ...
+
+#   31| [...]
+#-----|  -> default separator
+
+#   31| [...]
 #-----|  -> [...]
 
 #   33| case ...
@@ -5306,6 +5344,7 @@ cfg.swift:
 #-----|  -> Did not throw.
 
 #  386| call to print(_:separator:terminator:)
+#-----|  -> mightThrow(x:)
 
 #  386| default separator
 #-----|  -> default terminator
@@ -5324,6 +5363,49 @@ cfg.swift:
 
 #  386| [...]
 #-----|  -> [...]
+
+#  387| try! ...
+#-----|  -> print(_:separator:terminator:)
+
+#  387| mightThrow(x:)
+#-----|  -> 0
+
+#  387| call to mightThrow(x:)
+#-----| exception -> exit doWithoutCatch(x:) (normal)
+#-----|  -> try! ...
+
+#  387| 0
+#-----|  -> call to mightThrow(x:)
+
+#  388| print(_:separator:terminator:)
+#-----|  -> Still did not throw.
+
+#  388| call to print(_:separator:terminator:)
+#-----|  -> 0
+
+#  388| default separator
+#-----|  -> default terminator
+
+#  388| default terminator
+#-----|  -> call to print(_:separator:terminator:)
+
+#  388| (Any) ...
+#-----|  -> [...]
+
+#  388| Still did not throw.
+#-----|  -> (Any) ...
+
+#  388| [...]
+#-----|  -> default separator
+
+#  388| [...]
+#-----|  -> [...]
+
+#  390| return ...
+#-----| return -> exit doWithoutCatch(x:) (normal)
+
+#  390| 0
+#-----|  -> return ...
 
 #  394| (unnamed function decl)
 

--- a/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.expected
+++ b/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.expected
@@ -5,6 +5,9 @@ edges
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | UnsafeWebViewFetch.swift:167:25:167:39 | call to getRemoteData() |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() :  |
 | UnsafeWebViewFetch.swift:94:14:94:37 | call to ... :  | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  |
+| UnsafeWebViewFetch.swift:103:30:103:84 | call to ... :  | UnsafeWebViewFetch.swift:103:25:103:84 | try! ... |
+| UnsafeWebViewFetch.swift:105:18:105:72 | call to ... :  | UnsafeWebViewFetch.swift:106:25:106:25 | data |
+| UnsafeWebViewFetch.swift:109:30:109:53 | call to ... :  | UnsafeWebViewFetch.swift:109:25:109:53 | try! ... |
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:121:25:121:25 | remoteString |
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:124:25:124:51 | ... call to +(_:_:) ... |
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:127:25:127:25 | "..." |
@@ -36,6 +39,12 @@ edges
 nodes
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | semmle.label | try ... :  |
 | UnsafeWebViewFetch.swift:94:14:94:37 | call to ... :  | semmle.label | call to ... :  |
+| UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | semmle.label | try! ... |
+| UnsafeWebViewFetch.swift:103:30:103:84 | call to ... :  | semmle.label | call to ... :  |
+| UnsafeWebViewFetch.swift:105:18:105:72 | call to ... :  | semmle.label | call to ... :  |
+| UnsafeWebViewFetch.swift:106:25:106:25 | data | semmle.label | data |
+| UnsafeWebViewFetch.swift:109:25:109:53 | try! ... | semmle.label | try! ... |
+| UnsafeWebViewFetch.swift:109:30:109:53 | call to ... :  | semmle.label | call to ... :  |
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  | semmle.label | call to getRemoteData() :  |
 | UnsafeWebViewFetch.swift:120:25:120:39 | call to getRemoteData() | semmle.label | call to getRemoteData() |
 | UnsafeWebViewFetch.swift:121:25:121:25 | remoteString | semmle.label | remoteString |
@@ -71,6 +80,9 @@ nodes
 | UnsafeWebViewFetch.swift:211:25:211:25 | htmlData | semmle.label | htmlData |
 subpaths
 #select
+| UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | UnsafeWebViewFetch.swift:103:30:103:84 | call to ... :  | UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | Tainted data is used in a WebView fetch without restricting the base URL. |
+| UnsafeWebViewFetch.swift:106:25:106:25 | data | UnsafeWebViewFetch.swift:105:18:105:72 | call to ... :  | UnsafeWebViewFetch.swift:106:25:106:25 | data | Tainted data is used in a WebView fetch without restricting the base URL. |
+| UnsafeWebViewFetch.swift:109:25:109:53 | try! ... | UnsafeWebViewFetch.swift:109:30:109:53 | call to ... :  | UnsafeWebViewFetch.swift:109:25:109:53 | try! ... | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:120:25:120:39 | call to getRemoteData() | UnsafeWebViewFetch.swift:94:14:94:37 | call to ... :  | UnsafeWebViewFetch.swift:120:25:120:39 | call to getRemoteData() | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:121:25:121:25 | remoteString | UnsafeWebViewFetch.swift:94:14:94:37 | call to ... :  | UnsafeWebViewFetch.swift:121:25:121:25 | remoteString | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:124:25:124:51 | ... call to +(_:_:) ... | UnsafeWebViewFetch.swift:94:14:94:37 | call to ... :  | UnsafeWebViewFetch.swift:124:25:124:51 | ... call to +(_:_:) ... | Tainted data is used in a WebView fetch without restricting the base URL. |

--- a/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.swift
+++ b/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.swift
@@ -100,13 +100,13 @@ func getRemoteData() -> String {
 func testSimpleFlows() {
 	let webview = UIWebView()
 
-	webview.loadHTMLString(try! String(contentsOf: URL(string: "http://example.com/")!), baseURL: nil) // BAD [NOT DETECTED]
+	webview.loadHTMLString(try! String(contentsOf: URL(string: "http://example.com/")!), baseURL: nil) // BAD
 
 	let data = try! String(contentsOf: URL(string: "http://example.com/")!)
-	webview.loadHTMLString(data, baseURL: nil) // BAD [NOT DETECTED]
+	webview.loadHTMLString(data, baseURL: nil) // BAD
 
 	let url = URL(string: "http://example.com/")
-	webview.loadHTMLString(try! String(contentsOf: url!), baseURL: nil) // BAD [NOT DETECTED]
+	webview.loadHTMLString(try! String(contentsOf: url!), baseURL: nil) // BAD
 }
 
 func testUIWebView() {


### PR DESCRIPTION
We were not constructing CFGs for `any!` expressions. This led to unreachable CFG nodes, which led to missing dataflow nodes (as observed by @geoffw0).