### PR TITLE
Replaced http links with https links

### DIFF
--- a/cpp/ql/src/Architecture/FeatureEnvy.qhelp
+++ b/cpp/ql/src/Architecture/FeatureEnvy.qhelp
@@ -22,7 +22,7 @@ This function may be better placed in the other file, to avoid exposing internal
     <em>Design patterns: elements of reusable object-oriented software</em>.
     Addison-Wesley Longman Publishing Co., Inc. Boston, MA, 1995.</li>
 <li>
-  MSDN Magazine: <a href="http://msdn.microsoft.com/en-us/magazine/cc947917.aspx">Patterns in Practice: Cohesion And Coupling</a>
+  MSDN Magazine: <a href="https://msdn.microsoft.com/en-us/magazine/cc947917.aspx">Patterns in Practice: Cohesion And Coupling</a>
 </li>
 
 

--- a/cpp/ql/src/Architecture/General Class-Level Information/InheritanceDepthDistribution.qhelp
+++ b/cpp/ql/src/Architecture/General Class-Level Information/InheritanceDepthDistribution.qhelp
@@ -20,13 +20,13 @@ may not be exploiting object-orientation to the full.</p>
 <references>
 <li>
 Shyam R. Chidamber and Chris F. Kemerer,
-<i><a href="http://www.pitt.edu/~ckemerer/CK%20research%20papers/MetricForOOD_ChidamberKemerer94.pdf">A Metrics Suite for Object Oriented Design
+<i><a href="https://www.pitt.edu/~ckemerer/CK%20research%20papers/MetricForOOD_ChidamberKemerer94.pdf">A Metrics Suite for Object Oriented Design
 </a></i>.
 IEEE Transactions on Software Engineering,
 20(6), pages 476-493, June 1994.</li>
 
 <li>
-Lutz Prechelt, Barbara Unger, Michael Philippsen, and Walter Tich, <i><a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.159.2229&amp;rep=rep1&amp;type=pdf">A Controlled Experiment on Inheritance Depth as a Cost Factor for Code Maintenance
+Lutz Prechelt, Barbara Unger, Michael Philippsen, and Walter Tich, <i><a href="https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.159.2229&amp;rep=rep1&amp;type=pdf">A Controlled Experiment on Inheritance Depth as a Cost Factor for Code Maintenance
 </a></i>.
 Journal of Systems and Software, 65 (2):115-126, 2003.
 </li>

--- a/cpp/ql/src/Architecture/InappropriateIntimacy.qhelp
+++ b/cpp/ql/src/Architecture/InappropriateIntimacy.qhelp
@@ -28,7 +28,7 @@ try to make all the dependencies go in one direction.</p>
     <em>Design patterns: elements of reusable object-oriented software</em>.
     Addison-Wesley Longman Publishing Co., Inc. Boston, MA, 1995.</li>
 <li>
-  MSDN Magazine: <a href="http://msdn.microsoft.com/en-us/magazine/cc947917.aspx">Patterns in Practice: Cohesion And Coupling</a>
+  MSDN Magazine: <a href="https://msdn.microsoft.com/en-us/magazine/cc947917.aspx">Patterns in Practice: Cohesion And Coupling</a>
 </li>
 
 

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyDependencies.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyDependencies.qhelp
@@ -23,7 +23,7 @@ could be refactored into smaller, more cohesive classes.</p>
 
 <li>W. Stevens, G. Myers, L. Constantine, <em>Structured Design</em>, IBM Systems Journal, 13 (2), 115-139, 1974.</li>
 <li>
-Microsoft Patterns &amp; Practices Team. <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
+Microsoft Patterns &amp; Practices Team. <a href="https://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
 </li>
 <li>
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
@@ -25,7 +25,7 @@ and using composition.</p>
 
 <li>W. Stevens, G. Myers, L. Constantine, <em>Structured Design</em>. IBM Systems Journal, 13 (2), 115-139, 1974.</li>
 <li>
-Microsoft Patterns &amp; Practices Team, <em>Microsoft Application Architecture Guide (2nd Edition), Chapter 3: Architectural Patterns and Styles.</em> Microsoft Press, 2009 (<a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>).
+Microsoft Patterns &amp; Practices Team, <em>Microsoft Application Architecture Guide (2nd Edition), Chapter 3: Architectural Patterns and Styles.</em> Microsoft Press, 2009 (<a href="https://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>).
 </li>
 <li>
   Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>

--- a/cpp/ql/src/Best Practices/BlockWithTooManyStatements.qhelp
+++ b/cpp/ql/src/Best Practices/BlockWithTooManyStatements.qhelp
@@ -30,7 +30,7 @@ The top-level logic will be clearer if each complex statement is extracted to a 
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  Microsoft Patterns &amp; Practices Team. <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
+  Microsoft Patterns &amp; Practices Team. <a href="https://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
 </li>
 
 

--- a/cpp/ql/src/Best Practices/ComplexCondition.qhelp
+++ b/cpp/ql/src/Best Practices/ComplexCondition.qhelp
@@ -28,10 +28,10 @@ Naming intermediate results as local variables will make the logic easier to rea
 <references>
 
 <li>
-<a href="http://www.cplusplus.com/doc/tutorial/operators/">Operators</a>
+<a href="https://www.cplusplus.com/doc/tutorial/operators/">Operators</a>
 </li>
 <li>
-<a href="http://geosoft.no/development/cppstyle.html#Conditionals">Conditionals</a>
+<a href="https://geosoft.no/development/cppstyle.html#Conditionals">Conditionals</a>
 </li>
 
 

--- a/cpp/ql/src/Best Practices/Exceptions/AccidentalRethrow.qhelp
+++ b/cpp/ql/src/Best Practices/Exceptions/AccidentalRethrow.qhelp
@@ -33,7 +33,7 @@ void good() {
 </example>
 <references>
 
-  <li>Open Standards: <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3337.pdf">Standard for Programming Language C++, draft n3337</a> [except.throw], clause 9, page 380.</li>
+  <li>Open Standards: <a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3337.pdf">Standard for Programming Language C++, draft n3337</a> [except.throw], clause 9, page 380.</li>
 
 
 </references>

--- a/cpp/ql/src/Best Practices/Exceptions/CatchingByValue.qhelp
+++ b/cpp/ql/src/Best Practices/Exceptions/CatchingByValue.qhelp
@@ -43,7 +43,7 @@ void good() {
   <li>C++ FAQ: <a href="https://isocpp.org/wiki/faq/exceptions#what-to-throw">
     What should I throw?</a>, <a href="https://isocpp.org/wiki/faq/exceptions#what-to-catch">
     What should I catch?</a>.</li>
-  <li>Wikibooks: <a href="http://en.wikibooks.org/wiki/C%2B%2B_Programming/Exception_Handling#Throwing_objects">
+  <li>Wikibooks: <a href="https://en.wikibooks.org/wiki/C%2B%2B_Programming/Exception_Handling#Throwing_objects">
     Throwing objects</a>.</li>
 
 

--- a/cpp/ql/src/Best Practices/Exceptions/ThrowingPointers.qhelp
+++ b/cpp/ql/src/Best Practices/Exceptions/ThrowingPointers.qhelp
@@ -36,7 +36,7 @@ void good() {
   <li>C++ FAQ: <a href="https://isocpp.org/wiki/faq/exceptions#what-to-throw">
     What should I throw?</a>, <a href="https://isocpp.org/wiki/faq/exceptions#what-to-catch">
     What should I catch?</a>.</li>
-  <li>Wikibooks: <a href="http://en.wikibooks.org/wiki/C%2B%2B_Programming/Exception_Handling#Throwing_objects">
+  <li>Wikibooks: <a href="https://en.wikibooks.org/wiki/C%2B%2B_Programming/Exception_Handling#Throwing_objects">
     Throwing objects</a>.</li>
 
 

--- a/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.qhelp
+++ b/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.qhelp
@@ -19,9 +19,9 @@
 </example>
 <references>
 
-<li>cplusplus.com: <a href="http://www.cplusplus.com/reference/array/array/">
+<li>cplusplus.com: <a href="https://www.cplusplus.com/reference/array/array/">
   C++: array</a>.</li>
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Bounds_checking">
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Bounds_checking">
   Bounds checking</a>.</li>
 
 

--- a/cpp/ql/src/Best Practices/Likely Errors/Slicing.qhelp
+++ b/cpp/ql/src/Best Practices/Likely Errors/Slicing.qhelp
@@ -20,10 +20,10 @@ These assignments slice off all the fields added by the derived type, and can ca
 <references>
 
 <li>
-  Wikipedia: <a href="http://en.wikipedia.org/wiki/Object_slicing">Object slicing</a>.
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Object_slicing">Object slicing</a>.
 </li>
 <li>
-  DevX.com: <a href="http://www.devx.com/tips/Tip/14570">Slicing in C++</a>.
+  DevX.com: <a href="https://www.devx.com/tips/Tip/14570">Slicing in C++</a>.
 </li>
 
 

--- a/cpp/ql/src/Best Practices/Magic Constants/MagicConstantsNumbers.qhelp
+++ b/cpp/ql/src/Best Practices/Magic Constants/MagicConstantsNumbers.qhelp
@@ -35,7 +35,7 @@ then replace all the relevant occurrences in the code.</p>
 <references>
 
 <li>
-<a href="http://en.wikipedia.org/wiki/Magic_number_%28programming%29#Unnamed_numerical_constants">Magic number (Wikipedia)</a>
+<a href="https://en.wikipedia.org/wiki/Magic_number_%28programming%29#Unnamed_numerical_constants">Magic number (Wikipedia)</a>
 </li>
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, published by Prentice Hall PTR (1997). 

--- a/cpp/ql/src/Best Practices/Magic Constants/MagicConstantsString.qhelp
+++ b/cpp/ql/src/Best Practices/Magic Constants/MagicConstantsString.qhelp
@@ -34,7 +34,7 @@ constant.</p>
 
 
 <li>
-<a href="http://en.wikipedia.org/wiki/Magic_string">Magic string (Wikipedia)</a>
+<a href="https://en.wikipedia.org/wiki/Magic_string">Magic string (Wikipedia)</a>
 </li>
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, published by Prentice Hall PTR (1997). 

--- a/cpp/ql/src/Best Practices/RuleOfThree.qhelp
+++ b/cpp/ql/src/Best Practices/RuleOfThree.qhelp
@@ -15,6 +15,6 @@
 </recommendation>
 
 <references>
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)">Rule of three (C++ programming)</a></li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)">Rule of three (C++ programming)</a></li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Best Practices/RuleOfTwo.qhelp
+++ b/cpp/ql/src/Best Practices/RuleOfTwo.qhelp
@@ -38,14 +38,14 @@ should never be called.
 <references>
 
 <li>
-  <a href="http://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)">Rule of Three [Wikipedia]</a>
+  <a href="https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)">Rule of Three [Wikipedia]</a>
 </li>
 <li>
-  <a href="http://www.artima.com/cppsource/bigtwo.html">The Law of The Big Two</a>
+  <a href="https://www.artima.com/cppsource/bigtwo.html">The Law of The Big Two</a>
 </li>
 <li>
-  cppreference.com: <a href="http://en.cppreference.com/w/cpp/language/copy_constructor">copy constructor</a>
-  and <a href="http://en.cppreference.com/w/cpp/language/copy_assignment">copy assignment</a>
+  cppreference.com: <a href="https://en.cppreference.com/w/cpp/language/copy_constructor">copy constructor</a>
+  and <a href="https://en.cppreference.com/w/cpp/language/copy_assignment">copy assignment</a>
 </li>
 
 

--- a/cpp/ql/src/Best Practices/SloppyGlobal.qhelp
+++ b/cpp/ql/src/Best Practices/SloppyGlobal.qhelp
@@ -24,7 +24,7 @@ Review the purpose of the each global variable flagged by this rule and update e
   Chapter 1: Naming, Rec 1.1 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/42-global-variables/">Global variables</a>.
+  <a href="https://www.learncpp.com/cpp-tutorial/42-global-variables/">Global variables</a>.
 </li>
 
 

--- a/cpp/ql/src/Best Practices/SwitchLongCase.qhelp
+++ b/cpp/ql/src/Best Practices/SwitchLongCase.qhelp
@@ -24,7 +24,7 @@ Consider wrapping the code for each case in a function and just using the switch
 <references>
 
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/53-switch-statements/">Switch statements</a>
+  <a href="https://www.learncpp.com/cpp-tutorial/53-switch-statements/">Switch statements</a>
 </li>
 
 

--- a/cpp/ql/src/Best Practices/Unused Entities/UnusedLocals.qhelp
+++ b/cpp/ql/src/Best Practices/Unused Entities/UnusedLocals.qhelp
@@ -20,7 +20,7 @@ Unused variables should be removed to increase readability and avoid misuse.</p>
 <references>
 
 <li>
-  <a href="http://www.tutorialspoint.com/cplusplus/cpp_variable_scope.htm">Variable scope</a>
+  <a href="https://www.tutorialspoint.com/cplusplus/cpp_variable_scope.htm">Variable scope</a>
 </li>
 <li>
   <a href="https://wiki.sei.cmu.edu/confluence/display/c/MSC12-C.+Detect+and+remove+code+that+has+no+effect+or+is+never+executed">MSC12-C. Detect and remove code that has no effect</a>

--- a/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticVariables.qhelp
+++ b/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticVariables.qhelp
@@ -21,7 +21,7 @@ then removing it will make code more readable. If the static variable is needed 
 <references>
 
 <li>
-  <a href="http://www.tutorialspoint.com/cplusplus/cpp_variable_scope.htm">Variable scope</a>
+  <a href="https://www.tutorialspoint.com/cplusplus/cpp_variable_scope.htm">Variable scope</a>
 </li>
 <li>
   <a href="https://www.securecoding.cert.org/confluence/display/c/MSC12-C.+Detect+and+remove+code+that+has+no+effect+or+is+never+executed">Detect and remove code that has no effect</a>

--- a/cpp/ql/src/Best Practices/UseOfGoto.qhelp
+++ b/cpp/ql/src/Best Practices/UseOfGoto.qhelp
@@ -38,7 +38,7 @@ this rule.
   <em>Joint Strike Fighter Air Vehicle C++ Coding Standards</em>, AV Rule 189. Lockheed Martin Corporation, 2005.
 </li>
 <li>
-  E. W. Dijkstra Archive: <a href="http://www.cs.utexas.edu/users/EWD/transcriptions/EWD02xx/EWD215.html">A Case against the GO TO Statement (EWD-215)</a>.
+  E. W. Dijkstra Archive: <a href="https://www.cs.utexas.edu/users/EWD/transcriptions/EWD02xx/EWD215.html">A Case against the GO TO Statement (EWD-215)</a>.
 </li>
 <li>
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/cpp/goto-statement-cpp">goto Statement (C++)</a>.
@@ -48,7 +48,7 @@ this rule.
   (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 <li>
-  cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/control/">Control Structures</a>.
+  cplusplus.com: <a href="https://www.cplusplus.com/doc/tutorial/control/">Control Structures</a>.
 </li>
 
 

--- a/cpp/ql/src/Critical/LateNegativeTest.qhelp
+++ b/cpp/ql/src/Critical/LateNegativeTest.qhelp
@@ -38,7 +38,7 @@ If the value cannot be negative, the test should be removed.
 </example>
 
 <references>
-<li>cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/pointers/">Pointers</a>.</li>
+<li>cplusplus.com: <a href="https://www.cplusplus.com/doc/tutorial/pointers/">Pointers</a>.</li>
 <li>SEI CERT C Coding Standard: <a href="https://wiki.sei.cmu.edu/confluence/display/c/ARR30-C.+Do+not+form+or+use+out-of-bounds+pointers+or+array+subscripts">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a>.</li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Critical/MissingNegativityTest.qhelp
+++ b/cpp/ql/src/Critical/MissingNegativityTest.qhelp
@@ -34,7 +34,7 @@ is positive and safe to use as an array offset.
 </example>
 
 <references>
-<li>cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/pointers/">Pointers</a>.</li>
+<li>cplusplus.com: <a href="https://www.cplusplus.com/doc/tutorial/pointers/">Pointers</a>.</li>
 <li>SEI CERT C Coding Standard: <a href="https://wiki.sei.cmu.edu/confluence/display/c/ARR30-C.+Do+not+form+or+use+out-of-bounds+pointers+or+array+subscripts">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a>.</li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Critical/OverflowCalculated.qhelp
+++ b/cpp/ql/src/Critical/OverflowCalculated.qhelp
@@ -41,7 +41,7 @@ causing a second overflow.</p>
 </example>
 
 <references>
-<li><a href="http://cwe.mitre.org/data/definitions/131.html">CWE-131: Incorrect Calculation of Buffer Size</a></li>
+<li><a href="https://cwe.mitre.org/data/definitions/131.html">CWE-131: Incorrect Calculation of Buffer Size</a></li>
 <li>I. Gerg. <em>An Overview and Example of the Buffer-Overflow Exploit</em>. IANewsletter vol 7 no 4. 2005.</li>
 <li>M. Donaldson. <em>Inside the Buffer Overflow Attack: Mechanism, Method &amp; Prevention</em>. SANS Institute InfoSec Reading Room. 2002.</li>
 </references>

--- a/cpp/ql/src/Critical/ReturnStackAllocatedObject.qhelp
+++ b/cpp/ql/src/Critical/ReturnStackAllocatedObject.qhelp
@@ -31,7 +31,7 @@ heap-allocated memory.
 </example>
 
 <references>
-<li>cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/pointers/">Pointers</a>.</li>
+<li>cplusplus.com: <a href="https://www.cplusplus.com/doc/tutorial/pointers/">Pointers</a>.</li>
 <li>The craft of coding: <a href="https://craftofcoding.wordpress.com/2015/12/07/memory-in-c-the-stack-the-heap-and-static/">Memory in C - the stack, the heap, and static</a>.</li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Documentation/DocumentApi.qhelp
+++ b/cpp/ql/src/Documentation/DocumentApi.qhelp
@@ -22,10 +22,10 @@ Add comments to document the purpose of the function. In particular, ensure that
 <references>
 
 <li>
-  C++ Programming Wikibook: <a href="http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">Comments</a>
+  C++ Programming Wikibook: <a href="https://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">Comments</a>
 </li>
 <li>
-  Wikipedia: <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Need for comments</a>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Need for comments</a>
 </li>
 
 

--- a/cpp/ql/src/Documentation/FixmeComments.qhelp
+++ b/cpp/ql/src/Documentation/FixmeComments.qhelp
@@ -25,10 +25,10 @@ Fix the functionality indicated by the comment. If the comment no longer applies
 <references>
 
 <li>
-  <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Wikipedia: Comment tags</a>
+  <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Wikipedia: Comment tags</a>
 </li>
 <li>
-  <a href="http://wordaligned.org/articles/todo">The case against TODO (and FIXME)</a>
+  <a href="https://wordaligned.org/articles/todo">The case against TODO (and FIXME)</a>
 </li>
 
 

--- a/cpp/ql/src/Documentation/TodoComments.qhelp
+++ b/cpp/ql/src/Documentation/TodoComments.qhelp
@@ -25,13 +25,13 @@ Implement the functionality indicated by the comment. If the comment no longer a
 <references>
 
 <li>
-  <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Wikipedia: Comment tags</a>
+  <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Wikipedia: Comment tags</a>
 </li>
 <li>
-  <a href="http://www.approxion.com/?p=39">TODO or not TODO</a>
+  <a href="https://www.approxion.com/?p=39">TODO or not TODO</a>
 </li>
 <li>
-  <a href="http://wordaligned.org/articles/todo">The case against TODO</a>
+  <a href="https://wordaligned.org/articles/todo">The case against TODO</a>
 </li>
 
 

--- a/cpp/ql/src/Documentation/UncommentedFunction.qhelp
+++ b/cpp/ql/src/Documentation/UncommentedFunction.qhelp
@@ -23,10 +23,10 @@ cohesive functions.
 <references>
 
 <li>
-  <a href="http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
+  <a href="https://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
 </li>
 <li>
-  <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
+  <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
 </li>
 
 

--- a/cpp/ql/src/Header Cleanup/Cleanup-DuplicateIncludeGuard.qhelp
+++ b/cpp/ql/src/Header Cleanup/Cleanup-DuplicateIncludeGuard.qhelp
@@ -44,7 +44,7 @@ the second file, for example to ANOTHER_HEADER_FILE_H.</p>
 <references>
 
 <li>
-  Wikipedia: <a href="http://en.wikipedia.org/wiki/Include_guard">Include guard</a>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Include_guard">Include guard</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Likely Bugs/AmbiguouslySignedBitField.qhelp
+++ b/cpp/ql/src/Likely Bugs/AmbiguouslySignedBitField.qhelp
@@ -32,7 +32,7 @@ Declare all members of the bit field with explicit signedness.
   AV Rule 154, <em>Joint Strike Fighter Air Vehicle C++ Coding Standards</em>. Lockheed Martin Corporation, 2005.
 </li>
 <li>
-  <a href="http://en.cppreference.com/w/cpp/language/bit_field">C++ Bit Fields</a>
+  <a href="https://en.cppreference.com/w/cpp/language/bit_field">C++ Bit Fields</a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Arithmetic/BadAdditionOverflowCheck.qhelp
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/BadAdditionOverflowCheck.qhelp
@@ -34,7 +34,7 @@ the comparison would evaluate to <code>true</code>).
 <sample src="BadAdditionOverflowCheckExample2.cpp" />
 </example>
 <references>
-<li><a href="http://c-faq.com/expr/preservingrules.html">Preserving Rules</a></li>
+<li><a href="https://c-faq.com/expr/preservingrules.html">Preserving Rules</a></li>
 <li><a href="https://www.securecoding.cert.org/confluence/plugins/servlet/mobile#content/view/20086942">Understand integer conversion rules</a></li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Likely Bugs/Arithmetic/BadCheckOdd.qhelp
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/BadCheckOdd.qhelp
@@ -26,7 +26,7 @@ As a result, this check incorrectly considers all negative numbers as even.
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/cpp/multiplicative-operators-and-the-modulus-operator">Multiplicative Operators and the Modulus Operator</a>.
 </li>
 <li>
-  Wikipedia: <a href="http://en.wikipedia.org/wiki/Modulo_operation#Common_pitfalls">Modulo Operation - Common pitfalls</a>.
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Modulo_operation#Common_pitfalls">Modulo Operation - Common pitfalls</a>.
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Arithmetic/BitwiseSignCheck.qhelp
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/BitwiseSignCheck.qhelp
@@ -21,7 +21,7 @@
 <references>
 
 <li>
-  Code Project: <a href="http://www.codeproject.com/Articles/2247/An-introduction-to-bitwise-operators">An introduction to bitwise operators</a>
+  Code Project: <a href="https://www.codeproject.com/Articles/2247/An-introduction-to-bitwise-operators">An introduction to bitwise operators</a>
 </li>
 <li>
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/c-language/signed-bitwise-operations">Signed Bitwise Operations</a>

--- a/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonPrecedence.qhelp
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonPrecedence.qhelp
@@ -24,7 +24,7 @@ It is best to fully parenthesize complex comparison expressions to explicitly de
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/cpp/cpp-built-in-operators-precedence-and-associativity">C++ built-in operators, precedence, and associativity</a>
 </li>
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/operators/">Operators</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/operators/">Operators</a>
 </li>
 <li>
   <a href="https://wiki.sei.cmu.edu/confluence/display/c/EXP00-C.+Use+parentheses+for+precedence+of+operation">EXP00-C. Use parentheses for precedence of operation</a>

--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.qhelp
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.qhelp
@@ -26,7 +26,7 @@ the expression would produce a result that would be too large to fit in the smal
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/cpp/multiplicative-operators-and-the-modulus-operator">Multiplicative Operators and the Modulus Operator</a>.
 </li>
 <li>
-  Cplusplus.com: <a href="http://www.cplusplus.com/articles/DE18T05o/">Integer overflow</a>.
+  Cplusplus.com: <a href="https://www.cplusplus.com/articles/DE18T05o/">Integer overflow</a>.
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Arithmetic/SignedOverflowCheck.qhelp
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/SignedOverflowCheck.qhelp
@@ -98,7 +98,7 @@ the right-hand side does not need to be promoted to a <code>signed int</code>.
 <sample src="SignedOverflowCheck-good2.cpp" />
 </example>
 <references>
-<li><a href="http://c-faq.com/expr/preservingrules.html">comp.lang.c FAQ list · Question 3.19 (Preserving rules)</a></li>
+<li><a href="https://c-faq.com/expr/preservingrules.html">comp.lang.c FAQ list · Question 3.19 (Preserving rules)</a></li>
 <li><a href="https://wiki.sei.cmu.edu/confluence/display/c/INT31-C.+Ensure+that+integer+conversions+do+not+result+in+lost+or+misinterpreted+data">INT31-C. Ensure that integer conversions do not result in lost or misinterpreted data</a></li>
 <li>W. Dietz, P. Li, J. Regehr, V. Adve. <a href="https://www.cs.utah.edu/~regehr/papers/overflow12.pdf">Understanding Integer Overflow in C/C++</a></li>
 </references>

--- a/cpp/ql/src/Likely Bugs/Arithmetic/UnsignedGEZero.qhelp
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/UnsignedGEZero.qhelp
@@ -18,7 +18,7 @@
 <references>
 
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/variables/">Variables. Data types.</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/variables/">Variables. Data types.</a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Conversion/ImplicitDowncastFromBitfield.qhelp
+++ b/cpp/ql/src/Likely Bugs/Conversion/ImplicitDowncastFromBitfield.qhelp
@@ -26,10 +26,10 @@ overflow in the for loop.</p>
 
 <references>
 <li>
-  <a href="http://en.cppreference.com/w/cpp/language/bit_field">cpp-reference.com: Bit field</a>
+  <a href="https://en.cppreference.com/w/cpp/language/bit_field">cpp-reference.com: Bit field</a>
 </li>
 <li>
- <a href="http://en.cppreference.com/w/cpp/language/implicit_conversion">cpp-reference.com: Implicit conversion</a>
+ <a href="https://en.cppreference.com/w/cpp/language/implicit_conversion">cpp-reference.com: Implicit conversion</a>
 </li>
 <li>
   <a href="https://cwe.mitre.org/data/definitions/681.html">https://cwe.mitre.org/data/definitions/681.html</a>

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.qhelp
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.qhelp
@@ -21,7 +21,7 @@
   Microsoft Visual C++ Documentation: <a href="https://docs.microsoft.com/en-us/cpp/cpp/type-conversions-and-type-safety-modern-cpp?view=vs-2017">Type Conversions and Type Safety (Modern C++)</a>.
 </li>
 <li>
-  Cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/typecasting/">Type conversions</a>.
+  Cplusplus.com: <a href="https://www.cplusplus.com/doc/tutorial/typecasting/">Type conversions</a>.
 </li>
 
 </references>

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyPointerCast.qhelp
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyPointerCast.qhelp
@@ -26,7 +26,7 @@ the latter occupies eight bytes on a 64-bit machine.</p>
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/cpp/type-conversions-and-type-safety-modern-cpp">Type Conversions and Type Safety</a>.
 </li>
 <li>
-  Cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/typecasting/">Type conversions</a>.
+  Cplusplus.com: <a href="https://www.cplusplus.com/doc/tutorial/typecasting/">Type conversions</a>.
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Conversion/NonzeroValueCastToPointer.qhelp
+++ b/cpp/ql/src/Likely Bugs/Conversion/NonzeroValueCastToPointer.qhelp
@@ -21,7 +21,7 @@ This is a dangerous practice, since the meaning of the numerical value of pointe
 
 
 <li>
-  Cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/pointers/">Pointers</a>.
+  Cplusplus.com: <a href="https://www.cplusplus.com/doc/tutorial/pointers/">Pointers</a>.
 </li>
 <li>
   The CERT C Secure Coding Standard: <a href="https://www.securecoding.cert.org/confluence/display/c/INT36-C.+Converting+a+pointer+to+integer+or+integer+to+pointer">INT36-C. Converting a pointer to integer or integer to pointer</a>.

--- a/cpp/ql/src/Likely Bugs/Format/SnprintfOverflow.qhelp
+++ b/cpp/ql/src/Likely Bugs/Format/SnprintfOverflow.qhelp
@@ -20,7 +20,7 @@
 
 <references>
 
-<li>cplusplus.com: <a href="http://www.cplusplus.com/reference/cstdio/snprintf/">snprintf</a>.</li>
+<li>cplusplus.com: <a href="https://www.cplusplus.com/reference/cstdio/snprintf/">snprintf</a>.</li>
 <li>Red Hat Customer Portal: <a href="https://access.redhat.com/blogs/766093/posts/1976193">The trouble with snprintf</a>.</li>
 
 </references>

--- a/cpp/ql/src/Likely Bugs/Format/TooManyFormatArguments.qhelp
+++ b/cpp/ql/src/Likely Bugs/Format/TooManyFormatArguments.qhelp
@@ -22,7 +22,7 @@ function.
 </example>
 <references>
 
-<li>cplusplus.com: <a href="http://www.tutorialspoint.com/cplusplus/cpp_functions.htm">C++ Functions</a>.</li>
+<li>cplusplus.com: <a href="https://www.tutorialspoint.com/cplusplus/cpp_functions.htm">C++ Functions</a>.</li>
 <li>Microsoft C Runtime Library Reference: <a href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/printf-printf-l-wprintf-wprintf-l">printf, wprintf</a>.</li>
 
 

--- a/cpp/ql/src/Likely Bugs/Format/WrongNumberOfFormatArguments.qhelp
+++ b/cpp/ql/src/Likely Bugs/Format/WrongNumberOfFormatArguments.qhelp
@@ -32,7 +32,7 @@ function.
 
 <li>CERT C Coding
 Standard: <a href="https://www.securecoding.cert.org/confluence/display/c/FIO30-C.+Exclude+user+input+from+format+strings">FIO30-C. Exclude user input from format strings</a>.</li>
-<li>cplusplus.com: <a href="http://www.tutorialspoint.com/cplusplus/cpp_functions.htm">C++ Functions</a>.</li>
+<li>cplusplus.com: <a href="https://www.tutorialspoint.com/cplusplus/cpp_functions.htm">C++ Functions</a>.</li>
 <li>Microsoft C Runtime Library Reference: <a href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/printf-printf-l-wprintf-wprintf-l">printf, wprintf</a>.</li>
 
 

--- a/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.qhelp
+++ b/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.qhelp
@@ -22,7 +22,7 @@ the function.
 
 <li>CERT C Coding
 Standard: <a href="https://www.securecoding.cert.org/confluence/display/c/FIO30-C.+Exclude+user+input+from+format+strings">FIO30-C. Exclude user input from format strings</a>.</li>
-<li>cplusplus.com: <a href="http://www.tutorialspoint.com/cplusplus/cpp_functions.htm">C++ Functions</a>.</li>
+<li>cplusplus.com: <a href="https://www.tutorialspoint.com/cplusplus/cpp_functions.htm">C++ Functions</a>.</li>
 <li>CRT Alphabetical Function Reference: <a href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/printf-printf-l-wprintf-wprintf-l">printf, _printf_l, wprintf, _wprintf_l</a>.</li>
 
 

--- a/cpp/ql/src/Likely Bugs/InconsistentCallOnResult.qhelp
+++ b/cpp/ql/src/Likely Bugs/InconsistentCallOnResult.qhelp
@@ -23,7 +23,7 @@ may indicate misuse of the API and could cause resource leaks or other issues.
 
 
 <li>
-  Tutorialspoint - The C++ Programming Language: <a href="http://www.tutorialspoint.com/cplusplus/cpp_dynamic_memory.htm">C++ Dynamic Memory</a>
+  Tutorialspoint - The C++ Programming Language: <a href="https://www.tutorialspoint.com/cplusplus/cpp_dynamic_memory.htm">C++ Dynamic Memory</a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/InconsistentCheckReturnNull.qhelp
+++ b/cpp/ql/src/Likely Bugs/InconsistentCheckReturnNull.qhelp
@@ -35,11 +35,11 @@ value.</p>
 <references>
 
 <li>
-  Tutorialspoint - The C++ Programming Language: <a href="http://www.tutorialspoint.com/cplusplus/cpp_dynamic_memory.htm">C++ Dynamic Memory</a>, 
- <a href="http://www.tutorialspoint.com/cplusplus/cpp_null_pointers.htm">C++ NULL pointers</a>.
+  Tutorialspoint - The C++ Programming Language: <a href="https://www.tutorialspoint.com/cplusplus/cpp_dynamic_memory.htm">C++ Dynamic Memory</a>, 
+ <a href="https://www.tutorialspoint.com/cplusplus/cpp_null_pointers.htm">C++ NULL pointers</a>.
 </li>
 <li>
-  Code project: <a href="http://www.codeproject.com/Articles/109026/Chained-null-checks-and-the-Maybe-monad">Chained null checks and the Maybe monad</a>.
+  Code project: <a href="https://www.codeproject.com/Articles/109026/Chained-null-checks-and-the-Maybe-monad">Chained null checks and the Maybe monad</a>.
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Likely Typos/AssignWhereCompareMeant.qhelp
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/AssignWhereCompareMeant.qhelp
@@ -27,10 +27,10 @@ An assignment is only flagged if its right hand side is a compile-time constant.
 <references>
 
 <li>
-  Tutorialspoint - The C++ Programming Language: <a href="http://www.tutorialspoint.com/cplusplus/cpp_operators.htm">Operators in C++</a>
+  Tutorialspoint - The C++ Programming Language: <a href="https://www.tutorialspoint.com/cplusplus/cpp_operators.htm">Operators in C++</a>
 </li>
 <li>
-  Wikipedia: <a href="http://en.wikipedia.org/wiki/Operators_in_C_and_C%2B%2B#Comparison_operators.2Frelational_operators">Operators in C and C++</a>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Operators_in_C_and_C%2B%2B#Comparison_operators.2Frelational_operators">Operators in C and C++</a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Likely Typos/CompareWhereAssignMeant.qhelp
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/CompareWhereAssignMeant.qhelp
@@ -25,10 +25,10 @@ The rule flags every occurrence of an equality operator in a position where its 
 <references>
 
 <li>
-  Tutorialspoint - The C++ Programming Language: <a href="http://www.tutorialspoint.com/cplusplus/cpp_operators.htm">Operators in C++</a>
+  Tutorialspoint - The C++ Programming Language: <a href="https://www.tutorialspoint.com/cplusplus/cpp_operators.htm">Operators in C++</a>
 </li>
 <li>
-  Wikipedia: <a href="http://en.wikipedia.org/wiki/Operators_in_C_and_C%2B%2B#Comparison_operators.2Frelational_operators">Operators in C and C++</a>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Operators_in_C_and_C%2B%2B#Comparison_operators.2Frelational_operators">Operators in C and C++</a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.qhelp
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.qhelp
@@ -30,7 +30,7 @@ To document that the value of the expression is deliberately ignored, you could 
 <references>
 
 <li>
-  Tutorialspoint - The C++ Programming Language: <a href="http://www.tutorialspoint.com/cplusplus/cpp_comma_operator.htm">C++ Comma Operator</a>
+  Tutorialspoint - The C++ Programming Language: <a href="https://www.tutorialspoint.com/cplusplus/cpp_comma_operator.htm">C++ Comma Operator</a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/Likely Typos/MissingEnumCaseInSwitch.qhelp
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/MissingEnumCaseInSwitch.qhelp
@@ -20,7 +20,7 @@ indication that there may be cases unhandled by the <code>switch</code> statemen
 <references>
 
 <li>
-  Tutorialspoint - The C++ Programming Language: <a href="http://www.tutorialspoint.com/cplusplus/cpp_switch_statement.htm">C++ switch statement</a>
+  Tutorialspoint - The C++ Programming Language: <a href="https://www.tutorialspoint.com/cplusplus/cpp_switch_statement.htm">C++ switch statement</a>
 </li>
 <li>
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/cpp/switch-statement-cpp">switch statement (C++)</a>

--- a/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.qhelp
@@ -36,7 +36,7 @@ end of the loop.
 </example>
 <references>
 
-  <li>Linux Programmer's Manual: <a href="http://man7.org/linux/man-pages/man3/alloca.3.html">ALLOCA(3)</a>.</li>
+  <li>Linux Programmer's Manual: <a href="https://man7.org/linux/man-pages/man3/alloca.3.html">ALLOCA(3)</a>.</li>
 
 </references>
 </qhelp>

--- a/cpp/ql/src/Likely Bugs/Memory Management/ImproperNullTermination.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ImproperNullTermination.qhelp
@@ -41,7 +41,7 @@ the call to <code>strcat</code>.
 <references>
 
   <li>B. Chess and J. West, <em>Secure Programming with Static Analysis</em>, 6.2 Maintaining the Null Terminator. Addison-Wesley. 2007.</li>
-  <li>Linux Programmer's Manual: <a href="http://man7.org/linux/man-pages/man3/strncat.3.html">STRCAT(3)</a>.</li>
+  <li>Linux Programmer's Manual: <a href="https://man7.org/linux/man-pages/man3/strncat.3.html">STRCAT(3)</a>.</li>
 
 </references>
 </qhelp>

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.qhelp
@@ -25,7 +25,7 @@ These functions allow unbounded writes to buffers, which may cause an overflow w
 <references>
 
 <li>Common Weakness
-Enumeration: <a href="http://cwe.mitre.org/data/definitions/120.html">CWE-120: Buffer Copy without Checking Size of Input ('Classic Buffer Overflow').</a></li>
+Enumeration: <a href="https://cwe.mitre.org/data/definitions/120.html">CWE-120: Buffer Copy without Checking Size of Input ('Classic Buffer Overflow').</a></li>
 <li>CERT C Coding
 Standard: <a href="https://www.securecoding.cert.org/confluence/display/c/STR31-C.+Guarantee+that+storage+for+strings+has+sufficient+space+for+character+data+and+the+null+terminator">STR31-C. Guarantee
 that storage for strings has sufficient space for character data and

--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnCstrOfLocalStdString.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnCstrOfLocalStdString.qhelp
@@ -32,7 +32,7 @@ of the function.
 <example><sample src="ReturnCstrOfLocalStdStringGood.cpp" /></example>
 
 <references>
-<li>cplusplus.com: <a href="http://www.cplusplus.com/reference/string/string/c_str/">std::string::c_str</a></li>
+<li>cplusplus.com: <a href="https://www.cplusplus.com/reference/string/string/c_str/">std::string::c_str</a></li>
 <li>stackoverflow.com: <a href="https://stackoverflow.com/questions/6456359/what-is-stdstringc-str-lifetime/6456408">What
 is std::string::c_str() lifetime?</a></li>
 </references>

--- a/cpp/ql/src/Likely Bugs/Memory Management/StrncpyFlippedArgs.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/StrncpyFlippedArgs.qhelp
@@ -19,7 +19,7 @@ not the source buffer.</p>
 </example>
 <references>
 
-<li>cplusplus.com: <a href="http://www.cplusplus.com/reference/clibrary/cstring/strncpy/">strncpy</a>.</li>
+<li>cplusplus.com: <a href="https://www.cplusplus.com/reference/clibrary/cstring/strncpy/">strncpy</a>.</li>
 <li>
   I. Gerg. <em>An Overview and Example of the Buffer-Overflow Exploit</em>. IANewsletter vol 7 no 4. 2005.
 </li>

--- a/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToMemset.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToMemset.qhelp
@@ -27,7 +27,7 @@ For an array, the size is the number of elements of the array multiplied by the 
 <references>
 
 <li>
-  Cplusplus.comn: <a href="http://www.cplusplus.com/reference/clibrary/cstring/memset/">memset</a>
+  Cplusplus.comn: <a href="https://www.cplusplus.com/reference/clibrary/cstring/memset/">memset</a>
 </li>
 <li>
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/memset-wmemset">memset, wmemset</a>, <a href="https://docs.microsoft.com/en-us/cpp/cpp/sizeof-operator">sizeof Operator</a>

--- a/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToStrncat.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToStrncat.qhelp
@@ -27,8 +27,8 @@ byte to be written ouside the <code>dest</code> buffer.</p>
 </example>
 <references>
 
-<li>cplusplus.com: <a href="http://www.cplusplus.com/reference/clibrary/cstring/strncat/">strncat</a>,
-                   <a href="http://www.cplusplus.com/reference/clibrary/cstring/strncpy/">strncpy</a>.</li>
+<li>cplusplus.com: <a href="https://www.cplusplus.com/reference/clibrary/cstring/strncat/">strncat</a>,
+                   <a href="https://www.cplusplus.com/reference/clibrary/cstring/strncpy/">strncpy</a>.</li>
 <li>
   I. Gerg, <em>An Overview and Example of the Buffer-Overflow Exploit</em>. IANewsletter vol 7 no 4, 2005.
 </li>

--- a/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousSizeof.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousSizeof.qhelp
@@ -27,7 +27,7 @@ to get the size of an array instead of the pointer.
 <references>
 
 <li>
-  Comp.lang.c, Frequently Asked Questions: <a href="http://c-faq.com/aryptr/aryptrequiv.html">Question 6.3: So what is meant by the "equivalence of pointers and arrays" in C?</a>.
+  Comp.lang.c, Frequently Asked Questions: <a href="https://c-faq.com/aryptr/aryptrequiv.html">Question 6.3: So what is meant by the "equivalence of pointers and arrays" in C?</a>.
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/NestedLoopSameVar.qhelp
+++ b/cpp/ql/src/Likely Bugs/NestedLoopSameVar.qhelp
@@ -23,7 +23,7 @@ outer loop. </p>
 <references>
 
 <li>
-  Tutorialspoint - The C++ Programming Language: <a href="http://www.tutorialspoint.com/cplusplus/cpp_nested_loops.htm">C++ nested loops</a>
+  Tutorialspoint - The C++ Programming Language: <a href="https://www.tutorialspoint.com/cplusplus/cpp_nested_loops.htm">C++ nested loops</a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/OO/IncorrectConstructorDelegation.qhelp
+++ b/cpp/ql/src/Likely Bugs/OO/IncorrectConstructorDelegation.qhelp
@@ -58,9 +58,9 @@ public:
 </example>
 <references>
 
-  <li>Dr Dobb's Journal: <a href="http://www.drdobbs.com/delegating-constructors/184401647">
+  <li>Dr Dobb's Journal: <a href="https://www.drdobbs.com/delegating-constructors/184401647">
     Delegating constructors?</a></li>
-  <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/C%2B%2B11#Object_construction_improvement">
+  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/C%2B%2B11#Object_construction_improvement">
     Object construction improvement in C++11</a>.</li>
 
 

--- a/cpp/ql/src/Likely Bugs/OO/NonVirtualDestructorInBaseClass.qhelp
+++ b/cpp/ql/src/Likely Bugs/OO/NonVirtualDestructorInBaseClass.qhelp
@@ -30,7 +30,7 @@ Make sure that all classes with virtual functions also have a virtual destructor
   S. Meyers. <em>Effective C++ 3d ed.</em> pp 40-44. Addison-Wesley Professional, 2005.
 </li>
 <li>
-  <a href="http://blogs.msdn.com/b/oldnewthing/archive/2004/05/07/127826.aspx">When should your destructor be virtual?</a>
+  <a href="https://blogs.msdn.com/b/oldnewthing/archive/2004/05/07/127826.aspx">When should your destructor be virtual?</a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/OO/VirtualCallInStructor.qhelp
+++ b/cpp/ql/src/Likely Bugs/OO/VirtualCallInStructor.qhelp
@@ -18,6 +18,6 @@
 
 </example>
 <references>
-<li>S. Meyer. <em>Effective C++ 3d ed.</em> pp 48-52. Addison Wesley. 2005. Excerpt available <a href="http://www.artima.com/cppsource/nevercall.html">here</a>.
+<li>S. Meyer. <em>Effective C++ 3d ed.</em> pp 48-52. Addison Wesley. 2005. Excerpt available <a href="https://www.artima.com/cppsource/nevercall.html">here</a>.
 
 </li></references></qhelp>

--- a/cpp/ql/src/Likely Bugs/ReturnConstType.qhelp
+++ b/cpp/ql/src/Likely Bugs/ReturnConstType.qhelp
@@ -22,7 +22,7 @@ the superfluous one.</p>
 
 
 <li>
-  <a href="http://c-faq.com/aryptr/aryptrequiv.html">comp.lang.c FAQ list · Question 6.3 </a>
+  <a href="https://c-faq.com/aryptr/aryptrequiv.html">comp.lang.c FAQ list · Question 6.3 </a>
 </li>
 
 

--- a/cpp/ql/src/Likely Bugs/ShortLoopVarName.qhelp
+++ b/cpp/ql/src/Likely Bugs/ShortLoopVarName.qhelp
@@ -21,7 +21,7 @@ easier to understand code in complex, nested loops.</p>
 <references>
 
 <li>
-  <a href="http://wiki.ros.org/CppStyleGuide#Variables">ROS C++ Style Guide: Variables</a>
+  <a href="https://wiki.ros.org/CppStyleGuide#Variables">ROS C++ Style Guide: Variables</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Classes/CAfferentCoupling.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CAfferentCoupling.qhelp
@@ -73,7 +73,7 @@ in this situation, they can often be deleted.
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Classes/CEfferentCoupling.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CEfferentCoupling.qhelp
@@ -38,7 +38,7 @@ R. Martin. <em>Agile Software Development: Principles, Patterns and Practices</e
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Classes/CNumberOfFunctions.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CNumberOfFunctions.qhelp
@@ -90,10 +90,10 @@ M. Fowler. <em>Refactoring</em> pp. 65, 122-5. Addison-Wesley, 1999.
 R. Martin. <a href="https://drive.google.com/file/d/0ByOwmqah_nuGNHEtcU5OekdDMkk/view">The Single Responsibility Principle</a>. Published online.
 </li>
 <li>
-H. Sutter. <a href="http://www.gotw.ca/gotw/084.htm">GotW #84: Monoliths "Unstrung"</a>. Published online, 2002.
+H. Sutter. <a href="https://www.gotw.ca/gotw/084.htm">GotW #84: Monoliths "Unstrung"</a>. Published online, 2002.
 </li>
 <li>
-Microsoft Patterns &amp; Practices Team. <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
+Microsoft Patterns &amp; Practices Team. <a href="https://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Classes/CPercentageOfComplexCode.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CPercentageOfComplexCode.qhelp
@@ -43,7 +43,7 @@ new problem (as per the advice given for that situation).
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Classes/CSizeOfAPI.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CSizeOfAPI.qhelp
@@ -89,7 +89,7 @@ M. Fowler. <em>Refactoring</em> pp. 65, 122-5. Addison-Wesley, 1999.
 R. Martin. <a href="https://drive.google.com/file/d/0ByOwmqah_nuGNHEtcU5OekdDMkk/view">The Single Responsibility Principle</a>. Published online.
 </li>
 <li>
-H. Sutter. <a href="http://www.gotw.ca/gotw/084.htm">GotW #84: Monoliths "Unstrung"</a>. Published online, 2002.
+H. Sutter. <a href="https://www.gotw.ca/gotw/084.htm">GotW #84: Monoliths "Unstrung"</a>. Published online, 2002.
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/CommentedOutCodeReferences.inc.qhelp
+++ b/cpp/ql/src/Metrics/Files/CommentedOutCodeReferences.inc.qhelp
@@ -4,9 +4,9 @@
 <qhelp>
 <references>
 
-<li>Mark Needham: <a href="http://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
-<li>Los Techies: <a href="http://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
-<li>High Integrity C++ Coding Standard: <a href="http://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
+<li>Mark Needham: <a href="https://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
+<li>Los Techies: <a href="https://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
+<li>High Integrity C++ Coding Standard: <a href="https://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
 
 </references>
 </qhelp>

--- a/cpp/ql/src/Metrics/Files/FAfferentCoupling.qhelp
+++ b/cpp/ql/src/Metrics/Files/FAfferentCoupling.qhelp
@@ -47,7 +47,7 @@ with uses of its public API (augmenting it if necessary).</p>
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FCommentRatio.qhelp
+++ b/cpp/ql/src/Metrics/Files/FCommentRatio.qhelp
@@ -18,10 +18,10 @@ documenting the public functions first.</p>
 <references>
 
 <li>
-  <a href="http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
+  <a href="https://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
 </li>
 <li>
-  <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
+  <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FCyclomaticComplexity.qhelp
+++ b/cpp/ql/src/Metrics/Files/FCyclomaticComplexity.qhelp
@@ -64,13 +64,13 @@ M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.
 T. J. McCabe, <em>A Complexity Measure</em>. IEEE Transactions on Software Engineering, SE-2(4), December 1976.
 </li>
 <li>
-Dave Thomas, <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>, in Journal of Object Technology, vol. 4, no. 1, January-February 2005, pp. 7-11.
+Dave Thomas, <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>, in Journal of Object Technology, vol. 4, no. 1, January-February 2005, pp. 7-11.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Files/FDirectIncludes.qhelp
+++ b/cpp/ql/src/Metrics/Files/FDirectIncludes.qhelp
@@ -27,7 +27,7 @@ unnecessarily long.</p>
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FEfferentCoupling.qhelp
+++ b/cpp/ql/src/Metrics/Files/FEfferentCoupling.qhelp
@@ -31,7 +31,7 @@ purpose are more easily comprehended and maintained.</p>
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FLinesOfCode.qhelp
+++ b/cpp/ql/src/Metrics/Files/FLinesOfCode.qhelp
@@ -19,10 +19,10 @@
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="http://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FLinesOfComments.qhelp
+++ b/cpp/ql/src/Metrics/Files/FLinesOfComments.qhelp
@@ -18,10 +18,10 @@ should be given to long files.</p>
 <references>
 
 <li>
-  <a href="http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
+  <a href="https://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
 </li>
 <li>
-  <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
+  <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FMacroRatio.qhelp
+++ b/cpp/ql/src/Metrics/Files/FMacroRatio.qhelp
@@ -30,11 +30,11 @@ and IDE support than macros.</p>
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/preprocessor/macros-c-cpp">Macros (C/C++)</a>
 </li>
 <li>
-  <a href="http://www.stroustrup.com/icsm-2012-demacro.pdf">Rejuvenating C++ Programs through
+  <a href="https://www.stroustrup.com/icsm-2012-demacro.pdf">Rejuvenating C++ Programs through
 Demacrofication</a>
 </li>
 <li>
-  <a href="http://www.idinews.com/macroPhobe.html">Outgrowing Macrophobia</a>
+  <a href="https://www.idinews.com/macroPhobe.html">Outgrowing Macrophobia</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FNumberOfTests.qhelp
+++ b/cpp/ql/src/Metrics/Files/FNumberOfTests.qhelp
@@ -44,7 +44,7 @@
 <references>
 <li>
   Boost: official website at
-  <a href="http://www.boost.org/">http://www.boost.org/</a>.
+  <a href="https://www.boost.org/">http://www.boost.org/</a>.
 </li>
 <li>
   CppUnit: official website at

--- a/cpp/ql/src/Metrics/Files/FTimeInFrontend.qhelp
+++ b/cpp/ql/src/Metrics/Files/FTimeInFrontend.qhelp
@@ -18,10 +18,10 @@
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-include-directive-c-cpp">#include directive (C/C++)</a>
 </li>
 <li>
-  <a href="http://gcc.gnu.org/onlinedocs/cpp/Include-Operation.html#Include-Operation">Include operation</a>
+  <a href="https://gcc.gnu.org/onlinedocs/cpp/Include-Operation.html#Include-Operation">Include operation</a>
 </li>
 <li>
-  <a href="http://www.drdobbs.com/cpp/c-compilation-speed/228701711">C++ Compilation Speed</a>
+  <a href="https://www.drdobbs.com/cpp/c-compilation-speed/228701711">C++ Compilation Speed</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/FTodoComments.qhelp
+++ b/cpp/ql/src/Metrics/Files/FTodoComments.qhelp
@@ -21,13 +21,13 @@ for fixing them.</p>
 <references>
 
 <li>
-  <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Wikipedia: Comment tags</a>
+  <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Wikipedia: Comment tags</a>
 </li>
 <li>
-  <a href="http://www.approxion.com/?p=39">TODO or not TODO</a>
+  <a href="https://www.approxion.com/?p=39">TODO or not TODO</a>
 </li>
 <li>
-  <a href="http://wordaligned.org/articles/todo">The case against TODO</a>
+  <a href="https://wordaligned.org/articles/todo">The case against TODO</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Files/FTransitiveIncludes.qhelp
+++ b/cpp/ql/src/Metrics/Files/FTransitiveIncludes.qhelp
@@ -23,10 +23,10 @@ build time: the more included files, the longer the compilation time.</p>
 <references>
 
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/19-header-files/">Header files</a>
+  <a href="https://www.learncpp.com/cpp-tutorial/19-header-files/">Header files</a>
 </li>
 <li>
-  <a href="http://www.drdobbs.com/cpp/decoupling-c-header-files/212701130">Decoupling C Header Files</a>
+  <a href="https://www.drdobbs.com/cpp/decoupling-c-header-files/212701130">Decoupling C Header Files</a>
 </li>
 <li>
   <a href="https://accu.org/journals/overload/14/72/griffiths_1995/">C++ Best Practice -

--- a/cpp/ql/src/Metrics/Files/FTransitiveSourceIncludes.qhelp
+++ b/cpp/ql/src/Metrics/Files/FTransitiveSourceIncludes.qhelp
@@ -29,10 +29,10 @@ they are contributing to unnecessarily long build times and creating artificial 
 <references>
 
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/19-header-files/">Header files</a>
+  <a href="https://www.learncpp.com/cpp-tutorial/19-header-files/">Header files</a>
 </li>
 <li>
-  <a href="http://www.drdobbs.com/cpp/decoupling-c-header-files/212701130">Decoupling C Header Files</a>
+  <a href="https://www.drdobbs.com/cpp/decoupling-c-header-files/212701130">Decoupling C Header Files</a>
 </li>
 <li>
   <a href="https://accu.org/journals/overload/14/72/griffiths_1995/">C++ Best Practice -

--- a/cpp/ql/src/Metrics/Files/FunctionLength.qhelp
+++ b/cpp/ql/src/Metrics/Files/FunctionLength.qhelp
@@ -21,7 +21,7 @@
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/NumberOfFunctions.qhelp
+++ b/cpp/ql/src/Metrics/Files/NumberOfFunctions.qhelp
@@ -21,7 +21,7 @@ and split the file according to these tasks.</p>
 <references>
 
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
 </li>
 <li>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
@@ -30,7 +30,7 @@ and split the file according to these tasks.</p>
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/NumberOfGlobals.qhelp
+++ b/cpp/ql/src/Metrics/Files/NumberOfGlobals.qhelp
@@ -20,10 +20,10 @@ as well as functions into classes.</p>
 <references>
 
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/42-global-variables/">Global variables</a>
+  <a href="https://www.learncpp.com/cpp-tutorial/42-global-variables/">Global variables</a>
 </li>
 <li>
-  <a href="http://www-h.eng.cam.ac.uk/help/tpl/languages/C++/globals.html">C++: Global warning</a>
+  <a href="https://www-h.eng.cam.ac.uk/help/tpl/languages/C++/globals.html">C++: Global warning</a>
 </li>
 <li>
   <a href="https://www.securecoding.cert.org/confluence/display/c/DCL19-C.+Minimize+the+scope+of+variables+and+functions">Minimize the scope of variables and functions</a>

--- a/cpp/ql/src/Metrics/Files/NumberOfParameters.qhelp
+++ b/cpp/ql/src/Metrics/Files/NumberOfParameters.qhelp
@@ -36,7 +36,7 @@ encapsulated into a single struct, with utility functions for common operations.
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/NumberOfPublicFunctions.qhelp
+++ b/cpp/ql/src/Metrics/Files/NumberOfPublicFunctions.qhelp
@@ -25,7 +25,7 @@ questions:</p>
 <references>
 
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
 </li>
 <li>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
@@ -34,7 +34,7 @@ questions:</p>
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Files/NumberOfPublicGlobals.qhelp
+++ b/cpp/ql/src/Metrics/Files/NumberOfPublicGlobals.qhelp
@@ -26,10 +26,10 @@ that there is no global state.</p>
 <references>
 
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/42-global-variables/">Global variables</a>
+  <a href="https://www.learncpp.com/cpp-tutorial/42-global-variables/">Global variables</a>
 </li>
 <li>
-  <a href="http://www-h.eng.cam.ac.uk/help/tpl/languages/C++/globals.html">C++: Global warning</a>
+  <a href="https://www-h.eng.cam.ac.uk/help/tpl/languages/C++/globals.html">C++: Global warning</a>
 </li>
 <li>
   <a href="https://www.securecoding.cert.org/confluence/display/c/DCL19-C.+Minimize+the+scope+of+variables+and+functions">Minimize the scope of variables and functions</a>

--- a/cpp/ql/src/Metrics/Functions/FunCyclomaticComplexity.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunCyclomaticComplexity.qhelp
@@ -23,7 +23,7 @@ Straight-line code has zero cyclomatic complexity, while branches and loops incr
 <references>
 
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
 </li>
 <li>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
@@ -32,7 +32,7 @@ Straight-line code has zero cyclomatic complexity, while branches and loops incr
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Functions/FunLinesOfCode.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunLinesOfCode.qhelp
@@ -21,7 +21,7 @@
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Functions/FunLinesOfComments.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunLinesOfComments.qhelp
@@ -18,10 +18,10 @@ should be given to long, complex functions.</p>
 <references>
 
 <li>
-  <a href="http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
+  <a href="https://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
 </li>
 <li>
-  <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
+  <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Functions/FunNumberOfCalls.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunNumberOfCalls.qhelp
@@ -16,7 +16,7 @@
 <references>
 
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
 </li>
 <li>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
@@ -25,7 +25,7 @@
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Functions/FunNumberOfParameters.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunNumberOfParameters.qhelp
@@ -21,7 +21,7 @@ functions for the different use cases.</p>
 <references>
 
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
 </li>
 <li>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
@@ -30,7 +30,7 @@ functions for the different use cases.</p>
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Functions/FunNumberOfStatements.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunNumberOfStatements.qhelp
@@ -23,7 +23,7 @@ reuse of the extracted subfunctionality.</p>
 <references>
 
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/functions/">Functions</a>
 </li>
 <li>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
@@ -32,7 +32,7 @@ reuse of the extracted subfunctionality.</p>
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Functions/FunPercentageOfComments.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunPercentageOfComments.qhelp
@@ -17,10 +17,10 @@ documentation.</p>
 <references>
 
 <li>
-  <a href="http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
+  <a href="https://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments">C++ Programming, Coding style conventions</a>
 </li>
 <li>
-  <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
+  <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">Wikipedia: Need for comments</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Metrics/Functions/StatementNestingDepth.qhelp
+++ b/cpp/ql/src/Metrics/Functions/StatementNestingDepth.qhelp
@@ -26,7 +26,7 @@ Deep nesting makes code very difficult to read and modify, and is also a sign th
   <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
-  <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
+  <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>
 </li>
 
 </references>

--- a/cpp/ql/src/Security/CWE/CWE-079/CgiXss.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-079/CgiXss.qhelp
@@ -38,10 +38,10 @@ OWASP:
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 <li>
-IETF Tools: <a href="http://tools.ietf.org/html/draft-robinson-www-interface-00">The Common Gateway Specification (CGI)</a>.</li>
+IETF Tools: <a href="https://tools.ietf.org/html/draft-robinson-www-interface-00">The Common Gateway Specification (CGI)</a>.</li>
 
 
 </references>

--- a/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.qhelp
@@ -43,7 +43,7 @@ crash.
 <references>
 
   <li>B. Chess and J. West, <em>Secure Programming with Static Analysis</em>, 6.2 Maintaining the Null Terminator. Addison-Wesley. 2007.</li>
-  <li>Linux Programmer's Manual: <a href="http://man7.org/linux/man-pages/man2/read.2.html">READ(2)</a>, <a href="http://man7.org/linux/man-pages/man3/strncpy.3.html">STRCPY(3)</a>.</li>
+  <li>Linux Programmer's Manual: <a href="https://man7.org/linux/man-pages/man2/read.2.html">READ(2)</a>, <a href="https://man7.org/linux/man-pages/man3/strncpy.3.html">STRCPY(3)</a>.</li>
 
 </references>
 </qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-290/AuthenticationBypass.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-290/AuthenticationBypass.qhelp
@@ -17,7 +17,7 @@ that other authentication methods are also in place.</p>
 <example>
 
 <p>In this example (taken from
-<a href="http://cwe.mitre.org/data/definitions/290.html">CWE-290: Authentication Bypass by Spoofing</a>),
+<a href="https://cwe.mitre.org/data/definitions/290.html">CWE-290: Authentication Bypass by Spoofing</a>),
 the client is authenticated by checking that its IP address is <code>127.0.0.1</code>. An attacker might be able to
 bypass this authentication by spoofing their IP address.</p>
 

--- a/cpp/ql/src/Security/CWE/CWE-326/InsufficientKeySize.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-326/InsufficientKeySize.qhelp
@@ -26,7 +26,7 @@ considered sufficient. The second example uses 2048 bits, which is currently con
 </example>
 <references>
 
-<li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf">
+<li>NIST, FIPS 140 Annex a: <a href="https://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf">
 Approved Security Functions</a>.</li>
 <li>NIST, SP 800-131A: <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf">
 Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>

--- a/cpp/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -27,9 +27,9 @@ is a strong modern algorithm.</p>
 </example>
 <references>
 
-<li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf">
+<li>NIST, FIPS 140 Annex a: <a href="https://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf">
 Approved Security Functions</a>.</li>
-<li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf">
+<li>NIST, SP 800-131A: <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf">
 Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
 
 

--- a/cpp/ql/src/Security/CWE/CWE-676/DangerousFunctionOverflow.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-676/DangerousFunctionOverflow.qhelp
@@ -36,7 +36,7 @@ rules for the following CWEs:</p>
 
 </section>
 <references>
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Morris_worm">Morris worm</a>.</li>
-<li>E. Spafford. <i>The Internet Worm Program: An Analysis</i>. Purdue Technical Report CSD-TR-823, <a href="http://www.textfiles.com/100/tr823.txt">(online)</a>, 1988.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Morris_worm">Morris worm</a>.</li>
+<li>E. Spafford. <i>The Internet Worm Program: An Analysis</i>. Purdue Technical Report CSD-TR-823, <a href="https://www.textfiles.com/100/tr823.txt">(online)</a>, 1988.</li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-764/LockOrderCycle.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-764/LockOrderCycle.qhelp
@@ -49,13 +49,13 @@ simultaneously in separate threads then they could cause a deadlock.
 <references>
 
 <li>Dijkstra, E. W., <i>EWD-310:
-<a href="http://www.cs.utexas.edu/users/EWD/ewd03xx/EWD310.PDF">Hierarchical
+<a href="https://www.cs.utexas.edu/users/EWD/ewd03xx/EWD310.PDF">Hierarchical
 Ordering of Sequential Processes</a></i>.  E. W. Dijkstra
 Archive. Center for American History, University of Texas at Austin.
 </li>
 
 <li>Hoare, C. A. R.,
-<i><a href="http://www.usingcsp.com/cspbook.pdf">Communicating
+<i><a href="https://www.usingcsp.com/cspbook.pdf">Communicating
 Sequential Processes</a></i>,
 Section 2.5 - 'Example: The Dining Philosophers,' p. 55,
 2004 (originally published in 1985 by Prentice Hall International).</li>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-190/AllocMultiplicationOverflow.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-190/AllocMultiplicationOverflow.qhelp
@@ -18,7 +18,7 @@
 
 <references>
 <li>
-  Cplusplus.com: <a href="http://www.cplusplus.com/articles/DE18T05o/">Integer overflow</a>.
+  Cplusplus.com: <a href="https://www.cplusplus.com/articles/DE18T05o/">Integer overflow</a>.
 </li>
 </references>
 

--- a/cpp/ql/src/jsf/4.06 Pre-Processing Directives/AV Rule 32.qhelp
+++ b/cpp/ql/src/jsf/4.06 Pre-Processing Directives/AV Rule 32.qhelp
@@ -38,7 +38,7 @@ definitions in source files (<code>*.c, *.cpp</code>) files.
   Scott Meyers. Item 38, Effective C++: 50 Specific Ways to Improve Your Programs and Design, 2nd Edition. Addison-Wesley, 1998.
 </li>
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/19-header-files/">Header files</a>
+  <a href="https://www.learncpp.com/cpp-tutorial/19-header-files/">Header files</a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.07 Header Files/AV Rule 35.qhelp
+++ b/cpp/ql/src/jsf/4.07 Header Files/AV Rule 35.qhelp
@@ -63,10 +63,10 @@ some are after the final <code>#endif</code>. All three of these things must be 
   <a href="https://wiki.sei.cmu.edu/confluence/display/c/PRE06-C.+Enclose+header+files+in+an+include+guard">PRE06-C. Enclose header files in an inclusion guard</a>
 </li>
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/19-header-files/">Header files</a>
+  <a href="https://www.learncpp.com/cpp-tutorial/19-header-files/">Header files</a>
 </li>
 <li>
-  <a href="http://www.cplusplus.com/forum/articles/10627/">Headers and Includes: Why and How</a>
+  <a href="https://www.cplusplus.com/forum/articles/10627/">Headers and Includes: Why and How</a>
 </li>
 <li>
   <a href="https://gcc.gnu.org/onlinedocs/cppinternals/Guard-Macros.html">The Multiple-Include Optimization</a>

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 78.qhelp
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 78.qhelp
@@ -33,7 +33,7 @@ Make sure that all classes with virtual functions also have a virtual destructor
   S. Meyers. <em>Effective C++ 3d ed.</em> pp 40-44. Addison-Wesley Professional, 2005.
 </li>
 <li>
-  <a href="http://blogs.msdn.com/b/oldnewthing/archive/2004/05/07/127826.aspx">When should your destructor be virtual?</a>
+  <a href="https://blogs.msdn.com/b/oldnewthing/archive/2004/05/07/127826.aspx">When should your destructor be virtual?</a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.qhelp
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.qhelp
@@ -87,7 +87,7 @@ to a straightforward RAII pattern. This can be achieved in several steps:</p>
   S. Meyers. <em>Effective C++ 3d ed.</em> pp 61-66. Addison-Wesley Professional, 2005.
 </li>
 <li>
-  <a href="http://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization">Resource Acquisition Is Initialization</a>
+  <a href="https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization">Resource Acquisition Is Initialization</a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.qhelp
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.qhelp
@@ -38,7 +38,7 @@ function if the desired assignment operator differs significantly from the defau
   S. Meyers. <em>Effective C++ 3d ed.</em> pp 52-53. Addison-Wesley Professional, 2005.
 </li>
 <li>
-  <a href="http://courses.cms.caltech.edu/cs11/material/cpp/donnie/cpp-ops.html">C++ Operator Overloading Guidelines</a>
+  <a href="https://courses.cms.caltech.edu/cs11/material/cpp/donnie/cpp-ops.html">C++ Operator Overloading Guidelines</a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 97.qhelp
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 97.qhelp
@@ -33,7 +33,7 @@ Use the <code>Array</code> class, or explicitly declare the variable/parameter a
   AV Rule 97, <em>Joint Strike Fighter Air Vehicle C++ Coding Standards</em>. Lockheed Martin Corporation, 2005.
 </li>
 <li>
-  <a href="http://c-faq.com/aryptr/aryptrequiv.html">comp.lang.c FAQ list · Question 6.3 </a>
+  <a href="https://c-faq.com/aryptr/aryptrequiv.html">comp.lang.c FAQ list · Question 6.3 </a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.17 Types/AV Rule 148.qhelp
+++ b/cpp/ql/src/jsf/4.17 Types/AV Rule 148.qhelp
@@ -30,7 +30,7 @@ Use an enumeration instead of an integer to represent a limited set of choices.
   AV Rule 148, <em>Joint Strike Fighter Air Vehicle C++ Coding Standards</em>. Lockheed Martin Corporation, 2005.
 </li>
 <li>
-  <a href="http://www.tutorialspoint.com/cplusplus/cpp_switch_statement.htm">C++ Switch statement</a>
+  <a href="https://www.tutorialspoint.com/cplusplus/cpp_switch_statement.htm">C++ Switch statement</a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.20 Unions and Bit Fields/AV Rule 154.qhelp
+++ b/cpp/ql/src/jsf/4.20 Unions and Bit Fields/AV Rule 154.qhelp
@@ -34,7 +34,7 @@ The first field should also be declared to be unsigned.
   AV Rule 154, <em>Joint Strike Fighter Air Vehicle C++ Coding Standards</em>. Lockheed Martin Corporation, 2005.
 </li>
 <li>
-  C++ reference: <a href="http://en.cppreference.com/w/cpp/language/bit_field">Bit Fields</a>
+  C++ reference: <a href="https://en.cppreference.com/w/cpp/language/bit_field">Bit Fields</a>
 </li>
 </references>
 </qhelp>

--- a/cpp/ql/src/jsf/4.21 Operators/AV Rule 166.qhelp
+++ b/cpp/ql/src/jsf/4.21 Operators/AV Rule 166.qhelp
@@ -27,7 +27,7 @@ Simplify the <code>sizeof</code> parameter to use only the subexpression that is
   AV Rule 166, <em>Joint Strike Fighter Air Vehicle C++ Coding Standards</em>. Lockheed Martin Corporation, 2005.
 </li>
 <li>
-  Tutorialspoint - The C++ Programming Language: <a href="http://www.tutorialspoint.com/cplusplus/cpp_sizeof_operator.htm">C++ sizeof Operator</a>
+  Tutorialspoint - The C++ Programming Language: <a href="https://www.tutorialspoint.com/cplusplus/cpp_sizeof_operator.htm">C++ sizeof Operator</a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 189.qhelp
+++ b/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 189.qhelp
@@ -26,7 +26,7 @@ the break statement only exits from one level of the loop.</p>
   AV Rule 189, <em>Joint Strike Fighter Air Vehicle C++ Coding Standards</em>. Lockheed Martin Corporation, 2005.
 </li>
 <li>
-  <a href="http://www.cs.utexas.edu/users/EWD/transcriptions/EWD02xx/EWD215.html">A Case against the GO TO Statement (EWD-215).</a>
+  <a href="https://www.cs.utexas.edu/users/EWD/transcriptions/EWD02xx/EWD215.html">A Case against the GO TO Statement (EWD-215).</a>
 </li>
 <li>
   MSDN Library: <a href="https://docs.microsoft.com/en-us/cpp/cpp/goto-statement-cpp">goto Statement (C++)</a>.
@@ -36,7 +36,7 @@ the break statement only exits from one level of the loop.</p>
   Chapter 4: Control Flow, Rule 4.6 (<a href="https://web.archive.org/web/20190919025638/https://mongers.org/industrial-c++/">PDF</a>).
 </li>
 <li>
-  <a href="http://www.cplusplus.com/doc/tutorial/control/">www.cplusplus.com Control Structures</a>
+  <a href="https://www.cplusplus.com/doc/tutorial/control/">www.cplusplus.com Control Structures</a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 201.qhelp
+++ b/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 201.qhelp
@@ -35,7 +35,7 @@ loop if the loop requires more complicated variable iteration.
   MISRA C++ Rule 6-5-3, <em>Guidelines for the use of the C++ language in critical systems</em>. The Motor Industry Software Reliability Associate, 2008.
 </li>
 <li>
-  <a href="http://www.learncpp.com/cpp-tutorial/57-for-statements/">For statements</a>
+  <a href="https://www.learncpp.com/cpp-tutorial/57-for-statements/">For statements</a>
 </li>
 <li>
   Mats Henricson and Erik Nyquist, <i>Industrial Strength C++</i>, published by Prentice Hall PTR (1997). 

--- a/csharp/ql/src/API Abuse/CallToGCCollect.qhelp
+++ b/csharp/ql/src/API Abuse/CallToGCCollect.qhelp
@@ -21,7 +21,7 @@ resources are disposed of even if an exception interrupts your application.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.idisposable.aspx">The IDisposable interface</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.idisposable.aspx">The IDisposable interface</a>.</li>
   <li>Microsoft: <a href="https://docs.microsoft.com/en-us/visualstudio/profiling/memory-usage">Profile Memory Usage in Visual Studio</a>.</li>
 
 </references>

--- a/csharp/ql/src/ASP/NonInternationalizedText.qhelp
+++ b/csharp/ql/src/ASP/NonInternationalizedText.qhelp
@@ -30,7 +30,7 @@ to use will depend on the website, and might not be called exactly "I18n".
 <references>
 <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/ms973868.aspx">Introduction to ASP.NET and Web Forms</a>,
 <a href="https://msdn.microsoft.com/en-us/library/fy30at8h(v=vs.100).aspx">ASP.NET Page Syntax</a>.</li>
-<li>W3C: <a href="http://www.w3.org/standards/webdesign/i18n">Internationalization</a>,
-<a href="http://www.w3.org/International/questions/qa-i18n">Localization vs. Internationalization</a>.</li>
+<li>W3C: <a href="https://www.w3.org/standards/webdesign/i18n">Internationalization</a>,
+<a href="https://www.w3.org/International/questions/qa-i18n">Localization vs. Internationalization</a>.</li>
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/CallsUnmanagedCode.qhelp
+++ b/csharp/ql/src/Bad Practices/CallsUnmanagedCode.qhelp
@@ -27,8 +27,8 @@ the User32.dll library.</p>
 </section>
 <references>
 
-  <li>MSDN, C# Reference <a href="http://msdn.microsoft.com/en-us/library/e59b22c5(v=vs.80).aspx">extern</a>.</li>
-  <li>Wikipedia, <a href="http://en.wikipedia.org/wiki/Managed_code">Managed code</a>.</li>
+  <li>MSDN, C# Reference <a href="https://msdn.microsoft.com/en-us/library/e59b22c5(v=vs.80).aspx">extern</a>.</li>
+  <li>Wikipedia, <a href="https://en.wikipedia.org/wiki/Managed_code">Managed code</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/Comments/TodoComments.qhelp
+++ b/csharp/ql/src/Bad Practices/Comments/TodoComments.qhelp
@@ -40,11 +40,11 @@ adopted, the <code>TODO</code> comment should then be removed.
 
 <li>
 Approxion:
-    <a href="http://www.approxion.com/?p=39">TODO or not TODO</a>.
+    <a href="https://www.approxion.com/?p=39">TODO or not TODO</a>.
 </li>
 <li>
 Wikipedia:
-<a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Comment tags</a>.
+<a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Comment tags</a>.
 </li>
 
 

--- a/csharp/ql/src/Bad Practices/Declarations/EmptyInterface.qhelp
+++ b/csharp/ql/src/Bad Practices/Declarations/EmptyInterface.qhelp
@@ -24,7 +24,7 @@ being used as a marker.</p>
 </example>
 <references>
 
-  <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Marker_interface_pattern">Marker interface pattern</a></li>
+  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Marker_interface_pattern">Marker interface pattern</a></li>
   <li>Microsoft: <a href="https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/attributes">Using Attributes in C#</a></li>
 
 

--- a/csharp/ql/src/Bad Practices/Implementation Hiding/AbstractToConcreteCollection.qhelp
+++ b/csharp/ql/src/Bad Practices/Implementation Hiding/AbstractToConcreteCollection.qhelp
@@ -18,7 +18,7 @@ more difficult to change which implementation you are using at a later date.</p>
 </example>
 <references>
 
-  <li>C# Corner, <a href="http://www.c-sharpcorner.com/UploadFile/rmcochran/csharp_interrfaces03052006095933AM/csharp_interrfaces.aspx">C# Interface Based Development</a>.</li>
+  <li>C# Corner, <a href="https://www.c-sharpcorner.com/UploadFile/rmcochran/csharp_interrfaces03052006095933AM/csharp_interrfaces.aspx">C# Interface Based Development</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/Implementation Hiding/ExposeRepresentation.qhelp
+++ b/csharp/ql/src/Bad Practices/Implementation Hiding/ExposeRepresentation.qhelp
@@ -38,7 +38,7 @@ a short program showing what happens when an attempt is made to modify the data 
 <references>
 
   <li>MSDN, C# Programming Guide, <a href="https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/arrays-as-objects">Arrays as Objects</a>.</li>
-  <li>MSDN, <a href="http://msdn.microsoft.com/en-us/library/ms132474.aspx">ReadOnlyCollection&lt;T&gt;</a>.</li>
+  <li>MSDN, <a href="https://msdn.microsoft.com/en-us/library/ms132474.aspx">ReadOnlyCollection&lt;T&gt;</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/Implementation Hiding/StaticArray.qhelp
+++ b/csharp/ql/src/Bad Practices/Implementation Hiding/StaticArray.qhelp
@@ -25,7 +25,7 @@ cause the program not to compile.</p>
 <references>
 
   <li>MSDN, C# Programming Guide, <a href="https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/arrays-as-objects">Arrays as Objects</a>.</li>
-  <li>MSDN, <a href="http://msdn.microsoft.com/en-us/library/ms132474.aspx">ReadOnlyCollection&lt;T&gt;</a>.</li>
+  <li>MSDN, <a href="https://msdn.microsoft.com/en-us/library/ms132474.aspx">ReadOnlyCollection&lt;T&gt;</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/Naming Conventions/ConstantNaming.qhelp
+++ b/csharp/ql/src/Bad Practices/Naming Conventions/ConstantNaming.qhelp
@@ -20,7 +20,7 @@ PascalCase</code> constant is the only one named correctly.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-gb/library/vstudio/ms229043%28v=vs.100%29.aspx">Capitalization Conventions</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-gb/library/vstudio/ms229043%28v=vs.100%29.aspx">Capitalization Conventions</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/Naming Conventions/ControlNamePrefixes.qhelp
+++ b/csharp/ql/src/Bad Practices/Naming Conventions/ControlNamePrefixes.qhelp
@@ -14,7 +14,7 @@ radio buttons).</p>
 </recommendation>
 <references>
 
-  <li>MSDN, Visual Studio 6.0 Technical Articles, <a href="http://msdn.microsoft.com/en-us/library/aa260976(VS.60).aspx">Hungarian Notation</a>.</li>
+  <li>MSDN, Visual Studio 6.0 Technical Articles, <a href="https://msdn.microsoft.com/en-us/library/aa260976(VS.60).aspx">Hungarian Notation</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/Naming Conventions/FieldMasksSuperField.qhelp
+++ b/csharp/ql/src/Bad Practices/Naming Conventions/FieldMasksSuperField.qhelp
@@ -21,7 +21,7 @@ intended.</p>
 </example>
 <references>
 
-  <li>MSDN, C# Programming Guide, <a href="http://msdn.microsoft.com/en-us/library/aa691135(v=vs.71).aspx">Hiding through inheritance</a>.</li>
+  <li>MSDN, C# Programming Guide, <a href="https://msdn.microsoft.com/en-us/library/aa691135(v=vs.71).aspx">Hiding through inheritance</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/Naming Conventions/VariableNameTooShort.qhelp
+++ b/csharp/ql/src/Bad Practices/Naming Conventions/VariableNameTooShort.qhelp
@@ -30,7 +30,7 @@ mean.</p>
 </example>
 <references>
 
-  <li>Ars Technica. <a href="http://arstechnica.com/information-technology/2013/02/is-there-an-excuse-for-short-variable-names/">Is there an excuse for short variable names?</a>.</li>
+  <li>Ars Technica. <a href="https://arstechnica.com/information-technology/2013/02/is-there-an-excuse-for-short-variable-names/">Is there an excuse for short variable names?</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/UnmanagedCodeCheck.qhelp
+++ b/csharp/ql/src/Bad Practices/UnmanagedCodeCheck.qhelp
@@ -22,8 +22,8 @@ same function being performed by managed code is shown after.</p>
 </example>
 <references>
 
-  <li>MSDN, C# Reference <a href="http://msdn.microsoft.com/en-us/library/e59b22c5(v=vs.80).aspx">extern</a>.</li>
-  <li>Wikipedia, <a href="http://en.wikipedia.org/wiki/Managed_code">Managed code</a>.</li>
+  <li>MSDN, C# Reference <a href="https://msdn.microsoft.com/en-us/library/e59b22c5(v=vs.80).aspx">extern</a>.</li>
+  <li>Wikipedia, <a href="https://en.wikipedia.org/wiki/Managed_code">Managed code</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/CSI/CompareIdenticalValues.qhelp
+++ b/csharp/ql/src/CSI/CompareIdenticalValues.qhelp
@@ -36,7 +36,7 @@ should be replaced by <code>!double.IsNaN(...)</code> or <code>!float.IsNaN(...)
 </example>
 <references>
 
-  <li>MSDN, C# Reference, <a href="http://msdn.microsoft.com/en-GB/library/78kc05h3(v=vs.90).aspx">Compiler Warning (level 3) CS1718</a>.</li>
+  <li>MSDN, C# Reference, <a href="https://msdn.microsoft.com/en-GB/library/78kc05h3(v=vs.90).aspx">Compiler Warning (level 3) CS1718</a>.</li>
   <li>MSDN, C# Reference, <a href="https://msdn.microsoft.com/en-us/library/system.single.nan(v=vs.110).aspx">Single.NaN Field</a>.</li>
   <li>MSDN, C# Reference, <a href="https://msdn.microsoft.com/en-us/library/system.double.nan(v=vs.110).aspx">Double.NaN Field</a>.</li>
 

--- a/csharp/ql/src/Concurrency/FutileSyncOnField.qhelp
+++ b/csharp/ql/src/Concurrency/FutileSyncOnField.qhelp
@@ -38,7 +38,7 @@ value of <code>total</code> being incorrect.
 
 <li>
   MSDN, C# Reference: 
-  <a href="http://msdn.microsoft.com/en-us/library/c5kehkcz%28v=vs.110%29.aspx">lock Statement</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/c5kehkcz%28v=vs.110%29.aspx">lock Statement</a>.
 </li>
 
 

--- a/csharp/ql/src/Concurrency/LockOrder.qhelp
+++ b/csharp/ql/src/Concurrency/LockOrder.qhelp
@@ -26,7 +26,7 @@ is waiting to acquire <code>lock2</code>, whilst <code>thread2</code> holds <cod
 <references>
   <li>
     MSDN, C# Reference: 
-    <a href="http://msdn.microsoft.com/en-us/library/c5kehkcz%28v=vs.110%29.aspx">lock Statement</a>.
+    <a href="https://msdn.microsoft.com/en-us/library/c5kehkcz%28v=vs.110%29.aspx">lock Statement</a>.
   </li>
   <li>
     The CERT Oracle Coding Standard for Java: 

--- a/csharp/ql/src/Concurrency/LockThis.qhelp
+++ b/csharp/ql/src/Concurrency/LockThis.qhelp
@@ -23,7 +23,7 @@ variable called <code>mutex</code> to use in the <code>lock</code> statement.</p
 </example>
 <references>
 
-  <li>MSDN, C# Reference: <a href="http://msdn.microsoft.com/en-gb/library/c5kehkcz.aspx">lock Statement</a>.</li>
+  <li>MSDN, C# Reference: <a href="https://msdn.microsoft.com/en-gb/library/c5kehkcz.aspx">lock Statement</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Concurrency/LockedWait.qhelp
+++ b/csharp/ql/src/Concurrency/LockedWait.qhelp
@@ -35,7 +35,7 @@ is not locked for the duration of the wait.</p>
 </example>
 <references>
 
-   <li>MSDN, C# Reference: <a href="http://msdn.microsoft.com/en-gb/library/c5kehkcz.aspx">lock Statement</a>.</li>
+   <li>MSDN, C# Reference: <a href="https://msdn.microsoft.com/en-gb/library/c5kehkcz.aspx">lock Statement</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Concurrency/SynchSetUnsynchGet.qhelp
+++ b/csharp/ql/src/Concurrency/SynchSetUnsynchGet.qhelp
@@ -36,7 +36,7 @@ property getter, which could cause bugs on some CPU architectures.</p>
 </example>
 
 <references>
-  <li>MSDN, C# Reference: <a href="http://msdn.microsoft.com/en-gb/library/c5kehkcz.aspx">lock Statement</a>.</li>
+  <li>MSDN, C# Reference: <a href="https://msdn.microsoft.com/en-gb/library/c5kehkcz.aspx">lock Statement</a>.</li>
   <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Memory_barrier">Memory barrier</a>.</li>
 </references>
 </qhelp>

--- a/csharp/ql/src/Dead Code/DeadRefTypes.qhelp
+++ b/csharp/ql/src/Dead Code/DeadRefTypes.qhelp
@@ -18,7 +18,7 @@ outside the project.</p>
 </example>
 <references>
 
-  <li>MSDN, Code Analysis for Managed Code, <a href="http://msdn.microsoft.com/en-us/library/ms182265.aspx">CA1812: Avoid uninstantiated internal classes</a>.</li>
+  <li>MSDN, Code Analysis for Managed Code, <a href="https://msdn.microsoft.com/en-us/library/ms182265.aspx">CA1812: Avoid uninstantiated internal classes</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Dead Code/DeadStoreOfLocal.qhelp
+++ b/csharp/ql/src/Dead Code/DeadStoreOfLocal.qhelp
@@ -64,8 +64,8 @@ The revised example eliminates the unread assignments.</p>
 <references>
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Dead_store">Dead store</a>.</li>
-<li>MSDN, Code Analysis for Managed Code, <a href="http://msdn.microsoft.com/en-us/library/ms182278.aspx">CA1804: Remove unused locals</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Dead_store">Dead store</a>.</li>
+<li>MSDN, Code Analysis for Managed Code, <a href="https://msdn.microsoft.com/en-us/library/ms182278.aspx">CA1804: Remove unused locals</a>.</li>
 <li>Microsoft: <a href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#discards">What's new in C# 7 - Discards</a>.</li>
 
 </references>

--- a/csharp/ql/src/Dead Code/NonAssignedFields.qhelp
+++ b/csharp/ql/src/Dead Code/NonAssignedFields.qhelp
@@ -20,7 +20,7 @@ can detect.</p>
 </example>
 <references>
 
-  <li>MSDN, C# Reference, <a href="http://msdn.microsoft.com/en-us/library/03b5270t(v=vs.71).aspx">Compiler Warning (level 4) CS0649</a>.</li>
+  <li>MSDN, C# Reference, <a href="https://msdn.microsoft.com/en-us/library/03b5270t(v=vs.71).aspx">Compiler Warning (level 4) CS0649</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Documentation/XmldocExtraParam.qhelp
+++ b/csharp/ql/src/Documentation/XmldocExtraParam.qhelp
@@ -30,9 +30,9 @@ its <code>&lt;param&gt;</code> tag, which should be renamed to <code>incrementBy
 
 <li>
   MSDN, C# Programming Guide:
-  <a href="http://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
-  <a href="http://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
-  <a href="http://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
+  <a href="https://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
+  <a href="https://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Documentation/XmldocExtraTypeParam.qhelp
+++ b/csharp/ql/src/Documentation/XmldocExtraTypeParam.qhelp
@@ -30,9 +30,9 @@ parameter.</p>
 
 <li>
   MSDN, C# Programming Guide:
-  <a href="http://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
-  <a href="http://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
-  <a href="http://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
+  <a href="https://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
+  <a href="https://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Documentation/XmldocMissing.qhelp
+++ b/csharp/ql/src/Documentation/XmldocMissing.qhelp
@@ -49,9 +49,9 @@ and <code>&lt;exception&gt;</code> tags.
 
 <li>
   MSDN, C# Programming Guide:
-  <a href="http://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
-  <a href="http://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
-  <a href="http://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
+  <a href="https://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
+  <a href="https://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
 </li>
 
 

--- a/csharp/ql/src/Documentation/XmldocMissingException.qhelp
+++ b/csharp/ql/src/Documentation/XmldocMissingException.qhelp
@@ -30,9 +30,9 @@ thrown exception.</p>
 
 <li>
   MSDN, C# Programming Guide:
-  <a href="http://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
-  <a href="http://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
-  <a href="http://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
+  <a href="https://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
+  <a href="https://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
 </li>
 
 

--- a/csharp/ql/src/Documentation/XmldocMissingParam.qhelp
+++ b/csharp/ql/src/Documentation/XmldocMissingParam.qhelp
@@ -28,9 +28,9 @@ parameter.</p>
 
 <li>
   MSDN, C# Programming Guide:
-  <a href="http://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
-  <a href="http://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
-  <a href="http://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
+  <a href="https://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
+  <a href="https://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Documentation/XmldocMissingReturn.qhelp
+++ b/csharp/ql/src/Documentation/XmldocMissingReturn.qhelp
@@ -28,9 +28,9 @@ return value.</p>
 
 <li>
   MSDN, C# Programming Guide:
-  <a href="http://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
-  <a href="http://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
-  <a href="http://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
+  <a href="https://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
+  <a href="https://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Documentation/XmldocMissingSummary.qhelp
+++ b/csharp/ql/src/Documentation/XmldocMissingSummary.qhelp
@@ -29,9 +29,9 @@ Add a <code>&lt;summary&gt;</code> tag to any documentation comments which do no
 
 <li>
   MSDN, C# Programming Guide:
-  <a href="http://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
-  <a href="http://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
-  <a href="http://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
+  <a href="https://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
+  <a href="https://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
 </li>
 
 

--- a/csharp/ql/src/Documentation/XmldocMissingTypeParam.qhelp
+++ b/csharp/ql/src/Documentation/XmldocMissingTypeParam.qhelp
@@ -28,9 +28,9 @@ parameter.</p>
 
 <li>
   MSDN, C# Programming Guide:
-  <a href="http://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
-  <a href="http://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
-  <a href="http://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/b2s063f7.aspx">XML Documentation Comments</a>, 
+  <a href="https://msdn.microsoft.com/en-us/library/z04awywx.aspx">How to: Use the XML Documentation Features</a>,
+  <a href="https://msdn.microsoft.com/en-us/library/5ast78ax.aspx">Recommended Tags for Documentation Comments</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Input Validation/ValueShadowing.qhelp
+++ b/csharp/ql/src/Input Validation/ValueShadowing.qhelp
@@ -31,7 +31,7 @@ to using the cookie value, making it look like a forged request was initiated by
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.web.httprequest.item(v=VS.100).aspx">HttpRequest.Item</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.web.httprequest.item(v=VS.100).aspx">HttpRequest.Item</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Input Validation/ValueShadowingServerVariable.qhelp
+++ b/csharp/ql/src/Input Validation/ValueShadowingServerVariable.qhelp
@@ -30,8 +30,8 @@ not.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.web.httprequest.item(v=VS.100).aspx">HttpRequest.Item</a>.</li>
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/ms524602.aspx">IIS Server Variables</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.web.httprequest.item(v=VS.100).aspx">HttpRequest.Item</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/ms524602.aspx">IIS Server Variables</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Language Abuse/MissedUsingOpportunity.qhelp
+++ b/csharp/ql/src/Language Abuse/MissedUsingOpportunity.qhelp
@@ -29,7 +29,7 @@ instead.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/yh598w02(v=vs.80).aspx">using Statement</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/yh598w02(v=vs.80).aspx">using Statement</a>.</li>
   <li>J. Albahari and B. Albahari, <em>C# 4.0 in a Nutshell - The Definitive Reference</em>, p. 138.</li>
 
 

--- a/csharp/ql/src/Language Abuse/UnusedPropertyValue.qhelp
+++ b/csharp/ql/src/Language Abuse/UnusedPropertyValue.qhelp
@@ -46,7 +46,7 @@ in a property.</p>
 </example>
 <references>
 
-  <li>MSDN, C# Programming Guide: <a href="http://msdn.microsoft.com/en-us/library/w86s7x04.aspx">Using Properties</a>.</li>
+  <li>MSDN, C# Programming Guide: <a href="https://msdn.microsoft.com/en-us/library/w86s7x04.aspx">Using Properties</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Language Abuse/UselessIsBeforeAs.qhelp
+++ b/csharp/ql/src/Language Abuse/UselessIsBeforeAs.qhelp
@@ -26,8 +26,8 @@ since that also does a type test internally.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/scekt9xw(v=vs.71).aspx">is</a></li>
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/cscsdfbt(v=vs.71).aspx">as</a></li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/scekt9xw(v=vs.71).aspx">is</a></li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/cscsdfbt(v=vs.71).aspx">as</a></li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/BadCheckOdd.qhelp
+++ b/csharp/ql/src/Likely Bugs/BadCheckOdd.qhelp
@@ -33,10 +33,10 @@ Consider using <code>x % 2 != 0</code> to check for odd and <code>x % 2 == 0</co
 
 
 <li>
-  MSDN Library: <a href="http://msdn.microsoft.com/en-us/library/0w4e0fzs.aspx">% Operator (C# Reference)</a>.
+  MSDN Library: <a href="https://msdn.microsoft.com/en-us/library/0w4e0fzs.aspx">% Operator (C# Reference)</a>.
 </li>
 <li>
-  Wikipedia: <a href="http://en.wikipedia.org/wiki/Modulo_operation#Common_pitfalls">Modulo Operation - Common pitfalls</a>.
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Modulo_operation#Common_pitfalls">Modulo Operation - Common pitfalls</a>.
 </li>
 
 

--- a/csharp/ql/src/Likely Bugs/DangerousNonShortCircuitLogic.qhelp
+++ b/csharp/ql/src/Likely Bugs/DangerousNonShortCircuitLogic.qhelp
@@ -28,8 +28,8 @@ output but does not crash, unlike the previous example.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/sbf85k1c(v=vs.71).aspx">&amp; Operator</a></li>
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/kxszd0kx(v=vs.71).aspx">| Operator</a></li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/sbf85k1c(v=vs.71).aspx">&amp; Operator</a></li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/kxszd0kx(v=vs.71).aspx">| Operator</a></li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/Dynamic/BadDynamicCall.qhelp
+++ b/csharp/ql/src/Likely Bugs/Dynamic/BadDynamicCall.qhelp
@@ -26,7 +26,7 @@ RuntimeBinderException</code>.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-gb/library/dd264741.aspx">dynamic (C# Reference)</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-gb/library/dd264741.aspx">dynamic (C# Reference)</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Likely Bugs/EqualsArray.qhelp
+++ b/csharp/ql/src/Likely Bugs/EqualsArray.qhelp
@@ -28,7 +28,7 @@ comparison of the array.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.linq.enumerable.sequenceequal.aspx">Enumerable.SequenceEqual Method</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.linq.enumerable.sequenceequal.aspx">Enumerable.SequenceEqual Method</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Likely Bugs/EqualsUsesAs.qhelp
+++ b/csharp/ql/src/Likely Bugs/EqualsUsesAs.qhelp
@@ -31,7 +31,7 @@ d does not equal b.</pre>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/bsc2ak47(v=vs.80).aspx">Object.Equals Method (Object)</a></li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/bsc2ak47(v=vs.80).aspx">Object.Equals Method (Object)</a></li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/EqualsUsesIs.qhelp
+++ b/csharp/ql/src/Likely Bugs/EqualsUsesIs.qhelp
@@ -31,7 +31,7 @@ d does not equal b.</pre>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/bsc2ak47(v=vs.80).aspx">Object.Equals Method (Object)</a></li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/bsc2ak47(v=vs.80).aspx">Object.Equals Method (Object)</a></li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/HashedButNoHash.qhelp
+++ b/csharp/ql/src/Likely Bugs/HashedButNoHash.qhelp
@@ -19,7 +19,7 @@ can yield unexpected results if instances of those classes are stored in a hashi
 </example>
 <references>
 
-  <li>MSDN, C# Programmer's Reference, <a href="http://msdn.microsoft.com/en-us/library/system.object.gethashcode.aspx">Object.GetHashCode</a></li>
+  <li>MSDN, C# Programmer's Reference, <a href="https://msdn.microsoft.com/en-us/library/system.object.gethashcode.aspx">Object.GetHashCode</a></li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/IncomparableEquals.qhelp
+++ b/csharp/ql/src/Likely Bugs/IncomparableEquals.qhelp
@@ -19,7 +19,7 @@ or <code>String</code> because <code>ArrayList</code>s and <code>String</code>s 
 </example>
 <references>
 
-  <li>MSDN, <a href="http://msdn.microsoft.com/en-us/library/bsc2ak47.aspx">Object.Equals Method</a>.</li>
+  <li>MSDN, <a href="https://msdn.microsoft.com/en-us/library/bsc2ak47.aspx">Object.Equals Method</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/InconsistentCompareTo.qhelp
+++ b/csharp/ql/src/Likely Bugs/InconsistentCompareTo.qhelp
@@ -12,7 +12,7 @@ assumption, which can lead to confusion when the class is used.</p>
 
 <blockquote>
   <p>If the type implements IComparable, it should override Equals.</p>
-  <p><em>- Microsoft: <a href="http://msdn.microsoft.com/en-us/library/ms173147(v=vs.80).aspx">Guidelines for Overloading Equals() and Operator ==</a></em></p>
+  <p><em>- Microsoft: <a href="https://msdn.microsoft.com/en-us/library/ms173147(v=vs.80).aspx">Guidelines for Overloading Equals() and Operator ==</a></em></p>
 </blockquote>
 
 </overview>
@@ -31,7 +31,7 @@ a1 equals a2: False</pre>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.icomparable.compareto.aspx">IComparable.CompareTo Method</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.icomparable.compareto.aspx">IComparable.CompareTo Method</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/NestedLoopsSameVariable.qhelp
+++ b/csharp/ql/src/Likely Bugs/NestedLoopsSameVariable.qhelp
@@ -24,7 +24,7 @@ other programmers to understand and maintain.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/ch45axte.aspx">for</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/ch45axte.aspx">for</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/ObjectComparison.qhelp
+++ b/csharp/ql/src/Likely Bugs/ObjectComparison.qhelp
@@ -25,7 +25,7 @@ instead of using the <code>==</code> operator overloaded in <code>AlwaysEqual</c
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/53k8ybth.aspx">== Operator</a></li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/53k8ybth.aspx">== Operator</a></li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Likely Bugs/RandomUsedOnce.qhelp
+++ b/csharp/ql/src/Likely Bugs/RandomUsedOnce.qhelp
@@ -51,7 +51,7 @@ is initialized with the same time value.
 
 <li>
   MSDN:
-  <a href="http://msdn.microsoft.com/en-us/library/h343ddh9.aspx">Random Constructor</a>.
+  <a href="https://msdn.microsoft.com/en-us/library/h343ddh9.aspx">Random Constructor</a>.
 </li>
 
 

--- a/csharp/ql/src/Likely Bugs/RecursiveOperatorEquals.qhelp
+++ b/csharp/ql/src/Likely Bugs/RecursiveOperatorEquals.qhelp
@@ -27,7 +27,7 @@ arguments passed to it with null.</p>
 </example>
 <references>
 
-  <li><a href="http://msdn.microsoft.com/en-us/library/ms173147%28VS.80%29.aspx">Guidelines for Overloading Equals() and Operator== (C#)</a></li>
+  <li><a href="https://msdn.microsoft.com/en-us/library/ms173147%28VS.80%29.aspx">Guidelines for Overloading Equals() and Operator== (C#)</a></li>
 
 
 </references>

--- a/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.qhelp
+++ b/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.qhelp
@@ -24,7 +24,7 @@ really be compared using <code>i == j</code>.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.object.referenceequals.aspx">Object.ReferenceEquals Method</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.object.referenceequals.aspx">Object.ReferenceEquals Method</a>.</li>
   <li>The Way I See It: <a href="https://docs.microsoft.com/en-us/archive/blogs/vijaysk/object-referenceequalsvaluevar-valuevar-will-always-return-false">Object.ReferenceEquals(ValueVar, ValueVar) will always return false.</a></li>
 
 

--- a/csharp/ql/src/Likely Bugs/Statements/UseBraces.qhelp
+++ b/csharp/ql/src/Likely Bugs/Statements/UseBraces.qhelp
@@ -46,7 +46,7 @@ around both statements, as shown below.</p>
 
 <li>
   MSDN Documentation:
-  <a href="http://msdn.microsoft.com/en-us/library/5011f09h.aspx">if-else (C# Reference)</a>
+  <a href="https://msdn.microsoft.com/en-us/library/5011f09h.aspx">if-else (C# Reference)</a>
 </li>
 
 

--- a/csharp/ql/src/Likely Bugs/StaticFieldWrittenByInstance.qhelp
+++ b/csharp/ql/src/Likely Bugs/StaticFieldWrittenByInstance.qhelp
@@ -26,7 +26,7 @@ the static name field and affect all people.</p>
 </example>
 <references>
 
-  <li>MSDN, C# Reference, <a href="http://msdn.microsoft.com/en-us/library/98f28cdx(v=vs.71).aspx">static</a>.</li>
+  <li>MSDN, C# Reference, <a href="https://msdn.microsoft.com/en-us/library/98f28cdx(v=vs.71).aspx">static</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Linq/BadMultipleIteration.qhelp
+++ b/csharp/ql/src/Linq/BadMultipleIteration.qhelp
@@ -49,7 +49,7 @@ method as a list.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.collections.ienumerable.aspx">IEnumerable Interface</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.collections.ienumerable.aspx">IEnumerable Interface</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Linq/MissedAllOpportunity.qhelp
+++ b/csharp/ql/src/Linq/MissedAllOpportunity.qhelp
@@ -26,7 +26,7 @@ clearly expressed), shorter, less error-prone and more maintainable.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/bb548541.aspx">Enumerable.All&lt;TSource&gt; Method</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/bb548541.aspx">Enumerable.All&lt;TSource&gt; Method</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Linq/MissedCastOpportunity.qhelp
+++ b/csharp/ql/src/Linq/MissedCastOpportunity.qhelp
@@ -32,7 +32,7 @@ over that.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/bb341406.aspx">Enumerable.Cast&lt;TResult&gt; Method</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/bb341406.aspx">Enumerable.Cast&lt;TResult&gt; Method</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Linq/MissedOfTypeOpportunity.qhelp
+++ b/csharp/ql/src/Linq/MissedOfTypeOpportunity.qhelp
@@ -28,7 +28,7 @@ intent better and reducing the number of distinct variables in scope within the 
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/bb360913.aspx">Enumerable.OfType&lt;TResult&gt; Method</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/bb360913.aspx">Enumerable.OfType&lt;TResult&gt; Method</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Linq/MissedSelectOpportunity.qhelp
+++ b/csharp/ql/src/Linq/MissedSelectOpportunity.qhelp
@@ -26,7 +26,7 @@ expression.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.linq.enumerable.select.aspx">Enumerable.Select Method</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.linq.enumerable.select.aspx">Enumerable.Select Method</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Linq/MissedWhereOpportunity.qhelp
+++ b/csharp/ql/src/Linq/MissedWhereOpportunity.qhelp
@@ -29,7 +29,7 @@ on the even ones.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.linq.enumerable.where.aspx">Enumerable.Where Method</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.linq.enumerable.where.aspx">Enumerable.Where Method</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Metrics/Callables/CCyclomaticComplexity.qhelp
+++ b/csharp/ql/src/Metrics/Callables/CCyclomaticComplexity.qhelp
@@ -32,9 +32,9 @@ testing easier because each helper method can be tested individually.</p>
 </recommendation>
 <references>
 
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>.</li>
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/Control_flow_diagram">Control flow diagram</a>.</li>
-  <li>Wolfram MathWorld. <a href="http://mathworld.wolfram.com/LinearlyIndependent.html">Linearly Independent</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/Control_flow_diagram">Control flow diagram</a>.</li>
+  <li>Wolfram MathWorld. <a href="https://mathworld.wolfram.com/LinearlyIndependent.html">Linearly Independent</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/Callables/CLinesOfComment.qhelp
+++ b/csharp/ql/src/Metrics/Callables/CLinesOfComment.qhelp
@@ -17,7 +17,7 @@ increased without the need for more comments.</p>
 </recommendation>
 <references>
 
-  <li>Jeff Atwood. <a href="http://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
+  <li>Jeff Atwood. <a href="https://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
   <li>Steve McConnell. <em>Code Complete</em>. 2nd Edition. Microsoft Press. 2004.</li>
 
 </references>

--- a/csharp/ql/src/Metrics/Callables/CPercentageOfComments.qhelp
+++ b/csharp/ql/src/Metrics/Callables/CPercentageOfComments.qhelp
@@ -13,7 +13,7 @@ comments may indicate methods that are difficult to understand due to poor docum
 </recommendation>
 <references>
 
-  <li>Jeff Atwood. <a href="http://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
+  <li>Jeff Atwood. <a href="https://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
   <li>Steve McConnell. <em>Code Complete</em>. 2nd Edition. Microsoft Press. 2004.</li>
 
 </references>

--- a/csharp/ql/src/Metrics/Files/CommentedOutCodeReferences.inc.qhelp
+++ b/csharp/ql/src/Metrics/Files/CommentedOutCodeReferences.inc.qhelp
@@ -4,9 +4,9 @@
 <qhelp>
 <references>
 
-<li>Mark Needham: <a href="http://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
-<li>Los Techies: <a href="http://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
-<li>High Integrity C++ Coding Standard: <a href="http://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
+<li>Mark Needham: <a href="https://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
+<li>Los Techies: <a href="https://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
+<li>High Integrity C++ Coding Standard: <a href="https://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/Files/FCommentRatio.qhelp
+++ b/csharp/ql/src/Metrics/Files/FCommentRatio.qhelp
@@ -13,7 +13,7 @@ comments may indicate files that are difficult to understand due to poor documen
 </recommendation>
 <references>
 
-  <li>Jeff Atwood. <a href="http://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
+  <li>Jeff Atwood. <a href="https://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
   <li>Steve McConnell. <em>Code Complete</em>. 2nd Edition. Microsoft Press. 2004.</li>
 
 </references>

--- a/csharp/ql/src/Metrics/Files/FCyclomaticComplexity.qhelp
+++ b/csharp/ql/src/Metrics/Files/FCyclomaticComplexity.qhelp
@@ -64,13 +64,13 @@ M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.
 T. J. McCabe, <em>A Complexity Measure</em>. IEEE Transactions on Software Engineering, SE-2(4), December 1976.
 </li>
 <li>
-Dave Thomas, <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>, in Journal of Object Technology, vol. 4, no. 1, January-February 2005, pp. 7-11.
+Dave Thomas, <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>, in Journal of Object Technology, vol. 4, no. 1, January-February 2005, pp. 7-11.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
 </li>
 
 </references>

--- a/csharp/ql/src/Metrics/Files/FLinesOfCode.qhelp
+++ b/csharp/ql/src/Metrics/Files/FLinesOfCode.qhelp
@@ -26,7 +26,7 @@ refactored into smaller classes.</p>
 </recommendation>
 <references>
 
-  <li>MSDN. C# Programming Guide. <a href="http://msdn.microsoft.com/en-us/library/wa80x488%28VS.80%29.aspx">Partial Class Definitions</a>.</li>
+  <li>MSDN. C# Programming Guide. <a href="https://msdn.microsoft.com/en-us/library/wa80x488%28VS.80%29.aspx">Partial Class Definitions</a>.</li>
   <li>Martin Fowler. <em>Refactoring</em>. Addison-Wesley. 1999.</li>
 
 </references>

--- a/csharp/ql/src/Metrics/Files/FLinesOfComment.qhelp
+++ b/csharp/ql/src/Metrics/Files/FLinesOfComment.qhelp
@@ -14,7 +14,7 @@ to understand due to poor documentation.</p>
 </recommendation>
 <references>
 
-  <li>Jeff Atwood. <a href="http://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
+  <li>Jeff Atwood. <a href="https://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
   <li>Steve McConnell. <em>Code Complete</em>. 2nd Edition. Microsoft Press. 2004.</li>
 
 </references>

--- a/csharp/ql/src/Metrics/Files/FNumberOfClasses.qhelp
+++ b/csharp/ql/src/Metrics/Files/FNumberOfClasses.qhelp
@@ -19,7 +19,7 @@ consider moving them to their own files using partial classes.</p>
 </recommendation>
 <references>
 
-  <li>MSDN. C# Programming Guide. <a href="http://msdn.microsoft.com/en-us/library/wa80x488%28VS.80%29.aspx">Partial Class Definitions</a>.</li>
+  <li>MSDN. C# Programming Guide. <a href="https://msdn.microsoft.com/en-us/library/wa80x488%28VS.80%29.aspx">Partial Class Definitions</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/Files/FNumberOfInterfaces.qhelp
+++ b/csharp/ql/src/Metrics/Files/FNumberOfInterfaces.qhelp
@@ -14,7 +14,7 @@ compartmentalizing each interface into its own source file.</p>
 </recommendation>
 <references>
 
-  <li>MSDN. C# Programming Guide. <a href="http://msdn.microsoft.com/en-us/library/vstudio/ms173156.aspx">Interfaces</a>.</li>
+  <li>MSDN. C# Programming Guide. <a href="https://msdn.microsoft.com/en-us/library/vstudio/ms173156.aspx">Interfaces</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/Files/FNumberOfStructs.qhelp
+++ b/csharp/ql/src/Metrics/Files/FNumberOfStructs.qhelp
@@ -18,7 +18,7 @@ them in separate files.</p>
 </recommendation>
 <references>
 
-  <li>MSDN. <a href="http://msdn.microsoft.com/en-us/library/ah19swz4(v=vs.71).aspx">struct</a>.</li>
+  <li>MSDN. <a href="https://msdn.microsoft.com/en-us/library/ah19swz4(v=vs.71).aspx">struct</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/Files/FNumberOfTests.qhelp
+++ b/csharp/ql/src/Metrics/Files/FNumberOfTests.qhelp
@@ -47,7 +47,7 @@
 
 
 <li>
-  NUnit: official website at <a href="http://www.nunit.org/">http://www.nunit.org/</a>.
+  NUnit: official website at <a href="https://www.nunit.org/">http://www.nunit.org/</a>.
 </li>
 <li>
   Microsoft Visual Studio Unit Testing Framework: documentation at <a href="https://msdn.microsoft.com/en-us/library/microsoft.visualstudio.testtools.unittesting.aspx">MSDN</a>.

--- a/csharp/ql/src/Metrics/Files/FSelfContainedness.qhelp
+++ b/csharp/ql/src/Metrics/Files/FSelfContainedness.qhelp
@@ -19,7 +19,7 @@ should also try to use libraries with source code available.</p>
 </recommendation>
 <references>
 
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/Software_portability">Software Portability</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/Software_portability">Software Portability</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TInheritanceDepth.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TInheritanceDepth.qhelp
@@ -36,9 +36,9 @@ the position in the inheritance hierarchy.</p>
 </section>
 <references>
 
-  <li>Barbara Liskov. <a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.12.819&amp;rep=rep1&amp;type=pdf">Data Abstraction and Hierarchy</a>.</li>
+  <li>Barbara Liskov. <a href="https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.12.819&amp;rep=rep1&amp;type=pdf">Data Abstraction and Hierarchy</a>.</li>
   <li>Martin Fowler. <em>Refactoring</em>. Addison-Wesley. 1999.</li>
-  <li>Mick West. <a href="http://cowboyprogramming.com/2007/01/05/evolve-your-heirachy">Evolve Your Hierarchy</a>.</li>
+  <li>Mick West. <a href="https://cowboyprogramming.com/2007/01/05/evolve-your-heirachy">Evolve Your Hierarchy</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfCallables.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfCallables.qhelp
@@ -22,7 +22,7 @@ redesigned.</p>
 <references>
 
   <li>Martin Fowler. <em>Refactoring</em>. Addison-Wesley. 1999.</li>
-  <li>MSDN. Microsoft Application Architecture Guide 2nd Edition. <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">Chapter 3: Architectural Patterns and Styles</a>. Microsoft. 2009.</li>
+  <li>MSDN. Microsoft Application Architecture Guide 2nd Edition. <a href="https://msdn.microsoft.com/en-us/library/ee658117.aspx">Chapter 3: Architectural Patterns and Styles</a>. Microsoft. 2009.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfEvents.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfEvents.qhelp
@@ -29,7 +29,7 @@ that using a single event might be preferable.</p>
 </section>
 <references>
 
-  <li>MSDN. C# Programmer's Reference. <a href="http://msdn.microsoft.com/en-us/library/aa645739(v=vs.71).aspx">Events Tutorial</a>.</li>
+  <li>MSDN. C# Programmer's Reference. <a href="https://msdn.microsoft.com/en-us/library/aa645739(v=vs.71).aspx">Events Tutorial</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfFields.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfFields.qhelp
@@ -27,7 +27,7 @@ their address. As such these could be broken down into separate classes as shown
 </section>
 <references>
 
-  <li>MSDN, C# Reference. <a href="http://msdn.microsoft.com/en-us/library/ms173118.aspx">Fields</a>.</li>
+  <li>MSDN, C# Reference. <a href="https://msdn.microsoft.com/en-us/library/ms173118.aspx">Fields</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfIndexers.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfIndexers.qhelp
@@ -20,7 +20,7 @@ these methods can be named it can be made more obvious what they do.</p>
 </recommendation>
 <references>
 
-  <li>MSDN. C# Programming Guide. <a href="http://msdn.microsoft.com/en-us/library/vstudio/6x16t2tx.aspx">Indexers</a>.</li>
+  <li>MSDN. C# Programming Guide. <a href="https://msdn.microsoft.com/en-us/library/vstudio/6x16t2tx.aspx">Indexers</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfNonConstFields.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfNonConstFields.qhelp
@@ -27,7 +27,7 @@ their address. As such these could be broken down into separate classes as shown
 </section>
 <references>
 
-  <li>MSDN, C# Reference. <a href="http://msdn.microsoft.com/en-us/library/ms173118.aspx">Fields</a>.</li>
+  <li>MSDN, C# Reference. <a href="https://msdn.microsoft.com/en-us/library/ms173118.aspx">Fields</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfProperties.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfProperties.qhelp
@@ -27,7 +27,7 @@ person's name. As such the name properties could be extracted into a separate cl
 </section>
 <references>
 
-  <li>MSDN. C# Programming Guide. <a href="http://msdn.microsoft.com/en-us/library/x9fsa0sw(v=vs.80).aspx">Properties</a>.</li>
+  <li>MSDN. C# Programming Guide. <a href="https://msdn.microsoft.com/en-us/library/x9fsa0sw(v=vs.80).aspx">Properties</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TSizeOfAPI.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TSizeOfAPI.qhelp
@@ -14,7 +14,7 @@ be split up into multiple separate types for each function it performs.</p>
 </recommendation>
 <references>
 
-  <li>BlackWasp. <a href="http://www.blackwasp.co.uk/SRP.aspx">Single Responsibility Principle</a>.</li>
+  <li>BlackWasp. <a href="https://www.blackwasp.co.uk/SRP.aspx">Single Responsibility Principle</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Metrics/RefTypes/TUnmanagedCode.qhelp
+++ b/csharp/ql/src/Metrics/RefTypes/TUnmanagedCode.qhelp
@@ -27,8 +27,8 @@ unmanaged code from the <code>User32.dll</code> library.</p>
 </section>
 <references>
 
-  <li>MSDN, C# Reference. <a href="http://msdn.microsoft.com/en-us/library/e59b22c5(v=vs.80).aspx">extern</a>.</li>
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/Managed_code">Managed code</a>.</li>
+  <li>MSDN, C# Reference. <a href="https://msdn.microsoft.com/en-us/library/e59b22c5(v=vs.80).aspx">extern</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/Managed_code">Managed code</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Performance/StringBuilderInLoop.qhelp
+++ b/csharp/ql/src/Performance/StringBuilderInLoop.qhelp
@@ -31,6 +31,6 @@ iteration of the loop.</p>
 </example>
 
 <references>
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.text.stringbuilder.aspx">StringBuilder</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.text.stringbuilder.aspx">StringBuilder</a>.</li>
 </references>
 </qhelp>

--- a/csharp/ql/src/Performance/StringConcatenationInLoop.qhelp
+++ b/csharp/ql/src/Performance/StringConcatenationInLoop.qhelp
@@ -24,7 +24,7 @@ it is more efficient.</p>
 </section>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.text.stringbuilder.aspx">StringBuilder</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.text.stringbuilder.aspx">StringBuilder</a>.</li>
 
 
 </references>

--- a/csharp/ql/src/Security Features/CWE-079/XSS.qhelp
+++ b/csharp/ql/src/Security Features/CWE-079/XSS.qhelp
@@ -33,7 +33,7 @@ OWASP:
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 
 

--- a/csharp/ql/src/Security Features/CWE-090/LDAPInjection.qhelp
+++ b/csharp/ql/src/Security Features/CWE-090/LDAPInjection.qhelp
@@ -35,7 +35,7 @@ the query cannot be changed by a malicious user.</p>
 <references>
 <li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html">LDAP Injection Prevention Cheat Sheet</a>.</li>
 <li>OWASP: <a href="https://www.owasp.org/index.php/Preventing_LDAP_Injection_in_Java">Preventing LDAP Injection in Java</a>.</li>
-<li>AntiXSS doc: <a href="http://www.nudoq.org/#!/Packages/AntiXSS/AntiXssLibrary/Encoder/M/LdapFilterEncode">LdapFilterEncode</a>.</li>
-<li>AntiXSS doc: <a href="http://www.nudoq.org/#!/Packages/AntiXSS/AntiXssLibrary/Encoder/M/LdapDistinguishedNameEncode">LdapDistinguishedNameEncode</a>.</li>
+<li>AntiXSS doc: <a href="https://www.nudoq.org/#!/Packages/AntiXSS/AntiXssLibrary/Encoder/M/LdapFilterEncode">LdapFilterEncode</a>.</li>
+<li>AntiXSS doc: <a href="https://www.nudoq.org/#!/Packages/AntiXSS/AntiXssLibrary/Encoder/M/LdapDistinguishedNameEncode">LdapDistinguishedNameEncode</a>.</li>
 </references>
 </qhelp>

--- a/csharp/ql/src/Security Features/CWE-091/XMLInjection.qhelp
+++ b/csharp/ql/src/Security Features/CWE-091/XMLInjection.qhelp
@@ -36,7 +36,7 @@ which ensures the content is appropriately escaped.</p>
 
 <references>
   <li>
-    Web Application Security Consortium: <a href="http://projects.webappsec.org/w/page/13247004/XML%20Injection">XML Injection</a>.
+    Web Application Security Consortium: <a href="https://projects.webappsec.org/w/page/13247004/XML%20Injection">XML Injection</a>.
   </li>
   <li>
     Microsoft Docs: <a href="https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmlwriter.writeraw?view=netframework-4.8">WriteRaw</a>.

--- a/csharp/ql/src/Security Features/CookieWithOverlyBroadDomain.qhelp
+++ b/csharp/ql/src/Security Features/CookieWithOverlyBroadDomain.qhelp
@@ -25,7 +25,7 @@ which is much more secure.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.web.httpcookie.domain.aspx">HttpCookie.Domain Property</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.web.httpcookie.domain.aspx">HttpCookie.Domain Property</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Security Features/CookieWithOverlyBroadPath.qhelp
+++ b/csharp/ql/src/Security Features/CookieWithOverlyBroadPath.qhelp
@@ -26,7 +26,7 @@ path.</p>
 </example>
 <references>
 
-  <li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.web.httpcookie.path.aspx">HttpCookie.Path Property</a>.</li>
+  <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.web.httpcookie.path.aspx">HttpCookie.Path Property</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Security Features/HeaderCheckingDisabled.qhelp
+++ b/csharp/ql/src/Security Features/HeaderCheckingDisabled.qhelp
@@ -12,7 +12,7 @@
 </recommendation>
 <references>
 
-  <li>MSDN. <a href="http://msdn.microsoft.com/en-us/library/system.web.configuration.httpruntimesection.enableheaderchecking.aspx">HttpRuntimeSection.EnableHeaderChecking Property</a>.</li>
+  <li>MSDN. <a href="https://msdn.microsoft.com/en-us/library/system.web.configuration.httpruntimesection.enableheaderchecking.aspx">HttpRuntimeSection.EnableHeaderChecking Property</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Security Features/InadequateRSAPadding.qhelp
+++ b/csharp/ql/src/Security Features/InadequateRSAPadding.qhelp
@@ -12,7 +12,7 @@
 </recommendation>
 <references>
 
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/RSA_(algorithm)#Padding_schemes">RSA. Padding Schemes</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/RSA_(algorithm)#Padding_schemes">RSA. Padding Schemes</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Security Features/InsecureRandomness.qhelp
+++ b/csharp/ql/src/Security Features/InsecureRandomness.qhelp
@@ -65,8 +65,8 @@ a byte) to a series of permitted characters.
 
 <references>
 
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
-  <li>MSDN. <a href="http://msdn.microsoft.com/en-us/library/system.security.cryptography.randomnumbergenerator.aspx">RandomNumberGenerator</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
+  <li>MSDN. <a href="https://msdn.microsoft.com/en-us/library/system.security.cryptography.randomnumbergenerator.aspx">RandomNumberGenerator</a>.</li>
   <li>MSDN. <a href="https://msdn.microsoft.com/en-us/library/system.web.security.membership.generatepassword(v=vs.110).aspx">Membership.GeneratePassword</a>.</li>
 
 </references>

--- a/csharp/ql/src/Security Features/InsufficientKeySize.qhelp
+++ b/csharp/ql/src/Security Features/InsufficientKeySize.qhelp
@@ -14,7 +14,7 @@ symmetric encryption.</p>
 </recommendation>
 <references>
 
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/Key_size">Key size</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/Key_size">Key size</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Security Features/WeakEncryption.qhelp
+++ b/csharp/ql/src/Security Features/WeakEncryption.qhelp
@@ -17,8 +17,8 @@
 </example>
 <references>
 
-  <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Key_size">Key Size</a></li>
-  <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Data_Encryption_Standard">DES</a></li>
+  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Key_size">Key Size</a></li>
+  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Data_Encryption_Standard">DES</a></li>
 
 
 </references>

--- a/csharp/ql/src/Useless code/DefaultToString.qhelp
+++ b/csharp/ql/src/Useless code/DefaultToString.qhelp
@@ -37,7 +37,7 @@ to override <code>ToString</code> in that case). The output results are
 </example>
 <references>
 
-<li>MSDN: <a href="http://msdn.microsoft.com/en-us/library/system.object.tostring.aspx">Object.ToString Method</a>, <a href="https://msdn.microsoft.com/en-us/library/wb77sz3h(v=vs.110).aspx">ValueType.ToString Method</a>.</li>
+<li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/system.object.tostring.aspx">Object.ToString Method</a>, <a href="https://msdn.microsoft.com/en-us/library/wb77sz3h(v=vs.110).aspx">ValueType.ToString Method</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Useless code/FutileConditional.qhelp
+++ b/csharp/ql/src/Useless code/FutileConditional.qhelp
@@ -16,7 +16,7 @@
 </example>
 <references>
 
-  <li>MSDN, C# Reference, <a href="http://msdn.microsoft.com/en-us/library/5011f09h(v=vs.110).aspx">if-else</a></li>
+  <li>MSDN, C# Reference, <a href="https://msdn.microsoft.com/en-us/library/5011f09h(v=vs.110).aspx">if-else</a></li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/experimental/Security Features/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.qhelp
+++ b/csharp/ql/src/experimental/Security Features/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.qhelp
@@ -19,7 +19,7 @@
   </example>
   <references>
     <li>
-      <a href="http://aka.ms/azstorageclientencryptionblog">Azure Storage Client Encryption Blog.</a>
+      <a href="https://aka.ms/azstorageclientencryptionblog">Azure Storage Client Encryption Blog.</a>
     </li>
     <li>
       <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30187">CVE-2022-30187</a>

--- a/docs/codeql/index.html
+++ b/docs/codeql/index.html
@@ -253,11 +253,11 @@
                     <ul class="list-style-none f5">
                         <li class="lh-condensed mb-3"><a href="https://developer.github.com/"
                                 data-ga-click="Footer, go to api, text:api" class="link-gray">Developer API</a></li>
-                        <li class="lh-condensed mb-3"><a href="http://partner.github.com/"
+                        <li class="lh-condensed mb-3"><a href="https://partner.github.com/"
                                 data-ga-click="Footer, go to partner, text:partner" class="link-gray">Partners</a></li>
                         <li class="lh-condensed mb-3"><a href="https://atom.io"
                                 data-ga-click="Footer, go to atom, text:atom" class="link-gray">Atom</a></li>
-                        <li class="lh-condensed mb-3"><a href="http://electron.atom.io/"
+                        <li class="lh-condensed mb-3"><a href="https://electron.atom.io/"
                                 data-ga-click="Footer, go to electron, text:electron" class="link-gray">Electron</a>
                         </li>
                         <li class="lh-condensed mb-3"><a href="https://desktop.github.com/"

--- a/docs/codeql/ql-training/_static-training/slides-semmle-2/static/js/slide-deck.js
+++ b/docs/codeql/ql-training/_static-training/slides-semmle-2/static/js/slide-deck.js
@@ -384,7 +384,7 @@ SlideDeck.prototype.loadConfig_ = function(config) {
           '">' + p.gplus.replace(/https?:\/\//, '') + '</a>' : '';
 
       var twitter = p.twitter ? '<span>twitter</span>' +
-          '<a href="http://twitter.com/' + p.twitter + '">' +
+          '<a href="https://twitter.com/' + p.twitter + '">' +
           p.twitter + '</a>' : '';
 
       var www = p.www ? '<span>www</span><a href="' + p.www +

--- a/go/ql/src/Metrics/FLinesOfComment.qhelp
+++ b/go/ql/src/Metrics/FLinesOfComment.qhelp
@@ -18,7 +18,7 @@ explaining their purpose.
 </recommendation>
 
 <references>
-  <li>Jeff Atwood. <a href="http://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
+  <li>Jeff Atwood. <a href="https://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
   <li>Steve McConnell. <em>Code Complete</em>. 2nd Edition. Microsoft Press. 2004.</li>
 </references>
 </qhelp>

--- a/go/ql/src/RedundantCode/DeadStoreOfLocal.qhelp
+++ b/go/ql/src/RedundantCode/DeadStoreOfLocal.qhelp
@@ -39,7 +39,7 @@ use <code>_</code>.
 </example>
 
 <references>
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Dead_store">Dead store</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Dead_store">Dead store</a>.</li>
 <li>The Go Programming Language Specification: <a href="https://golang.org/ref/spec#Blank_identifier">Blank identifier</a>.</li>
 </references>
 </qhelp>

--- a/go/ql/src/RedundantCode/UnreachableStatement.qhelp
+++ b/go/ql/src/RedundantCode/UnreachableStatement.qhelp
@@ -31,6 +31,6 @@ statement:
 </example>
 
 <references>
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Unreachable_code">Unreachable code</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Unreachable_code">Unreachable code</a>.</li>
 </references>
 </qhelp>

--- a/go/ql/src/Security/CWE-079/ReflectedXss.qhelp
+++ b/go/ql/src/Security/CWE-079/ReflectedXss.qhelp
@@ -46,7 +46,7 @@ OWASP
 Scripting</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 </references>
 </qhelp>

--- a/go/ql/src/Security/CWE-079/StoredXss.qhelp
+++ b/go/ql/src/Security/CWE-079/StoredXss.qhelp
@@ -57,7 +57,7 @@
 		Scripting</a>.
 	</li>
 	<li>
-		Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+		Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 	</li>
 </references>
 </qhelp>

--- a/go/ql/src/Security/CWE-326/InsufficientKeySize.qhelp
+++ b/go/ql/src/Security/CWE-326/InsufficientKeySize.qhelp
@@ -43,8 +43,8 @@
           <li>Wikipedia: <a
           href="https://en.wikipedia.org/wiki/Strong_cryptography#Examples">Strong Cryptography Examples</a>.
           </li>
-          <li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
-          <li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
+          <li>NIST, FIPS 140 Annex a: <a href="https://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
+          <li>NIST, SP 800-131A: <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
      </references>
 
 </qhelp>

--- a/go/ql/src/Security/CWE-338/InsecureRandomness.qhelp
+++ b/go/ql/src/Security/CWE-338/InsecureRandomness.qhelp
@@ -42,7 +42,7 @@ Instead, use <code>crypto/rand</code>:
 </example>
 
 <references>
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
   <li>OWASP: <a href="https://owasp.org/www-community/vulnerabilities/Insecure_Randomness">Insecure Randomness</a>.</li>
   <li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#secure-random-number-generation">Secure Random Number Generation</a>.</li>
 </references>

--- a/go/ql/src/experimental/CWE-327/WeakCryptoAlgorithm.qhelp
+++ b/go/ql/src/experimental/CWE-327/WeakCryptoAlgorithm.qhelp
@@ -48,8 +48,8 @@
           <li>Wikipedia: <a
           href="https://en.wikipedia.org/wiki/Strong_cryptography#Examples">Strong Cryptography Examples</a>.
           </li>
-          <li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
-          <li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
+          <li>NIST, FIPS 140 Annex a: <a href="https://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
+          <li>NIST, SP 800-131A: <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
      </references>
 
 </qhelp>

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/examples/booking/app/views/footer.html
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/examples/booking/app/views/footer.html
@@ -1,7 +1,7 @@
     </div>
 
     <div id="footer">
-      Created with the <a href="http://github.com/revel/revel">Revel framework</a> and really inspirated from the booking sample application provided by <a href="http://www.playframework.org">play framework</a>, which was really inspired by the booking sample application provided by the <a href="http://seamframework.org/">seam framework</a>.
+      Created with the <a href="https://github.com/revel/revel">Revel framework</a> and really inspirated from the booking sample application provided by <a href="https://www.playframework.org">play framework</a>, which was really inspired by the booking sample application provided by the <a href="https://seamframework.org/">seam framework</a>.
     </div>
 
   </body>

--- a/java/ql/src/Architecture/Dependencies/UnusedMavenDependency.inc.qhelp
+++ b/java/ql/src/Architecture/Dependencies/UnusedMavenDependency.inc.qhelp
@@ -29,7 +29,7 @@ and the dependency should be restored.</p>
 
 <references>
 <li>Apache Maven Project:
-<a href="http://maven.apache.org/pom.html#Dependencies">Maven POM Reference: Dependencies</a>.
+<a href="https://maven.apache.org/pom.html#Dependencies">Maven POM Reference: Dependencies</a>.
 </li>
 </references>
 </qhelp>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbContainerInterference.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbContainerInterference.qhelp
@@ -26,7 +26,7 @@ could compromise security and decrease the container's ability to properly manag
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbFileIO.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbFileIO.qhelp
@@ -25,7 +25,7 @@ should use a resource manager API, such as JDBC, to store data.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbGraphics.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbGraphics.qhelp
@@ -25,7 +25,7 @@ attached to the server system.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbNative.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbNative.qhelp
@@ -24,7 +24,7 @@ create a security hole.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbReflection.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbReflection.qhelp
@@ -27,7 +27,7 @@ manner that is normally disallowed by the Java programming language could compro
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSecurityConfiguration.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSecurityConfiguration.qhelp
@@ -25,7 +25,7 @@ could compromise security.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSerialization.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSerialization.qhelp
@@ -24,7 +24,7 @@ Allowing the enterprise bean to use these functions could compromise security.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSetSocketOrUrlFactory.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSetSocketOrUrlFactory.qhelp
@@ -26,7 +26,7 @@ runtime environment.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSocketAsServer.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSocketAsServer.qhelp
@@ -26,7 +26,7 @@ the basic function of the enterprise bean&mdash;to serve the EJB clients.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbStaticFieldNonFinal.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbStaticFieldNonFinal.qhelp
@@ -27,7 +27,7 @@ multiple JVMs.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSynchronization.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSynchronization.qhelp
@@ -25,7 +25,7 @@ enterprise bean's instances across multiple JVMs.
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbThis.qhelp
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbThis.qhelp
@@ -23,7 +23,7 @@ enterprise bean must pass the result of <code>SessionContext.getBusinessObject</
 
 
 <li>
-  <a href="http://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
+  <a href="https://jcp.org/aboutJava/communityprocess/final/jsr220/index.html">
   JSR-220 Enterprise JavaBeans 3.0 Final Release</a> (ejbcore),
   Section 21.1.2 Programming Restrictions
 </li>

--- a/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/MissingParentBean.qhelp
+++ b/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/MissingParentBean.qhelp
@@ -36,7 +36,7 @@ properties with the same values.</p>
 
 <li>
 Spring Framework Reference Documentation 3.0: 
-<a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-ref-element">3.4.2.2 References to other beans (collaborators)</a>.
+<a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-ref-element">3.4.2.2 References to other beans (collaborators)</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/TooManyBeans.qhelp
+++ b/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/TooManyBeans.qhelp
@@ -30,7 +30,7 @@ two files were created by refactoring a file that contained too many bean defini
 
 <li>
 Spring Framework Reference Documentation 3.0:
-<a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-factory-xml-import">3.2.2.1 Composing XML-based configuration metadata</a>.
+<a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-factory-xml-import">3.2.2.1 Composing XML-based configuration metadata</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/UnusedBean.qhelp
+++ b/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/UnusedBean.qhelp
@@ -54,7 +54,7 @@ not used in any context, unlike the "petStore" bean.
 <references>
 <li>
 Spring Framework Reference Documentation 4.2:
-<a href="http://docs.spring.io/spring/docs/4.2.3.RELEASE/spring-framework-reference/html/beans.html#beans-definition">6.3 Bean overview</a>.
+<a href="https://docs.spring.io/spring/docs/4.2.3.RELEASE/spring-framework-reference/html/beans.html#beans-definition">6.3 Bean overview</a>.
 </li>
 </references>
 </qhelp>

--- a/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/UselessPropertyOverride.qhelp
+++ b/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/UselessPropertyOverride.qhelp
@@ -30,7 +30,7 @@ bean. It should be removed from the child bean.</p>
 
 <li>
 Spring Framework Reference Documentation 3.0:
-<a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-child-bean-definitions">3.7 Bean definition inheritance</a>.
+<a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-child-bean-definitions">3.7 Bean definition inheritance</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/AvoidAutowiring.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/AvoidAutowiring.qhelp
@@ -70,7 +70,7 @@ Spring Framework Reference Documentation 3.0:
 </li>
 <li>
 ONJava:
-<a href="http://onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=1">Twelve Best Practices For Spring XML Configurations</a>.
+<a href="https://onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=1">Twelve Best Practices For Spring XML Configurations</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/DontUseConstructorArgIndex.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/DontUseConstructorArgIndex.qhelp
@@ -36,7 +36,7 @@ Spring Framework Reference Documentation 3.0:
 </li>
 <li>
 ONJava:
-<a href="http://onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=2">Twelve Best Practices For Spring XML Configurations</a>.
+<a href="https://onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=2">Twelve Best Practices For Spring XML Configurations</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/ImportsFirst.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/ImportsFirst.qhelp
@@ -31,7 +31,7 @@ which all the <code>import</code> statements are at the top.</p>
 
 <li>
 Spring Framework Reference Documentation 3.0:
-<a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-factory-xml-import">3.2.2.1 Composing XML-based configuration metadata</a>.
+<a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-factory-xml-import">3.2.2.1 Composing XML-based configuration metadata</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/NoBeanDescription.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/NoBeanDescription.qhelp
@@ -31,7 +31,7 @@ Add a <code>&lt;description&gt;</code> element either in the <code>&lt;bean&gt;<
 
 <li>
 ONJava:
-<a href="http://onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=3">Twelve Best Practices For Spring XML Configurations</a>.
+<a href="https://onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=3">Twelve Best Practices For Spring XML Configurations</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/ParentShouldNotUseAbstractClass.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/ParentShouldNotUseAbstractClass.qhelp
@@ -41,7 +41,7 @@ provides property and constructor definitions to its children.
 
 
 <li>
-Spring Framework Reference Documentation 3.0: <a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-child-bean-definitions">3.7 Bean definition inheritance</a>.
+Spring Framework Reference Documentation 3.0: <a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-child-bean-definitions">3.7 Bean definition inheritance</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseIdInsteadOfName.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseIdInsteadOfName.qhelp
@@ -32,11 +32,11 @@ using the <code>id</code> attribute allows the XML parser to catch the typo.</p>
 
 <li>
 Spring Framework Reference Documentation 3.0:
-<a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-beanname">3.3.1 Naming beans</a>.
+<a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-beanname">3.3.1 Naming beans</a>.
 </li>
 <li>
 W3C:
-<a href="http://www.w3.org/TR/REC-xml/#sec-attribute-types">3.3.1 Attribute Types</a>.
+<a href="https://www.w3.org/TR/REC-xml/#sec-attribute-types">3.3.1 Attribute Types</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseLocalRef.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseLocalRef.qhelp
@@ -50,7 +50,7 @@ which cannot be checked by the XML parser. The <code>orderService</code> bean is
 
 <li>
 Spring Framework Reference Documentation 3.0:
-<a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-value-element">3.4.2.1 Straight values (primitives, Strings, and so on)</a>.
+<a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-value-element">3.4.2.1 Straight values (primitives, Strings, and so on)</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseSetterInjection.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseSetterInjection.qhelp
@@ -51,7 +51,7 @@ Martin Fowler:
 </li>
 <li>
 ONJava:
-<a href="http://www.onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=3">Twelve Best Practices for Spring XML Configurations</a>. 
+<a href="https://www.onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=3">Twelve Best Practices for Spring XML Configurations</a>. 
 </li>
 <li>
 Spring Framework Reference Documentation 3.0:

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseShortcutForms.qhelp
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseShortcutForms.qhelp
@@ -34,11 +34,11 @@ the same bean defined using nested <code>value</code> elements.</p>
 
 <li>
 ONJava:
-<a href="http://www.onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=1">Twelve Best Practices for Spring XML Configurations</a>. 
+<a href="https://www.onjava.com/pub/a/onjava/2006/01/25/spring-xml-configuration-best-practices.html?page=1">Twelve Best Practices for Spring XML Configurations</a>. 
 </li>
 <li>
 Spring Framework Reference Documentation 3.0:
-<a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-value-element">3.4.2.1 Straight values (primitives, Strings, and so on)</a>.
+<a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-value-element">3.4.2.1 Straight values (primitives, Strings, and so on)</a>.
 </li>
 
 

--- a/java/ql/src/Frameworks/Spring/XML Configuration Errors/MissingSetters.qhelp
+++ b/java/ql/src/Frameworks/Spring/XML Configuration Errors/MissingSetters.qhelp
@@ -35,7 +35,7 @@ in the class.</p>
 
 <li>
 Spring Framework Reference Documentation 3.0:
-<a href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-setter-injection">3.4.1.2 Setter-based dependency injection</a>.
+<a href="https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/beans.html#beans-setter-injection">3.4.1.2 Setter-based dependency injection</a>.
 </li>
 
 

--- a/java/ql/src/Likely Bugs/Comparison/EqualsUsesInstanceOf.qhelp
+++ b/java/ql/src/Likely Bugs/Comparison/EqualsUsesInstanceOf.qhelp
@@ -76,7 +76,7 @@ using <code>getClass</code> rather than <code>instanceof</code>.
     <a href="https://www.artima.com/lejava/articles/equality.html">How to Write an Equality Method in Java</a>.
 </li>
 <li>JavaSolutions, April 2002:
-<a href="http://www.angelikalanger.com/Articles/JavaSolutions/SecretsOfEquals/Equals.html">Secrets of equals()</a>.
+<a href="https://www.angelikalanger.com/Articles/JavaSolutions/SecretsOfEquals/Equals.html">Secrets of equals()</a>.
 </li>
 
 

--- a/java/ql/src/Likely Bugs/Concurrency/LazyInitStaticField.qhelp
+++ b/java/ql/src/Likely Bugs/Concurrency/LazyInitStaticField.qhelp
@@ -39,11 +39,11 @@ approach of using a static initializer to initialize <code>resource</code>.</p>
 <references>
 
 
-    <li>University of Maryland Department of Computer Science: <a href="http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html">The "Double-Checked Locking is Broken" Declaration</a>.</li>
+    <li>University of Maryland Department of Computer Science: <a href="https://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html">The "Double-Checked Locking is Broken" Declaration</a>.</li>
 
 
 <!--
-<p>Wikipedia article on the <a href="http://en.wikipedia.org/wiki/Double-checked_locking">Double-Checked Locking Pattern</a></p>
+<p>Wikipedia article on the <a href="https://en.wikipedia.org/wiki/Double-checked_locking">Double-Checked Locking Pattern</a></p>
 -->
 
 </references>

--- a/java/ql/src/Likely Bugs/Concurrency/PriorityCalls.qhelp
+++ b/java/ql/src/Likely Bugs/Concurrency/PriorityCalls.qhelp
@@ -38,7 +38,7 @@ recommended.</p>
 </li>
 <li>
   Inform IT:
-  <a href="http://www.informit.com/articles/article.aspx?p=26326&amp;seqNum=5">Adding Multithreading Capability to Your Java Applications</a>.
+  <a href="https://www.informit.com/articles/article.aspx?p=26326&amp;seqNum=5">Adding Multithreading Capability to Your Java Applications</a>.
 </li>
 
 

--- a/java/ql/src/Likely Bugs/Frameworks/JUnit/BadSuiteMethod.qhelp
+++ b/java/ql/src/Likely Bugs/Frameworks/JUnit/BadSuiteMethod.qhelp
@@ -32,7 +32,7 @@ because it has the expected signature.</p>
 
 
 <li>
-JUnit: <a href="http://junit.sourceforge.net/junit3.8.1/doc/cookbook/cookbook.htm">JUnit Cookbook</a>.
+JUnit: <a href="https://junit.sourceforge.net/junit3.8.1/doc/cookbook/cookbook.htm">JUnit Cookbook</a>.
 </li>
 
 

--- a/java/ql/src/Likely Bugs/Frameworks/JUnit/TearDownNoSuper.qhelp
+++ b/java/ql/src/Likely Bugs/Frameworks/JUnit/TearDownNoSuper.qhelp
@@ -32,7 +32,7 @@ which may cause subsequent tests to fail, or allow the internal state to be main
 
 
 <li>
-JUnit: <a href="http://junit.sourceforge.net/junit3.8.1/doc/cookbook/cookbook.htm">JUnit Cookbook</a>.
+JUnit: <a href="https://junit.sourceforge.net/junit3.8.1/doc/cookbook/cookbook.htm">JUnit Cookbook</a>.
 </li>
 
 

--- a/java/ql/src/Likely Bugs/Frameworks/JUnit/TestCaseNoTests.qhelp
+++ b/java/ql/src/Likely Bugs/Frameworks/JUnit/TestCaseNoTests.qhelp
@@ -45,7 +45,7 @@ methods. However, <code>MyTests</code> contains two valid JUnit test methods.</p
 
 
 <li>
-JUnit: <a href="http://junit.sourceforge.net/junit3.8.1/doc/cookbook/cookbook.htm">JUnit Cookbook</a>.
+JUnit: <a href="https://junit.sourceforge.net/junit3.8.1/doc/cookbook/cookbook.htm">JUnit Cookbook</a>.
 </li>
 
 

--- a/java/ql/src/Likely Bugs/Frameworks/Swing/ThreadSafety.qhelp
+++ b/java/ql/src/Likely Bugs/Frameworks/Swing/ThreadSafety.qhelp
@@ -94,7 +94,7 @@ D. Flanagan, <em>Java Foundation Classes in a Nutshell</em>, p.28. O'Reilly, 199
 </li>
 <li>
 Java Developer's Journal:
-<a href="http://www.comscigate.com/JDJ/archives/0605/ford/index.html">Building Thread-Safe GUIs with Swing</a>.
+<a href="https://www.comscigate.com/JDJ/archives/0605/ford/index.html">Building Thread-Safe GUIs with Swing</a>.
 </li>
 <li>
 The Java Tutorials:

--- a/java/ql/src/Metrics/Callables/CCyclomaticComplexity.qhelp
+++ b/java/ql/src/Metrics/Callables/CCyclomaticComplexity.qhelp
@@ -51,7 +51,7 @@ M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.
 T. J. McCabe, <em>A Complexity Measure</em>. IEEE Transactions on Software Engineering, SE-2(4), December 1976.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>.
 </li>
 
 

--- a/java/ql/src/Metrics/Callables/CLinesOfComment.qhelp
+++ b/java/ql/src/Metrics/Callables/CLinesOfComment.qhelp
@@ -60,7 +60,7 @@ documentation generator (see [Atwood]), don't say anything.
 
 
 <li>
-J. Atwood. <a href="http://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. Published online, 2005.
+J. Atwood. <a href="https://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. Published online, 2005.
 </li>
 <li>
 S. McConnell. <em>Code Complete</em>, 2nd Edition. Microsoft Press, 2004.

--- a/java/ql/src/Metrics/Files/CommentedOutCodeReferences.inc.qhelp
+++ b/java/ql/src/Metrics/Files/CommentedOutCodeReferences.inc.qhelp
@@ -4,9 +4,9 @@
 <qhelp>
 <references>
 
-<li>Mark Needham: <a href="http://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
-<li>Los Techies: <a href="http://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
-<li>High Integrity C++ Coding Standard: <a href="http://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
+<li>Mark Needham: <a href="https://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
+<li>Los Techies: <a href="https://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
+<li>High Integrity C++ Coding Standard: <a href="https://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
 
 </references>
 </qhelp>

--- a/java/ql/src/Metrics/Files/FCyclomaticComplexity.qhelp
+++ b/java/ql/src/Metrics/Files/FCyclomaticComplexity.qhelp
@@ -64,13 +64,13 @@ M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.
 T. J. McCabe, <em>A Complexity Measure</em>. IEEE Transactions on Software Engineering, SE-2(4), December 1976.
 </li>
 <li>
-Dave Thomas, <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>, in Journal of Object Technology, vol. 4, no. 1, January-February 2005, pp. 7-11.
+Dave Thomas, <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>, in Journal of Object Technology, vol. 4, no. 1, January-February 2005, pp. 7-11.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
 </li>
 
 </references>

--- a/java/ql/src/Metrics/Files/FLinesOfDuplicatedCodeCommon.inc.qhelp
+++ b/java/ql/src/Metrics/Files/FLinesOfDuplicatedCodeCommon.inc.qhelp
@@ -27,7 +27,7 @@ a shared library or module.
 <references> 
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 
 

--- a/java/ql/src/Metrics/Files/FLinesOfSimilarCode.qhelp
+++ b/java/ql/src/Metrics/Files/FLinesOfSimilarCode.qhelp
@@ -23,7 +23,7 @@ that can be reused across classes.
 <references> 
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 
 

--- a/java/ql/src/Metrics/Files/FNumberOfClasses.qhelp
+++ b/java/ql/src/Metrics/Files/FNumberOfClasses.qhelp
@@ -100,7 +100,7 @@ to enumerations.
 
 
 <li>
-H. Kabutz. <a href="http://www.devx.com/Java/Article/10686">Java History 101: Once Upon an Oak</a>. Published online.
+H. Kabutz. <a href="https://www.devx.com/Java/Article/10686">Java History 101: Once Upon an Oak</a>. Published online.
 </li>
 
 

--- a/java/ql/src/Metrics/Files/FNumberOfTests.qhelp
+++ b/java/ql/src/Metrics/Files/FNumberOfTests.qhelp
@@ -47,10 +47,10 @@
 
 
 <li>
-  JUnit: official website at <a href="http://junit.org/">http://junit.org/</a>.
+  JUnit: official website at <a href="https://junit.org/">http://junit.org/</a>.
 </li>
 <li>
-  TestNG: official website at <a href="http://testng.org/">http://testng.org/</a>.
+  TestNG: official website at <a href="https://testng.org/">http://testng.org/</a>.
 </li>
 
 </references>

--- a/java/ql/src/Metrics/Files/FSelfContainedness.qhelp
+++ b/java/ql/src/Metrics/Files/FSelfContainedness.qhelp
@@ -55,7 +55,7 @@ external libraries.
 
 
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Software_portability">Software portability</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Software_portability">Software portability</a>
 </li>
 <li>
   Oracle Technology Network: <a href="https://www.oracle.com/java/technologies/javase/compatibility.html">Java SE 6 Compatibility</a>

--- a/java/ql/src/Metrics/RefTypes/TInheritanceDepth.qhelp
+++ b/java/ql/src/Metrics/RefTypes/TInheritanceDepth.qhelp
@@ -95,7 +95,7 @@ For readers who are interested in this sort of approach, a good reference is
 M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-M. West. <a href="http://cowboyprogramming.com/2007/01/05/evolve-your-heirachy">Evolve Your Hierarchy</a>. Published online, 2007.
+M. West. <a href="https://cowboyprogramming.com/2007/01/05/evolve-your-heirachy">Evolve Your Hierarchy</a>. Published online, 2007.
 </li>
 
 

--- a/java/ql/src/Metrics/RefTypes/TNumberOfCallables.qhelp
+++ b/java/ql/src/Metrics/RefTypes/TNumberOfCallables.qhelp
@@ -91,10 +91,10 @@ R. Martin. <em>Agile Software Development: Principles, Patterns, and Practices</
 Chapter 8 - SRP: The Single-Responsibility Principle. Pearson Education, 2003.
 </li>
 <li>
-H. Sutter. <a href="http://www.gotw.ca/gotw/084.htm">GotW #84: Monoliths "Unstrung"</a>. Published online, 2002.
+H. Sutter. <a href="https://www.gotw.ca/gotw/084.htm">GotW #84: Monoliths "Unstrung"</a>. Published online, 2002.
 </li>
 <li>
-Microsoft Patterns &amp; Practices Team. <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
+Microsoft Patterns &amp; Practices Team. <a href="https://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
 </li>
 
 

--- a/java/ql/src/Metrics/RefTypes/TSelfContainedness.qhelp
+++ b/java/ql/src/Metrics/RefTypes/TSelfContainedness.qhelp
@@ -55,10 +55,10 @@ external libraries.
 
 
 <li>
-Wikipedia. <a href="http://en.wikipedia.org/wiki/Software_portability">Software portability</a>. Published online.
+Wikipedia. <a href="https://en.wikipedia.org/wiki/Software_portability">Software portability</a>. Published online.
 </li>
 <li>
-  Oracle Technology Network: <a href="http://www.oracle.com/technetwork/java/javase/compatibility-137541.html">Java SE 6 Compatibility</a>
+  Oracle Technology Network: <a href="https://www.oracle.com/technetwork/java/javase/compatibility-137541.html">Java SE 6 Compatibility</a>
 </li>
 <li>
   Java Language Specification:

--- a/java/ql/src/Metrics/RefTypes/TSizeOfAPI.qhelp
+++ b/java/ql/src/Metrics/RefTypes/TSizeOfAPI.qhelp
@@ -90,7 +90,7 @@ R. Martin. <em>Agile Software Development: Principles, Patterns, and Practices</
 Chapter 8 - SRP: The Single-Responsibility Principle. Pearson Education, 2003.
 </li>
 <li>
-H. Sutter. <a href="http://www.gotw.ca/gotw/084.htm">GotW #84: Monoliths "Unstrung"</a>. Published online, 2002.
+H. Sutter. <a href="https://www.gotw.ca/gotw/084.htm">GotW #84: Monoliths "Unstrung"</a>. Published online, 2002.
 </li>
 
 

--- a/java/ql/src/Security/CWE/CWE-079/XSS.qhelp
+++ b/java/ql/src/Security/CWE/CWE-079/XSS.qhelp
@@ -33,7 +33,7 @@ OWASP:
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 
 

--- a/java/ql/src/Security/CWE/CWE-094/MvelInjection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-094/MvelInjection.qhelp
@@ -30,7 +30,7 @@ before evaluating it.
 <references>
 <li>
   MVEL Documentation:
-  <a href="http://mvel.documentnode.com/">Language Guide for 2.0</a>.
+  <a href="https://mvel.documentnode.com/">Language Guide for 2.0</a>.
 </li>
 <li>
   OWASP:

--- a/java/ql/src/Security/CWE/CWE-113/ResponseSplitting.qhelp
+++ b/java/ql/src/Security/CWE/CWE-113/ResponseSplitting.qhelp
@@ -50,14 +50,14 @@ The second recommended approach in the example verifies the parameters before us
 
 <references>
 <li>
-InfosecWriters: <a href="http://www.infosecwriters.com/Papers/DCrab_HTTP_Response.pdf">HTTP response splitting</a>.
+InfosecWriters: <a href="https://www.infosecwriters.com/Papers/DCrab_HTTP_Response.pdf">HTTP response splitting</a>.
 </li>
 <li>
 OWASP:
 <a href="https://www.owasp.org/index.php/HTTP_Response_Splitting">HTTP Response Splitting</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/HTTP_response_splitting">HTTP response splitting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/HTTP_response_splitting">HTTP response splitting</a>.
 </li>
 <li>
 CAPEC: <a href="https://capec.mitre.org/data/definitions/105.html">CAPEC-105: HTTP Request Splitting</a>

--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -27,9 +27,9 @@ is a strong modern algorithm.</p>
 </example>
 <references>
 
-<li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf">
+<li>NIST, FIPS 140 Annex a: <a href="https://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf">
 Approved Security Functions</a>.</li>
-<li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf">
+<li>NIST, SP 800-131A: <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf">
 Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
 
 

--- a/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
+++ b/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
@@ -63,9 +63,9 @@ OWASP guidance on deserializing objects:
 </li>
 <li>
 Talks by Chris Frohoff &amp; Gabriel Lawrence:
-<a href="http://frohoff.github.io/appseccali-marshalling-pickles/">
+<a href="https://frohoff.github.io/appseccali-marshalling-pickles/">
 AppSecCali 2015: Marshalling Pickles - how deserializing objects will ruin your day</a>,
-<a href="http://frohoff.github.io/owaspsd-deserialize-my-shorts/">OWASP SD: Deserialize My Shorts:
+<a href="https://frohoff.github.io/owaspsd-deserialize-my-shorts/">OWASP SD: Deserialize My Shorts:
 Or How I Learned to Start Worrying and Hate Java Object Deserialization</a>.
 </li>
 <li>

--- a/java/ql/src/Security/CWE/CWE-730/ReDoSReferences.inc.qhelp
+++ b/java/ql/src/Security/CWE/CWE-730/ReDoSReferences.inc.qhelp
@@ -10,7 +10,7 @@
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
 		<li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
-		<a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+		<a href="https://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
 		</li>
 	</references>
 </qhelp>

--- a/java/ql/src/Violations of Best Practice/Comments/TodoComments.qhelp
+++ b/java/ql/src/Violations of Best Practice/Comments/TodoComments.qhelp
@@ -40,12 +40,12 @@ and prioritized relative to other defects and feature requests.</p>
 
 <li>
 Approxion:
-  <a href="http://www.approxion.com/?p=39">TODO or not TODO</a>.
+  <a href="https://www.approxion.com/?p=39">TODO or not TODO</a>.
 </li>
 <li>
 Wikipedia:
-<a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Comment tags</a>,
-<a href="http://en.wikipedia.org/wiki/Issue_tracking_system">Issue tracking system</a>.
+<a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Comment tags</a>,
+<a href="https://en.wikipedia.org/wiki/Issue_tracking_system">Issue tracking system</a>.
 </li>
 
 

--- a/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.qhelp
+++ b/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.qhelp
@@ -19,7 +19,7 @@ in the program may cause a programmer to waste time and effort maintaining and d
 
 <li>
   Wikipedia:
-  <a href="http://en.wikipedia.org/wiki/Unreachable_code">Unreachable code</a>.
+  <a href="https://en.wikipedia.org/wiki/Unreachable_code">Unreachable code</a>.
 </li>
 
 

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/AmbiguousOuterSuper.qhelp
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/AmbiguousOuterSuper.qhelp
@@ -40,7 +40,7 @@ method you intend to call. To preserve the behavior in the example, use <code>su
 
 <li>
 Inner Classes Specification:
-<a href="http://www.cis.upenn.edu/~bcpierce/courses/629/jdkdocs/guide/innerclasses/spec/innerclasses.doc1.html">What are top-level classes and inner classes?</a>.
+<a href="https://www.cis.upenn.edu/~bcpierce/courses/629/jdkdocs/guide/innerclasses/spec/innerclasses.doc1.html">What are top-level classes and inner classes?</a>.
 </li>
 
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.qhelp
@@ -55,7 +55,7 @@ uses a Regex pattern to check whether a user tries to run an allowed expression 
 </li>
 <li>
   JUEL:
-  <a href="http://juel.sourceforge.net">Home page</a>
+  <a href="https://juel.sourceforge.net">Home page</a>
 </li>
 </references>
 </qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.qhelp
@@ -14,7 +14,7 @@ symmetric encryption.</p>
 
         <li>
             Wikipedia.
-            <a href="http://en.wikipedia.org/wiki/Key_size">Key size</a>
+            <a href="https://en.wikipedia.org/wiki/Key_size">Key size</a>
         </li>
         <li>
             SonarSource.

--- a/java/ql/src/experimental/Security/CWE/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.qhelp
@@ -19,7 +19,7 @@
   </example>
   <references>
     <li>
-      <a href="http://aka.ms/azstorageclientencryptionblog">Azure Storage Client Encryption Blog.</a>
+      <a href="https://aka.ms/azstorageclientencryptionblog">Azure Storage Client Encryption Blog.</a>
     </li>
     <li>
       <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30187">CVE-2022-30187</a>

--- a/java/ql/src/experimental/Security/CWE/CWE-346/UnvalidatedCors.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-346/UnvalidatedCors.qhelp
@@ -70,7 +70,7 @@
 <references>
 	<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin">CORS, Access-Control-Allow-Origin</a>.</li>
 	<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials">CORS, Access-Control-Allow-Credentials</a>.</li>
-	<li>PortSwigger: <a href="http://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html">Exploiting CORS Misconfigurations for Bitcoins and Bounties</a></li>
+	<li>PortSwigger: <a href="https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html">Exploiting CORS Misconfigurations for Bitcoins and Bounties</a></li>
 	<li>W3C: <a href="https://w3c.github.io/webappsec-cors-for-developers/#resources">CORS for developers, Advice for Resource Owners</a></li>
 </references>
 </qhelp>

--- a/java/ql/test/stubs/amazon-aws-sdk-1.11.700/com/amazonaws/auth/AWSCredentials.java
+++ b/java/ql/test/stubs/amazon-aws-sdk-1.11.700/com/amazonaws/auth/AWSCredentials.java
@@ -23,7 +23,7 @@ package com.amazonaws.auth;
  * {@link BasicAWSCredentials}, but callers are free to provide their own
  * implementation, for example, to load AWS credentials from an encrypted file.
  * <p>
- * For more details on AWS access keys, see: <a href="http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html#AccessKeys"
+ * For more details on AWS access keys, see: <a href="https://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html#AccessKeys"
  * >http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/
  * AboutAWSCredentials.html#AccessKeys</a>
  */

--- a/java/ql/test/stubs/apache-commons-codec-1.14/org/apache/commons/codec/DecoderException.java
+++ b/java/ql/test/stubs/apache-commons-codec-1.14/org/apache/commons/codec/DecoderException.java
@@ -27,7 +27,7 @@ public class DecoderException extends Exception {
     /**
      * Declares the Serial Version Uid.
      *
-     * @see <a href="http://c2.com/cgi/wiki?AlwaysDeclareSerialVersionUid">Always Declare Serial Version Uid</a>
+     * @see <a href="https://c2.com/cgi/wiki?AlwaysDeclareSerialVersionUid">Always Declare Serial Version Uid</a>
      */
     private static final long serialVersionUID = 1L;
 

--- a/java/ql/test/stubs/apache-commons-codec-1.14/org/apache/commons/codec/EncoderException.java
+++ b/java/ql/test/stubs/apache-commons-codec-1.14/org/apache/commons/codec/EncoderException.java
@@ -28,7 +28,7 @@ public class EncoderException extends Exception {
     /**
      * Declares the Serial Version Uid.
      *
-     * @see <a href="http://c2.com/cgi/wiki?AlwaysDeclareSerialVersionUid">Always Declare Serial Version Uid</a>
+     * @see <a href="https://c2.com/cgi/wiki?AlwaysDeclareSerialVersionUid">Always Declare Serial Version Uid</a>
      */
     private static final long serialVersionUID = 1L;
 

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HeaderElementIterator.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HeaderElementIterator.java
@@ -39,7 +39,7 @@ import java.util.Iterator;
  * @version $Revision: 584542 $
  *
  * @deprecated Please use {@link java.net.URL#openConnection} instead.
- *     Please visit <a href="http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
+ *     Please visit <a href="https://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
  *     for further details.
  */
 @Deprecated

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpMessage.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpMessage.java
@@ -44,7 +44,7 @@ import org.apache.http.params.HttpParams;
  * @since 4.0
  *
  * @deprecated Please use {@link java.net.URL#openConnection} instead.
- *     Please visit <a href="http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
+ *     Please visit <a href="https://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
  *     for further details.
  */
 @Deprecated

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/NameValuePair.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/NameValuePair.java
@@ -39,7 +39,7 @@ package org.apache.http;
  * "http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2">Section
  * 2.2</a> and <a href=
  * "http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6">Section
- * 3.6</a> of <a href="http://www.w3.org/Protocols/rfc2616/rfc2616.txt">RFC
+ * 3.6</a> of <a href="https://www.w3.org/Protocols/rfc2616/rfc2616.txt">RFC
  * 2616</a>
  * </p>
  * <h>2.2 Basic Rules</h>

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpDelete.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpDelete.java
@@ -33,7 +33,7 @@ import java.net.URI;
  * HTTP DELETE method
  * <p>
  * The HTTP DELETE method is defined in section 9.7 of
- * <a href="http://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>:
+ * <a href="https://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>:
  * <blockquote>
  * The DELETE method requests that the origin server delete the resource
  * identified by the Request-URI. [...] The client cannot

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpGet.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpGet.java
@@ -36,7 +36,7 @@ import java.net.URI;
  * HTTP GET method.
  * <p>
  * The HTTP GET method is defined in section 9.3 of
- * <a href="http://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>: <blockquote> The
+ * <a href="https://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>: <blockquote> The
  * GET method means retrieve whatever information (in the form of an entity) is
  * identified by the Request-URI. If the Request-URI refers to a data-producing
  * process, it is the produced data which shall be returned as the entity in the

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpHead.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpHead.java
@@ -33,7 +33,7 @@ import java.net.URI;
  * HTTP HEAD method.
  * <p>
  * The HTTP HEAD method is defined in section 9.4 of
- * <a href="http://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>:
+ * <a href="https://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>:
  * </p>
  * <blockquote>
  * The HEAD method is identical to GET except that the server MUST NOT

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpOptions.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpOptions.java
@@ -41,7 +41,7 @@ import org.apache.http.util.Args;
  * HTTP OPTIONS method.
  * <p>
  * The HTTP OPTIONS method is defined in section 9.2 of
- * <a href="http://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>:
+ * <a href="https://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>:
  * </p>
  * <blockquote>
  *  The OPTIONS method represents a request for information about the

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpPost.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpPost.java
@@ -36,7 +36,7 @@ import java.net.URI;
  * HTTP POST method.
  * <p>
  * The HTTP POST method is defined in section 9.5 of
- * <a href="http://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>: <blockquote> The
+ * <a href="https://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>: <blockquote> The
  * POST method is used to request that the origin server accept the entity
  * enclosed in the request as a new subordinate of the resource identified by
  * the Request-URI in the Request-Line. POST is designed to allow a uniform

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpPut.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpPut.java
@@ -36,7 +36,7 @@ import java.net.URI;
  * HTTP PUT method.
  * <p>
  * The HTTP PUT method is defined in section 9.6 of
- * <a href="http://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>: <blockquote> The
+ * <a href="https://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>: <blockquote> The
  * PUT method requests that the enclosed entity be stored under the supplied
  * Request-URI. If the Request-URI refers to an already existing resource, the
  * enclosed entity SHOULD be considered as a modified version of the one

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpTrace.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpTrace.java
@@ -33,7 +33,7 @@ import java.net.URI;
  * HTTP TRACE method.
  * <p>
  * The HTTP TRACE method is defined in section 9.6 of
- * <a href="http://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>:
+ * <a href="https://www.ietf.org/rfc/rfc2616.txt">RFC2616</a>:
  * </p>
  * <blockquote>
  *  The TRACE method is used to invoke a remote, application-layer loop-

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpUriRequest.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/client/methods/HttpUriRequest.java
@@ -59,9 +59,9 @@ public interface HttpUriRequest extends HttpRequest {
      * <p>
      * To find the final URI after any redirects have been processed,
      * please see the section entitled
-     * <a href="http://hc.apache.org/httpcomponents-client-ga/tutorial/html/fundamentals.html#d4e205">HTTP execution context</a>
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/tutorial/html/fundamentals.html#d4e205">HTTP execution context</a>
      * in the
-     * <a href="http://hc.apache.org/httpcomponents-client-ga/tutorial/html">HttpClient Tutorial</a>
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/tutorial/html">HttpClient Tutorial</a>
      * </p>
      */
     URI getURI();

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/message/BasicRequestLine.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/message/BasicRequestLine.java
@@ -46,7 +46,7 @@ import org.apache.http.RequestLine;
  * @since 4.0
  *
  * @deprecated Please use {@link java.net.URL#openConnection} instead.
- *     Please visit <a href="http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
+ *     Please visit <a href="https://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
  *     for further details.
  */
 @Deprecated

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/params/HttpParams.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/params/HttpParams.java
@@ -39,7 +39,7 @@ package org.apache.http.params;
  * @since 4.0
  *
  * @deprecated Please use {@link java.net.URL#openConnection} instead.
- *     Please visit <a href="http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
+ *     Please visit <a href="https://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
  *     for further details.
  */
 @Deprecated

--- a/java/ql/test/stubs/javax-ws-rs-api-2.1.1/javax/ws/rs/core/Request.java
+++ b/java/ql/test/stubs/javax-ws-rs-api-2.1.1/javax/ws/rs/core/Request.java
@@ -31,7 +31,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
  * {@code ResponseBuilder} instance will have an appropriate status and will also include a {@code Vary} header if the
  * {@link #selectVariant(List)} method was called prior to to calling {@code evaluatePreconditions}. It is the
  * responsibility of the caller to check the status and add additional metadata if required. E.g., see
- * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1, section 10.3.5</a> for details
+ * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1, section 10.3.5</a> for details
  * of the headers that are expected to accompany a {@code 304 Not Modified} response.
  *
  * @author Paul Sandoz

--- a/java/ql/test/stubs/javax-ws-rs-api-3.0.0/jakarta/ws/rs/core/Request.java
+++ b/java/ql/test/stubs/javax-ws-rs-api-3.0.0/jakarta/ws/rs/core/Request.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.Response.ResponseBuilder;
  * {@code ResponseBuilder} instance will have an appropriate status and will also include a {@code Vary} header if the
  * {@link #selectVariant(List)} method was called prior to to calling {@code evaluatePreconditions}. It is the
  * responsibility of the caller to check the status and add additional metadata if required. E.g., see
- * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1, section 10.3.5</a> for details
+ * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1, section 10.3.5</a> for details
  * of the headers that are expected to accompany a {@code 304 Not Modified} response.
  *
  * @author Paul Sandoz

--- a/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/Cookie.java
+++ b/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/Cookie.java
@@ -47,7 +47,7 @@ package javax.ws.rs.core;
  *
  * @author Paul Sandoz
  * @author Marc Hadley
- * @see <a href="http://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>
+ * @see <a href="https://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>
  * @since 1.0
  */
 public class Cookie {

--- a/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/NewCookie.java
+++ b/java/ql/test/stubs/jsr311-api-1.1.1/javax/ws/rs/core/NewCookie.java
@@ -47,7 +47,7 @@ import java.util.Date;
  *
  * @author Paul Sandoz
  * @author Marc Hadley
- * @see <a href="http://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>
+ * @see <a href="https://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>
  * @since 1.0
  */
 public class NewCookie extends Cookie {

--- a/java/ql/test/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/JwtHandlerAdapter.java
+++ b/java/ql/test/stubs/jwtk-jjwt-0.11.2/io/jsonwebtoken/JwtHandlerAdapter.java
@@ -16,7 +16,7 @@
 package io.jsonwebtoken;
 
 /**
- * An <a href="http://en.wikipedia.org/wiki/Adapter_pattern">Adapter</a> implementation of the
+ * An <a href="https://en.wikipedia.org/wiki/Adapter_pattern">Adapter</a> implementation of the
  * {@link JwtHandler} interface that allows for anonymous subclasses to process only the JWT results that are
  * known/expected for a particular use case.
  *

--- a/javascript/extractor/src/com/semmle/js/extractor/YAMLExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/YAMLExtractor.java
@@ -25,7 +25,7 @@ import org.yaml.snakeyaml.resolver.Resolver;
 /**
  * Extractor for populating YAML files.
  *
- * <p>The extractor uses <a href="http://www.snakeyaml.org/">SnakeYAML</a> to parse YAML.
+ * <p>The extractor uses <a href="https://www.snakeyaml.org/">SnakeYAML</a> to parse YAML.
  */
 public class YAMLExtractor implements IExtractor {
   /** The tables constituting the YAML dbscheme. */

--- a/javascript/ql/src/Comments/CommentedOutCodeReferences.inc.qhelp
+++ b/javascript/ql/src/Comments/CommentedOutCodeReferences.inc.qhelp
@@ -4,9 +4,9 @@
 <qhelp>
 <references>
 
-<li>Mark Needham: <a href="http://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
-<li>Los Techies: <a href="http://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
-<li>High Integrity C++ Coding Standard: <a href="http://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
+<li>Mark Needham: <a href="https://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
+<li>Los Techies: <a href="https://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
+<li>High Integrity C++ Coding Standard: <a href="https://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
 
 </references>
 </qhelp>

--- a/javascript/ql/src/Comments/TodoComments.qhelp
+++ b/javascript/ql/src/Comments/TodoComments.qhelp
@@ -40,11 +40,11 @@ adopted, the <code>TODO</code> comment should then be removed.
 
 <li>
 Approxion:
-    <a href="http://www.approxion.com/?p=39">TODO or not TODO</a>.
+    <a href="https://www.approxion.com/?p=39">TODO or not TODO</a>.
 </li>
 <li>
 Wikipedia:
-<a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Comment tags</a>.
+<a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">Comment tags</a>.
 </li>
 
 

--- a/javascript/ql/src/DOM/Alert.qhelp
+++ b/javascript/ql/src/DOM/Alert.qhelp
@@ -20,7 +20,7 @@ may also indicate unfinished code.
 
 <p>
 Use one of the HTML-based dialog box widgets offered by frameworks such as
-<a href="http://jqueryui.com">jQuery UI</a>, and consider using a non-modal dialog box where possible.
+<a href="https://jqueryui.com">jQuery UI</a>, and consider using a non-modal dialog box where possible.
 </p>
 
 </recommendation>

--- a/javascript/ql/src/DOM/PseudoEval.qhelp
+++ b/javascript/ql/src/DOM/PseudoEval.qhelp
@@ -18,7 +18,7 @@ but a function.
 
 <p>
 Instead of using <code>document.write</code> to insert raw HTML into the DOM, use a framework such as
-<a href="http://jquery.com">jQuery</a>.
+<a href="https://jquery.com">jQuery</a>.
 </p>
 
 </recommendation>

--- a/javascript/ql/src/DOM/examples/ConflictingAttributes.html
+++ b/javascript/ql/src/DOM/examples/ConflictingAttributes.html
@@ -1,1 +1,1 @@
-<a href="http://semmle.com" href="https://semmle.com">Semmle</a>
+<a href="https://semmle.com" href="https://semmle.com">Semmle</a>

--- a/javascript/ql/src/DOM/examples/TargetBlank.js
+++ b/javascript/ql/src/DOM/examples/TargetBlank.js
@@ -1,1 +1,1 @@
-var link = <a href="http://example.com" target="_blank">Example</a>;
+var link = <a href="https://example.com" target="_blank">Example</a>;

--- a/javascript/ql/src/DOM/examples/TargetBlankGood.js
+++ b/javascript/ql/src/DOM/examples/TargetBlankGood.js
@@ -1,1 +1,1 @@
-var link = <a href="http://example.com" target="_blank" rel="noopener noreferrer">Example</a>;
+var link = <a href="https://example.com" target="_blank" rel="noopener noreferrer">Example</a>;

--- a/javascript/ql/src/Declarations/DeadStore.inc.qhelp
+++ b/javascript/ql/src/Declarations/DeadStore.inc.qhelp
@@ -41,7 +41,7 @@ succeeded or not, the value of <code>result</code> should be checked, perhaps li
 <references>
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Dead_store">Dead store</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Dead_store">Dead store</a>.</li>
 
 
 

--- a/javascript/ql/src/Declarations/DeadStoreOfGlobal.qhelp
+++ b/javascript/ql/src/Declarations/DeadStoreOfGlobal.qhelp
@@ -49,7 +49,7 @@ To fix this, correct the name of the local variable:
 
 <li>D. Crockford, <i>JavaScript: The Good Parts</i>, Appendix A. O'Reilly, 2008.</li>
 <li>Google Closure Tools: <a href="https://developers.google.com/closure/compiler/docs/api-tutorial3?csw=1#externs">Declaring externs</a>.</li>
-<li>JSLint: <a href="http://www.jslint.com/help.html#global">Global Variables</a>.</li>
+<li>JSLint: <a href="https://www.jslint.com/help.html#global">Global Variables</a>.</li>
 
 
 

--- a/javascript/ql/src/Declarations/TooManyParameters.qhelp
+++ b/javascript/ql/src/Declarations/TooManyParameters.qhelp
@@ -38,7 +38,7 @@ function have to be updated accordingly.
 <references>
 
 
-<li>Cunningham &amp; Cunningham, Inc: <a href="http://c2.com/cgi/wiki?TooManyParameters">Code Smell: Too Many Parameters</a>.</li>
+<li>Cunningham &amp; Cunningham, Inc: <a href="https://c2.com/cgi/wiki?TooManyParameters">Code Smell: Too Many Parameters</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/Declarations/UnusedParameter.qhelp
+++ b/javascript/ql/src/Declarations/UnusedParameter.qhelp
@@ -30,7 +30,7 @@ pieces of code. Instead, the second argument should simply be dropped.
 </example>
 <references>
 
-<li>Coding Horror: <a href="http://blog.codinghorror.com/code-smells/">Code Smells</a>.</li>
+<li>Coding Horror: <a href="https://blog.codinghorror.com/code-smells/">Code Smells</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/Declarations/UnusedProperty.qhelp
+++ b/javascript/ql/src/Declarations/UnusedProperty.qhelp
@@ -27,7 +27,7 @@
 	</example>
 	<references>
 
-		<li>Coding Horror: <a href="http://blog.codinghorror.com/code-smells/">Code Smells</a>.</li>
+		<li>Coding Horror: <a href="https://blog.codinghorror.com/code-smells/">Code Smells</a>.</li>
 
 
 	</references>

--- a/javascript/ql/src/Declarations/UnusedVariable.qhelp
+++ b/javascript/ql/src/Declarations/UnusedVariable.qhelp
@@ -62,7 +62,7 @@ the export statement is a default export, this variable is unused and can be eli
 <references>
 
 
-<li>Coding Horror: <a href="http://blog.codinghorror.com/code-smells/">Code Smells</a>.</li>
+<li>Coding Horror: <a href="https://blog.codinghorror.com/code-smells/">Code Smells</a>.</li>
 <li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en/docs/web/JavaScript/Reference/Operators/function#Named_function_expression">Named function expressions</a>.</li>
 <li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#Using_the_default_export">Using the default export</a>.</li>
 

--- a/javascript/ql/src/Expressions/ComparisonWithNaN.qhelp
+++ b/javascript/ql/src/Expressions/ComparisonWithNaN.qhelp
@@ -27,7 +27,7 @@ Instead of <code>x === NaN</code>, use <code>isNaN(x)</code>.
 <references>
 
 
-<li>Arvind Kumar: <a href="http://www.devarticles.in/javascript/javascript-common-mistake-of-comparing-variable-with-nan-and-not-with-isnan/">Javascript common mistake of comparing with NaN and not with isNaN</a>.</li>
+<li>Arvind Kumar: <a href="https://www.devarticles.in/javascript/javascript-common-mistake-of-comparing-variable-with-nan-and-not-with-isnan/">Javascript common mistake of comparing with NaN and not with isNaN</a>.</li>
 <li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN</a>.</li>
 
 

--- a/javascript/ql/src/Expressions/ExprHasNoEffect.qhelp
+++ b/javascript/ql/src/Expressions/ExprHasNoEffect.qhelp
@@ -53,7 +53,7 @@ assign it an initial value, which also serves to document its expected type:
 </example>
 <references>
 
-<li>JSLint Error Explanations: <a href="http://jslinterrors.com/expected-an-assignment-or-function-call">Expected an assignment or function call</a>.</li>
+<li>JSLint Error Explanations: <a href="https://jslinterrors.com/expected-an-assignment-or-function-call">Expected an assignment or function call</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/Expressions/UnknownDirective.qhelp
+++ b/javascript/ql/src/Expressions/UnknownDirective.qhelp
@@ -33,6 +33,6 @@
 
   <references>
     <li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode">"use strict"</a></li>
-    <li>asm.js: <a href="http://asmjs.org/spec/latest/#validation">"use asm"</a></li>
+    <li>asm.js: <a href="https://asmjs.org/spec/latest/#validation">"use asm"</a></li>
   </references>
 </qhelp>

--- a/javascript/ql/src/JSDoc/BadParamTag.qhelp
+++ b/javascript/ql/src/JSDoc/BadParamTag.qhelp
@@ -31,7 +31,7 @@ In the following example, the constructor <code>Message</code> has a JSDoc comme
 <references>
 
 
-<li>Use JSDoc: <a href="http://usejsdoc.org/tags-param.html">The @param tag</a>.</li>
+<li>Use JSDoc: <a href="https://usejsdoc.org/tags-param.html">The @param tag</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/JSDoc/JSDocForNonExistentParameter.qhelp
+++ b/javascript/ql/src/JSDoc/JSDocForNonExistentParameter.qhelp
@@ -37,7 +37,7 @@ second <code>@param</code> should be updated to refer to the parameter <code>bod
 <references>
 
 
-<li>Use JSDoc: <a href="http://usejsdoc.org/tags-param.html">The @param tag</a>.</li>
+<li>Use JSDoc: <a href="https://usejsdoc.org/tags-param.html">The @param tag</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/JSDoc/UndocumentedParameter.qhelp
+++ b/javascript/ql/src/JSDoc/UndocumentedParameter.qhelp
@@ -30,7 +30,7 @@ parameter <code>body</code>.
 <references>
 
 
-<li>Use JSDoc: <a href="http://usejsdoc.org/tags-param.html">The @param tag</a>.</li>
+<li>Use JSDoc: <a href="https://usejsdoc.org/tags-param.html">The @param tag</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/LanguageFeatures/ConditionalComments.qhelp
+++ b/javascript/ql/src/LanguageFeatures/ConditionalComments.qhelp
@@ -11,7 +11,7 @@ Conditional comments are only supported in Internet Explorer and should be avoid
 <recommendation>
 
 <p>
-Use feature detection (as offered by major frameworks such as <a href="http://jquery.com">jQuery</a>) instead.
+Use feature detection (as offered by major frameworks such as <a href="https://jquery.com">jQuery</a>) instead.
 </p>
 
 </recommendation>
@@ -33,7 +33,7 @@ Note that conditional comments are no longer supported in Internet Explorer 11 S
 <references>
 
 
-<li>Internet Explorer Dev Center: <a href="http://msdn.microsoft.com/en-us/library/ie/8ka90k2e(v=vs.94).aspx">@cc_on Statement (JavaScript)</a>.</li>
+<li>Internet Explorer Dev Center: <a href="https://msdn.microsoft.com/en-us/library/ie/8ka90k2e(v=vs.94).aspx">@cc_on Statement (JavaScript)</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/LanguageFeatures/DeleteVar.qhelp
+++ b/javascript/ql/src/LanguageFeatures/DeleteVar.qhelp
@@ -38,7 +38,7 @@ function <code>compute</code> to the outside world):
 <references>
 
 
-<li>JSLint Error Explanations: <a href="http://jslinterrors.com/only-properties-should-be-deleted">Only properties should be deleted</a>.</li>
+<li>JSLint Error Explanations: <a href="https://jslinterrors.com/only-properties-should-be-deleted">Only properties should be deleted</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/LanguageFeatures/Eval.qhelp
+++ b/javascript/ql/src/LanguageFeatures/Eval.qhelp
@@ -18,7 +18,7 @@ In many cases, better alternatives are available and should be used instead.
 There are few genuine uses of <code>eval</code> and <code>Function</code>. If you are trying to
 assign to a property whose name is not known until runtime, use a computed property access. If you
 are trying to evaluate a string to a JSON object, use <code>JSON.parse</code>. In other cases,
-you may be able to use the <a href="http://en.wikipedia.org/wiki/Interpreter_pattern">Interpreter
+you may be able to use the <a href="https://en.wikipedia.org/wiki/Interpreter_pattern">Interpreter
 pattern</a>.
 </p>
 

--- a/javascript/ql/src/Metrics/FCyclomaticComplexity.qhelp
+++ b/javascript/ql/src/Metrics/FCyclomaticComplexity.qhelp
@@ -64,13 +64,13 @@ M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.
 T. J. McCabe, <em>A Complexity Measure</em>. IEEE Transactions on Software Engineering, SE-2(4), December 1976.
 </li>
 <li>
-Dave Thomas, <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>, in Journal of Object Technology, vol. 4, no. 1, January-February 2005, pp. 7-11.
+Dave Thomas, <a href="https://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>, in Journal of Object Technology, vol. 4, no. 1, January-February 2005, pp. 7-11.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
 </li>
 
 </references>

--- a/javascript/ql/src/Metrics/FLinesOfComment.qhelp
+++ b/javascript/ql/src/Metrics/FLinesOfComment.qhelp
@@ -12,7 +12,7 @@
 </recommendation>
 <references>
 
-  <li>Jeff Atwood. <a href="http://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
+  <li>Jeff Atwood. <a href="https://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
   <li>Steve McConnell. <em>Code Complete</em>. 2nd Edition. Microsoft Press. 2004.</li>
 
 </references>

--- a/javascript/ql/src/Metrics/FLinesOfDuplicatedCodeCommon.inc.qhelp
+++ b/javascript/ql/src/Metrics/FLinesOfDuplicatedCodeCommon.inc.qhelp
@@ -27,7 +27,7 @@ a shared library or module.
 <references> 
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 
 

--- a/javascript/ql/src/Metrics/FLinesOfSimilarCodeCommon.inc.qhelp
+++ b/javascript/ql/src/Metrics/FLinesOfSimilarCodeCommon.inc.qhelp
@@ -28,7 +28,7 @@ that can be reused across modules.
 <references> 
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 
 

--- a/javascript/ql/src/Metrics/FNumberOfTests.qhelp
+++ b/javascript/ql/src/Metrics/FNumberOfTests.qhelp
@@ -18,8 +18,8 @@ testing.
 </recommendation>
 <references>
 <li><a href="https://qunitjs.com/">QUnit</a></li>
-<li><a href="http://xunitjs.shaege.com/">xUnit.js</a></li>
-<li><a href="http://jasmine.github.io/">Jasmine</a></li>
-<li><a href="http://unitjs.com/">Unit.js</a></li>
+<li><a href="https://xunitjs.shaege.com/">xUnit.js</a></li>
+<li><a href="https://jasmine.github.io/">Jasmine</a></li>
+<li><a href="https://unitjs.com/">Unit.js</a></li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Metrics/FUseOfES6.qhelp
+++ b/javascript/ql/src/Metrics/FUseOfES6.qhelp
@@ -24,7 +24,7 @@ the migration.
 </recommendation>
 <references>
 <li>
-Ecma International: <a href="http://www.ecma-international.org/ecma-262/6.0">ECMAScript 2015 Language Specification</a>.
+Ecma International: <a href="https://www.ecma-international.org/ecma-262/6.0">ECMAScript 2015 Language Specification</a>.
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Metrics/FunCyclomaticComplexity.qhelp
+++ b/javascript/ql/src/Metrics/FunCyclomaticComplexity.qhelp
@@ -34,7 +34,7 @@ M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 T. J. McCabe. <em>A Complexity Measure</em>. IEEE Transactions on Software Engineering, SE-2(4), December 1976.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>.
 </li>
 
 

--- a/javascript/ql/src/NodeJS/CyclicImport.qhelp
+++ b/javascript/ql/src/NodeJS/CyclicImport.qhelp
@@ -40,7 +40,7 @@ so that it no longer depends on <code>a.js</code>:
 
 
 <li>Brad Harris: <a href="https://web.archive.org/web/20200203213815/http://selfcontained.us/2012/05/08/node-js-circular-dependencies/">node.js and circular dependencies</a>.</li>
-<li>Node.js Manual: <a href="http://nodejs.org/api/modules.html#modules_cycles">Modules</a>.</li>
+<li>Node.js Manual: <a href="https://nodejs.org/api/modules.html#modules_cycles">Modules</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/NodeJS/DubiousImport.qhelp
+++ b/javascript/ql/src/NodeJS/DubiousImport.qhelp
@@ -40,7 +40,7 @@ the result of the <code>require</code> call:
 <references>
 
 
-<li>Node.js Manual: <a href="http://nodejs.org/api/modules.html">Modules</a>.</li>
+<li>Node.js Manual: <a href="https://nodejs.org/api/modules.html">Modules</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/NodeJS/InvalidExport.qhelp
+++ b/javascript/ql/src/NodeJS/InvalidExport.qhelp
@@ -41,7 +41,7 @@ Instead of assigning to <code>exports</code>, <code>point.js</code> should assig
 <references>
 
 
-<li>Node.js Manual: <a href="http://nodejs.org/api/modules.html#modules_exports_alias">exports alias</a>.</li>
+<li>Node.js Manual: <a href="https://nodejs.org/api/modules.html#modules_exports_alias">exports alias</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/NodeJS/MissingExports.qhelp
+++ b/javascript/ql/src/NodeJS/MissingExports.qhelp
@@ -42,7 +42,7 @@ the call should be qualified with <code>exports</code> like this:
 
 <references>
 <li>Node.js: <a href="https://nodejs.org/api/modules.html">Modules</a>.</li>
-<li>JSLint Help: <a href="http://www.jslint.com/help.html">JSLint Directives</a>.</li>
+<li>JSLint Help: <a href="https://www.jslint.com/help.html">JSLint Directives</a>.</li>
 <li>Closure Compiler: <a href="https://developers.google.com/closure/compiler/docs/api-tutorial3">Advanced Compilation and Externs</a>.</li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Performance/ReDoSReferences.inc.qhelp
+++ b/javascript/ql/src/Performance/ReDoSReferences.inc.qhelp
@@ -10,7 +10,7 @@
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
 		<li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
-		<a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+		<a href="https://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
 		</li>
 	</references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-078/UselessUseOfCat.qhelp
+++ b/javascript/ql/src/Security/CWE-078/UselessUseOfCat.qhelp
@@ -38,7 +38,7 @@ and if the input is user-controlled, a command injection attack can happen.</p>
 
 <li>OWASP: <a href="https://www.owasp.org/index.php/Command_Injection">Command Injection</a>.</li>
 <li>Node.js: <a href="https://nodejs.org/api/fs.html">File System API</a>.</li>
-<li><a href="http://porkmail.org/era/unix/award.html#cat">The Useless Use of Cat Award</a>.</li>
+<li><a href="https://porkmail.org/era/unix/award.html#cat">The Useless Use of Cat Award</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/Security/CWE-079/ExceptionXss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/ExceptionXss.qhelp
@@ -61,7 +61,7 @@ OWASP
 Scripting</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-079/ReflectedXss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/ReflectedXss.qhelp
@@ -46,7 +46,7 @@ OWASP
 Scripting</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-079/StoredXss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/StoredXss.qhelp
@@ -57,7 +57,7 @@
 		Scripting</a>.
 	</li>
 	<li>
-		Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+		Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 	</li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-079/UnsafeHtmlConstruction.qhelp
+++ b/javascript/ql/src/Security/CWE-079/UnsafeHtmlConstruction.qhelp
@@ -71,7 +71,7 @@
 		Scripting</a>.
 	</li>
 	<li>
-		Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+		Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 	</li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.qhelp
+++ b/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.qhelp
@@ -89,7 +89,7 @@
 			Scripting</a>.
 		</li>
 		<li>
-			Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+			Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 		</li>
 		<li>
 			jQuery: <a href="https://learn.jquery.com/plugins/basic-plugin-creation/">Plugin creation</a>.

--- a/javascript/ql/src/Security/CWE-079/Xss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/Xss.qhelp
@@ -51,7 +51,7 @@ OWASP
 Scripting</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-079/XssThroughDom.qhelp
+++ b/javascript/ql/src/Security/CWE-079/XssThroughDom.qhelp
@@ -64,7 +64,7 @@ OWASP
 Scripting</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
@@ -91,7 +91,7 @@
 			<a href="https://owasp.org/www-community/Types_of_Cross-Site_Scripting">Types of Cross-Site</a>.
 		</li>
 		<li>
-			Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+			Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 		</li>
 	</references>
 

--- a/javascript/ql/src/Security/CWE-116/UnsafeHtmlExpansion.qhelp
+++ b/javascript/ql/src/Security/CWE-116/UnsafeHtmlExpansion.qhelp
@@ -101,7 +101,7 @@
 			<a href="https://owasp.org/www-community/Types_of_Cross-Site_Scripting">Types of Cross-Site</a>.
 		</li>
 		<li>
-			Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+			Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 		</li>
 	</references>
 

--- a/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -42,8 +42,8 @@
 	</example>
 
 	<references>
-		<li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
-		<li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
+		<li>NIST, FIPS 140 Annex a: <a href="https://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
+		<li>NIST, SP 800-131A: <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
 		<li>OWASP: <a
 		href="https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#rule---use-strong-approved-authenticated-encryption">Rule
 		- Use strong approved cryptographic algorithms</a>.

--- a/javascript/ql/src/Security/CWE-338/InsecureRandomness.qhelp
+++ b/javascript/ql/src/Security/CWE-338/InsecureRandomness.qhelp
@@ -68,7 +68,7 @@
 	</example>
 
 	<references>
-		<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
+		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
 		<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/API/RandomSource/getRandomValues">RandomSource.getRandomValues</a>.</li>
 		<li>NodeJS: <a href="https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback">crypto.randomBytes</a></li>
 	</references>

--- a/javascript/ql/src/Security/CWE-346/CorsMisconfigurationForCredentials.qhelp
+++ b/javascript/ql/src/Security/CWE-346/CorsMisconfigurationForCredentials.qhelp
@@ -79,7 +79,7 @@
 <references>
 	<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin">CORS, Access-Control-Allow-Origin</a>.</li>
 	<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials">CORS, Access-Control-Allow-Credentials</a>.</li>
-	<li>PortSwigger: <a href="http://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html">Exploiting CORS Misconfigurations for Bitcoins and Bounties</a></li>
+	<li>PortSwigger: <a href="https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html">Exploiting CORS Misconfigurations for Bitcoins and Bounties</a></li>
 	<li>W3C: <a href="https://w3c.github.io/webappsec-cors-for-developers/#resources">CORS for developers, Advice for Resource Owners</a></li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.qhelp
+++ b/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.qhelp
@@ -76,7 +76,7 @@
 		<a href="https://npmjs.com/advisories/566">hoek</a>.
 	</li>
 	<li> Penetration testing report:
-		<a href="http://seclists.org/pen-test/2009/Mar/67">
+		<a href="https://seclists.org/pen-test/2009/Mar/67">
 			header name injection attack</a>
 	</li>
 	<li> npm blog post:

--- a/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.qhelp
+++ b/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.qhelp
@@ -39,7 +39,7 @@
 
     <p>
       Alternatively, the header can be set by a proxy.  As an example,
-      a <a href="http://www.haproxy.org/">HAProxy</a> configuration
+      a <a href="https://www.haproxy.org/">HAProxy</a> configuration
       should contain: <code>rspadd X-Frame-Options:\ DENY</code> to
       set the header automatically.
     </p>

--- a/javascript/ql/src/Security/CWE-611/Xxe.qhelp
+++ b/javascript/ql/src/Security/CWE-611/Xxe.qhelp
@@ -33,7 +33,7 @@ To guard against XXE attacks, the <code>noent</code> option should be omitted or
 <code>false</code>. This means that no entity expansion is undertaken at all, not even for standard
 internal entities such as <code>&amp;amp;</code> or <code>&amp;gt;</code>. If desired, these
 entities can be expanded in a separate step using utility functions provided by libraries such
-as <a href="http://underscorejs.org/#unescape">underscore</a>,
+as <a href="https://underscorejs.org/#unescape">underscore</a>,
 <a href="https://lodash.com/docs/4.17.15#unescape">lodash</a> or
 <a href="https://github.com/mathiasbynens/he">he</a>.
 </p>

--- a/javascript/ql/src/Statements/DanglingElse.qhelp
+++ b/javascript/ql/src/Statements/DanglingElse.qhelp
@@ -52,7 +52,7 @@ curly braces:
 <references>
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Dangling_else">Dangling else</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Dangling_else">Dangling else</a>.</li>
 
 </references>
 </qhelp>

--- a/javascript/ql/src/Statements/MisleadingIndentationAfterControlStmt.qhelp
+++ b/javascript/ql/src/Statements/MisleadingIndentationAfterControlStmt.qhelp
@@ -51,7 +51,7 @@ should be decreased like this:
 <references>
 
 
-<li>Tutorialzine: <a href="http://tutorialzine.com/2014/04/10-mistakes-javascript-beginners-make/">10 Mistakes That JavaScript Beginners Often Make</a>.</li>
+<li>Tutorialzine: <a href="https://tutorialzine.com/2014/04/10-mistakes-javascript-beginners-make/">10 Mistakes That JavaScript Beginners Often Make</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/Statements/UnreachableStatement.qhelp
+++ b/javascript/ql/src/Statements/UnreachableStatement.qhelp
@@ -37,7 +37,7 @@ To correct this issue, remove the spurious semicolon:
 <references>
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Unreachable_code">Unreachable code</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Unreachable_code">Unreachable code</a>.</li>
 
 </references>
 </qhelp>

--- a/javascript/ql/test/query-tests/DOM/HTML/ConflictingAttributes.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/ConflictingAttributes.html
@@ -1,1 +1,1 @@
-<a href="http://semmle.com" href="https://semmle.com">Semmle</a>
+<a href="https://semmle.com" href="https://semmle.com">Semmle</a>

--- a/javascript/ql/test/query-tests/DOM/HTML/tst.js
+++ b/javascript/ql/test/query-tests/DOM/HTML/tst.js
@@ -3,7 +3,7 @@ var div1 = <div id="theDiff"></div>;
 var div2 = <div id="theDiff"></div>;
 
 // not OK
-<a href="http://semmle.com" href="https://semmle.com">Semmle</a>;
+<a href="https://semmle.com" href="https://semmle.com">Semmle</a>;
 
 // not OK
 <a href="https://semmle.com" href="https://semmle.com">Semmle</a>;
@@ -13,7 +13,7 @@ var div2 = <div id="theDiff"></div>;
 <div id="a b"></div>;
 
 // not OK
-<a href="http://semmle.com" href={someValue()}>Semmle</a>;
+<a href="https://semmle.com" href={someValue()}>Semmle</a>;
 
 // OK
 <div id={someOtherValue()}></div>;

--- a/python/ql/src/Classes/ConflictingAttributesInBaseClasses.qhelp
+++ b/python/ql/src/Classes/ConflictingAttributesInBaseClasses.qhelp
@@ -7,7 +7,7 @@
 <p>
 When a class subclasses multiple base classes, attribute lookup is performed from left to right amongst the base classes.
 This form of attribute lookup is called "method resolution order" and is a solution to the 
-<a href="http://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem">diamond inheritance problem</a> where several base classes
+<a href="https://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem">diamond inheritance problem</a> where several base classes
 override a method in a shared superclass.
 </p>
 <p>
@@ -52,7 +52,7 @@ functionality provided by the two base classes does not overlap, as shown in cla
     <li>Python Language Reference: <a href="https://docs.python.org/2/reference/datamodel.html">Data model</a>.</li>
     <li>Python releases: <a href="https://www.python.org/download/releases/2.3/mro/">The Python 2.3 Method Resolution Order</a>.</li>
     <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/C3_linearization">C3 linearization</a>.</li>
-    <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
+    <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/DefineEqualsWhenAddingAttributes.qhelp
+++ b/python/ql/src/Classes/DefineEqualsWhenAddingAttributes.qhelp
@@ -31,7 +31,7 @@ but does not override the <code>__eq__</code> method.
 </example>
 <references>
 
-<li>Peter Grogono, Philip Santas: <a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.48.5109&amp;rep=rep1&amp;type=pdf">Equality in Object Oriented Languages</a></li>
+<li>Peter Grogono, Philip Santas: <a href="https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.48.5109&amp;rep=rep1&amp;type=pdf">Equality in Object Oriented Languages</a></li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Classes/EqualsOrHash.qhelp
+++ b/python/ql/src/Classes/EqualsOrHash.qhelp
@@ -38,8 +38,8 @@ by a separate rule).</p>
 <references>
 
 
-<li>Python Language Reference: <a href="http://docs.python.org/reference/datamodel.html#object.__hash__">object.__hash__</a>.</li>
-<li>Python Glossary: <a href="http://docs.python.org/2/glossary.html#term-hashable">hashable</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/reference/datamodel.html#object.__hash__">object.__hash__</a>.</li>
+<li>Python Glossary: <a href="https://docs.python.org/2/glossary.html#term-hashable">hashable</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/EqualsOrNotEquals.qhelp
+++ b/python/ql/src/Classes/EqualsOrNotEquals.qhelp
@@ -29,8 +29,8 @@ a separate rule).</p>
 <references>
 
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/datamodel.html#object.__ne__">object.__ne__</a>, 
-<a href="http://docs.python.org/2/reference/expressions.html#comparisons">Comparisons</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/datamodel.html#object.__ne__">object.__ne__</a>, 
+<a href="https://docs.python.org/2/reference/expressions.html#comparisons">Comparisons</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/IncompleteOrdering.qhelp
+++ b/python/ql/src/Classes/IncompleteOrdering.qhelp
@@ -28,7 +28,7 @@ inconsistent behavior. <code>__gt__</code>, <code>__le__</code>, <code>__ge__</c
 </example>
 <references>
 
-  <li>Python Language Reference: <a href="http://docs.python.org/2/reference/datamodel.html#object.__lt__">Rich comparisons in Python</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2/reference/datamodel.html#object.__lt__">Rich comparisons in Python</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/InconsistentMRO.qhelp
+++ b/python/ql/src/Classes/InconsistentMRO.qhelp
@@ -24,7 +24,7 @@ the definition of <code>Y</code> but the opposite is true in the MRO of <code>X<
 </example>
 <references>
 
-  <li>Python: <a href="http://www.python.org/download/releases/2.3/mro/">The Python 2.3 Method Resolution Order</a>.</li>
+  <li>Python: <a href="https://www.python.org/download/releases/2.3/mro/">The Python 2.3 Method Resolution Order</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Classes/InitCallsSubclassMethod.qhelp
+++ b/python/ql/src/Classes/InitCallsSubclassMethod.qhelp
@@ -33,8 +33,8 @@ object creation.
 
 <li>CERT Secure Coding: <a href="https://www.securecoding.cert.org/confluence/display/java/MET05-J.+Ensure+that+constructors+do+not+call+overridable+methods">
 Rule MET05-J</a>. Although this is a Java rule it applies to most object-oriented languages.</li>
-<li>Python Standard Library: <a href="http://docs.python.org/library/functions.html#staticmethod">Static methods</a>.</li>
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
+<li>Python Standard Library: <a href="https://docs.python.org/library/functions.html#staticmethod">Static methods</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
 
 
 

--- a/python/ql/src/Classes/MaybeUndefinedClassAttribute.qhelp
+++ b/python/ql/src/Classes/MaybeUndefinedClassAttribute.qhelp
@@ -25,7 +25,7 @@ This may result in an <code>AttributeError</code> at run time.
 </example>
 <references>
 
-<li>Python Standard Library: <a href="http://docs.python.org/library/exceptions.html#exceptions.AttributeError">exception AttributeError</a>.
+<li>Python Standard Library: <a href="https://docs.python.org/library/exceptions.html#exceptions.AttributeError">exception AttributeError</a>.
 </li>
 
 </references>

--- a/python/ql/src/Classes/MissingCallToDel.qhelp
+++ b/python/ql/src/Classes/MissingCallToDel.qhelp
@@ -43,8 +43,8 @@ use <code>super()</code> throughout the inheritance hierarchy.</p>
 
         <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/classes.html">Classes</a>.</li>
         <li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html#super">super</a>.</li>
-        <li>Artima Developer: <a href="http://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
-        <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
+        <li>Artima Developer: <a href="https://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
+        <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Classes/MissingCallToInit.qhelp
+++ b/python/ql/src/Classes/MissingCallToInit.qhelp
@@ -45,8 +45,8 @@ use <code>super()</code> throughout the inheritance hierarchy.</p>
 
         <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/classes.html">Classes</a>.</li>
         <li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html#super">super</a>.</li>
-        <li>Artima Developer: <a href="http://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
-        <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
+        <li>Artima Developer: <a href="https://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
+        <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Classes/PropertyInOldStyleClass.qhelp
+++ b/python/ql/src/Classes/PropertyInOldStyleClass.qhelp
@@ -29,13 +29,13 @@ property is only available for the <code>NewStyle</code> and <code>InheritNewSty
 </example>
 <references>
 
-<li>Python Glossary: <a href="http://docs.python.org/glossary.html#term-new-style-class">New-style class</a>.</li>
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/datamodel.html#newstyle">New-style and classic 
+<li>Python Glossary: <a href="https://docs.python.org/glossary.html#term-new-style-class">New-style class</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/datamodel.html#newstyle">New-style and classic 
 classes</a>,
- <a href="http://docs.python.org/2/reference/datamodel.html#implementing-descriptors">
+ <a href="https://docs.python.org/2/reference/datamodel.html#implementing-descriptors">
 Descriptors</a>.</li>
-<li>Python Standard Library: <a href="http://docs.python.org/library/functions.html#property">Property</a>.</li>
-<li>The History of Python: <a href="http://python-history.blogspot.co.uk/2010/06/inside-story-on-new-style-classes.html">
+<li>Python Standard Library: <a href="https://docs.python.org/library/functions.html#property">Property</a>.</li>
+<li>The History of Python: <a href="https://python-history.blogspot.co.uk/2010/06/inside-story-on-new-style-classes.html">
 Inside story on new-style classes</a>.</li>
 
 

--- a/python/ql/src/Classes/ShouldBeContextManager.qhelp
+++ b/python/ql/src/Classes/ShouldBeContextManager.qhelp
@@ -32,11 +32,11 @@ updated to use a context manager.</p>
 <references>
 
 <li>Effbot: <a href="https://web.archive.org/web/20201012110738/http://effbot.org/zone/python-with-statement.htm">Python with statement</a>.</li>
-<li>Python Standard Library: <a href="http://docs.python.org/library/stdtypes.html#context-manager-types">Context manager
+<li>Python Standard Library: <a href="https://docs.python.org/library/stdtypes.html#context-manager-types">Context manager
 </a>.</li>
-<li>Python Language Reference: <a href="http://docs.python.org/2.7/reference/datamodel.html#with-statement-context-managers">
+<li>Python Language Reference: <a href="https://docs.python.org/2.7/reference/datamodel.html#with-statement-context-managers">
 With Statement Context Managers</a>.</li>
-<li>Python PEP 343: <a href="http://www.python.org/dev/peps/pep-0343">The "with" Statement</a>.</li>
+<li>Python PEP 343: <a href="https://www.python.org/dev/peps/pep-0343">The "with" Statement</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
+++ b/python/ql/src/Classes/SlotsInOldStyleClass.qhelp
@@ -27,10 +27,10 @@ the slots list and saves space by not creating attribute dictionaries.</p>
 </example>
 <references>
 
-<li>Python Glossary: <a href="http://docs.python.org/glossary.html#term-new-style-class">New-style class</a>.</li>
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/datamodel.html#newstyle">New-style and classic
+<li>Python Glossary: <a href="https://docs.python.org/glossary.html#term-new-style-class">New-style class</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/datamodel.html#newstyle">New-style and classic
 classes</a>,
- <a href="http://docs.python.org/reference/datamodel.html#__slots__">__slots__</a>.</li>
+ <a href="https://docs.python.org/reference/datamodel.html#__slots__">__slots__</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/SuperInOldStyleClass.qhelp
+++ b/python/ql/src/Classes/SuperInOldStyleClass.qhelp
@@ -28,10 +28,10 @@ demonstrates the correct way to call a superclass from an old-style class.</p>
 </example>
 <references>
 
-<li>Python Glossary: <a href="http://docs.python.org/glossary.html#term-new-style-class">New-style class</a>.</li>
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/datamodel.html#newstyle">New-style and classic 
+<li>Python Glossary: <a href="https://docs.python.org/glossary.html#term-new-style-class">New-style class</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/datamodel.html#newstyle">New-style and classic 
 classes</a>.</li>
-<li>Python Standard Library: <a href="http://docs.python.org/library/functions.html#super">super</a>.</li>
+<li>Python Standard Library: <a href="https://docs.python.org/library/functions.html#super">super</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/SuperclassDelCalledMultipleTimes.qhelp
+++ b/python/ql/src/Classes/SuperclassDelCalledMultipleTimes.qhelp
@@ -50,8 +50,8 @@ To fix this example, <code>super()</code> should be used throughout.
 
         <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/classes.html">Classes</a>.</li>
         <li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html#super">super</a>.</li>
-        <li>Artima Developer: <a href="http://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
-        <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
+        <li>Artima Developer: <a href="https://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
+        <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/SuperclassInitCalledMultipleTimes.qhelp
+++ b/python/ql/src/Classes/SuperclassInitCalledMultipleTimes.qhelp
@@ -50,8 +50,8 @@ To fix this example, <code>super()</code> should be used throughout.
 
         <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/classes.html">Classes</a>.</li>
         <li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html#super">super</a>.</li>
-        <li>Artima Developer: <a href="http://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
-        <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
+        <li>Artima Developer: <a href="https://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
+        <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Composition_over_inheritance">Composition over inheritance</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/UndefinedClassAttribute.qhelp
+++ b/python/ql/src/Classes/UndefinedClassAttribute.qhelp
@@ -26,7 +26,7 @@ This may result in an <code>AttributeError</code> at run time.
 </example>
 <references>
 
-<li>Python Standard Library: <a href="http://docs.python.org/library/exceptions.html#exceptions.AttributeError">exception AttributeError</a>.</li>
+<li>Python Standard Library: <a href="https://docs.python.org/library/exceptions.html#exceptions.AttributeError">exception AttributeError</a>.</li>
 
 
 </references>

--- a/python/ql/src/Classes/UselessClass.qhelp
+++ b/python/ql/src/Classes/UselessClass.qhelp
@@ -29,7 +29,7 @@ class. It should be a method on its own that takes <code>a</code> and <code>b</c
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/tutorial/classes.html">Classes</a>.</li>
+  <li>Python: <a href="https://docs.python.org/tutorial/classes.html">Classes</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Exceptions/CatchingBaseException.qhelp
+++ b/python/ql/src/Exceptions/CatchingBaseException.qhelp
@@ -45,8 +45,8 @@ leaving <code>KeyboardInterrupt</code> to propagate.
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2.7/reference/compound_stmts.html#try">The try statement</a>, 
-<a href="http://docs.python.org/2.7/reference/executionmodel.html#exceptions">Exceptions</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2.7/reference/compound_stmts.html#try">The try statement</a>, 
+<a href="https://docs.python.org/2.7/reference/executionmodel.html#exceptions">Exceptions</a>.</li>
 <li>M. Lutz, Learning Python, Section 35.3: Exception Design Tips and Gotchas, O'Reilly Media, 2013.</li>
 <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/errors.html">Errors and Exceptions</a>.</li>
 

--- a/python/ql/src/Exceptions/IncorrectExceptOrder.qhelp
+++ b/python/ql/src/Exceptions/IncorrectExceptOrder.qhelp
@@ -37,8 +37,8 @@ subsequent handler from ever executing.</p>
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2.7/reference/compound_stmts.html#try">The try statement</a>, 
-<a href="http://docs.python.org/2.7/reference/executionmodel.html#exceptions">Exceptions</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2.7/reference/compound_stmts.html#try">The try statement</a>, 
+<a href="https://docs.python.org/2.7/reference/executionmodel.html#exceptions">Exceptions</a>.</li>
 
 
 </references>

--- a/python/ql/src/Expressions/CallToSuperWrongClass.qhelp
+++ b/python/ql/src/Expressions/CallToSuperWrongClass.qhelp
@@ -38,7 +38,7 @@ skips <code>StatusSymbol.__init__()</code>.
 <references>
 
     <li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html#super">super</a>.</li>
-    <li>Artima Developer: <a href="http://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
+    <li>Artima Developer: <a href="https://www.artima.com/weblogs/viewpost.jsp?thread=236275">Things to Know About Python Super</a>.</li>
 
 
 </references>

--- a/python/ql/src/Expressions/CompareConstants.qhelp
+++ b/python/ql/src/Expressions/CompareConstants.qhelp
@@ -29,7 +29,7 @@ This code has been unnecessary on all versions of Python released since 2003 and
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/expressions.html#not-in">Comparisons</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/expressions.html#not-in">Comparisons</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/CompareIdenticalValues.qhelp
+++ b/python/ql/src/Expressions/CompareIdenticalValues.qhelp
@@ -29,7 +29,7 @@ This makes the code difficult to understand as the reader may not be immediately
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/expressions.html#not-in">Comparisons</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/expressions.html#not-in">Comparisons</a>.</li>
 <li>Python Library Reference: <a href="https://docs.python.org/2/library/math.html#math.isnan">math.isnan()</a>.</li>
 <li>Python Library Reference: <a href="https://docs.python.org/2/library/cmath.html#cmath.isnan">cmath.isnan()</a>.</li>
 

--- a/python/ql/src/Expressions/CompareIdenticalValuesMissingSelf.qhelp
+++ b/python/ql/src/Expressions/CompareIdenticalValuesMissingSelf.qhelp
@@ -26,7 +26,7 @@ or similar.</p>
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/expressions.html#not-in">Comparisons</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/expressions.html#not-in">Comparisons</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/Comparisons/UselessComparisonTest.qhelp
+++ b/python/ql/src/Expressions/Comparisons/UselessComparisonTest.qhelp
@@ -29,7 +29,7 @@ second test will always be false, and the function <code>_compare</code> will on
 
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/expressions.html#not-in">Comparisons</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/expressions.html#not-in">Comparisons</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/ContainsNonContainer.qhelp
+++ b/python/ql/src/Expressions/ContainsNonContainer.qhelp
@@ -34,8 +34,8 @@ will be raised. Adding a <code>__getitem__</code> method to the
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/reference/expressions.html#membership-test-details">Membership test details</a>.</li>
-  <li>Python: <a href="http://docs.python.org/reference/datamodel.html#object.__contains__">The __contains__ method</a>.</li>
+  <li>Python: <a href="https://docs.python.org/reference/expressions.html#membership-test-details">Membership test details</a>.</li>
+  <li>Python: <a href="https://docs.python.org/reference/datamodel.html#object.__contains__">The __contains__ method</a>.</li>
 
 
 </references>

--- a/python/ql/src/Expressions/DuplicateKeyInDictionaryLiteral.qhelp
+++ b/python/ql/src/Expressions/DuplicateKeyInDictionaryLiteral.qhelp
@@ -22,7 +22,7 @@ mapping from 2 to "c". The programmer may have meant to map 3 to "c" instead.</p
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/2/reference/expressions.html#dictionary-displays">Dictionary literals</a>.</li>
+  <li>Python: <a href="https://docs.python.org/2/reference/expressions.html#dictionary-displays">Dictionary literals</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/EqualsNone.qhelp
+++ b/python/ql/src/Expressions/EqualsNone.qhelp
@@ -26,8 +26,8 @@ function because it uses an identity comparison.</p>
 <references>
 
 
-<li>Python Language Reference: <a href="http://docs.python.org/reference/expressions.html#is">Comparisons</a>, 
-<a href="http://docs.python.org/reference/datamodel.html#object.__eq__">object.__eq__</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/reference/expressions.html#is">Comparisons</a>, 
+<a href="https://docs.python.org/reference/datamodel.html#object.__eq__">object.__eq__</a>.</li>
 
 
 </references>

--- a/python/ql/src/Expressions/ExpectedMappingForFormatString.qhelp
+++ b/python/ql/src/Expressions/ExpectedMappingForFormatString.qhelp
@@ -24,7 +24,7 @@ To fix this example, ensure that <code>args</code> is a mapping when <code>unlik
 </example>
 <references>
 
-  <li>Python Library Reference: <a href="http://docs.python.org/library/stdtypes.html#string-formatting">String Formatting.</a></li>
+  <li>Python Library Reference: <a href="https://docs.python.org/library/stdtypes.html#string-formatting">String Formatting.</a></li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/ExplicitCallToDel.qhelp
+++ b/python/ql/src/Expressions/ExplicitCallToDel.qhelp
@@ -27,7 +27,7 @@ A safer alternative is shown in the second example.
 </example>
 <references>
 
-<li>Python Standard Library: <a href="http://docs.python.org/reference/datamodel.html#object.__del__">object.__del__</a></li>
+<li>Python Standard Library: <a href="https://docs.python.org/reference/datamodel.html#object.__del__">object.__del__</a></li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/HashedButNoHash.qhelp
+++ b/python/ql/src/Expressions/HashedButNoHash.qhelp
@@ -34,10 +34,10 @@ as a key in a mapping which will fail with a <code>TypeError</code>.
 </example>
 <references>
 
-  <li>Python Standard Library: <a href="http://docs.python.org/library/functions.html#hash">hash</a>.</li>
-  <li>Python Language Reference: <a href="http://docs.python.org/reference/datamodel.html#object.__hash__">object.__hash__</a>.</li>
-        <li>Python Standard Library: <a href="http://docs.python.org/library/stdtypes.html#mapping-types-dict">Mapping Types &mdash; dict</a>.</li>
-        <li>Python Standard Library: <a href="http://docs.python.org/2/library/stdtypes.html#set-types-set-frozenset">Set Types &mdash; set, frozenset</a>.</li>
+  <li>Python Standard Library: <a href="https://docs.python.org/library/functions.html#hash">hash</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/reference/datamodel.html#object.__hash__">object.__hash__</a>.</li>
+        <li>Python Standard Library: <a href="https://docs.python.org/library/stdtypes.html#mapping-types-dict">Mapping Types &mdash; dict</a>.</li>
+        <li>Python Standard Library: <a href="https://docs.python.org/2/library/stdtypes.html#set-types-set-frozenset">Set Types &mdash; set, frozenset</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/IncorrectComparisonUsingIs.qhelp
+++ b/python/ql/src/Expressions/IncorrectComparisonUsingIs.qhelp
@@ -37,7 +37,7 @@ either of the alternatives below.
 </example>
 <references>
 
-     <li>Python Standard Library: <a href="http://docs.python.org/2/library/stdtypes.html#comparisons">Comparisons</a>.</li>
+     <li>Python Standard Library: <a href="https://docs.python.org/2/library/stdtypes.html#comparisons">Comparisons</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/NonCallableCalled.qhelp
+++ b/python/ql/src/Expressions/NonCallableCalled.qhelp
@@ -32,8 +32,8 @@ which will fail with a  <code>TypeError</code>.
 </example>
 <references>
 
-  <li>Python Standard Library: <a href="http://docs.python.org/2/library/functions.html#callable">callable</a>.</li>
-  <li>Python Language Reference: <a href="http://docs.python.org/2/reference/datamodel.html#object.__call__">object.__call__</a>.</li>
+  <li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html#callable">callable</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2/reference/datamodel.html#object.__call__">object.__call__</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/NonPortableComparisonUsingIs.qhelp
+++ b/python/ql/src/Expressions/NonPortableComparisonUsingIs.qhelp
@@ -37,8 +37,8 @@ To function correctly for all implementations, change the expression <code>x is 
 </example>
 <references>
 
-     <li>Python Standard Library: <a href="http://docs.python.org/2/library/stdtypes.html#comparisons">Comparisons</a>.</li>
-     <li>Stack Overflow: <a href="http://stackoverflow.com/questions/306313/python-is-operator-behaves-unexpectedly-with-integers">Python "is" operator behaves unexpectedly with integers</a>.</li>
+     <li>Python Standard Library: <a href="https://docs.python.org/2/library/stdtypes.html#comparisons">Comparisons</a>.</li>
+     <li>Stack Overflow: <a href="https://stackoverflow.com/questions/306313/python-is-operator-behaves-unexpectedly-with-integers">Python "is" operator behaves unexpectedly with integers</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/Regex/DuplicateCharacterInSet.qhelp
+++ b/python/ql/src/Expressions/Regex/DuplicateCharacterInSet.qhelp
@@ -38,7 +38,7 @@ To fix this problem, the regular expression should be rewritten to <code>r"(pass
 <references>
 
 <li>Python Standard Library: <a href="https://docs.python.org/library/re.html">Regular expression operations</a>.</li>
-<li>Regular-Expressions.info: <a href="http://www.regular-expressions.info/charclass.html">Character Classes or Character Sets</a>.</li>
+<li>Regular-Expressions.info: <a href="https://www.regular-expressions.info/charclass.html">Character Classes or Character Sets</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/Regex/MissingPartSpecialGroup.qhelp
+++ b/python/ql/src/Expressions/Regex/MissingPartSpecialGroup.qhelp
@@ -31,7 +31,7 @@ The fixed version, <code>fixed_matcher</code>, includes the "?" and will work as
 <references>
 
 <li>Python Standard Library: <a href="https://docs.python.org/library/re.html">Regular expression operations</a>.</li>
-<li>Regular-Expressions.info: <a href="http://www.regular-expressions.info/named.html">Named Capturing Groups</a>.</li>
+<li>Regular-Expressions.info: <a href="https://www.regular-expressions.info/named.html">Named Capturing Groups</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/Regex/UnmatchableCaret.qhelp
+++ b/python/ql/src/Expressions/Regex/UnmatchableCaret.qhelp
@@ -34,7 +34,7 @@ In the second regular expression, <code>r"[^.]*\.css"</code>, the caret is part 
 <references>
 
 <li>Python Standard Library: <a href="https://docs.python.org/library/re.html">Regular expression operations</a>.</li>
-<li>Regular-Expressions.info: <a href="http://www.regular-expressions.info/anchors.html">Start of String and End of String Anchors</a>.</li>
+<li>Regular-Expressions.info: <a href="https://www.regular-expressions.info/anchors.html">Start of String and End of String Anchors</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/Regex/UnmatchableDollar.qhelp
+++ b/python/ql/src/Expressions/Regex/UnmatchableDollar.qhelp
@@ -35,7 +35,7 @@ The second regular expression, <code>r"\.\(\w+\)$"</code>, has the dollar at the
 <references>
 
 <li>Python Standard Library: <a href="https://docs.python.org/library/re.html">Regular expression operations</a>.</li>
-<li>Regular-Expressions.info: <a href="http://www.regular-expressions.info/anchors.html">Start of String and End of String Anchors</a>.</li>
+<li>Regular-Expressions.info: <a href="https://www.regular-expressions.info/anchors.html">Start of String and End of String Anchors</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/UnnecessaryLambda.qhelp
+++ b/python/ql/src/Expressions/UnnecessaryLambda.qhelp
@@ -23,7 +23,7 @@ call_with_x_squared</code>.</p>
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/2.7/reference/expressions.html#lambda">lambdas</a>.</li>
+  <li>Python: <a href="https://docs.python.org/2.7/reference/expressions.html#lambda">lambdas</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/UnsupportedFormatCharacter.qhelp
+++ b/python/ql/src/Expressions/UnsupportedFormatCharacter.qhelp
@@ -22,7 +22,7 @@ Otherwise, a <code>ValueError</code> will be raised.
 </example>
 <references>
 
-  <li>Python Library Reference: <a href="http://docs.python.org/library/stdtypes.html#string-formatting">String Formatting.</a> </li>
+  <li>Python Library Reference: <a href="https://docs.python.org/library/stdtypes.html#string-formatting">String Formatting.</a> </li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/UseofApply.qhelp
+++ b/python/ql/src/Expressions/UseofApply.qhelp
@@ -20,8 +20,8 @@ Replace <code>apply(function, args, keywords)</code> with <code>function(*args, 
 </recommendation>
 <references>
 
-     <li>Python Standard Library: <a href="http://docs.python.org/2/library/functions.html#apply">apply</a>.</li>
-     <li>Python PEP-290: <a href="http://www.python.org/dev/peps/pep-0290/">Code Migration and Modernization</a>.</li>
+     <li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html#apply">apply</a>.</li>
+     <li>Python PEP-290: <a href="https://www.python.org/dev/peps/pep-0290/">Code Migration and Modernization</a>.</li>
 
 
 </references>

--- a/python/ql/src/Expressions/UseofInput.qhelp
+++ b/python/ql/src/Expressions/UseofInput.qhelp
@@ -15,9 +15,9 @@ string, then <code>ast.literal_eval()</code> can always be used safely.</p>
 </recommendation>
 <references>
 
-  <li>Python Standard Library: <a href="http://docs.python.org/2/library/functions.html#input">input</a>,
-  <a href="http://docs.python.org/2/library/ast.html#ast.literal_eval">ast.literal_eval</a>.</li>
-  <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Data_validation">Data validation</a>.</li>
+  <li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html#input">input</a>,
+  <a href="https://docs.python.org/2/library/ast.html#ast.literal_eval">ast.literal_eval</a>.</li>
+  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Data_validation">Data validation</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
+++ b/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
@@ -20,7 +20,7 @@ arguments on the right hand side of the expression. Otherwise, a <code>TypeError
 </example>
 <references>
 
-  <li>Python Library Reference: <a href="http://docs.python.org/library/stdtypes.html#string-formatting">String Formatting.</a> </li>
+  <li>Python Library Reference: <a href="https://docs.python.org/library/stdtypes.html#string-formatting">String Formatting.</a> </li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Functions/ConsistentReturns.qhelp
+++ b/python/ql/src/Functions/ConsistentReturns.qhelp
@@ -29,7 +29,7 @@ return value of <code>None</code> as this equates to <code>False</code>. However
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#function">Function definitions</a>.
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/compound_stmts.html#function">Function definitions</a>.
 </li>
 
 

--- a/python/ql/src/Functions/ExplicitReturnInInit.qhelp
+++ b/python/ql/src/Functions/ExplicitReturnInInit.qhelp
@@ -22,7 +22,7 @@ object. This is an error and the return method should be removed.</p>
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/2.7/reference/datamodel.html#object.__init__">The __init__ method</a>.</li>
+  <li>Python: <a href="https://docs.python.org/2.7/reference/datamodel.html#object.__init__">The __init__ method</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Functions/IncorrectRaiseInSpecialMethod.qhelp
+++ b/python/ql/src/Functions/IncorrectRaiseInSpecialMethod.qhelp
@@ -62,7 +62,7 @@ the <code>__getitem__</code> method.
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/dev/reference/datamodel.html#special-method-names">Special Method Names</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/dev/reference/datamodel.html#special-method-names">Special Method Names</a>.</li>
 <li>Python Library Reference: <a href="https://docs.python.org/2/library/exceptions.html">Exceptions</a>.</li>
 
 

--- a/python/ql/src/Functions/IncorrectlyOverriddenMethod.qhelp
+++ b/python/ql/src/Functions/IncorrectlyOverriddenMethod.qhelp
@@ -34,7 +34,7 @@ parameters accepted by the base method then an error would occur.</p>
 </example>
 <references>
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Liskov_substitution_principle">Liskov Substitution Principle</a>, <a href="http://en.wikipedia.org/wiki/Method_overriding#Python">Method overriding</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Liskov_substitution_principle">Liskov Substitution Principle</a>, <a href="https://en.wikipedia.org/wiki/Method_overriding#Python">Method overriding</a>.</li>
 
 
 </references>

--- a/python/ql/src/Functions/IncorrectlySpecifiedOverriddenMethod.qhelp
+++ b/python/ql/src/Functions/IncorrectlySpecifiedOverriddenMethod.qhelp
@@ -32,7 +32,7 @@ match that of the extension method.
 </example>
 <references>
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Liskov_substitution_principle">Liskov Substitution Principle</a>, <a href="http://en.wikipedia.org/wiki/Method_overriding#Python">Method overriding</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Liskov_substitution_principle">Liskov Substitution Principle</a>, <a href="https://en.wikipedia.org/wiki/Method_overriding#Python">Method overriding</a>.</li>
 
 
 </references>

--- a/python/ql/src/Functions/InitIsGenerator.qhelp
+++ b/python/ql/src/Functions/InitIsGenerator.qhelp
@@ -22,7 +22,7 @@ not logical in the context of an initializer.</p>
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/2.7/reference/datamodel.html#object.__init__">The __init__ method</a>.</li>
+  <li>Python: <a href="https://docs.python.org/2.7/reference/datamodel.html#object.__init__">The __init__ method</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Functions/IterReturnsNonSelf.qhelp
+++ b/python/ql/src/Functions/IterReturnsNonSelf.qhelp
@@ -29,8 +29,8 @@ to use the iterator in a <code>for</code> loop or <code>in</code> statement.</p>
 </example>
 <references>
 
-  <li>Python Language Reference: <a href="http://docs.python.org/2.7/reference/datamodel.html#object.__iter__">object.__iter__</a>.</li>
-  <li>Python Standard Library: <a href="http://docs.python.org/2/library/stdtypes.html#typeiter">Iterators</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2.7/reference/datamodel.html#object.__iter__">object.__iter__</a>.</li>
+  <li>Python Standard Library: <a href="https://docs.python.org/2/library/stdtypes.html#typeiter">Iterators</a>.</li>
 
 
 </references>

--- a/python/ql/src/Functions/ModificationOfParameterWithDefault.qhelp
+++ b/python/ql/src/Functions/ModificationOfParameterWithDefault.qhelp
@@ -37,7 +37,7 @@ function with a default of <code>default=None</code>, check if the parameter is
 <references>
 
   <li>Effbot: <a href="https://web.archive.org/web/20201112004749/http://effbot.org/zone/default-values.htm">Default Parameter Values in Python</a>.</li>
-  <li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#function-definitions">Function definitions</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2/reference/compound_stmts.html#function-definitions">Function definitions</a>.</li>
 
 
 </references>

--- a/python/ql/src/Functions/NonCls.qhelp
+++ b/python/ql/src/Functions/NonCls.qhelp
@@ -27,8 +27,8 @@ for ease of comprehension.
 </example>
 <references>
 
-<li>Python PEP 8: <a href="http://www.python.org/dev/peps/pep-0008/#function-and-method-arguments">Function and method arguments</a>.</li>
-<li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/classes.html">Classes</a>.</li>
+<li>Python PEP 8: <a href="https://www.python.org/dev/peps/pep-0008/#function-and-method-arguments">Function and method arguments</a>.</li>
+<li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/classes.html">Classes</a>.</li>
 
 
 </references>

--- a/python/ql/src/Functions/NonSelf.qhelp
+++ b/python/ql/src/Functions/NonSelf.qhelp
@@ -28,9 +28,9 @@ used.</p>
 </example>
 <references>
 
-<li>Python PEP 8: <a href="http://www.python.org/dev/peps/pep-0008/#function-and-method-arguments">Function and 
+<li>Python PEP 8: <a href="https://www.python.org/dev/peps/pep-0008/#function-and-method-arguments">Function and 
 method arguments</a>.</li>
-<li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/classes.html">Classes</a>.</li>
+<li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/classes.html">Classes</a>.</li>
 
 
 

--- a/python/ql/src/Functions/OverlyComplexDelMethod.qhelp
+++ b/python/ql/src/Functions/OverlyComplexDelMethod.qhelp
@@ -36,7 +36,7 @@ The second example shows an improved version of the class where <code>__del__</c
 </example>
 <references>
 
-  <li>Python Standard Library: <a href="http://docs.python.org/library/stdtypes.html#context-manager-types">Context manager</a>.</li>
+  <li>Python Standard Library: <a href="https://docs.python.org/library/stdtypes.html#context-manager-types">Context manager</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Functions/ReturnConsistentTupleSizes.qhelp
+++ b/python/ql/src/Functions/ReturnConsistentTupleSizes.qhelp
@@ -31,7 +31,7 @@
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#function">Function definitions</a>.
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/compound_stmts.html#function">Function definitions</a>.
 </li>
 
 

--- a/python/ql/src/Functions/ReturnValueIgnored.qhelp
+++ b/python/ql/src/Functions/ReturnValueIgnored.qhelp
@@ -38,7 +38,7 @@ The <code>do_not_ignore_error</code> function checks the error condition and rai
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#function">Function definitions</a>.
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/compound_stmts.html#function">Function definitions</a>.
 </li>
 
 </references>

--- a/python/ql/src/Functions/SignatureOverriddenMethod.qhelp
+++ b/python/ql/src/Functions/SignatureOverriddenMethod.qhelp
@@ -34,7 +34,7 @@ parameters accepted by the base method then an error would occur.</p>
 </example>
 <references>
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Liskov_substitution_principle">Liskov Substitution Principle</a>, <a href="http://en.wikipedia.org/wiki/Method_overriding#Python">Method overriding</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Liskov_substitution_principle">Liskov Substitution Principle</a>, <a href="https://en.wikipedia.org/wiki/Method_overriding#Python">Method overriding</a>.</li>
 
 
 </references>

--- a/python/ql/src/Functions/SignatureSpecialMethods.qhelp
+++ b/python/ql/src/Functions/SignatureSpecialMethods.qhelp
@@ -27,7 +27,7 @@ is a <code>Point</code> then it will fail with a <code>TypeError</code>.
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/dev/reference/datamodel.html#special-method-names">Special Method Names</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/dev/reference/datamodel.html#special-method-names">Special Method Names</a>.</li>
 
 
 </references>

--- a/python/ql/src/Functions/UseImplicitNoneReturnValue.qhelp
+++ b/python/ql/src/Functions/UseImplicitNoneReturnValue.qhelp
@@ -26,7 +26,7 @@ Using the return value is misleading in subsequent code.
 </example>
 <references>
 
-  <li>Python Library Reference: <a href="http://docs.python.org/library/constants.html#None">None</a>.</li>
+  <li>Python Library Reference: <a href="https://docs.python.org/library/constants.html#None">None</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Imports/CyclicImport.qhelp
+++ b/python/ql/src/Imports/CyclicImport.qhelp
@@ -27,8 +27,8 @@ import that.
 <references>
 
 
-<li>Python Language  Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
-<li>Python: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
+<li>Python Language  Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
+<li>Python: <a href="https://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
 <li> Effbot: <a href="https://web.archive.org/web/20200917011425/https://effbot.org/zone/import-confusion.htm">Import Confusion</a>.</li>
 
 

--- a/python/ql/src/Imports/DeprecatedModule.qhelp
+++ b/python/ql/src/Imports/DeprecatedModule.qhelp
@@ -16,7 +16,7 @@ See PEP 4 for a list of all deprecated modules.
 </recommendation>
 <references>
 
-<li>Python PEPs: <a href="http://www.python.org/dev/peps/pep-0004/">PEP 4 -- Deprecation of Standard Modules </a>.</li>
+<li>Python PEPs: <a href="https://www.python.org/dev/peps/pep-0004/">PEP 4 -- Deprecation of Standard Modules </a>.</li>
 
 
 </references>

--- a/python/ql/src/Imports/EncodingError.qhelp
+++ b/python/ql/src/Imports/EncodingError.qhelp
@@ -30,7 +30,7 @@ was able to persist and address that problem as well.
 </recommendation>
 <references>
     <li>Python PEPs: <a href="https://www.python.org/dev/peps/pep-0263/">PEP 263 — Defining Python Source Code Encodings.</a></li>
-    <li>Python Tutorial: <a href="http://docs.python.org/tutorial/errors.html#syntax-errors">SyntaxErrors.</a></li>
+    <li>Python Tutorial: <a href="https://docs.python.org/tutorial/errors.html#syntax-errors">SyntaxErrors.</a></li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Imports/FromImportOfMutableAttribute.qhelp
+++ b/python/ql/src/Imports/FromImportOfMutableAttribute.qhelp
@@ -37,8 +37,8 @@ The problem can be fixed by rewriting the first module to import the <code>sys</
 
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
-<li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
+<li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
 
 
 </references>

--- a/python/ql/src/Imports/ImportStarUsed.qhelp
+++ b/python/ql/src/Imports/ImportStarUsed.qhelp
@@ -19,8 +19,8 @@ Use explicit imports. For example <code>from xxx import a, b, c</code>
 <references>
 
 
-<li>Python Language  Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
-<li>Python PEP-8: <a href="http://www.python.org/dev/peps/pep-0008/#imports">Imports</a>.</li>
+<li>Python Language  Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
+<li>Python PEP-8: <a href="https://www.python.org/dev/peps/pep-0008/#imports">Imports</a>.</li>
 
 
 </references>

--- a/python/ql/src/Imports/ImportandImportFrom.qhelp
+++ b/python/ql/src/Imports/ImportandImportFrom.qhelp
@@ -22,6 +22,6 @@ Add <code>yyy = xxx.yyy</code> if required.</p>
 
 </example>
 <references>
-  <li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
 </references>
 </qhelp>

--- a/python/ql/src/Imports/Imports.qhelp
+++ b/python/ql/src/Imports/Imports.qhelp
@@ -22,8 +22,8 @@ acceptable to define multiple imports from a subprocess in a single statement.</
 </example>
 <references>
 
-  <li>Python Language  Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
-  <li>Python PEP 8: <a href="http://www.python.org/dev/peps/pep-0008/#imports">Imports</a>.</li>
+  <li>Python Language  Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
+  <li>Python PEP 8: <a href="https://www.python.org/dev/peps/pep-0008/#imports">Imports</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Imports/ModuleImportsItself.qhelp
+++ b/python/ql/src/Imports/ModuleImportsItself.qhelp
@@ -27,7 +27,7 @@ referencing the module it is in as well.</p>
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
+  <li>Python: <a href="https://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Imports/ModuleLevelCyclicImport.qhelp
+++ b/python/ql/src/Imports/ModuleLevelCyclicImport.qhelp
@@ -31,8 +31,8 @@ import that.
 <references>
 
 
-<li>Python Language  Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
-<li>Python: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
+<li>Python Language  Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
+<li>Python: <a href="https://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
 <li> Effbot: <a href="https://web.archive.org/web/20200917011425/https://effbot.org/zone/import-confusion.htm">Import Confusion</a>.</li>
 
 

--- a/python/ql/src/Imports/MultipleImports.qhelp
+++ b/python/ql/src/Imports/MultipleImports.qhelp
@@ -17,7 +17,7 @@ confuses readers of the code.</p>
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/reference/simple_stmts.html#import">import statement</a>.</li>
+  <li>Python: <a href="https://docs.python.org/reference/simple_stmts.html#import">import statement</a>.</li>
 
 
 </references>

--- a/python/ql/src/Imports/SyntaxError.qhelp
+++ b/python/ql/src/Imports/SyntaxError.qhelp
@@ -33,7 +33,7 @@ described <a href="https://lgtm.com/help/lgtm/python-extraction">here</a>.
 </recommendation>
 <references>
 
-    <li>Python Tutorial: <a href="http://docs.python.org/tutorial/errors.html#syntax-errors">SyntaxErrors.</a></li>
+    <li>Python Tutorial: <a href="https://docs.python.org/tutorial/errors.html#syntax-errors">SyntaxErrors.</a></li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Imports/UnintentionalImport.qhelp
+++ b/python/ql/src/Imports/UnintentionalImport.qhelp
@@ -34,9 +34,9 @@ could replace <code>from finance import *</code> with <code>from finance import 
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.
 </li>
-<li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
+<li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
 
 
 

--- a/python/ql/src/Imports/UnusedImport.qhelp
+++ b/python/ql/src/Imports/UnusedImport.qhelp
@@ -17,7 +17,7 @@ more difficult to read.
 </recommendation>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/reference/simple_stmts.html#import">import statement</a>.</li>
+  <li>Python: <a href="https://docs.python.org/reference/simple_stmts.html#import">import statement</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Lexical/CommentedOutCodeReferences.inc.qhelp
+++ b/python/ql/src/Lexical/CommentedOutCodeReferences.inc.qhelp
@@ -4,9 +4,9 @@
 <qhelp>
 <references>
 
-<li>Mark Needham: <a href="http://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
-<li>Los Techies: <a href="http://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
-<li>High Integrity C++ Coding Standard: <a href="http://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
+<li>Mark Needham: <a href="https://www.markhneedham.com/blog/2009/01/17/the-danger-of-commenting-out-code/">The danger of commenting out code</a>.</li>
+<li>Los Techies: <a href="https://lostechies.com/rodpaddock/2010/12/29/commented-code-technical-debt">Commented Code == Technical Debt</a>.</li>
+<li>High Integrity C++ Coding Standard: <a href="https://www.codingstandard.com/rule/2-3-2-do-not-comment-out-code/">2.3.2 Do not comment out code</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Lexical/OldOctalLiteral.qhelp
+++ b/python/ql/src/Lexical/OldOctalLiteral.qhelp
@@ -27,8 +27,8 @@ Use the 0oXXX form instead of the 0XXX form. Alternatively use binary or hexadec
 <references>
 
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/lexical_analysis.html#integer-and-long-integer-literals">Integer Literals</a>.</li>
-<li>Python PEP 3127: <a href="http://www.python.org/dev/peps/pep-3127/">Integer Literal Support and Syntax</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/lexical_analysis.html#integer-and-long-integer-literals">Integer Literals</a>.</li>
+<li>Python PEP 3127: <a href="https://www.python.org/dev/peps/pep-3127/">Integer Literal Support and Syntax</a>.</li>
 
 
 </references>

--- a/python/ql/src/Lexical/ToDoComment.qhelp
+++ b/python/ql/src/Lexical/ToDoComment.qhelp
@@ -44,7 +44,7 @@ comment deleted.</p>
 <references>
 
 <li>
-  Wikipedia: <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags">
   Comment tags</a>.
 </li>
 

--- a/python/ql/src/Metrics/CommentRatio.qhelp
+++ b/python/ql/src/Metrics/CommentRatio.qhelp
@@ -22,12 +22,12 @@ public modules, functions, classes and methods.</p>
 </recommendation>
 <references>
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Need_for_comments">
 Need for comments</a>.</li>
-<li>Python PEP 8: <a href="http://www.python.org/dev/peps/pep-0008/#comments">Comments</a>.</li>
-<li>Python for Beginners: <a href="http://www.pythonforbeginners.com/basics/python-docstrings/">
+<li>Python PEP 8: <a href="https://www.python.org/dev/peps/pep-0008/#comments">Comments</a>.</li>
+<li>Python for Beginners: <a href="https://www.pythonforbeginners.com/basics/python-docstrings/">
 Python Docstrings</a>.</li>
-<li>Python PEP 257: <a href="http://www.python.org/dev/peps/pep-0257/">Docstring Conventions</a>.</li>
+<li>Python PEP 257: <a href="https://www.python.org/dev/peps/pep-0257/">Docstring Conventions</a>.</li>
 
 
 </references>

--- a/python/ql/src/Metrics/CyclomaticComplexity.qhelp
+++ b/python/ql/src/Metrics/CyclomaticComplexity.qhelp
@@ -32,7 +32,7 @@ introducing defects by copying and pasting code.</li>
 <li>M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 <li>T. J. McCabe. <em>A Complexity Measure</em>. IEEE Transactions on Software Engineering, SE-2(4), 
 December 1976.</li>
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity">Cyclomatic complexity</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Metrics/DirectImports.qhelp
+++ b/python/ql/src/Metrics/DirectImports.qhelp
@@ -17,7 +17,7 @@ well-defined role.</p>
 </recommendation>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.
 </li><li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>.</li>
 

--- a/python/ql/src/Metrics/DocStringRatio.qhelp
+++ b/python/ql/src/Metrics/DocStringRatio.qhelp
@@ -24,11 +24,11 @@ the public functions first.</p>
 </recommendation>
 <references>
 
-<li>Python for Beginners: <a href="http://www.pythonforbeginners.com/basics/python-docstrings/">
+<li>Python for Beginners: <a href="https://www.pythonforbeginners.com/basics/python-docstrings/">
 Python Docstrings</a>.</li>
-<li>Python PEP 8: <a href="http://www.python.org/dev/peps/pep-0008/#documentation-strings">Documentation 
+<li>Python PEP 8: <a href="https://www.python.org/dev/peps/pep-0008/#documentation-strings">Documentation 
 Strings</a>.</li>
-<li>Python PEP 257: <a href="http://www.python.org/dev/peps/pep-0257/">Docstring Conventions</a>.</li>
+<li>Python PEP 257: <a href="https://www.python.org/dev/peps/pep-0257/">Docstring Conventions</a>.</li>
 
 
 </references>

--- a/python/ql/src/Metrics/FClasses.qhelp
+++ b/python/ql/src/Metrics/FClasses.qhelp
@@ -31,7 +31,7 @@ then you should refactor the code and create new files, each containing logicall
 </recommendation>
 <references>
 
-<li>Python: <a href="http://docs.python.org/2/reference/compound_stmts.html#class-definitions">Class 
+<li>Python: <a href="https://docs.python.org/2/reference/compound_stmts.html#class-definitions">Class 
 Definitions</a>.</li>
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>.</li>

--- a/python/ql/src/Metrics/FFunctionsAndMethods.qhelp
+++ b/python/ql/src/Metrics/FFunctionsAndMethods.qhelp
@@ -18,7 +18,7 @@ the file according to these tasks.</p>
 </recommendation>
 <references>
 
-<li>Python: <a href="http://docs.python.org/2/reference/compound_stmts.html#function">Function Definitions</a>.</li>
+<li>Python: <a href="https://docs.python.org/2/reference/compound_stmts.html#function">Function Definitions</a>.</li>
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>.</li>
 

--- a/python/ql/src/Metrics/FLinesOfComments.qhelp
+++ b/python/ql/src/Metrics/FLinesOfComments.qhelp
@@ -12,7 +12,7 @@
 </recommendation>
 <references>
 
-  <li>Jeff Atwood. <a href="http://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
+  <li>Jeff Atwood. <a href="https://www.codinghorror.com/blog/2005/11/avoiding-undocumentation.html">Avoiding Undocumentation</a>. 2005.</li>
   <li>Steve McConnell. <em>Code Complete</em>. 2nd Edition. Microsoft Press. 2004.</li>
 
 </references>

--- a/python/ql/src/Metrics/FLinesOfDuplicatedCodeCommon.inc.qhelp
+++ b/python/ql/src/Metrics/FLinesOfDuplicatedCodeCommon.inc.qhelp
@@ -27,7 +27,7 @@ a shared library or module.
 <references> 
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 
 

--- a/python/ql/src/Metrics/FLinesOfSimilarCode.qhelp
+++ b/python/ql/src/Metrics/FLinesOfSimilarCode.qhelp
@@ -23,7 +23,7 @@ that can be reused across modules.
 <references> 
 
 
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Duplicate_code">Duplicate code</a>.</li>
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 
 

--- a/python/ql/src/Metrics/FNumberOfTests.qhelp
+++ b/python/ql/src/Metrics/FNumberOfTests.qhelp
@@ -45,8 +45,8 @@
 
 <li>Python Standard Library: <a href="https://docs.python.org/library/unittest.html">unitest</a>.</li>
 <li>Python Standard Library: <a href="https://docs.python.org/2/library/doctest.html">doctest</a>.</li>
-<li><a href="http://pytest.org/latest/">http://pytest.org</a>.</li>
-<li>Read the docs: <a href="http://nose.readthedocs.org/en/latest/">http://nose.readthedocs.org/en/latest</a>.</li>
+<li><a href="https://pytest.org/latest/">http://pytest.org</a>.</li>
+<li>Read the docs: <a href="https://nose.readthedocs.org/en/latest/">http://nose.readthedocs.org/en/latest</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Metrics/LackofCohesionInMethodsHM.qhelp
+++ b/python/ql/src/Metrics/LackofCohesionInMethodsHM.qhelp
@@ -38,7 +38,7 @@ example.
 
 
 <li>
- <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.409.4862">
+ <a href="https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.409.4862">
  Measuring coupling and cohesion in object-oriented systems by Martin Hitz, Behzad Montazeri (1995).</a>
  Proceedings of International Symposium on Applied Corporate Computing</li>
 <li>
@@ -48,7 +48,7 @@ M. Fowler, <em>Refactoring</em>, pp. 65, 122-5. Addison-Wesley, 1999.
 Wikipedia: <a href="https://en.wikipedia.org/wiki/Single_responsibility_principle">The Single Responsibility Principle</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Glossary_of_graph_theory#Strongly_connected_component">Strongly connected component</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Glossary_of_graph_theory#Strongly_connected_component">Strongly connected component</a>.
 </li>
 
 

--- a/python/ql/src/Metrics/TransitiveImports.qhelp
+++ b/python/ql/src/Metrics/TransitiveImports.qhelp
@@ -17,7 +17,7 @@ well-defined role.</p>
 </recommendation>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.
 </li><li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
 <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>.</li>
 

--- a/python/ql/src/Resources/FileNotAlwaysClosed.qhelp
+++ b/python/ql/src/Resources/FileNotAlwaysClosed.qhelp
@@ -30,9 +30,9 @@ closed on exiting the method.</p>
 <references>
 
 
-<li>Python Language Reference: <a href="http://docs.python.org/reference/compound_stmts.html#the-with-statement">The with statement</a>,
- <a href="http://docs.python.org/reference/compound_stmts.html#the-try-statement">The try statement</a>.</li>
-<li>Python PEP 343: <a href="http://www.python.org/dev/peps/pep-0343">The "with" Statement</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/reference/compound_stmts.html#the-with-statement">The with statement</a>,
+ <a href="https://docs.python.org/reference/compound_stmts.html#the-try-statement">The try statement</a>.</li>
+<li>Python PEP 343: <a href="https://www.python.org/dev/peps/pep-0343">The "with" Statement</a>.</li>
 
 
 

--- a/python/ql/src/Security/CWE-022/PathInjection.qhelp
+++ b/python/ql/src/Security/CWE-022/PathInjection.qhelp
@@ -57,6 +57,6 @@ known prefix. This ensures that regardless of the user input, the resulting path
 
 <references>
 <li>OWASP: <a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.</li>
-<li>npm: <a href="http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename">werkzeug.utils.secure_filename</a>.</li>
+<li>npm: <a href="https://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename">werkzeug.utils.secure_filename</a>.</li>
 </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-079/Jinja2WithoutEscaping.qhelp
+++ b/python/ql/src/Security/CWE-079/Jinja2WithoutEscaping.qhelp
@@ -32,10 +32,10 @@ The second view is safe as <code>first_name</code> is escaped, so it is not vuln
 
 <references>
 <li>
-Jinja2: <a href="http://jinja.pocoo.org/docs/2.10/api/">API</a>.
+Jinja2: <a href="https://jinja.pocoo.org/docs/2.10/api/">API</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 <li>
 OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS (Cross Site Scripting) Prevention Cheat Sheet</a>.

--- a/python/ql/src/Security/CWE-079/ReflectedXss.qhelp
+++ b/python/ql/src/Security/CWE-079/ReflectedXss.qhelp
@@ -35,7 +35,7 @@ OWASP:
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>
-Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 <li>
 Python Library Reference:

--- a/python/ql/src/Security/CWE-215/FlaskDebug.qhelp
+++ b/python/ql/src/Security/CWE-215/FlaskDebug.qhelp
@@ -31,8 +31,8 @@
      </example>
 
      <references>
-       <li>Flask Quickstart Documentation: <a href="http://flask.pocoo.org/docs/1.0/quickstart/#debug-mode">Debug Mode</a>.</li>
-       <li>Werkzeug Documentation: <a href="http://werkzeug.pocoo.org/docs/0.14/debug/">Debugging Applications</a>.</li>
+       <li>Flask Quickstart Documentation: <a href="https://flask.pocoo.org/docs/1.0/quickstart/#debug-mode">Debug Mode</a>.</li>
+       <li>Werkzeug Documentation: <a href="https://werkzeug.pocoo.org/docs/0.14/debug/">Debugging Applications</a>.</li>
      </references>
 
 </qhelp>

--- a/python/ql/src/Security/CWE-295/MissingHostKeyValidation.qhelp
+++ b/python/ql/src/Security/CWE-295/MissingHostKeyValidation.qhelp
@@ -36,7 +36,7 @@ verification fails.
 
 <references>
 <li>
-Paramiko documentation: <a href="http://docs.paramiko.org/en/2.4/api/client.html?highlight=set_missing_host_key_policy#paramiko.client.SSHClient.set_missing_host_key_policy">set_missing_host_key_policy</a>.
+Paramiko documentation: <a href="https://docs.paramiko.org/en/2.4/api/client.html?highlight=set_missing_host_key_policy#paramiko.client.SSHClient.set_missing_host_key_policy">set_missing_host_key_policy</a>.
 </li>
 </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-295/RequestWithoutValidation.qhelp
+++ b/python/ql/src/Security/CWE-295/RequestWithoutValidation.qhelp
@@ -29,7 +29,7 @@ The example shows two unsafe calls to <a href="https://semmle.com">semmle.com</a
 
 <references>
 <li>
-Python requests documentation: <a href="http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification">SSL Cert Verification</a>.
+Python requests documentation: <a href="https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification">SSL Cert Verification</a>.
 </li>
 </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -56,8 +56,8 @@
      </example>
 
      <references>
-          <li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
-          <li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
+          <li>NIST, FIPS 140 Annex a: <a href="https://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
+          <li>NIST, SP 800-131A: <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
           <li>OWASP: <a
           href="https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#rule---use-strong-approved-authenticated-encryption">Rule
           - Use strong approved cryptographic algorithms</a>.

--- a/python/ql/src/Security/CWE-502/UnsafeDeserialization.qhelp
+++ b/python/ql/src/Security/CWE-502/UnsafeDeserialization.qhelp
@@ -56,7 +56,7 @@ OWASP guidance on deserializing objects:
 </li>
 <li>
 Talks by Chris Frohoff &amp; Gabriel Lawrence:
-<a href="http://frohoff.github.io/appseccali-marshalling-pickles/">
+<a href="https://frohoff.github.io/appseccali-marshalling-pickles/">
 AppSecCali 2015: Marshalling Pickles - how deserializing objects will ruin your day</a>
 </li>
 </references>

--- a/python/ql/src/Security/CWE-730/ReDoSReferences.inc.qhelp
+++ b/python/ql/src/Security/CWE-730/ReDoSReferences.inc.qhelp
@@ -10,7 +10,7 @@
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
 		<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
 		<li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
-		<a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+		<a href="https://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
 		</li>
 	</references>
 </qhelp>

--- a/python/ql/src/Statements/AssertOnTuple.qhelp
+++ b/python/ql/src/Statements/AssertOnTuple.qhelp
@@ -38,8 +38,8 @@ individually.</p>
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2.7/reference/simple_stmts.html#the-assert-statement">The assert statement</a>.</li>
-<li>Tutorials Point: <a href="http://www.tutorialspoint.com/python/assertions_in_python.htm">Assertions in Python</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2.7/reference/simple_stmts.html#the-assert-statement">The assert statement</a>.</li>
+<li>Tutorials Point: <a href="https://www.tutorialspoint.com/python/assertions_in_python.htm">Assertions in Python</a>.</li>
 
 
 </references>

--- a/python/ql/src/Statements/BreakOrReturnInFinally.qhelp
+++ b/python/ql/src/Statements/BreakOrReturnInFinally.qhelp
@@ -22,9 +22,9 @@ that the resulting behavior is correct.</p>
 <references>
 
 <li>
-Python Language Reference: <a href="http://docs.python.org/2.7/reference/compound_stmts.html#the-try-statement">
-The try statement</a>, <a href="http://docs.python.org/2/reference/simple_stmts.html#break">
-The break statement</a>, <a href="http://docs.python.org/2/reference/simple_stmts.html#return">
+Python Language Reference: <a href="https://docs.python.org/2.7/reference/compound_stmts.html#the-try-statement">
+The try statement</a>, <a href="https://docs.python.org/2/reference/simple_stmts.html#break">
+The break statement</a>, <a href="https://docs.python.org/2/reference/simple_stmts.html#return">
 The return statement</a>.</li>
 
 

--- a/python/ql/src/Statements/C_StyleParentheses.qhelp
+++ b/python/ql/src/Statements/C_StyleParentheses.qhelp
@@ -36,7 +36,7 @@ This is harder to read than the second example, especially to a programmer more 
 
 <li>Python Language Reference: <a href="https://docs.python.org/2/reference/grammar.html">Full grammar specification</a>.</li>
 <li>Google Python Style Guide: <a href="https://google.github.io/styleguide/pyguide.html#Parentheses">Use parentheses sparingly</a>.</li>
-<li>Python PEP Index: <a href="http://legacy.python.org/dev/peps/pep-0008/">PEP 8</a>.</li>
+<li>Python PEP Index: <a href="https://legacy.python.org/dev/peps/pep-0008/">PEP 8</a>.</li>
 
 
 </references>

--- a/python/ql/src/Statements/ConstantInConditional.qhelp
+++ b/python/ql/src/Statements/ConstantInConditional.qhelp
@@ -25,9 +25,9 @@ and that the test should be corrected, rather than deleted.
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/reference/compound_stmts.html#the-if-statement">The If Statement</a>.</li>
-  <li>Python: <a href="http://docs.python.org/reference/compound_stmts.html#the-while-statement">The While Statement</a>.</li>
-  <li>Python: <a href="http://docs.python.org/reference/expressions.html#literals">Literals (constant values)</a>.</li>
+  <li>Python: <a href="https://docs.python.org/reference/compound_stmts.html#the-if-statement">The If Statement</a>.</li>
+  <li>Python: <a href="https://docs.python.org/reference/compound_stmts.html#the-while-statement">The While Statement</a>.</li>
+  <li>Python: <a href="https://docs.python.org/reference/expressions.html#literals">Literals (constant values)</a>.</li>
 
 
 </references>

--- a/python/ql/src/Statements/DocStrings.qhelp
+++ b/python/ql/src/Statements/DocStrings.qhelp
@@ -29,8 +29,8 @@ immediately after the <code>def</code> line.</p>
 </p></example>
 <references>
 
-<li>Python PEP 8: <a href="http://www.python.org/dev/peps/pep-0008/#documentation-strings">Documentation strings</a>.</li>
-<li>Python PEP 257: <a href="http://www.python.org/dev/peps/pep-0257">Documentation string conventions
+<li>Python PEP 8: <a href="https://www.python.org/dev/peps/pep-0008/#documentation-strings">Documentation strings</a>.</li>
+<li>Python PEP 257: <a href="https://www.python.org/dev/peps/pep-0257">Documentation string conventions
 </a>.</li>
 
 

--- a/python/ql/src/Statements/IterableStringOrSequence.qhelp
+++ b/python/ql/src/Statements/IterableStringOrSequence.qhelp
@@ -36,10 +36,10 @@ It is likely that the programmer forgot to wrap the <code>"Hello"</code> in brac
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/reference/compound_stmts.html#the-for-statement">The for statement</a>,
- <a href="http://docs.python.org/2.7/reference/datamodel.html#object.__iter__">object.__iter__</a>.</li>
-<li>Python Standard Library: <a href="http://docs.python.org/dev/library/stdtypes.html#iterator-types">Iterator types</a>.</li>
-<li>Scipy lecture notes: <a href="http://scipy-lectures.github.io/advanced/advanced_python/#iterators">Iterators,
+<li>Python Language Reference: <a href="https://docs.python.org/reference/compound_stmts.html#the-for-statement">The for statement</a>,
+ <a href="https://docs.python.org/2.7/reference/datamodel.html#object.__iter__">object.__iter__</a>.</li>
+<li>Python Standard Library: <a href="https://docs.python.org/dev/library/stdtypes.html#iterator-types">Iterator types</a>.</li>
+<li>Scipy lecture notes: <a href="https://scipy-lectures.github.io/advanced/advanced_python/#iterators">Iterators,
 generator expressions and generators</a>.</li>
 
 

--- a/python/ql/src/Statements/MismatchInMultipleAssignment.qhelp
+++ b/python/ql/src/Statements/MismatchInMultipleAssignment.qhelp
@@ -25,9 +25,9 @@ one of the values in the assignment has been duplicated, causing an exception at
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#grammar-token-assignment_stmt">
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#grammar-token-assignment_stmt">
 Assignment statements</a>.</li>
-<li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/introduction.html#first-steps-towards-programming">
+<li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/introduction.html#first-steps-towards-programming">
 First steps towards programming</a>.</li> 
 
 

--- a/python/ql/src/Statements/ModificationOfLocals.qhelp
+++ b/python/ql/src/Statements/ModificationOfLocals.qhelp
@@ -26,8 +26,8 @@ is modified.
 </example>
 <references>
 
-  <li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#the-for-statement">The for statement</a>.</li>
-  <li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/controlflow.html#for-statements">for statements</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2/reference/compound_stmts.html#the-for-statement">The for statement</a>.</li>
+  <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/controlflow.html#for-statements">for statements</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Statements/NestedLoopsSameVariable.qhelp
+++ b/python/ql/src/Statements/NestedLoopsSameVariable.qhelp
@@ -25,8 +25,8 @@ particularly considering what would happen if the inner or outer variable were r
 </example>
 <references>
 
-  <li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#the-for-statement">The for statement</a>.</li>
-  <li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/controlflow.html#for-statements">for statements</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2/reference/compound_stmts.html#the-for-statement">The for statement</a>.</li>
+  <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/controlflow.html#for-statements">for statements</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Statements/NestedLoopsSameVariableWithReuse.qhelp
+++ b/python/ql/src/Statements/NestedLoopsSameVariableWithReuse.qhelp
@@ -35,8 +35,8 @@
 </example>
 <references>
 
-  <li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#the-for-statement">The for statement</a>.</li>
-  <li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/controlflow.html#for-statements">for statements</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2/reference/compound_stmts.html#the-for-statement">The for statement</a>.</li>
+  <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/controlflow.html#for-statements">for statements</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Statements/NonIteratorInForLoop.qhelp
+++ b/python/ql/src/Statements/NonIteratorInForLoop.qhelp
@@ -25,10 +25,10 @@ It is likely that the programmer forgot to test for <code>None</code> before the
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/reference/compound_stmts.html#the-for-statement">The for statement</a>,
- <a href="http://docs.python.org/2.7/reference/datamodel.html#object.__iter__">object.__iter__</a>.</li>
-<li>Python Standard Library: <a href="http://docs.python.org/dev/library/stdtypes.html#iterator-types">Iterator types</a>.</li>
-<li>Scipy lecture notes: <a href="http://scipy-lectures.github.io/advanced/advanced_python/#iterators">Iterators,
+<li>Python Language Reference: <a href="https://docs.python.org/reference/compound_stmts.html#the-for-statement">The for statement</a>,
+ <a href="https://docs.python.org/2.7/reference/datamodel.html#object.__iter__">object.__iter__</a>.</li>
+<li>Python Standard Library: <a href="https://docs.python.org/dev/library/stdtypes.html#iterator-types">Iterator types</a>.</li>
+<li>Scipy lecture notes: <a href="https://scipy-lectures.github.io/advanced/advanced_python/#iterators">Iterators,
 generator expressions and generators</a>.</li>
 
 

--- a/python/ql/src/Statements/RedundantAssignment.qhelp
+++ b/python/ql/src/Statements/RedundantAssignment.qhelp
@@ -21,7 +21,7 @@ mistake.</p>
 <references>
 
 
-<li>Python Language Reference: <a href="http://docs.python.org/reference/simple_stmts.html#assignment-statements">
+<li>Python Language Reference: <a href="https://docs.python.org/reference/simple_stmts.html#assignment-statements">
 The assignment statement</a>.</li>
 
 

--- a/python/ql/src/Statements/ShouldUseWithStatement.qhelp
+++ b/python/ql/src/Statements/ShouldUseWithStatement.qhelp
@@ -26,11 +26,11 @@ a simpler <code>with</code> statement.</p>
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/reference/compound_stmts.html#the-with-statement">The with 
+<li>Python Language Reference: <a href="https://docs.python.org/reference/compound_stmts.html#the-with-statement">The with 
 statement</a>.</li>
-<li>Python Standard Library: <a href="http://docs.python.org/library/stdtypes.html#context-manager-types">Context manager
+<li>Python Standard Library: <a href="https://docs.python.org/library/stdtypes.html#context-manager-types">Context manager
 </a>.</li>
-<li>Python PEP 343: <a href="http://www.python.org/dev/peps/pep-0343">The "with" Statement</a>.</li>
+<li>Python PEP 343: <a href="https://www.python.org/dev/peps/pep-0343">The "with" Statement</a>.</li>
 
 
 </references>

--- a/python/ql/src/Statements/SideEffectInAssert.qhelp
+++ b/python/ql/src/Statements/SideEffectInAssert.qhelp
@@ -29,8 +29,8 @@ of <code>subprocess.call()</code> to a temporary variable, and to assert that va
 </example>
 <references>
 
-<li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#assert">The assert statement</a>.</li>
-<li>TutorialsPoint, Python Programming: <a href="http://www.tutorialspoint.com/python/assertions_in_python.htm">Assertions in Python</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#assert">The assert statement</a>.</li>
+<li>TutorialsPoint, Python Programming: <a href="https://www.tutorialspoint.com/python/assertions_in_python.htm">Assertions in Python</a>.</li>
 
 
 </references>

--- a/python/ql/src/Statements/StringConcatenationInLoop.qhelp
+++ b/python/ql/src/Statements/StringConcatenationInLoop.qhelp
@@ -18,8 +18,8 @@ At the end of the loop, convert the list to a string by using <code>''.join(list
 <references>
 
 
-<li>Python Standard Library: <a href="http://docs.python.org/library/string.html#string.join">The str.join method</a>.</li>
-<li>Python Frequently Asked Questions: <a href="http://docs.python.org/3/faq/programming.html#what-is-the-most-efficient-way-to-concatenate-many-strings-together">
+<li>Python Standard Library: <a href="https://docs.python.org/library/string.html#string.join">The str.join method</a>.</li>
+<li>Python Frequently Asked Questions: <a href="https://docs.python.org/3/faq/programming.html#what-is-the-most-efficient-way-to-concatenate-many-strings-together">
 What is the most efficient way to concatenate many strings together?</a>.</li>
 
 

--- a/python/ql/src/Statements/TopLevelPrint.qhelp
+++ b/python/ql/src/Statements/TopLevelPrint.qhelp
@@ -24,9 +24,9 @@ real output to standard out.
 </example>
 <references>
 
-    <li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#the-print-statement">The print statement</a>.</li>
-    <li>Python Standard Library: <a href="http://docs.python.org/3/library/functions.html#print">The print function</a>.</li>
-    <li>Python tutorial: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
+    <li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#the-print-statement">The print statement</a>.</li>
+    <li>Python Standard Library: <a href="https://docs.python.org/3/library/functions.html#print">The print function</a>.</li>
+    <li>Python tutorial: <a href="https://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
 
 
 </references>

--- a/python/ql/src/Statements/UnnecessaryElseClause.qhelp
+++ b/python/ql/src/Statements/UnnecessaryElseClause.qhelp
@@ -25,8 +25,8 @@ The third example function, <code>with_break</code>, shows a version where the <
 </example>
 <references>
 
-     <li>Python Language Reference: <a href="http://docs.python.org/2/reference/compound_stmts.html#the-while-statement">The while statement</a>.</li>
-     <li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/controlflow.html#break-and-continue-statements-and-else-clauses-on-loops">Break and continue statements, and else clauses on loops</a>.</li>
+     <li>Python Language Reference: <a href="https://docs.python.org/2/reference/compound_stmts.html#the-while-statement">The while statement</a>.</li>
+     <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/controlflow.html#break-and-continue-statements-and-else-clauses-on-loops">Break and continue statements, and else clauses on loops</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Statements/UnnecessaryPass.qhelp
+++ b/python/ql/src/Statements/UnnecessaryPass.qhelp
@@ -15,7 +15,7 @@ If the block already contains other statements then the <code>pass</code> statem
 </recommendation>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/2/tutorial/controlflow.html#pass-statements">pass</a>.</li>
+  <li>Python: <a href="https://docs.python.org/2/tutorial/controlflow.html#pass-statements">pass</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Statements/UnreachableCode.qhelp
+++ b/python/ql/src/Statements/UnreachableCode.qhelp
@@ -21,7 +21,7 @@ return</code> statement on the previous line.</p>
 </example>
 <references>
 
-    <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Unreachable_code">Unreachable Code</a>.</li>
+    <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Unreachable_code">Unreachable Code</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Variables/Global.qhelp
+++ b/python/ql/src/Variables/Global.qhelp
@@ -14,7 +14,7 @@ of that function, making the code harder to understand.</p>
 
 <references>
 
-  <li>Python Language Reference: <a href="http://docs.python.org/reference/simple_stmts.html#the-global-statement">The global statement</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/reference/simple_stmts.html#the-global-statement">The global statement</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Variables/GlobalAtModuleLevel.qhelp
+++ b/python/ql/src/Variables/GlobalAtModuleLevel.qhelp
@@ -14,7 +14,7 @@ At the module level, this statement is redundant because the local scope and glo
 </recommendation>
 <references>
 
-  <li>Python Language Reference: <a href="http://docs.python.org/reference/simple_stmts.html#the-global-statement">The global statement</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/reference/simple_stmts.html#the-global-statement">The global statement</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Variables/LeakingListComprehension.qhelp
+++ b/python/ql/src/Variables/LeakingListComprehension.qhelp
@@ -34,7 +34,7 @@ In Python 2, evaluation of the list comprehension occurs in the scope of <code>t
 <references>
     
     <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/datastructures.html#list-comprehensions">List Comprehensions</a>.</li>
-    <li>The History of Python: <a href="http://python-history.blogspot.co.uk/2010/06/from-list-comprehensions-to-generator.html">From List Comprehensions to Generator Expressions</a>.</li>
+    <li>The History of Python: <a href="https://python-history.blogspot.co.uk/2010/06/from-list-comprehensions-to-generator.html">From List Comprehensions to Generator Expressions</a>.</li>
     <li>Python Language Reference: <a href="https://docs.python.org/2/reference/expressions.html#list-displays">List displays</a>.</li>
 
 </references>

--- a/python/ql/src/Variables/LoopVariableCapture.qhelp
+++ b/python/ql/src/Variables/LoopVariableCapture.qhelp
@@ -53,7 +53,7 @@ This can be fixed by adding the default value as shown below. The default value 
 
 </example>
 <references>
-<li>The Hitchhiker’s Guide to Python: <a href="http://docs.python-guide.org/en/latest/writing/gotchas/#late-binding-closures">Late Binding Closures</a></li>
+<li>The Hitchhiker’s Guide to Python: <a href="https://docs.python-guide.org/en/latest/writing/gotchas/#late-binding-closures">Late Binding Closures</a></li>
 <li>Python Language Reference: <a href="https://docs.python.org/reference/executionmodel.html#naming-and-binding">Naming and binding</a></li>
 
 </references>

--- a/python/ql/src/Variables/MultiplyDefined.qhelp
+++ b/python/ql/src/Variables/MultiplyDefined.qhelp
@@ -23,7 +23,7 @@ before <code>x</code> is used. This makes the first assignment useless.</p>
 </example>
 <references>
 
-    <li>Python: <a href="http://docs.python.org/reference/simple_stmts.html#assignment-statements">Assignment statements</a>.</li>
+    <li>Python: <a href="https://docs.python.org/reference/simple_stmts.html#assignment-statements">Assignment statements</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Variables/ShadowBuiltin.qhelp
+++ b/python/ql/src/Variables/ShadowBuiltin.qhelp
@@ -23,8 +23,8 @@ confusion as a reader of the code may expect the variable to refer to a built-in
 </example>
 <references>
 
-<li>Python Standard Library: <a href="http://docs.python.org/2/library/functions.html">Built-in Functions</a>,
-                            <a href="http://docs.python.org/2/library/stdtypes.html">Built-in Types</a>.</li>
+<li>Python Standard Library: <a href="https://docs.python.org/2/library/functions.html">Built-in Functions</a>,
+                            <a href="https://docs.python.org/2/library/stdtypes.html">Built-in Types</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Variables/ShadowGlobal.qhelp
+++ b/python/ql/src/Variables/ShadowGlobal.qhelp
@@ -27,7 +27,7 @@ variable should be renamed to make the code easier to interpret.</p>
 <references>
 
 <li>J. Lusth, <i>The Art and Craft of Programming - Python Edition</i>, Section: Scope. University of Alabama, 2012. (<a href="https://web.archive.org/web/20190919091129/http://troll.cs.ua.edu/ACP-PY/index_13.html">Published online</a>).</li>
-<li>Python Language Reference: <a href="http://docs.python.org/reference/simple_stmts.html#the-global-statement">The global statement</a>.</li>
+<li>Python Language Reference: <a href="https://docs.python.org/reference/simple_stmts.html#the-global-statement">The global statement</a>.</li>
 
 
 

--- a/python/ql/src/Variables/UndefinedExport.qhelp
+++ b/python/ql/src/Variables/UndefinedExport.qhelp
@@ -29,8 +29,8 @@ Correcting the spelling will fix the defect.
 </example>
 <references>
 
-  <li>Python Language Reference: <a href="http://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
-  <li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/modules.html#importing-from-a-package">Importing * from a Package</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2/reference/simple_stmts.html#import">The import statement</a>.</li>
+  <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/modules.html#importing-from-a-package">Importing * from a Package</a>.</li>
 
 
 </references>

--- a/python/ql/src/Variables/UndefinedGlobal.qhelp
+++ b/python/ql/src/Variables/UndefinedGlobal.qhelp
@@ -29,7 +29,7 @@ Nonetheless, the code will be more robust and clearer if the variable is set to 
 <references>
 
 <li>Python Standard Library: <a href="https://docs.python.org/library/exceptions.html#exceptions.NameError">NameError</a>.</li>
-<li>The Python Tutorial: <a href="http://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
+<li>The Python Tutorial: <a href="https://docs.python.org/2/tutorial/modules.html">Modules</a>.</li>
 
 
 </references>

--- a/python/ql/src/Variables/UninitializedLocal.qhelp
+++ b/python/ql/src/Variables/UninitializedLocal.qhelp
@@ -31,11 +31,11 @@ before it is initialized.</p>
 </example>
 <references>
 
-  <li>Python Standard Library: <a href="http://docs.python.org/library/exceptions.html#exceptions.UnboundLocalError">Built-in Exceptions: UnboundLocalError</a>.</li>
-  <li>Python Frequently Asked Questions: <a href="http://docs.python.org/2/faq/programming.html#why-am-i-getting-an-unboundlocalerror-when-the-variable-has-a-value">Why am I getting an UnboundLocalError when the variable has a value?</a>.</li>
-  <li>Python Course: <a href="http://www.python-course.eu/global_vs_local_variables.php">Global and Local Variables</a>.</li>
-  <li>Python Language Reference: <a href="http://docs.python.org/2.7/reference/simple_stmts.html#index-54">The global statement</a>,
-    <a href="http://docs.python.org/3.3/reference/simple_stmts.html#index-43">The nonlocal statement</a>.</li>
+  <li>Python Standard Library: <a href="https://docs.python.org/library/exceptions.html#exceptions.UnboundLocalError">Built-in Exceptions: UnboundLocalError</a>.</li>
+  <li>Python Frequently Asked Questions: <a href="https://docs.python.org/2/faq/programming.html#why-am-i-getting-an-unboundlocalerror-when-the-variable-has-a-value">Why am I getting an UnboundLocalError when the variable has a value?</a>.</li>
+  <li>Python Course: <a href="https://www.python-course.eu/global_vs_local_variables.php">Global and Local Variables</a>.</li>
+  <li>Python Language Reference: <a href="https://docs.python.org/2.7/reference/simple_stmts.html#index-54">The global statement</a>,
+    <a href="https://docs.python.org/3.3/reference/simple_stmts.html#index-43">The nonlocal statement</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Variables/UnusedLocalVariable.qhelp
+++ b/python/ql/src/Variables/UnusedLocalVariable.qhelp
@@ -25,7 +25,7 @@ assignment in line 10.</p>
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/2/reference/simple_stmts.html#assignment-statements">Assignment statements</a>.</li>
+  <li>Python: <a href="https://docs.python.org/2/reference/simple_stmts.html#assignment-statements">Assignment statements</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/Variables/UnusedModuleVariable.qhelp
+++ b/python/ql/src/Variables/UnusedModuleVariable.qhelp
@@ -26,9 +26,9 @@ assignment in line 9.</p>
 </example>
 <references>
 
-  <li>Python: <a href="http://docs.python.org/reference/simple_stmts.html#assignment-statements">Assignment statements</a>,
-  <a href="http://docs.python.org/reference/simple_stmts.html#the-import-statement">The import statement</a>.</li>
-  <li>Python Tutorial: <a href="http://docs.python.org/2/tutorial/modules.html#importing-from-a-package">Importing * from a package</a>.</li>
+  <li>Python: <a href="https://docs.python.org/reference/simple_stmts.html#assignment-statements">Assignment statements</a>,
+  <a href="https://docs.python.org/reference/simple_stmts.html#the-import-statement">The import statement</a>.</li>
+  <li>Python Tutorial: <a href="https://docs.python.org/2/tutorial/modules.html#importing-from-a-package">Importing * from a package</a>.</li>
 
 </references>
 </qhelp>

--- a/python/ql/src/experimental/Security/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.qhelp
+++ b/python/ql/src/experimental/Security/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.qhelp
@@ -19,7 +19,7 @@
   </example>
   <references>
     <li>
-      <a href="http://aka.ms/azstorageclientencryptionblog">Azure Storage Client Encryption Blog.</a>
+      <a href="https://aka.ms/azstorageclientencryptionblog">Azure Storage Client Encryption Blog.</a>
     </li>
     <li>
       <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30187">CVE-2022-30187</a>

--- a/python/ql/src/experimental/Security/CWE-338/InsecureRandomness.qhelp
+++ b/python/ql/src/experimental/Security/CWE-338/InsecureRandomness.qhelp
@@ -41,7 +41,7 @@ Instead, use <code>secrets</code>:
 </example>
 
 <references>
-  <li>Wikipedia. <a href="http://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
+  <li>Wikipedia. <a href="https://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudo-random number generator</a>.</li>
   <li>OWASP: <a href="https://owasp.org/www-community/vulnerabilities/Insecure_Randomness">Insecure Randomness</a>.</li>
   <li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#secure-random-number-generation">Secure Random Number Generation</a>.</li>
 </references>

--- a/python/ql/src/experimental/Security/CWE-943/NoSQLInjection.qhelp
+++ b/python/ql/src/experimental/Security/CWE-943/NoSQLInjection.qhelp
@@ -30,8 +30,8 @@
 </example>
 
 <references>
-  <li>Mongoengine: <a href="http://mongoengine.org/">Documentation</a>.</li>
-  <li>Flask-Mongoengine: <a href="http://docs.mongoengine.org/projects/flask-mongoengine/en/latest/">Documentation</a>.</li>
+  <li>Mongoengine: <a href="https://mongoengine.org/">Documentation</a>.</li>
+  <li>Flask-Mongoengine: <a href="https://docs.mongoengine.org/projects/flask-mongoengine/en/latest/">Documentation</a>.</li>
   <li>PyMongo: <a href="https://pypi.org/project/pymongo/">Documentation</a>.</li>
   <li>Flask-PyMongo: <a href="https://flask-pymongo.readthedocs.io/en/latest/">Documentation</a>.</li>
   <li>OWASP: <a href="https://owasp.org/www-pdf-archive/GOD16-NOSQL.pdf">NoSQL Injection</a>.</li>

--- a/ruby/ql/src/queries/security/cwe-079/ReflectedXSS.qhelp
+++ b/ruby/ql/src/queries/security/cwe-079/ReflectedXSS.qhelp
@@ -49,7 +49,7 @@
         Ruby on Rails Cheatsheet</a>.
     </li>
     <li>
-      Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+      Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
     </li>
   </references>
 </qhelp>

--- a/ruby/ql/src/queries/security/cwe-079/StoredXSS.qhelp
+++ b/ruby/ql/src/queries/security/cwe-079/StoredXSS.qhelp
@@ -65,7 +65,7 @@
         Ruby on Rails Cheatsheet</a>.
     </li>
     <li>
-      Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+      Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
     </li>
   </references>
 </qhelp>

--- a/ruby/ql/src/queries/security/cwe-1333/ReDoSReferences.inc.qhelp
+++ b/ruby/ql/src/queries/security/cwe-1333/ReDoSReferences.inc.qhelp
@@ -7,7 +7,7 @@
     <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/ReDoS">ReDoS</a>.</li>
     <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Time_complexity">Time complexity</a>.</li>
     <li>James Kirrage, Asiri Rathnayake, Hayo Thielecke:
-      <a href="http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
+      <a href="https://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf">Static Analysis for Regular Expression Denial-of-Service Attack</a>.
     </li>
   </references>
 </qhelp>

--- a/ruby/ql/src/queries/security/cwe-327/BrokenCryptoAlgorithm.qhelp
+++ b/ruby/ql/src/queries/security/cwe-327/BrokenCryptoAlgorithm.qhelp
@@ -33,8 +33,8 @@
     <sample src="examples/broken_crypto.rb" />
   </example>
   <references>
-    <li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
-    <li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
+    <li>NIST, FIPS 140 Annex a: <a href="https://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
+    <li>NIST, SP 800-131A: <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
     <li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#rule---use-strong-approved-authenticated-encryption">Rule - Use strong approved cryptographic algorithms</a>.
     </li>
   </references>


### PR DESCRIPTION
This commit primarily replaces links in .qhelp files by doing a simple search and replace of '<a href="http://' with '<a href="https://'

This should address a large part of the concern outlined in Issue https://github.com/github/codeql/issues/5163