### PR TITLE
C#: Include both source code and hand-written summaries in data flow

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -105,15 +105,12 @@ class DataFlowSummarizedCallable instanceof FlowSummary::SummarizedCallable {
 private module Cached {
   /**
    * The following heuristic is used to rank when to use source code or when to use summaries for DataFlowCallables.
-   * 1. Use hand written summaries.
-   * 2. Use source code.
-   * 3. Use auto generated summaries.
+   * 1. Use hand written summaries or source code.
+   * 2. Use auto generated summaries.
    */
   cached
   newtype TDataFlowCallable =
-    TDotNetCallable(DotNet::Callable c) {
-      c.isUnboundDeclaration() and not c instanceof DataFlowSummarizedCallable
-    } or
+    TDotNetCallable(DotNet::Callable c) { c.isUnboundDeclaration() } or
     TSummarizedCallable(DataFlowSummarizedCallable sc)
 
   cached
@@ -370,7 +367,7 @@ class NonDelegateDataFlowCall extends DataFlowCall, TNonDelegateCall {
   override DataFlow::ExprNode getNode() { result.getControlFlowNode() = cfn }
 
   override DataFlowCallable getEnclosingCallable() {
-    result.getUnderlyingCallable() = cfn.getEnclosingCallable()
+    result.asCallable() = cfn.getEnclosingCallable()
   }
 
   override string toString() { result = cfn.toString() }
@@ -400,7 +397,7 @@ class ExplicitDelegateLikeDataFlowCall extends DelegateDataFlowCall, TExplicitDe
   override DataFlow::ExprNode getNode() { result.getControlFlowNode() = cfn }
 
   override DataFlowCallable getEnclosingCallable() {
-    result.getUnderlyingCallable() = cfn.getEnclosingCallable()
+    result.asCallable() = cfn.getEnclosingCallable()
   }
 
   override string toString() { result = cfn.toString() }
@@ -419,14 +416,14 @@ class TransitiveCapturedDataFlowCall extends DataFlowCall, TTransitiveCapturedCa
 
   TransitiveCapturedDataFlowCall() { this = TTransitiveCapturedCall(cfn, target) }
 
-  override DataFlowCallable getARuntimeTarget() { result.getUnderlyingCallable() = target }
+  override DataFlowCallable getARuntimeTarget() { result.asCallable() = target }
 
   override ControlFlow::Nodes::ElementNode getControlFlowNode() { result = cfn }
 
   override DataFlow::ExprNode getNode() { none() }
 
   override DataFlowCallable getEnclosingCallable() {
-    result.getUnderlyingCallable() = cfn.getEnclosingCallable()
+    result.asCallable() = cfn.getEnclosingCallable()
   }
 
   override string toString() { result = "[transitive] " + cfn.toString() }
@@ -450,7 +447,7 @@ class CilDataFlowCall extends DataFlowCall, TCilCall {
   override DataFlow::ExprNode getNode() { result.getExpr() = call }
 
   override DataFlowCallable getEnclosingCallable() {
-    result.getUnderlyingCallable() = call.getEnclosingCallable()
+    result.asCallable() = call.getEnclosingCallable()
   }
 
   override string toString() { result = call.toString() }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -65,9 +65,11 @@ abstract class NodeImpl extends Node {
 
 private class ExprNodeImpl extends ExprNode, NodeImpl {
   override DataFlowCallable getEnclosingCallableImpl() {
-    result.getUnderlyingCallable() = this.getExpr().(CIL::Expr).getEnclosingCallable()
-    or
-    result.getUnderlyingCallable() = this.getControlFlowNodeImpl().getEnclosingCallable()
+    result.asCallable() =
+      [
+        this.getExpr().(CIL::Expr).getEnclosingCallable().(DotNet::Callable),
+        this.getControlFlowNodeImpl().getEnclosingCallable()
+      ]
   }
 
   override DotNet::Type getTypeImpl() {
@@ -852,7 +854,7 @@ class SsaDefinitionNode extends NodeImpl, TSsaDefinitionNode {
   Ssa::Definition getDefinition() { result = def }
 
   override DataFlowCallable getEnclosingCallableImpl() {
-    result.getUnderlyingCallable() = def.getEnclosingCallable()
+    result.asCallable() = def.getEnclosingCallable()
   }
 
   override Type getTypeImpl() { result = def.getSourceVariable().getType() }
@@ -914,9 +916,7 @@ private module ParameterNodes {
       callable = c.asCallable() and pos.isThisParameter()
     }
 
-    override DataFlowCallable getEnclosingCallableImpl() {
-      result.getUnderlyingCallable() = callable
-    }
+    override DataFlowCallable getEnclosingCallableImpl() { result.asCallable() = callable }
 
     override Type getTypeImpl() { result = callable.getDeclaringType() }
 
@@ -963,7 +963,7 @@ private module ParameterNodes {
 
     override predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
       pos.isImplicitCapturedParameterPosition(def.getSourceVariable().getAssignable()) and
-      c.getUnderlyingCallable() = this.getEnclosingCallable()
+      c.asCallable() = this.getEnclosingCallable()
     }
   }
 
@@ -1078,7 +1078,7 @@ private module ArgumentNodes {
     }
 
     override DataFlowCallable getEnclosingCallableImpl() {
-      result.getUnderlyingCallable() = cfn.getEnclosingCallable()
+      result.asCallable() = cfn.getEnclosingCallable()
     }
 
     override Type getTypeImpl() { result = v.getType() }
@@ -1107,7 +1107,7 @@ private module ArgumentNodes {
     override ControlFlow::Node getControlFlowNodeImpl() { result = cfn }
 
     override DataFlowCallable getEnclosingCallableImpl() {
-      result.getUnderlyingCallable() = cfn.getEnclosingCallable()
+      result.asCallable() = cfn.getEnclosingCallable()
     }
 
     override Type getTypeImpl() { result = cfn.getElement().(Expr).getType() }
@@ -1146,7 +1146,7 @@ private module ArgumentNodes {
     }
 
     override DataFlowCallable getEnclosingCallableImpl() {
-      result.getUnderlyingCallable() = callCfn.getEnclosingCallable()
+      result.asCallable() = callCfn.getEnclosingCallable()
     }
 
     override Type getTypeImpl() { result = this.getParameter().getType() }
@@ -1227,7 +1227,7 @@ private module ReturnNodes {
     override NormalReturnKind getKind() { any() }
 
     override DataFlowCallable getEnclosingCallableImpl() {
-      result.getUnderlyingCallable() = yrs.getEnclosingCallable()
+      result.asCallable() = yrs.getEnclosingCallable()
     }
 
     override Type getTypeImpl() { result = yrs.getEnclosingCallable().getReturnType() }
@@ -1253,7 +1253,7 @@ private module ReturnNodes {
     override NormalReturnKind getKind() { any() }
 
     override DataFlowCallable getEnclosingCallableImpl() {
-      result.getUnderlyingCallable() = expr.getEnclosingCallable()
+      result.asCallable() = expr.getEnclosingCallable()
     }
 
     override Type getTypeImpl() { result = expr.getEnclosingCallable().getReturnType() }
@@ -1330,9 +1330,10 @@ private module ReturnNodes {
  * In this case we adjust it to instead be a return node.
  */
 private predicate summaryPostUpdateNodeIsOutOrRef(SummaryNode n, Parameter p) {
-  exists(ParameterNode pn |
+  exists(ParameterNodeImpl pn, DataFlowCallable c, ParameterPosition pos |
     FlowSummaryImpl::Private::summaryPostUpdateNode(n, pn) and
-    pn.getParameter() = p and
+    pn.isParameterOf(c, pos) and
+    p = c.getUnderlyingCallable().getParameter(pos.getPosition()) and
     p.isOutOrRef()
   )
 }
@@ -1903,7 +1904,7 @@ private module PostUpdateNodes {
     }
 
     override DataFlowCallable getEnclosingCallableImpl() {
-      result.getUnderlyingCallable() = cfn.getEnclosingCallable()
+      result.asCallable() = cfn.getEnclosingCallable()
     }
 
     override DotNet::Type getTypeImpl() { result = oc.getType() }
@@ -1923,7 +1924,7 @@ private module PostUpdateNodes {
     override ExprNode getPreUpdateNode() { cfn = result.getControlFlowNode() }
 
     override DataFlowCallable getEnclosingCallableImpl() {
-      result.getUnderlyingCallable() = cfn.getEnclosingCallable()
+      result.asCallable() = cfn.getEnclosingCallable()
     }
 
     override Type getTypeImpl() { result = cfn.getElement().(Expr).getType() }
@@ -2012,12 +2013,11 @@ class LambdaCallKind = Unit;
 /** Holds if `creation` is an expression that creates a delegate for `c`. */
 predicate lambdaCreation(ExprNode creation, LambdaCallKind kind, DataFlowCallable c) {
   exists(Expr e | e = creation.getExpr() |
-    c.getUnderlyingCallable() = e.(AnonymousFunctionExpr)
-    or
-    c.getUnderlyingCallable() = e.(CallableAccess).getTarget().getUnboundDeclaration()
-    or
-    c.getUnderlyingCallable() =
-      e.(AddressOfExpr).getOperand().(CallableAccess).getTarget().getUnboundDeclaration()
+    c.asCallable() =
+      [
+        e.(AnonymousFunctionExpr), e.(CallableAccess).getTarget().getUnboundDeclaration(),
+        e.(AddressOfExpr).getOperand().(CallableAccess).getTarget().getUnboundDeclaration()
+      ]
   ) and
   kind = TMkUnit()
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1333,7 +1333,7 @@ private predicate summaryPostUpdateNodeIsOutOrRef(SummaryNode n, Parameter p) {
   exists(ParameterNodeImpl pn, DataFlowCallable c, ParameterPosition pos |
     FlowSummaryImpl::Private::summaryPostUpdateNode(n, pn) and
     pn.isParameterOf(c, pos) and
-    p = c.getUnderlyingCallable().getParameter(pos.getPosition()) and
+    p = c.asSummarizedCallable().getParameter(pos.getPosition()) and
     p.isOutOrRef()
   )
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -41,7 +41,7 @@ class Node extends TNode {
 
   /** Gets the enclosing callable of this node. */
   final Callable getEnclosingCallable() {
-    result = this.(NodeImpl).getEnclosingCallableImpl().getUnderlyingCallable()
+    result = this.(NodeImpl).getEnclosingCallableImpl().asCallable()
   }
 
   /** Gets the control flow node corresponding to this node, if any. */
@@ -103,7 +103,7 @@ class ParameterNode extends Node instanceof ParameterNodeImpl {
   DotNet::Parameter getParameter() {
     exists(DataFlowCallable c, ParameterPosition ppos |
       super.isParameterOf(c, ppos) and
-      result = c.getUnderlyingCallable().getParameter(ppos.getPosition())
+      result = c.asCallable().getParameter(ppos.getPosition())
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
@@ -568,7 +568,7 @@ class DelegateLikeCall extends Call, DelegateLikeCall_ {
   final override Callable getARuntimeTarget() {
     exists(ExplicitDelegateLikeDataFlowCall call |
       this = call.getCall() and
-      result = viableCallableLambda(call, _).getUnderlyingCallable()
+      result = viableCallableLambda(call, _).asCallable()
     )
   }
 

--- a/csharp/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
@@ -112,7 +112,7 @@ string returnNodeAsOutput(DataFlowImplCommon::ReturnNodeExt node) {
  * Gets the enclosing callable of `ret`.
  */
 CS::Callable returnNodeEnclosingCallable(DataFlowImplCommon::ReturnNodeExt ret) {
-  result = DataFlowImplCommon::getNodeEnclosingCallable(ret).getUnderlyingCallable()
+  result = DataFlowImplCommon::getNodeEnclosingCallable(ret).asCallable()
 }
 
 /**


### PR DESCRIPTION
As discussed with @aschackmull offline, it makes sense to include source code also when there is a manually written flow summary, since there might be a source or a sink in the source code that was not modeled.