### PR TITLE
C++: Expose `PresentIRFunction` and override in `cpp/count-ir-inconsistencies`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
@@ -22,7 +22,7 @@ module InstructionConsistency {
     abstract Language::Location getLocation();
   }
 
-  private class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
+  class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
     private IRFunction irFunc;
 
     PresentIRFunction() { this = TPresentIRFunction(irFunc) }
@@ -37,6 +37,8 @@ module InstructionConsistency {
       result =
         min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
+
+    IRFunction getIRFunction() { result = irFunc }
   }
 
   private class MissingIRFunction extends OptionalIRFunction, TMissingIRFunction {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
@@ -22,7 +22,7 @@ module InstructionConsistency {
     abstract Language::Location getLocation();
   }
 
-  private class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
+  class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
     private IRFunction irFunc;
 
     PresentIRFunction() { this = TPresentIRFunction(irFunc) }
@@ -37,6 +37,8 @@ module InstructionConsistency {
       result =
         min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
+
+    IRFunction getIRFunction() { result = irFunc }
   }
 
   private class MissingIRFunction extends OptionalIRFunction, TMissingIRFunction {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -22,7 +22,7 @@ module InstructionConsistency {
     abstract Language::Location getLocation();
   }
 
-  private class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
+  class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
     private IRFunction irFunc;
 
     PresentIRFunction() { this = TPresentIRFunction(irFunc) }
@@ -37,6 +37,8 @@ module InstructionConsistency {
       result =
         min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
+
+    IRFunction getIRFunction() { result = irFunc }
   }
 
   private class MissingIRFunction extends OptionalIRFunction, TMissingIRFunction {

--- a/cpp/ql/src/Metrics/Internal/IRConsistency.ql
+++ b/cpp/ql/src/Metrics/Internal/IRConsistency.ql
@@ -10,6 +10,12 @@ import cpp
 import semmle.code.cpp.ir.implementation.aliased_ssa.IR
 import semmle.code.cpp.ir.implementation.aliased_ssa.IRConsistency as IRConsistency
 
+class PresentIRFunction extends IRConsistency::PresentIRFunction {
+  override string toString() {
+    result = min(string name | name = this.getIRFunction().getFunction().getQualifiedName() | name)
+  }
+}
+
 select count(Instruction i | IRConsistency::missingOperand(i, _, _, _) | i) as missingOperand,
   count(Instruction i | IRConsistency::unexpectedOperand(i, _, _, _) | i) as unexpectedOperand,
   count(Instruction i | IRConsistency::duplicateOperand(i, _, _, _) | i) as duplicateOperand,

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRConsistency.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRConsistency.qll
@@ -22,7 +22,7 @@ module InstructionConsistency {
     abstract Language::Location getLocation();
   }
 
-  private class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
+  class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
     private IRFunction irFunc;
 
     PresentIRFunction() { this = TPresentIRFunction(irFunc) }
@@ -37,6 +37,8 @@ module InstructionConsistency {
       result =
         min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
+
+    IRFunction getIRFunction() { result = irFunc }
   }
 
   private class MissingIRFunction extends OptionalIRFunction, TMissingIRFunction {

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -22,7 +22,7 @@ module InstructionConsistency {
     abstract Language::Location getLocation();
   }
 
-  private class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
+  class PresentIRFunction extends OptionalIRFunction, TPresentIRFunction {
     private IRFunction irFunc;
 
     PresentIRFunction() { this = TPresentIRFunction(irFunc) }
@@ -37,6 +37,8 @@ module InstructionConsistency {
       result =
         min(Language::Location loc | loc = irFunc.getLocation() | loc order by loc.toString())
     }
+
+    IRFunction getIRFunction() { result = irFunc }
   }
 
   private class MissingIRFunction extends OptionalIRFunction, TMissingIRFunction {


### PR DESCRIPTION
The `toString` implementtion that `PresentIRFunction` uses may result in very long strings that may crash the evaluator. Overriding allows is to limit the string size and still suffices when just counting the number of inconsistencies.