### PR TITLE
delete the dead TypeRepr files

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/typerepr/ArrayTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/ArrayTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.ArrayTypeRepr
-
-class ArrayTypeRepr extends ArrayTypeReprBase {
-  override string toString() { result = "[...]" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/AttributedTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/AttributedTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.AttributedTypeRepr
-
-class AttributedTypeRepr extends AttributedTypeReprBase {
-  override string toString() { result = "@..." }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/CompileTimeConstTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/CompileTimeConstTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.CompileTimeConstTypeRepr
-
-class CompileTimeConstTypeRepr extends CompileTimeConstTypeReprBase {
-  override string toString() { result = "_const ..." }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/CompoundIdentTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/CompoundIdentTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.CompoundIdentTypeRepr
-
-class CompoundIdentTypeRepr extends CompoundIdentTypeReprBase {
-  override string toString() { result = "...<...>" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/DictionaryTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/DictionaryTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.DictionaryTypeRepr
-
-class DictionaryTypeRepr extends DictionaryTypeReprBase {
-  override string toString() { result = "[... : ...]" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/FunctionTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/FunctionTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.FunctionTypeRepr
-
-class FunctionTypeRepr extends FunctionTypeReprBase {
-  override string toString() { result = "... -> ..." }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/GenericIdentTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/GenericIdentTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.GenericIdentTypeRepr
-
-class GenericIdentTypeRepr extends GenericIdentTypeReprBase {
-  override string toString() { result = "...<...>" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/ImplicitlyUnwrappedOptionalTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/ImplicitlyUnwrappedOptionalTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.ImplicitlyUnwrappedOptionalTypeRepr
-
-class ImplicitlyUnwrappedOptionalTypeRepr extends ImplicitlyUnwrappedOptionalTypeReprBase {
-  override string toString() { result = "...!" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/InOutTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/InOutTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.InOutTypeRepr
-
-class InOutTypeRepr extends InOutTypeReprBase {
-  override string toString() { result = "inout ..." }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/IsolatedTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/IsolatedTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.IsolatedTypeRepr
-
-class IsolatedTypeRepr extends IsolatedTypeReprBase {
-  override string toString() { result = "isolated ..." }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/MetatypeTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/MetatypeTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.MetatypeTypeRepr
-
-class MetatypeTypeRepr extends MetatypeTypeReprBase {
-  override string toString() { result = ".Type" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/OptionalTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/OptionalTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.OptionalTypeRepr
-
-class OptionalTypeRepr extends OptionalTypeReprBase {
-  override string toString() { result = "...?" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/OwnedTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/OwnedTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.OwnedTypeRepr
-
-class OwnedTypeRepr extends OwnedTypeReprBase {
-  override string toString() { result = "owned ..." }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/ProtocolTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/ProtocolTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.ProtocolTypeRepr
-
-class ProtocolTypeRepr extends ProtocolTypeReprBase {
-  override string toString() { result = ".Protocol" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/SharedTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/SharedTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.SharedTypeRepr
-
-class SharedTypeRepr extends SharedTypeReprBase {
-  override string toString() { result = "shared ..." }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/SilBoxTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/SilBoxTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.SilBoxTypeRepr
-
-class SilBoxTypeRepr extends SilBoxTypeReprBase {
-  override string toString() { result = "{ ... }" }
-}

--- a/swift/ql/lib/codeql/swift/elements/typerepr/TupleTypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/typerepr/TupleTypeRepr.qll
@@ -1,5 +1,0 @@
-private import codeql.swift.generated.typerepr.TupleTypeRepr
-
-class TupleTypeRepr extends TupleTypeReprBase {
-  override string toString() { result = "(...)" }
-}


### PR DESCRIPTION
It looks like https://github.com/github/codeql/pull/9805 forgot to delete some files, and those files don't compile 
(QL-for-QL didn't like that). 

So I deleted them.  