### PR TITLE
Kotlin: Refactor TypeResults

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -848,7 +848,7 @@ open class KotlinFileExtractor(
                     paramTypes
                 }
 
-                val paramsSignature = allParamTypes.joinToString(separator = ",", prefix = "(", postfix = ")") { it.javaResult.signature!! }
+                val paramsSignature = allParamTypes.joinToString(separator = ",", prefix = "(", postfix = ")") { it.javaResult.signature }
 
                 val adjustedReturnType = addJavaLoweringWildcards(getAdjustedReturnType(f), false, (javaCallable as? JavaMethod)?.returnType)
                 val substReturnType = typeSubstitution?.let { it(adjustedReturnType, TypeContext.RETURN, pluginContext) } ?: adjustedReturnType
@@ -3866,7 +3866,7 @@ open class KotlinFileExtractor(
             Pair(paramId, paramType)
         }
 
-        val paramsSignature = parameters.joinToString(separator = ",", prefix = "(", postfix = ")") { it.second.javaResult.signature!! }
+        val paramsSignature = parameters.joinToString(separator = ",", prefix = "(", postfix = ")") { it.second.javaResult.signature }
 
         val rt = useType(returnType, TypeContext.RETURN)
         tw.writeMethods(methodId, name, "$name$paramsSignature", rt.javaResult.id, parentId, methodId)
@@ -4041,7 +4041,7 @@ open class KotlinFileExtractor(
     /**
      * Extracts a single wildcard type access expression with no enclosing callable and statement.
      */
-    private fun extractWildcardTypeAccess(type: TypeResults, location: Label<out DbLocation>, parent: Label<out DbExprparent>, idx: Int): Label<out DbExpr> {
+    private fun extractWildcardTypeAccess(type: TypeResultsWithoutSignatures, location: Label<out DbLocation>, parent: Label<out DbExprparent>, idx: Int): Label<out DbExpr> {
         val id = tw.getFreshIdLabel<DbWildcardtypeaccess>()
         tw.writeExprs_wildcardtypeaccess(id, type.javaResult.id, parent, idx)
         tw.writeExprsKotlinType(id, type.kotlinResult.id)
@@ -4079,7 +4079,7 @@ open class KotlinFileExtractor(
      * No enclosing callable and statement is extracted, this is useful for type access extraction in field declarations.
      */
     private fun extractWildcardTypeAccessRecursive(t: IrTypeArgument, location: Label<out DbLocation>, parent: Label<out DbExprparent>, idx: Int) {
-        val typeLabels by lazy { TypeResults(getTypeArgumentLabel(t), TypeResult(fakeKotlinType(), "TODO", "TODO")) }
+        val typeLabels by lazy { TypeResultsWithoutSignatures(getTypeArgumentLabel(t), TypeResultWithoutSignature(fakeKotlinType(), Unit, "TODO")) }
         when (t) {
             is IrStarProjection -> extractWildcardTypeAccess(typeLabels, location, parent, idx)
             is IrTypeProjection -> when(t.variance) {

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -1357,7 +1357,7 @@ open class KotlinUsesExtractor(
             return useAnonymousClass(c).javaResult.id.cast<DbClass>()
         }
 
-        // For source classes, the label doesn't include and type arguments
+        // For source classes, the label doesn't include any type arguments
         val classTypeResult = addClassLabel(c, listOf())
         return classTypeResult.id
     }

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -290,11 +290,7 @@ open class KotlinUsesExtractor(
                 f.valueParameters
             }
 
-            val paramSigs = parameters.map { useType(erase(it.type)).javaResult.signature }.requireNoNullsOrNull()
-            if (paramSigs == null) {
-                logger.warn("Null signature for a parameter of ${f.name}")
-                return
-            }
+            val paramSigs = parameters.map { useType(erase(it.type)).javaResult.signature }
             val signature = paramSigs.joinToString(separator = ",", prefix = "(", postfix = ")")
             dependencyCollector?.addDependency(f, signature)
             externalClassExtractor.extractLater(f, signature)

--- a/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
+++ b/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
@@ -1,7 +1,6 @@
 package com.github.codeql
 
 import com.github.codeql.KotlinUsesExtractor.LocallyVisibleFunctionLabels
-import com.github.codeql.KotlinUsesExtractor.TypeResults
 import com.github.codeql.utils.versions.FileEntry
 import java.io.BufferedWriter
 import java.io.File

--- a/java/kotlin-extractor/src/main/kotlin/utils/TypeResults.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/TypeResults.kt
@@ -1,0 +1,30 @@
+package com.github.codeql
+
+/**
+ * A triple of a type's database label, its signature for use in callable signatures, and its short name for use
+ * in all tables that provide a user-facing type name.
+ *
+ * `signature` is a Java primitive name (e.g. "int"), a fully-qualified class name ("package.OuterClass.InnerClass"),
+ * or an array ("componentSignature[]")
+ * Type variables have the signature of their upper bound.
+ * Type arguments and anonymous types do not have a signature.
+ *
+ * `shortName` is a Java primitive name (e.g. "int"), a class short name with Java-style type arguments ("InnerClass<E>" or
+ * "OuterClass<ConcreteArgument>" or "OtherClass<? extends Bound>") or an array ("componentShortName[]").
+ */
+data class TypeResultGeneric<SignatureType,out LabelType>(val id: Label<out LabelType>, val signature: SignatureType, val shortName: String) {
+    fun <U> cast(): TypeResult<U> {
+        @Suppress("UNCHECKED_CAST")
+        return this as TypeResult<U>
+    }
+}
+data class TypeResultsGeneric<SignatureType>(val javaResult: TypeResultGeneric<SignatureType,DbType>, val kotlinResult: TypeResultGeneric<SignatureType,DbKt_type>)
+
+typealias TypeResult<T> = TypeResultGeneric<String,T>
+typealias TypeResultWithoutSignature<T> = TypeResultGeneric<Unit,T>
+typealias TypeResults = TypeResultsGeneric<String>
+typealias TypeResultsWithoutSignatures = TypeResultsGeneric<Unit>
+
+fun <T> TypeResult<T>.forgetSignature(): TypeResultWithoutSignature<T> {
+    return TypeResultWithoutSignature(this.id, Unit, this.shortName)
+}


### PR DESCRIPTION
We statically know when we expect to have no signature, so now we tell the type system what we know, rather than having signature always be nullable.