### PR TITLE
Dataflow: Fix identification of source PathNodes in the presence of source-to-source flow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -3061,7 +3061,7 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
       else cc instanceof CallContextAny
     ) and
     sc instanceof SummaryCtxNone and
-    ap instanceof AccessPathNil
+    ap = TAccessPathNil(node.getDataFlowType())
   }
 
   predicate isAtSink() {


### PR DESCRIPTION
If one source could flow to another with a different tracked type, we would end up duplicating the reported results for the latter source.