### PR TITLE
Java: Remove SensitiveLoggingQuery results that flow through a source.

### DIFF
--- a/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
@@ -28,4 +28,6 @@ class SensitiveLoggerConfiguration extends TaintTracking::Configuration {
   override predicate isSanitizer(DataFlow::Node sanitizer) {
     sanitizer.asExpr() instanceof LiveLiteral
   }
+
+  override predicate isSanitizerIn(Node node) { isSource(node) }
 }

--- a/java/ql/src/change-notes/2022-08-10-sensitive-log-dedup.md
+++ b/java/ql/src/change-notes/2022-08-10-sensitive-log-dedup.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* The query `java/sensitive-log` has been improved to no longer report results that are effectively duplicates due to one source flowing to another source.


### PR DESCRIPTION
This query was particularly prone to source-to-source flow due to its heuristic nature of its source definition. So adding an `inBarrier` will remove a lot of results that are effectively useless duplicates. In one observed case this removed several thousand results.