### PR TITLE
Ruby: Recognise Rails render calls as HTTP responses

### DIFF
--- a/ruby/ql/lib/change-notes/2022-08-16-action-controller-response-body.md
+++ b/ruby/ql/lib/change-notes/2022-08-16-action-controller-response-body.md
@@ -1,5 +1,5 @@
 ---
 category: minorAnalysis
 ---
-* Calls to `render` in Rails controllers and views are now recognised as HTTP
+* Calls to `render` in Rails controllers and views are now recognized as HTTP
   response bodies.

--- a/ruby/ql/lib/change-notes/2022-08-16-action-controller-response-body.md
+++ b/ruby/ql/lib/change-notes/2022-08-16-action-controller-response-body.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Calls to `render` in Rails controllers and views are now recognised as HTTP
+  response bodies.

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -149,26 +149,26 @@ class CookiesSource extends HTTP::Server::RequestInputAccess::Range {
   override string getSourceType() { result = "ActionController::Metal#cookies" }
 }
 
-// A call to `cookies` from within a controller.
+/** A call to `cookies` from within a controller. */
 private class ActionControllerCookiesCall extends ActionControllerContextCall, CookiesCall { }
 
-// A call to `params` from within a controller.
+/** A call to `params` from within a controller. */
 private class ActionControllerParamsCall extends ActionControllerContextCall, ParamsCall { }
 
-// A call to `render` from within a controller.
+/** A call to `render` from within a controller. */
 private class ActionControllerRenderCall extends ActionControllerContextCall, RenderCall { }
 
-// A call to `render_to` from within a controller.
+/** A call to `render_to` from within a controller. */
 private class ActionControllerRenderToCall extends ActionControllerContextCall, RenderToCall { }
 
-// A call to `html_safe` from within a controller.
+/** A call to `html_safe` from within a controller. */
 private class ActionControllerHtmlSafeCall extends HtmlSafeCall {
   ActionControllerHtmlSafeCall() {
     this.getEnclosingModule() instanceof ActionControllerControllerClass
   }
 }
 
-// A call to `html_escape` from within a controller.
+/** A call to `html_escape` from within a controller. */
 private class ActionControllerHtmlEscapeCall extends HtmlEscapeCall {
   ActionControllerHtmlEscapeCall() {
     this.getEnclosingModule() instanceof ActionControllerControllerClass

--- a/ruby/ql/test/library-tests/frameworks/ActionController.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionController.expected
@@ -4,7 +4,7 @@ actionControllerControllerClasses
 | active_record/ActiveRecord.rb:66:1:94:3 | BazController |
 | active_record/ActiveRecord.rb:96:1:104:3 | AnnotatedController |
 | app/controllers/comments_controller.rb:1:1:7:3 | CommentsController |
-| app/controllers/foo/bars_controller.rb:3:1:39:3 | BarsController |
+| app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController |
 | app/controllers/photos_controller.rb:1:1:4:3 | PhotosController |
 | app/controllers/posts_controller.rb:1:1:10:3 | PostsController |
 | app/controllers/users/notifications_controller.rb:2:3:5:5 | NotificationsController |
@@ -28,6 +28,7 @@ actionControllerActionMethods
 | app/controllers/foo/bars_controller.rb:20:3:24:5 | show |
 | app/controllers/foo/bars_controller.rb:26:3:28:5 | go_back |
 | app/controllers/foo/bars_controller.rb:30:3:32:5 | go_back_2 |
+| app/controllers/foo/bars_controller.rb:34:3:39:5 | show_2 |
 | app/controllers/photos_controller.rb:2:3:3:5 | show |
 | app/controllers/posts_controller.rb:2:3:3:5 | index |
 | app/controllers/posts_controller.rb:5:3:6:5 | show |
@@ -103,8 +104,8 @@ redirectToCalls
 | app/controllers/foo/bars_controller.rb:31:5:31:56 | call to redirect_back |
 actionControllerHelperMethods
 getAssociatedControllerClasses
-| app/controllers/foo/bars_controller.rb:3:1:39:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
-| app/controllers/foo/bars_controller.rb:3:1:39:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |
+| app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
+| app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |
 controllerTemplateFiles
-| app/controllers/foo/bars_controller.rb:3:1:39:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
-| app/controllers/foo/bars_controller.rb:3:1:39:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |
+| app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
+| app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |

--- a/ruby/ql/test/library-tests/frameworks/ActionView.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionView.expected
@@ -14,9 +14,19 @@ rawCalls
 renderCalls
 | app/controllers/foo/bars_controller.rb:6:5:6:37 | call to render |
 | app/controllers/foo/bars_controller.rb:23:5:23:76 | call to render |
-| app/controllers/foo/bars_controller.rb:37:5:37:17 | call to render |
+| app/controllers/foo/bars_controller.rb:35:5:35:33 | call to render |
+| app/controllers/foo/bars_controller.rb:38:5:38:50 | call to render |
+| app/controllers/foo/bars_controller.rb:44:5:44:17 | call to render |
 | app/views/foo/bars/show.html.erb:31:5:31:89 | call to render |
 renderToCalls
 | app/controllers/foo/bars_controller.rb:15:16:15:97 | call to render_to_string |
+| app/controllers/foo/bars_controller.rb:36:12:36:67 | call to render_to_string |
 linkToCalls
 | app/views/foo/bars/show.html.erb:33:5:33:41 | call to link_to |
+httpResponses
+| app/controllers/foo/bars_controller.rb:15:16:15:97 | call to render_to_string | app/controllers/foo/bars_controller.rb:15:33:15:47 | "foo/bars/show" | text/html |
+| app/controllers/foo/bars_controller.rb:23:5:23:76 | call to render | app/controllers/foo/bars_controller.rb:23:12:23:26 | "foo/bars/show" | text/html |
+| app/controllers/foo/bars_controller.rb:35:5:35:33 | call to render | app/controllers/foo/bars_controller.rb:35:18:35:33 | call to [] | application/json |
+| app/controllers/foo/bars_controller.rb:36:12:36:67 | call to render_to_string | app/controllers/foo/bars_controller.rb:36:29:36:33 | @user | application/json |
+| app/controllers/foo/bars_controller.rb:38:5:38:50 | call to render | app/controllers/foo/bars_controller.rb:38:12:38:22 | call to backtrace | text/plain |
+| app/controllers/foo/bars_controller.rb:44:5:44:17 | call to render | app/controllers/foo/bars_controller.rb:44:12:44:17 | "show" | text/html |

--- a/ruby/ql/test/library-tests/frameworks/ActionView.ql
+++ b/ruby/ql/test/library-tests/frameworks/ActionView.ql
@@ -1,5 +1,7 @@
-import codeql.ruby.frameworks.ActionController
-import codeql.ruby.frameworks.ActionView
+private import codeql.ruby.frameworks.ActionController
+private import codeql.ruby.frameworks.ActionView
+private import codeql.ruby.Concepts
+private import codeql.ruby.DataFlow
 
 query predicate htmlSafeCalls(HtmlSafeCall c) { any() }
 
@@ -10,3 +12,7 @@ query predicate renderCalls(RenderCall c) { any() }
 query predicate renderToCalls(RenderToCall c) { any() }
 
 query predicate linkToCalls(LinkToCall c) { any() }
+
+query predicate httpResponses(HTTP::Server::HttpResponse r, DataFlow::Node body, string mimeType) {
+  r.getBody() = body and r.getMimetype() = mimeType
+}

--- a/ruby/ql/test/library-tests/frameworks/app/controllers/foo/bars_controller.rb
+++ b/ruby/ql/test/library-tests/frameworks/app/controllers/foo/bars_controller.rb
@@ -31,6 +31,13 @@ class BarsController < ApplicationController
     redirect_back fallback_location: { action: "index" }
   end
 
+  def show_2
+    render json: { some: "data" }
+    body = render_to_string @user, content_type: "application/json"
+  rescue => e
+    render e.backtrace, content_type: "text/plain"
+  end
+
   private
 
   def unreachable_action


### PR DESCRIPTION
What it says on the tin. We now recognise calls to `render`, `render_to_string` and `render_to_body` such as

```rb
def show
  render json: { some: "data" }
  render @user
  render html: "<p>hello</p>"
end
```

as instances of `HTTP::Server::HttpResponse`.

@nickrolfe hopefully this will be useful for you!