### PR TITLE
Docs: Replace HTTP broken links to equivalent HTTPS resources

### DIFF
--- a/cpp/ql/src/Likely Bugs/OO/NonVirtualDestructorInBaseClass.qhelp
+++ b/cpp/ql/src/Likely Bugs/OO/NonVirtualDestructorInBaseClass.qhelp
@@ -30,7 +30,7 @@ Make sure that all classes with virtual functions also have a virtual destructor
   S. Meyers. <em>Effective C++ 3d ed.</em> pp 40-44. Addison-Wesley Professional, 2005.
 </li>
 <li>
-  <a href="http://blogs.msdn.com/b/oldnewthing/archive/2004/05/07/127826.aspx">When should your destructor be virtual?</a>
+  <a href="https://devblogs.microsoft.com/oldnewthing/20040507-00/?p=39443">When should your destructor be virtual?</a>
 </li>
 
 

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 78.qhelp
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 78.qhelp
@@ -33,7 +33,7 @@ Make sure that all classes with virtual functions also have a virtual destructor
   S. Meyers. <em>Effective C++ 3d ed.</em> pp 40-44. Addison-Wesley Professional, 2005.
 </li>
 <li>
-  <a href="http://blogs.msdn.com/b/oldnewthing/archive/2004/05/07/127826.aspx">When should your destructor be virtual?</a>
+  <a href="https://devblogs.microsoft.com/oldnewthing/20040507-00/?p=39443">When should your destructor be virtual?</a>
 </li>
 
 

--- a/java/ql/src/Metrics/Files/FNumberOfClasses.qhelp
+++ b/java/ql/src/Metrics/Files/FNumberOfClasses.qhelp
@@ -100,7 +100,7 @@ to enumerations.
 
 
 <li>
-H. Kabutz. <a href="http://www.devx.com/Java/Article/10686">Java History 101: Once Upon an Oak</a>. Published online.
+H. Kabutz. <a href="https://www.devx.com/java-zone/10686/">Java History 101: Once Upon an Oak</a>. Published online.
 </li>
 
 

--- a/java/ql/src/Security/CWE/CWE-113/ResponseSplitting.qhelp
+++ b/java/ql/src/Security/CWE/CWE-113/ResponseSplitting.qhelp
@@ -50,7 +50,7 @@ The second recommended approach in the example verifies the parameters before us
 
 <references>
 <li>
-InfosecWriters: <a href="http://www.infosecwriters.com/Papers/DCrab_HTTP_Response.pdf">HTTP response splitting</a>.
+SecLists.org: <a href="https://seclists.org/bugtraq/2005/Apr/187">HTTP response splitting</a>.
 </li>
 <li>
 OWASP:

--- a/javascript/ql/src/LanguageFeatures/ConditionalComments.qhelp
+++ b/javascript/ql/src/LanguageFeatures/ConditionalComments.qhelp
@@ -33,7 +33,7 @@ Note that conditional comments are no longer supported in Internet Explorer 11 S
 <references>
 
 
-<li>Internet Explorer Dev Center: <a href="http://msdn.microsoft.com/en-us/library/ie/8ka90k2e(v=vs.94).aspx">@cc_on Statement (JavaScript)</a>.</li>
+<li>Internet Explorer Dev Center: <a href="http://web.archive.org/web/20121103072038/http://msdn.microsoft.com/en-us/library/ie/8ka90k2e(v=vs.94).aspx">@cc_on Statement (JavaScript)</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/Metrics/FUseOfES6.qhelp
+++ b/javascript/ql/src/Metrics/FUseOfES6.qhelp
@@ -24,7 +24,7 @@ the migration.
 </recommendation>
 <references>
 <li>
-Ecma International: <a href="http://www.ecma-international.org/ecma-262/6.0">ECMAScript 2015 Language Specification</a>.
+Ecma International: <a href="https://262.ecma-international.org/6.0/">ECMAScript 2015 Language Specification</a>.
 </li>
 </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-295/RequestWithoutValidation.qhelp
+++ b/python/ql/src/Security/CWE-295/RequestWithoutValidation.qhelp
@@ -29,7 +29,7 @@ The example shows two unsafe calls to <a href="https://semmle.com">semmle.com</a
 
 <references>
 <li>
-Python requests documentation: <a href="http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification">SSL Cert Verification</a>.
+Python requests documentation: <a href="https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification">SSL Cert Verification</a>.
 </li>
 </references>
 </qhelp>


### PR DESCRIPTION
## TL;DR ⏱

This PR eliminates some broken HTTP links in *.qhelp files. The PR focuses specifically on `qhelp` files to ensure the changes are low-risk doc changes. 

## Context 🎨

This PR takes a (very) small step towards eliminating some of the http links throughout this repo, as mentioned in [this issue](https://github.com/github/codeql/issues/5163). Before we do a simple search and replace, I thought a good start would be to remove the broken (HTTP status 403 / 404) links.

## How to Review 👀

Just make sure the new links work, and are appropriate for the context in which they are being used. Best reviewed one commit at a time 🍻 🍕 

## How the links were found 🛠

### grep + sort to find all unique http links in `qhelp` files 🔬

```sh
grep -Eo "http://[a-zA-Z0-9./?=_-]*" -r --no-filename --include \*.qhelp . | sort -u > httpUrls.txt
```

### Quick / Hacky NodeJS script to dump the invalid URLs into a file 🧑‍💻

```js
import fetch, { AbortError } from 'node-fetch';
import fs from 'fs';

const AbortController = globalThis.AbortController;

async function findInvalidUrls() {
    var file = fs.readFileSync('./httpUrls.txt', 'utf8');
    var lines = file.split('\n');
    
    var errorUrlsFile = fs.createWriteStream('./invalidHttpUrls.txt');
    errorUrlsFile.on('error', function (err) {
        console.log(err);
    });

    for (var i = 0; i < lines.length; i++) {
        const controller = new AbortController();
        const timeout = setTimeout(() => {
            controller.abort();
        }, 10000);
        var line = lines[i];
        try {
            const response = await fetch(line, { signal: controller.signal });
            console.log(line + " " + response.status);
            if (response.status >= 400) {
                errorUrlsFile.write(`${line} | ${response.status}\n`);
            }
        } catch (e) {
            if (
                e.code === 'ERR_INVALID_URL' ||
                e.code === 'ENOTFOUND' ||
                e.code === 'ECONNREFUSED'
            ) {
                console.log('At index ' + i + ', ' + line + ' is not a valid url');
            } else if (e instanceof AbortError) {
                console.log('At index ' + i + ', ' + line + ' - Request aborted');
            }
        } finally {
            clearTimeout(timeout);
        }
    }
    errorUrlsFile.end();
}

findInvalidUrls();
```

### Script output 🚰
[invalidHttpUrls.txt](https://github.com/github/codeql/files/9339242/invalidHttpUrls.txt)

Some were false positives, but the rest were indeed bad URLs. I found the appropriate replacements and have made the changes.