### PR TITLE
C#: ASP.NET MapGet Routing endpoints (Remote Flow Sources)

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
@@ -366,6 +366,27 @@ class MicrosoftAspNetCoreBuilderEndpointRouteBuilderExtensions extends Class {
     this.hasQualifiedName("Microsoft.AspNetCore.Builder", "EndpointRouteBuilderExtensions")
   }
 
-  /** Gets the `UseMap` extension method. */
+  /** Gets the `Map` extension method. */
+  Method getMapMethod() { result = this.getAMethod("Map") }
+
+  /** Gets the `MapGet` extension method. */
   Method getMapGetMethod() { result = this.getAMethod("MapGet") }
+
+  /** Gets the `MapPost` extension method. */
+  Method getMapPostMethod() { result = this.getAMethod("MapPost") }
+
+  /** Gets the `MapPut` extension method. */
+  Method getMapPutMethod() { result = this.getAMethod("MapPut") }
+
+  /** Gets the `MapDelete` extension method. */
+  Method getMapDeleteMethod() { result = this.getAMethod("MapDelete") }
+
+  /** Get a `Map` like extenion methods. */
+  Method getAMapMethod() {
+    result =
+      [
+        this.getMapMethod(), this.getMapGetMethod(), this.getMapPostMethod(),
+        this.getMapPutMethod(), this.getMapDeleteMethod()
+      ]
+  }
 }

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
@@ -357,3 +357,15 @@ class MicrosoftAspNetCoreHttpHtmlString extends Class {
     this.hasQualifiedName("Microsoft.AspNetCore.Html", "HtmlString")
   }
 }
+
+/**
+ * The `Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions` class.
+ */
+class MicrosoftAspNetCoreBuilderEndpointRouteBuilderExtensions extends Class {
+  MicrosoftAspNetCoreBuilderEndpointRouteBuilderExtensions() {
+    this.hasQualifiedName("Microsoft.AspNetCore.Builder", "EndpointRouteBuilderExtensions")
+  }
+
+  /** Gets the `UseMap` extension method. */
+  Method getMapGetMethod() { result = this.getAMethod("MapGet") }
+}

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
@@ -171,6 +171,22 @@ class ActionMethodParameter extends RemoteFlowSource, DataFlow::ParameterNode {
 /** A data flow source of remote user input (ASP.NET Core). */
 abstract class AspNetCoreRemoteFlowSource extends RemoteFlowSource { }
 
+/** A parameter to a routing method delegate. */
+class RoutingMethodParameter extends AspNetCoreRemoteFlowSource, DataFlow::ParameterNode {
+  RoutingMethodParameter() {
+    exists(Parameter p, MethodCall m |
+      p = this.getParameter() and
+      p.fromSource()
+    |
+      m.getTarget() =
+        any(MicrosoftAspNetCoreBuilderEndpointRouteBuilderExtensions c).getMapGetMethod() and
+      p = m.getArgument(2).(AnonymousFunctionExpr).getAParameter()
+    )
+  }
+
+  override string getSourceType() { result = "ASP.NET Core routing endpoint." }
+}
+
 /**
  * Data flow for ASP.NET Core.
  *

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
@@ -173,8 +173,7 @@ abstract class AspNetCoreRemoteFlowSource extends RemoteFlowSource { }
 
 private predicate reachesMapGetArg(DataFlow::Node n) {
   exists(MethodCall mc |
-    mc.getTarget() =
-      any(MicrosoftAspNetCoreBuilderEndpointRouteBuilderExtensions c).getMapGetMethod() and
+    mc.getTarget() = any(MicrosoftAspNetCoreBuilderEndpointRouteBuilderExtensions c).getAMapMethod() and
     n.asExpr() = mc.getArgument(2)
   )
   or

--- a/csharp/ql/src/change-notes/2022-08-16-aspnetcore-remoteflowsources.md
+++ b/csharp/ql/src/change-notes/2022-08-16-aspnetcore-remoteflowsources.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Parameters of delegates passed to routing endpoint calls like `MapGet` in ASP.NET Core are now considered remote flow sources.

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
@@ -24,7 +24,6 @@ namespace Testing
 
     public class AspRoutingEndpoints
     {
-
         public void M1(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
@@ -32,6 +31,7 @@ namespace Testing
 
             // The delegate parameters are considered flow sources.
             app.MapGet("/api/redirect/{newUrl}", (string newUrl) => { });
+            app.MapGet("/{myApi}/redirect/{myUrl}", (string myApi, string myUrl) => { } );
 
             app.Run();
         }

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace Testing
 {
@@ -24,6 +25,10 @@ namespace Testing
 
     public class AspRoutingEndpoints
     {
+        public delegate void MapGetHandler(string delegateparam);
+
+        public void HandlerMethod(string param) { }
+
         public void M1(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
@@ -31,8 +36,13 @@ namespace Testing
 
             // The delegate parameters are considered flow sources.
             app.MapGet("/api/redirect/{newUrl}", (string newUrl) => { });
-            app.MapGet("/{myApi}/redirect/{myUrl}", (string myApi, string myUrl) => { } );
+            app.MapGet("/{myApi}/redirect/{myUrl}", (string myApi, string myUrl) => { });
 
+            Action<string> handler = (string lambdaParam) => { };
+            app.MapGet("/api/redirect/{lambdaParam}", handler);
+
+            MapGetHandler handler2 = HandlerMethod;
+            app.MapGet("/api/redirect/{param}", handler2);
             app.Run();
         }
     }

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
@@ -25,7 +25,7 @@ namespace Testing
 
     public class AspRoutingEndpoints
     {
-        public delegate void MapGetHandler(string delegateparam);
+        public delegate void MapGetHandler(string param);
 
         public void HandlerMethod(string param) { }
 
@@ -42,7 +42,12 @@ namespace Testing
             app.MapGet("/api/redirect/{lambdaParam}", handler);
 
             MapGetHandler handler2 = HandlerMethod;
-            app.MapGet("/api/redirect/{param}", handler2);
+            app.MapGet("/api/redirect/{mapGetParam}", handler2);
+
+            app.MapPost("/api/redirect/{mapPostParam}", (string mapPostParam) => { });
+            app.MapPut("/api/redirect/{mapPutParam}", (string mapPutParam) => { });
+            app.MapDelete("/api/redirect/{mapDeleteParam}", (string mapDeleteParam) => { });
+
             app.Run();
         }
     }

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
@@ -23,6 +23,11 @@ namespace Testing
         }
     }
 
+    public class Item
+    {
+        public string Tainted { get; set; }
+    }
+
     public class AspRoutingEndpoints
     {
         public delegate void MapGetHandler(string param);
@@ -47,6 +52,8 @@ namespace Testing
             app.MapPost("/api/redirect/{mapPostParam}", (string mapPostParam) => { });
             app.MapPut("/api/redirect/{mapPutParam}", (string mapPutParam) => { });
             app.MapDelete("/api/redirect/{mapDeleteParam}", (string mapDeleteParam) => { });
+
+            app.MapPost("/items", (Item item) => { });
 
             app.Run();
         }

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Testing
@@ -18,6 +19,21 @@ namespace Testing
         public object MyAction(ViewModel viewModel)
         {
             throw null;
+        }
+    }
+
+    public class AspRoutingEndpoints
+    {
+
+        public void M1(string[] args)
+        {
+            var builder = WebApplication.CreateBuilder(args);
+            var app = builder.Build();
+
+            // The delegate parameters are considered flow sources.
+            app.MapGet("/api/redirect/{newUrl}", (string newUrl) => { });
+
+            app.Run();
         }
     }
 }

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
@@ -1,12 +1,14 @@
 remoteFlowSourceMembers
 | AspRemoteFlowSource.cs:10:23:10:31 | RequestId |
+| AspRemoteFlowSource.cs:28:23:28:29 | Tainted |
 remoteFlowSources
 | AspRemoteFlowSource.cs:20:42:20:50 | viewModel |
-| AspRemoteFlowSource.cs:30:42:30:46 | param |
-| AspRemoteFlowSource.cs:38:58:38:63 | newUrl |
-| AspRemoteFlowSource.cs:39:61:39:65 | myApi |
-| AspRemoteFlowSource.cs:39:75:39:79 | myUrl |
-| AspRemoteFlowSource.cs:41:46:41:56 | lambdaParam |
-| AspRemoteFlowSource.cs:47:65:47:76 | mapPostParam |
-| AspRemoteFlowSource.cs:48:63:48:73 | mapPutParam |
-| AspRemoteFlowSource.cs:49:69:49:82 | mapDeleteParam |
+| AspRemoteFlowSource.cs:35:42:35:46 | param |
+| AspRemoteFlowSource.cs:43:58:43:63 | newUrl |
+| AspRemoteFlowSource.cs:44:61:44:65 | myApi |
+| AspRemoteFlowSource.cs:44:75:44:79 | myUrl |
+| AspRemoteFlowSource.cs:46:46:46:56 | lambdaParam |
+| AspRemoteFlowSource.cs:52:65:52:76 | mapPostParam |
+| AspRemoteFlowSource.cs:53:63:53:73 | mapPutParam |
+| AspRemoteFlowSource.cs:54:69:54:82 | mapDeleteParam |
+| AspRemoteFlowSource.cs:56:41:56:44 | item |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
@@ -1,4 +1,4 @@
 remoteFlowSourceMembers
-| AspRemoteFlowSource.cs:8:23:8:31 | RequestId |
+| AspRemoteFlowSource.cs:9:23:9:31 | RequestId |
 remoteFlowSources
-| AspRemoteFlowSource.cs:18:42:18:50 | viewModel |
+| AspRemoteFlowSource.cs:19:42:19:50 | viewModel |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
@@ -1,7 +1,9 @@
 remoteFlowSourceMembers
-| AspRemoteFlowSource.cs:9:23:9:31 | RequestId |
+| AspRemoteFlowSource.cs:10:23:10:31 | RequestId |
 remoteFlowSources
-| AspRemoteFlowSource.cs:19:42:19:50 | viewModel |
-| AspRemoteFlowSource.cs:33:58:33:63 | newUrl |
-| AspRemoteFlowSource.cs:34:61:34:65 | myApi |
-| AspRemoteFlowSource.cs:34:75:34:79 | myUrl |
+| AspRemoteFlowSource.cs:20:42:20:50 | viewModel |
+| AspRemoteFlowSource.cs:30:42:30:46 | param |
+| AspRemoteFlowSource.cs:38:58:38:63 | newUrl |
+| AspRemoteFlowSource.cs:39:61:39:65 | myApi |
+| AspRemoteFlowSource.cs:39:75:39:79 | myUrl |
+| AspRemoteFlowSource.cs:41:46:41:56 | lambdaParam |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
@@ -2,3 +2,4 @@ remoteFlowSourceMembers
 | AspRemoteFlowSource.cs:9:23:9:31 | RequestId |
 remoteFlowSources
 | AspRemoteFlowSource.cs:19:42:19:50 | viewModel |
+| AspRemoteFlowSource.cs:34:58:34:63 | newUrl |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
@@ -2,4 +2,6 @@ remoteFlowSourceMembers
 | AspRemoteFlowSource.cs:9:23:9:31 | RequestId |
 remoteFlowSources
 | AspRemoteFlowSource.cs:19:42:19:50 | viewModel |
-| AspRemoteFlowSource.cs:34:58:34:63 | newUrl |
+| AspRemoteFlowSource.cs:33:58:33:63 | newUrl |
+| AspRemoteFlowSource.cs:34:61:34:65 | myApi |
+| AspRemoteFlowSource.cs:34:75:34:79 | myUrl |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
@@ -7,3 +7,6 @@ remoteFlowSources
 | AspRemoteFlowSource.cs:39:61:39:65 | myApi |
 | AspRemoteFlowSource.cs:39:75:39:79 | myUrl |
 | AspRemoteFlowSource.cs:41:46:41:56 | lambdaParam |
+| AspRemoteFlowSource.cs:47:65:47:76 | mapPostParam |
+| AspRemoteFlowSource.cs:48:63:48:73 | mapPutParam |
+| AspRemoteFlowSource.cs:49:69:49:82 | mapDeleteParam |


### PR DESCRIPTION
Parameters of delegates passed to routing endpoint calls like `MapGet` in ASP.NET Core are now considered remote flow sources.