### PR TITLE
QL: support signature parameters in QL-for-QL

### DIFF
--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -44,7 +44,7 @@ jobs:
           CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
       - name: Check QL formatting
         run: |
-          find ql/ql "(" -name "*.ql" -or -name "*.qll" ")" -print0 | xargs -0 "${CODEQL}" query format --check-only
+          find ql/ql/src "(" -name "*.ql" -or -name "*.qll" ")" -print0 | xargs -0 "${CODEQL}" query format --check-only
         env:
           CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
       - name: Check QL compilation

--- a/ql/Cargo.lock
+++ b/ql/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ql"
 version = "0.19.0"
-source = "git+https://github.com/tree-sitter/tree-sitter-ql.git?rev=4b8078c7fdcce9d4ca06ce3cfec3a61e8c3f4555#4b8078c7fdcce9d4ca06ce3cfec3a61e8c3f4555"
+source = "git+https://github.com/tree-sitter/tree-sitter-ql.git?rev=d08db734f8dc52f6bc04db53a966603122bc6985#d08db734f8dc52f6bc04db53a966603122bc6985"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ql/extractor/Cargo.toml
+++ b/ql/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = ">= 0.20, < 0.21"
-tree-sitter-ql = { git = "https://github.com/tree-sitter/tree-sitter-ql.git", rev = "4b8078c7fdcce9d4ca06ce3cfec3a61e8c3f4555"}
+tree-sitter-ql = { git = "https://github.com/tree-sitter/tree-sitter-ql.git", rev = "d08db734f8dc52f6bc04db53a966603122bc6985"}
 tree-sitter-ql-dbscheme = { git = "https://github.com/erik-krogh/tree-sitter-ql-dbscheme.git", rev = "63e1344353f63931e88bfbc2faa2e78e1421b213"}
 tree-sitter-ql-yaml = {git = "https://github.com/erik-krogh/tree-sitter-ql.git", rev = "cf704bf3671e1ae148e173464fb65a4d2bbf5f99"}
 clap = "2.33"

--- a/ql/generator/Cargo.toml
+++ b/ql/generator/Cargo.toml
@@ -11,6 +11,6 @@ clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-tree-sitter-ql = { git = "https://github.com/tree-sitter/tree-sitter-ql.git", rev = "4b8078c7fdcce9d4ca06ce3cfec3a61e8c3f4555"}
+tree-sitter-ql = { git = "https://github.com/tree-sitter/tree-sitter-ql.git", rev = "d08db734f8dc52f6bc04db53a966603122bc6985"}
 tree-sitter-ql-dbscheme = { git = "https://github.com/erik-krogh/tree-sitter-ql-dbscheme.git", rev = "63e1344353f63931e88bfbc2faa2e78e1421b213"}
 tree-sitter-ql-yaml = {git = "https://github.com/erik-krogh/tree-sitter-ql.git", rev = "cf704bf3671e1ae148e173464fb65a4d2bbf5f99"}

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -743,7 +743,9 @@ class Module extends TModule, ModuleDeclaration {
   }
 
   /** Gets a ref to the module that this module implements. */
-  TypeExpr getImplements(int i) { toQL(result) = mod.getImplements(i).getTypeExpr() }
+  TypeRef getImplements(int i) {
+    exists(SignatureExpr sig | sig.toQL() = mod.getImplements(i) | result = sig.asType())
+  }
 
   /** Gets the module expression that this module is an alias for, if any. */
   ModuleExpr getAlias() { toQL(result) = mod.getAFieldOrChild().(QL::ModuleAliasBody).getChild() }

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2293,7 +2293,7 @@ class ModuleExpr extends TModuleExpr, TypeRef {
 
   /**
    * Gets the `i`th type argument if this module is a module instantiation.
-   * The result is either a `PredicateExpr` or a `TypeExpr`.
+   * The result is either a `PredicateExpr`, `TypeExpr`, or `ModuleExpr`.
    */
   SignatureExpr getArgument(int i) {
     result.toQL() = me.getAFieldOrChild().(QL::ModuleInstantiation).getChild(i)
@@ -2313,7 +2313,7 @@ class ModuleExpr extends TModuleExpr, TypeRef {
   }
 }
 
-/** A signature expression, either a `PredicateExpr` or a `TypeExpr`. */
+/** A signature expression, either a `PredicateExpr`, a `TypeExpr`, or a `ModuleExpr`. */
 class SignatureExpr extends TSignatureExpr, AstNode {
   QL::SignatureExpr sig;
 
@@ -2321,6 +2321,8 @@ class SignatureExpr extends TSignatureExpr, AstNode {
     toQL(this) = sig.getPredicate()
     or
     toQL(this) = sig.getTypeExpr()
+    or
+    toQL(this) = sig.getModExpr()
   }
 
   /** Gets the generated AST node that contains this signature expression. */
@@ -2329,8 +2331,8 @@ class SignatureExpr extends TSignatureExpr, AstNode {
   /** Gets this signature expression if it represents a predicate expression. */
   PredicateExpr asPredicate() { result = this }
 
-  /** Gets this signature expression if it represents a type expression. */
-  TypeExpr asType() { result = this }
+  /** Gets this signature expression if it represents a type expression (either a `TypeExpr` or a `ModuleExpr`). */
+  TypeRef asType() { result = this }
 }
 
 /** An argument to an annotation. */

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
@@ -88,7 +88,7 @@ class TTypeRef = TImport or TModuleExpr or TType;
 
 class TYamlNode = TYamlCommemt or TYamlEntry or TYamlKey or TYamlListitem or TYamlValue;
 
-class TSignatureExpr = TPredicateExpr or TType;
+class TSignatureExpr = TPredicateExpr or TType or TModuleExpr;
 
 class TComment = TQLDoc or TBlockComment or TLineComment;
 

--- a/ql/ql/src/codeql_ql/ast/internal/Module.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Module.qll
@@ -314,7 +314,7 @@ private predicate definesModule(
   )
   or
   // signature module in a paramertized module
-  exists(Module mod, SignatureExpr sig, TypeExpr ty, int i |
+  exists(Module mod, SignatureExpr sig, TypeRef ty, int i |
     mod = container.asModule() and
     mod.hasParameter(i, name, sig) and
     public = false and

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -1069,6 +1069,9 @@ module QL {
     /** Gets the name of the primary QL class for this element. */
     final override string getAPrimaryQlClass() { result = "SignatureExpr" }
 
+    /** Gets the node corresponding to the field `mod_expr`. */
+    final ModuleExpr getModExpr() { ql_signature_expr_mod_expr(this, result) }
+
     /** Gets the node corresponding to the field `predicate`. */
     final PredicateExpr getPredicate() { ql_signature_expr_predicate(this, result) }
 
@@ -1077,7 +1080,9 @@ module QL {
 
     /** Gets a field or child node of this node. */
     final override AstNode getAFieldOrChild() {
-      ql_signature_expr_predicate(this, result) or ql_signature_expr_type_expr(this, result)
+      ql_signature_expr_mod_expr(this, result) or
+      ql_signature_expr_predicate(this, result) or
+      ql_signature_expr_type_expr(this, result)
     }
   }
 

--- a/ql/ql/src/ql.dbscheme
+++ b/ql/ql/src/ql.dbscheme
@@ -737,6 +737,11 @@ ql_set_literal_def(
   unique int id: @ql_set_literal
 );
 
+ql_signature_expr_mod_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int mod_expr: @ql_module_expr ref
+);
+
 ql_signature_expr_predicate(
   unique int ql_signature_expr: @ql_signature_expr ref,
   unique int predicate: @ql_predicate_expr ref

--- a/ql/ql/test/callgraph/ParamSig.qll
+++ b/ql/ql/test/callgraph/ParamSig.qll
@@ -1,0 +1,19 @@
+signature class Foo;
+
+class FooImpl extends string {
+  FooImpl() { this = "foo" }
+}
+
+signature module ParamSig<Foo F> {
+  F getThing();
+}
+
+module ParamImpl implements ParamSig<FooImpl> {
+  FooImpl getThing() { any() }
+}
+
+module ParamMod<ParamSig<FooImpl> Impl> {
+  FooImpl getTheThing() { result = Impl::getThing() }
+}
+
+FooImpl foo() { result = ParamMod<ParamImpl>::getTheThing() }

--- a/ql/ql/test/callgraph/callgraph.expected
+++ b/ql/ql/test/callgraph/callgraph.expected
@@ -36,6 +36,9 @@ getTarget
 | ParamModules.qll:59:30:59:45 | PredicateCall | ParamModules.qll:37:7:37:14 | ClasslessPredicate getThing |
 | ParamModules.qll:59:30:59:53 | MemberCall | ParamModules.qll:46:14:46:18 | ClassPredicate myFoo |
 | ParamModules.qll:61:39:61:47 | MemberCall | ParamModules.qll:46:14:46:18 | ClassPredicate myFoo |
+| ParamSig.qll:16:36:16:51 | PredicateCall | ParamSig.qll:8:5:8:12 | ClasslessPredicate getThing |
+| ParamSig.qll:16:36:16:51 | PredicateCall | ParamSig.qll:12:11:12:18 | ClasslessPredicate getThing |
+| ParamSig.qll:19:26:19:59 | PredicateCall | ParamSig.qll:16:11:16:21 | ClasslessPredicate getTheThing |
 | packs/other/OtherThing.qll:5:3:5:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:11:1:13 | ClasslessPredicate foo |
 | packs/other/OtherThing.qll:6:3:6:8 | PredicateCall | packs/src/SrcThing.qll:8:11:8:13 | ClasslessPredicate bar |
 | packs/src/SrcThing.qll:4:3:4:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:11:1:13 | ClasslessPredicate foo |


### PR DESCRIPTION
See the test-case for an example.  

The syntax is not yet supported in the latest version of CodeQL, but that will happen soon. 
(See the backref).  

I don't quite like how the grammar is done, but I don't see a better way. 
I can't in the grammar always determine if something is a reference to a module, or to some other type.  
One solution would just be to combine it all into one big `TypeExpr`.  
But in some places we know that the reference cannot be a module, so I want to keep those grammar rules separate.   

In the QL side it all becomes a `TypeRef`, so it all ends up working, even though some references to modules might be parsed as a `TypeExpr` instead of a `ModuleExpr`.  

A review of https://github.com/tree-sitter/tree-sitter-ql/pull/18 would also be nice 🥺 