### PR TITLE
Go: implement conservative cross-thread dataflow

### DIFF
--- a/go/ql/lib/change-notes/2022-08-12-cross-thread-flow.md
+++ b/go/ql/lib/change-notes/2022-08-12-cross-thread-flow.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Fixed data-flow to captured variable references.
+* We now assume that if a channel-typed field is only referred to twice in the user codebase, once in a send operation and once in a receive, then data flows from the send to the receive statement. This enables finding some cross-goroutine flow.

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
@@ -169,10 +169,10 @@ module ControlFlow {
     /**
      * Holds if this node writes `rhs` to `channel`.
      */
-    predicate writesToChannel(DataFlow::Node channel, DataFlow::Node rhs) {
+    predicate writesToChannel(DataFlow::ExprNode channel, DataFlow::ExprNode rhs) {
       exists(SendStmt send |
-        send.getChannel() = channel.(DataFlow::ExprNode).asExpr() and
-        send.getValue() = rhs.(DataFlow::ExprNode).asExpr()
+        send.getChannel() = channel.asExpr() and
+        send.getValue() = rhs.asExpr()
       )
     }
 

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
@@ -167,10 +167,20 @@ module ControlFlow {
     }
 
     /**
+     * Holds if this node writes `rhs` to `channel`.
+     */
+    predicate writesToChannel(DataFlow::Node channel, DataFlow::Node rhs) {
+      exists(SendStmt send |
+        send.getChannel() = channel.(DataFlow::ExprNode).asExpr() and
+        send.getValue() = rhs.(DataFlow::ExprNode).asExpr()
+      )
+    }
+
+    /**
      * Holds if this node sets any field or element of `base` to `rhs`.
      */
     predicate writesComponent(DataFlow::Node base, DataFlow::Node rhs) {
-      writesElement(base, _, rhs) or writesField(base, _, rhs)
+      writesElement(base, _, rhs) or writesField(base, _, rhs) or writesToChannel(base, rhs)
     }
   }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/ContainerFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/ContainerFlow.qll
@@ -24,9 +24,7 @@ predicate containerStoreStep(Node node1, Node node2, Content c) {
   )
   or
   c instanceof CollectionContent and
-  exists(SendStmt send |
-    send.getChannel() = node2.(ExprNode).asExpr() and send.getValue() = node1.(ExprNode).asExpr()
-  )
+  exists(Write w | w.writesToChannel(node2, node1))
   or
   c instanceof MapKeyContent and
   node2.getType() instanceof MapType and

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -634,9 +634,7 @@ module Public {
     predicate isReceiverOf(MethodDecl m) { parm.isReceiverOf(m) }
   }
 
-  private Node getADirectlyWrittenNode() {
-    exists(Write w | w.writesField(result, _, _) or w.writesElement(result, _, _))
-  }
+  private Node getADirectlyWrittenNode() { exists(Write w | w.writesComponent(result, _)) }
 
   private DataFlow::Node getAccessPathPredecessor(DataFlow::Node node) {
     result = node.(PointerDereferenceNode).getOperand()

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalFlowStep.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalFlowStep.expected
@@ -60,10 +60,8 @@
 | main.go:11:14:11:14 | z | main.go:11:9:11:15 | type conversion |
 | main.go:14:6:14:10 | function test2 | main.go:34:8:34:12 | test2 |
 | main.go:14:6:14:10 | function test2 | main.go:34:19:34:23 | test2 |
-| main.go:15:2:15:4 | definition of acc | main.go:16:9:16:9 | capture variable acc |
 | main.go:15:9:15:9 | 0 | main.go:15:2:15:4 | definition of acc |
 | main.go:16:9:16:9 | capture variable acc | main.go:17:3:17:5 | acc |
-| main.go:17:3:17:7 | definition of acc | main.go:16:9:16:9 | capture variable acc |
 | main.go:17:3:17:7 | definition of acc | main.go:18:10:18:12 | acc |
 | main.go:17:3:17:7 | rhs of increment statement | main.go:17:3:17:7 | definition of acc |
 | main.go:22:12:22:12 | argument corresponding to b | main.go:22:12:22:12 | definition of b |


### PR DESCRIPTION
Steps into captured variables are moved into jumpStep where they always should have been, and the store/load step implementation for channels is completed.

For the time being this takes a very conservative approach to identify channels that are likely connected: if there is exactly one receive site and one send site for a field, the two are presumed connected.