### PR TITLE
rename all occurrences of XML to Xml

### DIFF
--- a/cpp/ql/lib/change-notes/2022-08-22-xml-rename.md
+++ b/cpp/ql/lib/change-notes/2022-08-22-xml-rename.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Classes/predicates that had upper-case acronym XML in their name have been renamed to Xml to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/cpp/ql/lib/semmle/code/cpp/XML.qll
+++ b/cpp/ql/lib/semmle/code/cpp/XML.qll
@@ -36,12 +36,12 @@ class XmlLocatable extends @xmllocatable, TXmlLocatable {
 deprecated class XMLLocatable = XmlLocatable;
 
 /**
- * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
+ * An `XmlParent` is either an `XmlElement` or an `XmlFile`,
  * both of which can contain other elements.
  */
 class XmlParent extends @xmlparent {
   XmlParent() {
-    // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
+    // explicitly restrict `this` to be either an `XmlElement` or an `XmlFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
   }

--- a/cpp/ql/lib/semmle/code/cpp/XML.qll
+++ b/cpp/ql/lib/semmle/code/cpp/XML.qll
@@ -132,7 +132,7 @@ class XmlFile extends XmlParent, File {
   XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
-  XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
+  XmlDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
 /** DEPRECATED: Alias for XmlFile */
@@ -149,7 +149,7 @@ deprecated class XMLFile = XmlFile;
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XmlLocatable, @xmldtd {
+class XmlDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -173,6 +173,9 @@ class XMLDTD extends XmlLocatable, @xmldtd {
     result = this.getRoot() + " SYSTEM '" + this.getSystemId() + "'"
   }
 }
+
+/** DEPRECATED: Alias for XmlDTD */
+deprecated class XMLDTD = XmlDTD;
 
 /**
  * An XML element in an XML file.

--- a/cpp/ql/lib/semmle/code/cpp/XML.qll
+++ b/cpp/ql/lib/semmle/code/cpp/XML.qll
@@ -8,7 +8,7 @@ private class TXmlLocatable =
   @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
-class XMLLocatable extends @xmllocatable, TXmlLocatable {
+class XmlLocatable extends @xmllocatable, TXmlLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -32,12 +32,15 @@ class XMLLocatable extends @xmllocatable, TXmlLocatable {
   string toString() { none() } // overridden in subclasses
 }
 
+/** DEPRECATED: Alias for XmlLocatable */
+deprecated class XMLLocatable = XmlLocatable;
+
 /**
  * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
  * both of which can contain other elements.
  */
-class XMLParent extends @xmlparent {
-  XMLParent() {
+class XmlParent extends @xmlparent {
+  XmlParent() {
     // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
@@ -50,28 +53,28 @@ class XMLParent extends @xmlparent {
   string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
-  XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }
+  XmlFile getFile() { result = this or xmlElements(this, _, _, _, result) }
 
   /** Gets the child element at a specified index of this XML parent. */
-  XMLElement getChild(int index) { xmlElements(result, _, this, index, _) }
+  XmlElement getChild(int index) { xmlElements(result, _, this, index, _) }
 
   /** Gets a child element of this XML parent. */
-  XMLElement getAChild() { xmlElements(result, _, this, _, _) }
+  XmlElement getAChild() { xmlElements(result, _, this, _, _) }
 
   /** Gets a child element of this XML parent with the given `name`. */
-  XMLElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
+  XmlElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
 
   /** Gets a comment that is a child of this XML parent. */
-  XMLComment getAComment() { xmlComments(result, _, this, _) }
+  XmlComment getAComment() { xmlComments(result, _, this, _) }
 
   /** Gets a character sequence that is a child of this XML parent. */
-  XMLCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
+  XmlCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
 
-  /** Gets the depth in the tree. (Overridden in XMLElement.) */
+  /** Gets the depth in the tree. (Overridden in XmlElement.) */
   int getDepth() { result = 0 }
 
   /** Gets the number of child XML elements of this XML parent. */
-  int getNumberOfChildren() { result = count(XMLElement e | xmlElements(e, _, this, _, _)) }
+  int getNumberOfChildren() { result = count(XmlElement e | xmlElements(e, _, this, _, _)) }
 
   /** Gets the number of places in the body of this XML parent where text occurs. */
   int getNumberOfCharacterSets() { result = count(int pos | xmlChars(_, _, this, pos, _, _)) }
@@ -92,9 +95,12 @@ class XMLParent extends @xmlparent {
   string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlParent */
+deprecated class XMLParent = XmlParent;
+
 /** An XML file. */
-class XMLFile extends XMLParent, File {
-  XMLFile() { xmlEncoding(this, _) }
+class XmlFile extends XmlParent, File {
+  XmlFile() { xmlEncoding(this, _) }
 
   /** Gets a printable representation of this XML file. */
   override string toString() { result = this.getName() }
@@ -120,14 +126,17 @@ class XMLFile extends XMLParent, File {
   string getEncoding() { xmlEncoding(this, result) }
 
   /** Gets the XML file itself. */
-  override XMLFile getFile() { result = this }
+  override XmlFile getFile() { result = this }
 
   /** Gets a top-most element in an XML file. */
-  XMLElement getARootElement() { result = this.getAChild() }
+  XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
+
+/** DEPRECATED: Alias for XmlFile */
+deprecated class XMLFile = XmlFile;
 
 /**
  * An XML document type definition (DTD).
@@ -140,7 +149,7 @@ class XMLFile extends XMLParent, File {
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XMLLocatable, @xmldtd {
+class XMLDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -154,7 +163,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
   predicate isPublic() { not xmlDTDs(this, _, "", _, _) }
 
   /** Gets the parent of this DTD. */
-  XMLParent getParent() { xmlDTDs(this, _, _, _, result) }
+  XmlParent getParent() { xmlDTDs(this, _, _, _, result) }
 
   override string toString() {
     this.isPublic() and
@@ -176,7 +185,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
  * </manifest>
  * ```
  */
-class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
+class XmlElement extends @xmlelement, XmlParent, XmlLocatable {
   /** Holds if this XML element has the given `name`. */
   predicate hasName(string name) { name = this.getName() }
 
@@ -184,10 +193,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string getName() { xmlElements(this, result, _, _, _) }
 
   /** Gets the XML file in which this XML element occurs. */
-  override XMLFile getFile() { xmlElements(this, _, _, _, result) }
+  override XmlFile getFile() { xmlElements(this, _, _, _, result) }
 
   /** Gets the parent of this XML element. */
-  XMLParent getParent() { xmlElements(this, _, result, _, _) }
+  XmlParent getParent() { xmlElements(this, _, result, _, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getIndex() { xmlElements(this, _, _, result, _) }
@@ -196,7 +205,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this XML element, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getElementPositionIndex() { xmlElements(this, _, _, result, _) }
@@ -205,10 +214,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override int getDepth() { result = this.getParent().getDepth() + 1 }
 
   /** Gets an XML attribute of this XML element. */
-  XMLAttribute getAnAttribute() { result.getElement() = this }
+  XmlAttribute getAnAttribute() { result.getElement() = this }
 
   /** Gets the attribute with the specified `name`, if any. */
-  XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
+  XmlAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
   predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
@@ -220,6 +229,9 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlElement */
+deprecated class XMLElement = XmlElement;
+
 /**
  * An attribute that occurs inside an XML element.
  *
@@ -230,18 +242,18 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
  * android:versionCode="1"
  * ```
  */
-class XMLAttribute extends @xmlattribute, XMLLocatable {
+class XmlAttribute extends @xmlattribute, XmlLocatable {
   /** Gets the name of this attribute. */
   string getName() { xmlAttrs(this, _, result, _, _, _) }
 
   /** Gets the XML element to which this attribute belongs. */
-  XMLElement getElement() { xmlAttrs(this, result, _, _, _, _) }
+  XmlElement getElement() { xmlAttrs(this, result, _, _, _, _) }
 
   /** Holds if this attribute has a namespace. */
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this attribute, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the value of this attribute. */
   string getValue() { xmlAttrs(this, _, _, result, _, _) }
@@ -249,6 +261,9 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
   /** Gets a printable representation of this XML attribute. */
   override string toString() { result = this.getName() + "=" + this.getValue() }
 }
+
+/** DEPRECATED: Alias for XmlAttribute */
+deprecated class XMLAttribute = XmlAttribute;
 
 /**
  * A namespace used in an XML file.
@@ -259,7 +274,7 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
  * xmlns:android="http://schemas.android.com/apk/res/android"
  * ```
  */
-class XMLNamespace extends XMLLocatable, @xmlnamespace {
+class XmlNamespace extends XmlLocatable, @xmlnamespace {
   /** Gets the prefix of this namespace. */
   string getPrefix() { xmlNs(this, result, _, _) }
 
@@ -276,6 +291,9 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
   }
 }
 
+/** DEPRECATED: Alias for XmlNamespace */
+deprecated class XMLNamespace = XmlNamespace;
+
 /**
  * A comment in an XML file.
  *
@@ -285,16 +303,19 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
  * <!-- This is a comment. -->
  * ```
  */
-class XMLComment extends @xmlcomment, XMLLocatable {
+class XmlComment extends @xmlcomment, XmlLocatable {
   /** Gets the text content of this XML comment. */
   string getText() { xmlComments(this, result, _, _) }
 
   /** Gets the parent of this XML comment. */
-  XMLParent getParent() { xmlComments(this, _, result, _) }
+  XmlParent getParent() { xmlComments(this, _, result, _) }
 
   /** Gets a printable representation of this XML comment. */
   override string toString() { result = this.getText() }
 }
+
+/** DEPRECATED: Alias for XmlComment */
+deprecated class XMLComment = XmlComment;
 
 /**
  * A sequence of characters that occurs between opening and
@@ -306,12 +327,12 @@ class XMLComment extends @xmlcomment, XMLLocatable {
  * <content>This is a sequence of characters.</content>
  * ```
  */
-class XMLCharacters extends @xmlcharacters, XMLLocatable {
+class XmlCharacters extends @xmlcharacters, XmlLocatable {
   /** Gets the content of this character sequence. */
   string getCharacters() { xmlChars(this, result, _, _, _, _) }
 
   /** Gets the parent of this character sequence. */
-  XMLParent getParent() { xmlChars(this, _, result, _, _, _) }
+  XmlParent getParent() { xmlChars(this, _, result, _, _, _) }
 
   /** Holds if this character sequence is CDATA. */
   predicate isCDATA() { xmlChars(this, _, _, _, 1, _) }
@@ -319,3 +340,6 @@ class XMLCharacters extends @xmlcharacters, XMLLocatable {
   /** Gets a printable representation of this XML character sequence. */
   override string toString() { result = this.getCharacters() }
 }
+
+/** DEPRECATED: Alias for XmlCharacters */
+deprecated class XMLCharacters = XmlCharacters;

--- a/cpp/ql/test/library-tests/files/Files.ql
+++ b/cpp/ql/test/library-tests/files/Files.ql
@@ -7,7 +7,7 @@ string describe(File f) {
   f.compiledAsCpp() and
   result = "C++"
   or
-  f instanceof XMLParent and
+  f instanceof XmlParent and
   result = "XMLParent" // regression tests a bug in the characteristic predicate of XMLParent
 }
 

--- a/csharp/ql/lib/change-notes/2022-08-22-xml-rename.md
+++ b/csharp/ql/lib/change-notes/2022-08-22-xml-rename.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Classes/predicates that had upper-case acronym XML in their name have been renamed to Xml to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/csharp/ql/lib/semmle/code/asp/WebConfig.qll
+++ b/csharp/ql/lib/semmle/code/asp/WebConfig.qll
@@ -7,7 +7,7 @@ import csharp
 /**
  * A `Web.config` file.
  */
-class WebConfigXml extends XMLFile {
+class WebConfigXml extends XmlFile {
   WebConfigXml() { this.getName().matches("%Web.config") }
 }
 
@@ -15,7 +15,7 @@ class WebConfigXml extends XMLFile {
 deprecated class WebConfigXML = WebConfigXml;
 
 /** A `<configuration>` tag in an ASP.NET configuration file. */
-class ConfigurationXmlElement extends XMLElement {
+class ConfigurationXmlElement extends XmlElement {
   ConfigurationXmlElement() { this.getName().toLowerCase() = "configuration" }
 }
 
@@ -23,7 +23,7 @@ class ConfigurationXmlElement extends XMLElement {
 deprecated class ConfigurationXMLElement = ConfigurationXmlElement;
 
 /** A `<location>` tag in an ASP.NET configuration file. */
-class LocationXmlElement extends XMLElement {
+class LocationXmlElement extends XmlElement {
   LocationXmlElement() {
     this.getParent() instanceof ConfigurationXmlElement and
     this.getName().toLowerCase() = "location"
@@ -34,7 +34,7 @@ class LocationXmlElement extends XMLElement {
 deprecated class LocationXMLElement = LocationXmlElement;
 
 /** A `<system.web>` tag in an ASP.NET configuration file. */
-class SystemWebXmlElement extends XMLElement {
+class SystemWebXmlElement extends XmlElement {
   SystemWebXmlElement() {
     (
       this.getParent() instanceof ConfigurationXmlElement
@@ -49,7 +49,7 @@ class SystemWebXmlElement extends XMLElement {
 deprecated class SystemWebXMLElement = SystemWebXmlElement;
 
 /** A `<system.webServer>` tag in an ASP.NET configuration file. */
-class SystemWebServerXmlElement extends XMLElement {
+class SystemWebServerXmlElement extends XmlElement {
   SystemWebServerXmlElement() {
     (
       this.getParent() instanceof ConfigurationXmlElement
@@ -64,7 +64,7 @@ class SystemWebServerXmlElement extends XMLElement {
 deprecated class SystemWebServerXMLElement = SystemWebServerXmlElement;
 
 /** A `<customErrors>` tag in an ASP.NET configuration file. */
-class CustomErrorsXmlElement extends XMLElement {
+class CustomErrorsXmlElement extends XmlElement {
   CustomErrorsXmlElement() {
     this.getParent() instanceof SystemWebXmlElement and
     this.getName().toLowerCase() = "customerrors"
@@ -75,7 +75,7 @@ class CustomErrorsXmlElement extends XMLElement {
 deprecated class CustomErrorsXMLElement = CustomErrorsXmlElement;
 
 /** A `<httpRuntime>` tag in an ASP.NET configuration file. */
-class HttpRuntimeXmlElement extends XMLElement {
+class HttpRuntimeXmlElement extends XmlElement {
   HttpRuntimeXmlElement() {
     this.getParent() instanceof SystemWebXmlElement and
     this.getName().toLowerCase() = "httpruntime"
@@ -86,7 +86,7 @@ class HttpRuntimeXmlElement extends XMLElement {
 deprecated class HttpRuntimeXMLElement = HttpRuntimeXmlElement;
 
 /** A `<forms>` tag under `<system.web><authentication>` in an ASP.NET configuration file. */
-class FormsElement extends XMLElement {
+class FormsElement extends XmlElement {
   FormsElement() {
     this = any(SystemWebXmlElement sw).getAChild("authentication").getAChild("forms")
   }
@@ -105,7 +105,7 @@ class FormsElement extends XMLElement {
 }
 
 /** A `<httpCookies>` tag in an ASP.NET configuration file. */
-class HttpCookiesElement extends XMLElement {
+class HttpCookiesElement extends XmlElement {
   HttpCookiesElement() { this = any(SystemWebXmlElement sw).getAChild("httpCookies") }
 
   /**

--- a/csharp/ql/lib/semmle/code/csharp/XML.qll
+++ b/csharp/ql/lib/semmle/code/csharp/XML.qll
@@ -36,12 +36,12 @@ class XmlLocatable extends @xmllocatable, TXmlLocatable {
 deprecated class XMLLocatable = XmlLocatable;
 
 /**
- * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
+ * An `XmlParent` is either an `XmlElement` or an `XmlFile`,
  * both of which can contain other elements.
  */
 class XmlParent extends @xmlparent {
   XmlParent() {
-    // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
+    // explicitly restrict `this` to be either an `XmlElement` or an `XmlFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
   }

--- a/csharp/ql/lib/semmle/code/csharp/XML.qll
+++ b/csharp/ql/lib/semmle/code/csharp/XML.qll
@@ -132,7 +132,7 @@ class XmlFile extends XmlParent, File {
   XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
-  XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
+  XmlDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
 /** DEPRECATED: Alias for XmlFile */
@@ -149,7 +149,7 @@ deprecated class XMLFile = XmlFile;
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XmlLocatable, @xmldtd {
+class XmlDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -173,6 +173,9 @@ class XMLDTD extends XmlLocatable, @xmldtd {
     result = this.getRoot() + " SYSTEM '" + this.getSystemId() + "'"
   }
 }
+
+/** DEPRECATED: Alias for XmlDTD */
+deprecated class XMLDTD = XmlDTD;
 
 /**
  * An XML element in an XML file.

--- a/csharp/ql/lib/semmle/code/csharp/XML.qll
+++ b/csharp/ql/lib/semmle/code/csharp/XML.qll
@@ -8,7 +8,7 @@ private class TXmlLocatable =
   @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
-class XMLLocatable extends @xmllocatable, TXmlLocatable {
+class XmlLocatable extends @xmllocatable, TXmlLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -32,12 +32,15 @@ class XMLLocatable extends @xmllocatable, TXmlLocatable {
   string toString() { none() } // overridden in subclasses
 }
 
+/** DEPRECATED: Alias for XmlLocatable */
+deprecated class XMLLocatable = XmlLocatable;
+
 /**
  * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
  * both of which can contain other elements.
  */
-class XMLParent extends @xmlparent {
-  XMLParent() {
+class XmlParent extends @xmlparent {
+  XmlParent() {
     // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
@@ -50,28 +53,28 @@ class XMLParent extends @xmlparent {
   string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
-  XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }
+  XmlFile getFile() { result = this or xmlElements(this, _, _, _, result) }
 
   /** Gets the child element at a specified index of this XML parent. */
-  XMLElement getChild(int index) { xmlElements(result, _, this, index, _) }
+  XmlElement getChild(int index) { xmlElements(result, _, this, index, _) }
 
   /** Gets a child element of this XML parent. */
-  XMLElement getAChild() { xmlElements(result, _, this, _, _) }
+  XmlElement getAChild() { xmlElements(result, _, this, _, _) }
 
   /** Gets a child element of this XML parent with the given `name`. */
-  XMLElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
+  XmlElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
 
   /** Gets a comment that is a child of this XML parent. */
-  XMLComment getAComment() { xmlComments(result, _, this, _) }
+  XmlComment getAComment() { xmlComments(result, _, this, _) }
 
   /** Gets a character sequence that is a child of this XML parent. */
-  XMLCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
+  XmlCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
 
-  /** Gets the depth in the tree. (Overridden in XMLElement.) */
+  /** Gets the depth in the tree. (Overridden in XmlElement.) */
   int getDepth() { result = 0 }
 
   /** Gets the number of child XML elements of this XML parent. */
-  int getNumberOfChildren() { result = count(XMLElement e | xmlElements(e, _, this, _, _)) }
+  int getNumberOfChildren() { result = count(XmlElement e | xmlElements(e, _, this, _, _)) }
 
   /** Gets the number of places in the body of this XML parent where text occurs. */
   int getNumberOfCharacterSets() { result = count(int pos | xmlChars(_, _, this, pos, _, _)) }
@@ -92,9 +95,12 @@ class XMLParent extends @xmlparent {
   string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlParent */
+deprecated class XMLParent = XmlParent;
+
 /** An XML file. */
-class XMLFile extends XMLParent, File {
-  XMLFile() { xmlEncoding(this, _) }
+class XmlFile extends XmlParent, File {
+  XmlFile() { xmlEncoding(this, _) }
 
   /** Gets a printable representation of this XML file. */
   override string toString() { result = this.getName() }
@@ -120,14 +126,17 @@ class XMLFile extends XMLParent, File {
   string getEncoding() { xmlEncoding(this, result) }
 
   /** Gets the XML file itself. */
-  override XMLFile getFile() { result = this }
+  override XmlFile getFile() { result = this }
 
   /** Gets a top-most element in an XML file. */
-  XMLElement getARootElement() { result = this.getAChild() }
+  XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
+
+/** DEPRECATED: Alias for XmlFile */
+deprecated class XMLFile = XmlFile;
 
 /**
  * An XML document type definition (DTD).
@@ -140,7 +149,7 @@ class XMLFile extends XMLParent, File {
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XMLLocatable, @xmldtd {
+class XMLDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -154,7 +163,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
   predicate isPublic() { not xmlDTDs(this, _, "", _, _) }
 
   /** Gets the parent of this DTD. */
-  XMLParent getParent() { xmlDTDs(this, _, _, _, result) }
+  XmlParent getParent() { xmlDTDs(this, _, _, _, result) }
 
   override string toString() {
     this.isPublic() and
@@ -176,7 +185,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
  * </manifest>
  * ```
  */
-class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
+class XmlElement extends @xmlelement, XmlParent, XmlLocatable {
   /** Holds if this XML element has the given `name`. */
   predicate hasName(string name) { name = this.getName() }
 
@@ -184,10 +193,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string getName() { xmlElements(this, result, _, _, _) }
 
   /** Gets the XML file in which this XML element occurs. */
-  override XMLFile getFile() { xmlElements(this, _, _, _, result) }
+  override XmlFile getFile() { xmlElements(this, _, _, _, result) }
 
   /** Gets the parent of this XML element. */
-  XMLParent getParent() { xmlElements(this, _, result, _, _) }
+  XmlParent getParent() { xmlElements(this, _, result, _, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getIndex() { xmlElements(this, _, _, result, _) }
@@ -196,7 +205,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this XML element, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getElementPositionIndex() { xmlElements(this, _, _, result, _) }
@@ -205,10 +214,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override int getDepth() { result = this.getParent().getDepth() + 1 }
 
   /** Gets an XML attribute of this XML element. */
-  XMLAttribute getAnAttribute() { result.getElement() = this }
+  XmlAttribute getAnAttribute() { result.getElement() = this }
 
   /** Gets the attribute with the specified `name`, if any. */
-  XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
+  XmlAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
   predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
@@ -220,6 +229,9 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlElement */
+deprecated class XMLElement = XmlElement;
+
 /**
  * An attribute that occurs inside an XML element.
  *
@@ -230,18 +242,18 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
  * android:versionCode="1"
  * ```
  */
-class XMLAttribute extends @xmlattribute, XMLLocatable {
+class XmlAttribute extends @xmlattribute, XmlLocatable {
   /** Gets the name of this attribute. */
   string getName() { xmlAttrs(this, _, result, _, _, _) }
 
   /** Gets the XML element to which this attribute belongs. */
-  XMLElement getElement() { xmlAttrs(this, result, _, _, _, _) }
+  XmlElement getElement() { xmlAttrs(this, result, _, _, _, _) }
 
   /** Holds if this attribute has a namespace. */
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this attribute, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the value of this attribute. */
   string getValue() { xmlAttrs(this, _, _, result, _, _) }
@@ -249,6 +261,9 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
   /** Gets a printable representation of this XML attribute. */
   override string toString() { result = this.getName() + "=" + this.getValue() }
 }
+
+/** DEPRECATED: Alias for XmlAttribute */
+deprecated class XMLAttribute = XmlAttribute;
 
 /**
  * A namespace used in an XML file.
@@ -259,7 +274,7 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
  * xmlns:android="http://schemas.android.com/apk/res/android"
  * ```
  */
-class XMLNamespace extends XMLLocatable, @xmlnamespace {
+class XmlNamespace extends XmlLocatable, @xmlnamespace {
   /** Gets the prefix of this namespace. */
   string getPrefix() { xmlNs(this, result, _, _) }
 
@@ -276,6 +291,9 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
   }
 }
 
+/** DEPRECATED: Alias for XmlNamespace */
+deprecated class XMLNamespace = XmlNamespace;
+
 /**
  * A comment in an XML file.
  *
@@ -285,16 +303,19 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
  * <!-- This is a comment. -->
  * ```
  */
-class XMLComment extends @xmlcomment, XMLLocatable {
+class XmlComment extends @xmlcomment, XmlLocatable {
   /** Gets the text content of this XML comment. */
   string getText() { xmlComments(this, result, _, _) }
 
   /** Gets the parent of this XML comment. */
-  XMLParent getParent() { xmlComments(this, _, result, _) }
+  XmlParent getParent() { xmlComments(this, _, result, _) }
 
   /** Gets a printable representation of this XML comment. */
   override string toString() { result = this.getText() }
 }
+
+/** DEPRECATED: Alias for XmlComment */
+deprecated class XMLComment = XmlComment;
 
 /**
  * A sequence of characters that occurs between opening and
@@ -306,12 +327,12 @@ class XMLComment extends @xmlcomment, XMLLocatable {
  * <content>This is a sequence of characters.</content>
  * ```
  */
-class XMLCharacters extends @xmlcharacters, XMLLocatable {
+class XmlCharacters extends @xmlcharacters, XmlLocatable {
   /** Gets the content of this character sequence. */
   string getCharacters() { xmlChars(this, result, _, _, _, _) }
 
   /** Gets the parent of this character sequence. */
-  XMLParent getParent() { xmlChars(this, _, result, _, _, _) }
+  XmlParent getParent() { xmlChars(this, _, result, _, _, _) }
 
   /** Holds if this character sequence is CDATA. */
   predicate isCDATA() { xmlChars(this, _, _, _, 1, _) }
@@ -319,3 +340,6 @@ class XMLCharacters extends @xmlcharacters, XMLLocatable {
   /** Gets a printable representation of this XML character sequence. */
   override string toString() { result = this.getCharacters() }
 }
+
+/** DEPRECATED: Alias for XmlCharacters */
+deprecated class XMLCharacters = XmlCharacters;

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/XMLEntityInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/XMLEntityInjectionQuery.qll
@@ -6,7 +6,7 @@ import csharp
 private import semmle.code.csharp.security.dataflow.flowsources.Remote
 private import semmle.code.csharp.frameworks.System
 private import semmle.code.csharp.frameworks.system.text.RegularExpressions
-private import semmle.code.csharp.security.xml.InsecureXMLQuery as InsecureXML
+private import semmle.code.csharp.security.xml.InsecureXMLQuery as InsecureXml
 private import semmle.code.csharp.security.Sanitizers
 
 /**
@@ -32,7 +32,7 @@ private class InsecureXmlSink extends Sink {
   private string reason;
 
   InsecureXmlSink() {
-    exists(InsecureXML::InsecureXmlProcessing r | r.isUnsafe(reason) |
+    exists(InsecureXml::InsecureXmlProcessing r | r.isUnsafe(reason) |
       this.getExpr() = r.getAnArgument()
     )
   }

--- a/csharp/ql/src/Configuration/EmptyPasswordInConfigurationFile.ql
+++ b/csharp/ql/src/Configuration/EmptyPasswordInConfigurationFile.ql
@@ -13,7 +13,7 @@
 
 import csharp
 
-from XMLAttribute a
+from XmlAttribute a
 where
   a.getName().toLowerCase() = "password" and a.getValue() = ""
   or

--- a/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
+++ b/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
@@ -14,7 +14,7 @@
 
 import csharp
 
-from XMLAttribute a
+from XmlAttribute a
 where
   a.getName().toLowerCase() = "password" and not a.getValue() = ""
   or

--- a/csharp/ql/src/Security Features/CWE-011/ASPNetDebug.ql
+++ b/csharp/ql/src/Security Features/CWE-011/ASPNetDebug.ql
@@ -17,7 +17,7 @@
 import csharp
 import semmle.code.asp.WebConfig
 
-from SystemWebXmlElement web, XMLAttribute debugAttribute
+from SystemWebXmlElement web, XmlAttribute debugAttribute
 where
   debugAttribute = web.getAChild("compilation").getAttribute("debug") and
   not debugAttribute.getValue().toLowerCase() = "false"

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
@@ -14,7 +14,7 @@
 import csharp
 import semmle.code.asp.WebConfig
 
-from SystemWebXmlElement web, XMLAttribute maxReqLength
+from SystemWebXmlElement web, XmlAttribute maxReqLength
 where
   maxReqLength =
     web.getAChild(any(string s | s.toLowerCase() = "httpruntime"))

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequest.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequest.ql
@@ -13,7 +13,7 @@
 import csharp
 import semmle.code.asp.WebConfig
 
-from SystemWebXmlElement web, XMLAttribute requestvalidateAttribute
+from SystemWebXmlElement web, XmlAttribute requestvalidateAttribute
 where
   requestvalidateAttribute = web.getAChild("pages").getAttribute("validateRequest") and
   requestvalidateAttribute.getValue().toLowerCase() = "false"

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetRequestValidationMode.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetRequestValidationMode.ql
@@ -13,7 +13,7 @@
 
 import csharp
 
-from XMLAttribute reqValidationMode
+from XmlAttribute reqValidationMode
 where
   reqValidationMode.getName().toLowerCase() = "requestvalidationmode" and
   reqValidationMode.getValue().toFloat() < 4.5

--- a/csharp/ql/src/Security Features/CWE-548/ASPNetDirectoryListing.ql
+++ b/csharp/ql/src/Security Features/CWE-548/ASPNetDirectoryListing.ql
@@ -13,7 +13,7 @@
 import csharp
 import semmle.code.asp.WebConfig
 
-from SystemWebServerXmlElement ws, XMLAttribute a
+from SystemWebServerXmlElement ws, XmlAttribute a
 where
   ws.getAChild("directoryBrowse").getAttribute("enabled") = a and
   a.getValue() = "true"

--- a/csharp/ql/src/Security Features/CWE-614/RequireSSL.ql
+++ b/csharp/ql/src/Security Features/CWE-614/RequireSSL.ql
@@ -19,7 +19,7 @@ import semmle.code.csharp.frameworks.system.Web
 
 // the query is a subset of `cs/web/cookie-secure-not-set` and
 // should be removed once it is promoted from experimental
-from XMLElement element
+from XmlElement element
 where
   element instanceof FormsElement and
   not element.(FormsElement).isRequireSSL()

--- a/csharp/ql/src/Security Features/HeaderCheckingDisabled.ql
+++ b/csharp/ql/src/Security Features/HeaderCheckingDisabled.ql
@@ -27,7 +27,7 @@ where
   )
   or
   // header checking is disabled in a configuration file
-  exists(HttpRuntimeXmlElement e, XMLAttribute a |
+  exists(HttpRuntimeXmlElement e, XmlAttribute a |
     a = e.getAttribute("enableHeaderChecking") and
     a.getValue().toLowerCase() = "false" and
     a = l

--- a/csharp/ql/src/experimental/Security Features/CWE-1004/CookieWithoutHttpOnly.ql
+++ b/csharp/ql/src/experimental/Security Features/CWE-1004/CookieWithoutHttpOnly.ql
@@ -109,7 +109,7 @@ where
         // the property wasn't explicitly set, so a default value from config is used
         not isPropertySet(oc, "HttpOnly") and
         // the default in config is not set to `true`
-        not exists(XMLElement element |
+        not exists(XmlElement element |
           element instanceof HttpCookiesElement and
           element.(HttpCookiesElement).isHttpOnlyCookies()
         )

--- a/csharp/ql/src/experimental/Security Features/CWE-614/CookieWithoutSecure.ql
+++ b/csharp/ql/src/experimental/Security Features/CWE-614/CookieWithoutSecure.ql
@@ -64,7 +64,7 @@ where
         not isPropertySet(oc, "Secure") and
         // the default in config is not set to `true`
         // the `exists` below covers the `cs/web/requiressl-not-set`
-        not exists(XMLElement element |
+        not exists(XmlElement element |
           element instanceof FormsElement and
           element.(FormsElement).isRequireSSL()
           or

--- a/java/ql/consistency-queries/getAPrimaryQlClass.ql
+++ b/java/ql/consistency-queries/getAPrimaryQlClass.ql
@@ -6,5 +6,5 @@ where
   // TypeBound doesn't extend Top (but probably should); part of Kotlin #6
   not t instanceof TypeBound and
   // XMLLocatable doesn't extend Top (but probably should); part of Kotlin #6
-  not t instanceof XMLLocatable
+  not t instanceof XmlLocatable
 select t, concat(t.getAPrimaryQlClass(), ",")

--- a/java/ql/consistency-queries/locations.ql
+++ b/java/ql/consistency-queries/locations.ql
@@ -26,7 +26,7 @@ Location backwardsLocation() {
 // least to locate a `File`, so such a location does end up with a single use.
 Location unusedLocation() {
   not exists(Top t | t.getLocation() = result) and
-  not exists(XMLLocatable x | x.getLocation() = result) and
+  not exists(XmlLocatable x | x.getLocation() = result) and
   not exists(ConfigLocatable c | c.getLocation() = result) and
   not exists(Diagnostic d | d.getLocation() = result) and
   not (

--- a/java/ql/consistency-queries/toString.ql
+++ b/java/ql/consistency-queries/toString.ql
@@ -7,7 +7,7 @@ string topToString(Top t) {
   result = t.(TypeBound).toString()
   or
   // XMLLocatable doesn't extend Top (but probably should); part of Kotlin #6
-  result = t.(XMLLocatable).toString()
+  result = t.(XmlLocatable).toString()
   or
   // Java #142
   t instanceof FieldDeclaration and not exists(t.toString()) and result = "<FieldDeclaration>"

--- a/java/ql/lib/change-notes/2022-08-22-xml-rename.md
+++ b/java/ql/lib/change-notes/2022-08-22-xml-rename.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Classes/predicates that had upper-case acronym XML in their name have been renamed to Xml to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/java/ql/lib/semmle/code/java/Reflection.qll
+++ b/java/ql/lib/semmle/code/java/Reflection.qll
@@ -33,7 +33,7 @@ predicate referencedInXmlFile(Field f) {
  * Gets an XML element with an attribute whose value is the name of `f`,
  * suggesting that it might reference `f`.
  */
-private XMLElement elementReferencingField(Field f) {
+private XmlElement elementReferencingField(Field f) {
   exists(elementReferencingType(f.getDeclaringType())) and
   result.getAnAttribute().getValue() = f.getName()
 }
@@ -42,7 +42,7 @@ private XMLElement elementReferencingField(Field f) {
  * Gets an XML element with an attribute whose value is the fully qualified
  * name of `rt`, suggesting that it might reference `rt`.
  */
-private XMLElement elementReferencingType(RefType rt) {
+private XmlElement elementReferencingType(RefType rt) {
   result.getAnAttribute().getValue() = rt.getSourceDeclaration().getQualifiedName()
 }
 

--- a/java/ql/lib/semmle/code/java/deadcode/EntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/EntryPoints.qll
@@ -430,7 +430,7 @@ class PersistenceCallbackMethod extends CallableEntryPoint {
 class ArbitraryXmlEntryPoint extends ReflectivelyConstructedClass {
   ArbitraryXmlEntryPoint() {
     this.fromSource() and
-    exists(XMLAttribute attribute |
+    exists(XmlAttribute attribute |
       attribute.getName() = "className" or
       attribute.getName().matches("%ClassName") or
       attribute.getName() = "class" or

--- a/java/ql/lib/semmle/code/java/frameworks/gwt/GwtUiBinderXml.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/gwt/GwtUiBinderXml.qll
@@ -5,7 +5,7 @@
 import java
 
 /** A GWT UiBinder XML template file with a `.ui.xml` suffix. */
-class GwtUiTemplateXmlFile extends XMLFile {
+class GwtUiTemplateXmlFile extends XmlFile {
   GwtUiTemplateXmlFile() { this.getBaseName().matches("%.ui.xml") }
 
   /** Gets the top-level UiBinder element. */
@@ -13,7 +13,7 @@ class GwtUiTemplateXmlFile extends XMLFile {
 }
 
 /** The top-level `<ui:UiBinder>` element of a GWT UiBinder template XML file. */
-class GwtUiBinderTemplateElement extends XMLElement {
+class GwtUiBinderTemplateElement extends XmlElement {
   GwtUiBinderTemplateElement() {
     this.getParent() instanceof GwtUiTemplateXmlFile and
     this.getName() = "UiBinder" and
@@ -24,7 +24,7 @@ class GwtUiBinderTemplateElement extends XMLElement {
 /**
  * A component reference within a GWT UiBinder template.
  */
-class GwtComponentTemplateElement extends XMLElement {
+class GwtComponentTemplateElement extends XmlElement {
   GwtComponentTemplateElement() {
     exists(GwtUiBinderTemplateElement templateElement | this = templateElement.getAChild*() |
       this.getNamespace().getURI().substring(0, 10) = "urn:import"

--- a/java/ql/lib/semmle/code/java/frameworks/gwt/GwtXml.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/gwt/GwtXml.qll
@@ -8,7 +8,7 @@ import semmle.code.xml.XML
 predicate isGwtXmlIncluded() { exists(GwtXmlFile webXml) }
 
 /** A GWT module XML file with a `.gwt.xml` suffix. */
-class GwtXmlFile extends XMLFile {
+class GwtXmlFile extends XmlFile {
   GwtXmlFile() { this.getBaseName().matches("%.gwt.xml") }
 
   /** Gets the top-level module element of a GWT module XML file. */
@@ -57,7 +57,7 @@ class GwtXmlFile extends XMLFile {
 }
 
 /** The top-level `<module>` element of a GWT module XML file. */
-class GwtModuleElement extends XMLElement {
+class GwtModuleElement extends XmlElement {
   GwtModuleElement() {
     this.getParent() instanceof GwtXmlFile and
     this.getName() = "module"
@@ -74,7 +74,7 @@ class GwtModuleElement extends XMLElement {
 }
 
 /** An `<inherits>` element within a GWT module XML file. */
-class GwtInheritsElement extends XMLElement {
+class GwtInheritsElement extends XmlElement {
   GwtInheritsElement() {
     this.getParent() instanceof GwtModuleElement and
     this.getName() = "inherits"
@@ -85,7 +85,7 @@ class GwtInheritsElement extends XMLElement {
 }
 
 /** An `<entry-point>` element within a GWT module XML file. */
-class GwtEntryPointElement extends XMLElement {
+class GwtEntryPointElement extends XmlElement {
   GwtEntryPointElement() {
     this.getParent() instanceof GwtModuleElement and
     this.getName() = "entry-point"
@@ -96,7 +96,7 @@ class GwtEntryPointElement extends XMLElement {
 }
 
 /** A `<source>` element within a GWT module XML file. */
-class GwtSourceElement extends XMLElement {
+class GwtSourceElement extends XmlElement {
   GwtSourceElement() {
     this.getParent() instanceof GwtModuleElement and
     this.getName() = "source"
@@ -113,7 +113,7 @@ class GwtSourceElement extends XMLElement {
 }
 
 /** A `<servlet>` element within a GWT module XML file. */
-class GwtServletElement extends XMLElement {
+class GwtServletElement extends XmlElement {
   GwtServletElement() {
     this.getParent() instanceof GwtModuleElement and
     this.getName() = "servlet"

--- a/java/ql/lib/semmle/code/java/frameworks/javaee/PersistenceXML.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/javaee/PersistenceXML.qll
@@ -8,7 +8,7 @@ import java
 /**
  * A JavaEE persistence configuration XML file (persistence.xml).
  */
-class PersistenceXmlFile extends XMLFile {
+class PersistenceXmlFile extends XmlFile {
   PersistenceXmlFile() { this.getStem() = "persistence" }
 
   /** Gets the root XML element in this `persistence.xml` file. */
@@ -30,7 +30,7 @@ class PersistenceXmlFile extends XMLFile {
 deprecated class PersistenceXMLFile = PersistenceXmlFile;
 
 /** The root `persistence` XML element in a `persistence.xml` file. */
-class PersistenceXmlRoot extends XMLElement {
+class PersistenceXmlRoot extends XmlElement {
   PersistenceXmlRoot() {
     this.getParent() instanceof PersistenceXmlFile and
     this.getName() = "persistence"
@@ -44,7 +44,7 @@ class PersistenceXmlRoot extends XMLElement {
  * A `persistence-unit` child XML element of the root
  * `persistence` XML element in a `persistence.xml` file.
  */
-class PersistenceUnitElement extends XMLElement {
+class PersistenceUnitElement extends XmlElement {
   PersistenceUnitElement() {
     this.getParent() instanceof PersistenceXmlRoot and
     this.getName() = "persistence-unit"
@@ -61,7 +61,7 @@ class PersistenceUnitElement extends XMLElement {
  * A `shared-cache-mode` child XML element of a `persistence-unit`
  * XML element in a `persistence.xml` file.
  */
-class SharedCacheModeElement extends XMLElement {
+class SharedCacheModeElement extends XmlElement {
   SharedCacheModeElement() {
     this.getParent() instanceof PersistenceUnitElement and
     this.getName() = "shared-cache-mode"
@@ -78,7 +78,7 @@ class SharedCacheModeElement extends XMLElement {
  * A `properties` child XML element of a `persistence-unit`
  * XML element in a `persistence.xml` file.
  */
-class PersistencePropertiesElement extends XMLElement {
+class PersistencePropertiesElement extends XmlElement {
   PersistencePropertiesElement() {
     this.getParent() instanceof PersistenceUnitElement and
     this.getName() = "properties"
@@ -92,7 +92,7 @@ class PersistencePropertiesElement extends XMLElement {
  * A `property` child XML element of a `properties`
  * XML element in a `persistence.xml` file.
  */
-class PersistencePropertyElement extends XMLElement {
+class PersistencePropertyElement extends XmlElement {
   PersistencePropertyElement() {
     this.getParent() instanceof PersistencePropertiesElement and
     this.getName() = "property"

--- a/java/ql/lib/semmle/code/java/frameworks/javaee/ejb/EJBJarXML.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/javaee/ejb/EJBJarXML.qll
@@ -8,7 +8,7 @@ import java
 /**
  * An EJB deployment descriptor XML file named `ejb-jar.xml`.
  */
-class EjbJarXmlFile extends XMLFile {
+class EjbJarXmlFile extends XmlFile {
   EjbJarXmlFile() { this.getStem() = "ejb-jar" }
 
   /** Gets the root `ejb-jar` XML element of this `ejb-jar.xml` file. */
@@ -39,7 +39,7 @@ class EjbJarXmlFile extends XMLFile {
 deprecated class EjbJarXMLFile = EjbJarXmlFile;
 
 /** The root `ejb-jar` XML element in an `ejb-jar.xml` file. */
-class EjbJarRootElement extends XMLElement {
+class EjbJarRootElement extends XmlElement {
   EjbJarRootElement() {
     this.getParent() instanceof EjbJarXmlFile and
     this.getName() = "ejb-jar"
@@ -53,7 +53,7 @@ class EjbJarRootElement extends XMLElement {
  * An `enterprise-beans` child XML element of the root
  * `ejb-jar` XML element in an `ejb-jar.xml` file.
  */
-class EjbJarEnterpriseBeansElement extends XMLElement {
+class EjbJarEnterpriseBeansElement extends XmlElement {
   EjbJarEnterpriseBeansElement() {
     this.getParent() instanceof EjbJarRootElement and
     this.getName() = "enterprise-beans"
@@ -83,11 +83,11 @@ class EjbJarEnterpriseBeansElement extends XMLElement {
  *
  * This is either a `message-driven` element, a `session` element, or an `entity` element.
  */
-abstract class EjbJarBeanTypeElement extends XMLElement {
+abstract class EjbJarBeanTypeElement extends XmlElement {
   EjbJarBeanTypeElement() { this.getParent() instanceof EjbJarEnterpriseBeansElement }
 
   /** Gets an `ejb-class` child XML element of this bean type element. */
-  XMLElement getAnEjbClassElement() {
+  XmlElement getAnEjbClassElement() {
     result = this.getAChild() and
     result.getName() = "ejb-class"
   }
@@ -100,13 +100,13 @@ class EjbJarSessionElement extends EjbJarBeanTypeElement {
   EjbJarSessionElement() { this.getName() = "session" }
 
   /** Gets a `business-local` child XML element of this `session` XML element. */
-  XMLElement getABusinessLocalElement() {
+  XmlElement getABusinessLocalElement() {
     result = this.getAChild() and
     result.getName() = "business-local"
   }
 
   /** Gets a `business-remote` child XML element of this `session` XML element. */
-  XMLElement getABusinessRemoteElement() {
+  XmlElement getABusinessRemoteElement() {
     result = this.getAChild() and
     result.getName() = "business-remote"
   }
@@ -116,31 +116,31 @@ class EjbJarSessionElement extends EjbJarBeanTypeElement {
    *
    * This is either a `business-local` or `business-remote` element.
    */
-  XMLElement getABusinessElement() {
+  XmlElement getABusinessElement() {
     result = this.getABusinessLocalElement() or
     result = this.getABusinessRemoteElement()
   }
 
   /** Gets a `remote` child XML element of this `session` XML element. */
-  XMLElement getARemoteElement() {
+  XmlElement getARemoteElement() {
     result = this.getAChild() and
     result.getName() = "remote"
   }
 
   /** Gets a `home` child XML element of this `session` XML element. */
-  XMLElement getARemoteHomeElement() {
+  XmlElement getARemoteHomeElement() {
     result = this.getAChild() and
     result.getName() = "home"
   }
 
   /** Gets a `local` child XML element of this `session` XML element. */
-  XMLElement getALocalElement() {
+  XmlElement getALocalElement() {
     result = this.getAChild() and
     result.getName() = "local"
   }
 
   /** Gets a `local-home` child XML element of this `session` XML element. */
-  XMLElement getALocalHomeElement() {
+  XmlElement getALocalHomeElement() {
     result = this.getAChild() and
     result.getName() = "local-home"
   }
@@ -155,7 +155,7 @@ class EjbJarSessionElement extends EjbJarBeanTypeElement {
    * Gets a `method-name` child XML element of a `create-method`
    * XML element nested within this `session` XML element.
    */
-  XMLElement getACreateMethodNameElement() {
+  XmlElement getACreateMethodNameElement() {
     result = this.getAnInitMethodElement().getACreateMethodElement().getAMethodNameElement()
   }
 
@@ -163,7 +163,7 @@ class EjbJarSessionElement extends EjbJarBeanTypeElement {
    * Gets a `method-name` child XML element of a `bean-method`
    * XML element nested within this `session` XML element.
    */
-  XMLElement getABeanMethodNameElement() {
+  XmlElement getABeanMethodNameElement() {
     result = this.getAnInitMethodElement().getABeanMethodElement().getAMethodNameElement()
   }
 }
@@ -183,7 +183,7 @@ class EjbJarEntityElement extends EjbJarBeanTypeElement {
 }
 
 /** A `session-type` child XML element of a `session` element in an `ejb-jar.xml` file. */
-class EjbJarSessionTypeElement extends XMLElement {
+class EjbJarSessionTypeElement extends XmlElement {
   EjbJarSessionTypeElement() {
     this.getParent() instanceof EjbJarSessionElement and
     this.getName() = "session-type"
@@ -197,7 +197,7 @@ class EjbJarSessionTypeElement extends XMLElement {
 }
 
 /** An `init-method` child XML element of a `session` element in an `ejb-jar.xml` file. */
-class EjbJarInitMethodElement extends XMLElement {
+class EjbJarInitMethodElement extends XmlElement {
   EjbJarInitMethodElement() {
     this.getParent() instanceof EjbJarSessionElement and
     this.getName() = "init-method"
@@ -221,9 +221,9 @@ class EjbJarInitMethodElement extends XMLElement {
  *
  * This is either a `create-method` element, or a `bean-method` element.
  */
-abstract class EjbJarInitMethodChildElement extends XMLElement {
+abstract class EjbJarInitMethodChildElement extends XmlElement {
   /** Gets a `method-name` child XML element of this `create-method` or `bean-method` XML element. */
-  XMLElement getAMethodNameElement() {
+  XmlElement getAMethodNameElement() {
     result = this.getAChild() and
     result.getName() = "method-name"
   }

--- a/java/ql/lib/semmle/code/java/frameworks/javaee/jsf/JSFFacesContextXML.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/javaee/jsf/JSFFacesContextXML.qll
@@ -8,10 +8,10 @@ import default
  * A JSF "application configuration resources file", typically called `faces-config.xml`, which
  * contains the configuration for a JSF application
  */
-class FacesConfigXmlFile extends XMLFile {
+class FacesConfigXmlFile extends XmlFile {
   FacesConfigXmlFile() {
     // Contains a single top-level XML node named "faces-Config".
-    count(XMLElement e | e = this.getAChild()) = 1 and
+    count(XmlElement e | e = this.getAChild()) = 1 and
     this.getAChild().getName() = "faces-config"
   }
 }
@@ -22,7 +22,7 @@ deprecated class FacesConfigXMLFile = FacesConfigXmlFile;
 /**
  * An XML element in a `FacesConfigXMLFile`.
  */
-class FacesConfigXmlElement extends XMLElement {
+class FacesConfigXmlElement extends XmlElement {
   FacesConfigXmlElement() { this.getFile() instanceof FacesConfigXmlFile }
 
   /**

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringBean.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringBean.qll
@@ -57,7 +57,7 @@ class SpringBean extends SpringXmlElement {
 
   /** Holds if the bean is abstract. */
   predicate isAbstract() {
-    exists(XMLAttribute a |
+    exists(XmlAttribute a |
       a = this.getAttribute("abstract") and
       a.getValue() = "true"
     )
@@ -255,7 +255,7 @@ class SpringBean extends SpringXmlElement {
 
   /** Holds if the bean has been declared to be a `primary` bean for autowiring. */
   predicate isPrimary() {
-    exists(XMLAttribute a | a = this.getAttribute("primary") and a.getValue() = "true")
+    exists(XmlAttribute a | a = this.getAttribute("primary") and a.getValue() = "true")
   }
 
   /** Gets the scope of the bean. */

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringBeanFile.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringBeanFile.qll
@@ -6,9 +6,9 @@ import semmle.code.java.frameworks.spring.SpringBean
  *
  * This class includes methods to access attributes of the `<beans>` element.
  */
-class SpringBeanFile extends XMLFile {
+class SpringBeanFile extends XmlFile {
   SpringBeanFile() {
-    count(XMLElement e | e = this.getAChild()) = 1 and
+    count(XmlElement e | e = this.getAChild()) = 1 and
     this.getAChild().getName() = "beans"
   }
 
@@ -24,7 +24,7 @@ class SpringBeanFile extends XMLFile {
   SpringBean getABean() { exists(SpringBean b | b.getFile() = this and result = b) }
 
   /** Gets the `<beans>` element of the file. */
-  XMLElement getBeansElement() {
+  XmlElement getBeansElement() {
     result = this.getAChild() and
     result.getName() = "beans"
   }
@@ -85,7 +85,7 @@ class SpringBeanFile extends XMLFile {
 
   /** Holds if `default-lazy-init` is specified to be `true` for this file. */
   predicate isDefaultLazyInit() {
-    exists(XMLAttribute a |
+    exists(XmlAttribute a |
       this.getBeansElement().getAttribute("default-lazy-init") = a and
       a.getValue() = "true"
     )
@@ -93,7 +93,7 @@ class SpringBeanFile extends XMLFile {
 
   /** Holds if `default-merge` is specified to be `true` for this file. */
   predicate isDefaultMerge() {
-    exists(XMLAttribute a |
+    exists(XmlAttribute a |
       this.getBeansElement().getAttribute("default-merge") = a and
       a.getValue() = "true"
     )

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringXMLElement.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringXMLElement.qll
@@ -3,7 +3,7 @@ import semmle.code.java.frameworks.spring.SpringBeanFile
 import semmle.code.java.frameworks.spring.SpringBean
 
 /** A common superclass for all Spring XML elements. */
-class SpringXmlElement extends XMLElement {
+class SpringXmlElement extends XmlElement {
   SpringXmlElement() { this.getFile() instanceof SpringBeanFile }
 
   /** Gets a child of this Spring XML element. */

--- a/java/ql/lib/semmle/code/java/frameworks/struts/StrutsActions.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/struts/StrutsActions.qll
@@ -16,7 +16,7 @@ class Struts2ActionClass extends Class {
   Struts2ActionClass() {
     // If there are no XML files present, then we assume we any class that extends a struts 2
     // action must be reflectively constructed, as we have no better indication.
-    not exists(XMLFile xmlFile) and
+    not exists(XmlFile xmlFile) and
     this.getAnAncestor().hasQualifiedName("com.opensymphony.xwork2", "Action")
     or
     // If there is a struts.xml file, then any class that is specified as an action is considered
@@ -72,7 +72,7 @@ class Struts2ActionClass extends Class {
           result = this.(Struts2ConventionActionClass).getAnActionMethod()
           or
           // In the fall-back case, use both the "execute" and any annotated methods
-          not exists(XMLFile xmlFile) and
+          not exists(XmlFile xmlFile) and
           (
             result.hasName("executes") or
             exists(StrutsActionAnnotation actionAnnotation |

--- a/java/ql/lib/semmle/code/java/frameworks/struts/StrutsXML.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/struts/StrutsXML.qll
@@ -11,10 +11,10 @@ deprecated predicate isStrutsXMLIncluded = isStrutsXmlIncluded/0;
 /**
  * A struts 2 configuration file.
  */
-abstract class StrutsXmlFile extends XMLFile {
+abstract class StrutsXmlFile extends XmlFile {
   StrutsXmlFile() {
     // Contains a single top-level XML node named "struts".
-    count(XMLElement e | e = this.getAChild()) = 1 and
+    count(XmlElement e | e = this.getAChild()) = 1 and
     this.getAChild().getName() = "struts"
   }
 
@@ -107,7 +107,7 @@ class StrutsFolder extends Folder {
 /**
  * An XML element in a `StrutsXMLFile`.
  */
-class StrutsXmlElement extends XMLElement {
+class StrutsXmlElement extends XmlElement {
   StrutsXmlElement() { this.getFile() instanceof StrutsXmlFile }
 
   /**
@@ -134,7 +134,7 @@ class StrutsXmlInclude extends StrutsXmlElement {
    * We have no notion of classpath, so we assume that any file that matches the path could
    * potentially be included.
    */
-  XMLFile getIncludedFile() {
+  XmlFile getIncludedFile() {
     exists(string file | file = this.getAttribute("file").getValue() |
       result.getAbsolutePath().matches("%" + escapeForMatch(file))
     )

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -7,10 +7,10 @@ import XML
 /**
  * An Android manifest file, named `AndroidManifest.xml`.
  */
-class AndroidManifestXmlFile extends XMLFile {
+class AndroidManifestXmlFile extends XmlFile {
   AndroidManifestXmlFile() {
     this.getBaseName() = "AndroidManifest.xml" and
-    count(XMLElement e | e = this.getAChild()) = 1 and
+    count(XmlElement e | e = this.getAChild()) = 1 and
     this.getAChild().getName() = "manifest"
   }
 
@@ -28,7 +28,7 @@ class AndroidManifestXmlFile extends XMLFile {
 /**
  * A `<manifest>` element in an Android manifest file.
  */
-class AndroidManifestXmlElement extends XMLElement {
+class AndroidManifestXmlElement extends XmlElement {
   AndroidManifestXmlElement() {
     this.getParent() instanceof AndroidManifestXmlFile and this.getName() = "manifest"
   }
@@ -47,7 +47,7 @@ class AndroidManifestXmlElement extends XMLElement {
 /**
  * An `<application>` element in an Android manifest file.
  */
-class AndroidApplicationXmlElement extends XMLElement {
+class AndroidApplicationXmlElement extends XmlElement {
   AndroidApplicationXmlElement() {
     this.getParent() instanceof AndroidManifestXmlElement and this.getName() = "application"
   }
@@ -93,7 +93,7 @@ class AndroidReceiverXmlElement extends AndroidComponentXmlElement {
 /**
  * An XML attribute with the `android:` prefix.
  */
-class AndroidXmlAttribute extends XMLAttribute {
+class AndroidXmlAttribute extends XmlAttribute {
   AndroidXmlAttribute() { this.getNamespace().getPrefix() = "android" }
 }
 
@@ -130,7 +130,7 @@ class AndroidProviderXmlElement extends AndroidComponentXmlElement {
 /**
  * The attribute `android:perrmission`, `android:readPermission`, or `android:writePermission`.
  */
-class AndroidPermissionXmlAttribute extends XMLAttribute {
+class AndroidPermissionXmlAttribute extends XmlAttribute {
   AndroidPermissionXmlAttribute() {
     this.getNamespace().getPrefix() = "android" and
     this.getName() = ["permission", "readPermission", "writePermission"]
@@ -149,7 +149,7 @@ class AndroidPermissionXmlAttribute extends XMLAttribute {
 /**
  * The `<path-permission`> element of a `<provider>` in an Android manifest file.
  */
-class AndroidPathPermissionXmlElement extends XMLElement {
+class AndroidPathPermissionXmlElement extends XmlElement {
   AndroidPathPermissionXmlElement() {
     this.getParent() instanceof AndroidProviderXmlElement and
     this.hasName("path-permission")
@@ -159,7 +159,7 @@ class AndroidPathPermissionXmlElement extends XMLElement {
 /**
  * An Android component element in an Android manifest file.
  */
-class AndroidComponentXmlElement extends XMLElement {
+class AndroidComponentXmlElement extends XmlElement {
   AndroidComponentXmlElement() {
     this.getParent() instanceof AndroidApplicationXmlElement and
     this.getName().regexpMatch("(activity|service|receiver|provider)")
@@ -174,7 +174,7 @@ class AndroidComponentXmlElement extends XMLElement {
    * Gets the value of the `android:name` attribute of this component element.
    */
   string getComponentName() {
-    exists(XMLAttribute attr |
+    exists(XmlAttribute attr |
       attr = this.getAnAttribute() and
       attr.getNamespace().getPrefix() = "android" and
       attr.getName() = "name"
@@ -191,7 +191,7 @@ class AndroidComponentXmlElement extends XMLElement {
     then
       result =
         this.getParent()
-              .(XMLElement)
+              .(XmlElement)
               .getParent()
               .(AndroidManifestXmlElement)
               .getPackageAttributeValue() + this.getComponentName()
@@ -202,7 +202,7 @@ class AndroidComponentXmlElement extends XMLElement {
    * Gets the value of the `android:exported` attribute of this component element.
    */
   string getExportedAttributeValue() {
-    exists(XMLAttribute attr |
+    exists(XmlAttribute attr |
       attr = this.getAnAttribute() and
       attr.getNamespace().getPrefix() = "android" and
       attr.getName() = "exported"
@@ -225,7 +225,7 @@ class AndroidComponentXmlElement extends XMLElement {
 /**
  * An `<intent-filter>` element in an Android manifest file.
  */
-class AndroidIntentFilterXmlElement extends XMLElement {
+class AndroidIntentFilterXmlElement extends XmlElement {
   AndroidIntentFilterXmlElement() {
     this.getFile() instanceof AndroidManifestXmlFile and this.getName() = "intent-filter"
   }
@@ -239,7 +239,7 @@ class AndroidIntentFilterXmlElement extends XMLElement {
 /**
  * An `<action>` element in an Android manifest file.
  */
-class AndroidActionXmlElement extends XMLElement {
+class AndroidActionXmlElement extends XmlElement {
   AndroidActionXmlElement() {
     this.getFile() instanceof AndroidManifestXmlFile and this.getName() = "action"
   }
@@ -248,7 +248,7 @@ class AndroidActionXmlElement extends XMLElement {
    * Gets the name of this action.
    */
   string getActionName() {
-    exists(XMLAttribute attr |
+    exists(XmlAttribute attr |
       attr = this.getAnAttribute() and
       attr.getNamespace().getPrefix() = "android" and
       attr.getName() = "name"

--- a/java/ql/lib/semmle/code/xml/Ant.qll
+++ b/java/ql/lib/semmle/code/xml/Ant.qll
@@ -5,7 +5,7 @@
 import XML
 
 /** An XML element that represents an Ant target. */
-class AntTarget extends XMLElement {
+class AntTarget extends XmlElement {
   AntTarget() { super.getName() = "target" }
 
   /** Gets the name of this Ant target. */

--- a/java/ql/lib/semmle/code/xml/MavenPom.qll
+++ b/java/ql/lib/semmle/code/xml/MavenPom.qll
@@ -17,7 +17,7 @@ private string normalize(string path) {
  * to retrieve child XML elements named "groupId", "artifactId"
  * and "version", typically contained in Maven POM XML files.
  */
-class ProtoPom extends XMLElement {
+class ProtoPom extends XmlElement {
   /** Gets a child XML element named "groupId". */
   Group getGroup() { result = this.getAChild() }
 
@@ -280,7 +280,7 @@ class PomDependency extends Dependency {
  * An XML element that provides access to its value string
  * in the context of Maven POM XML files.
  */
-class PomElement extends XMLElement {
+class PomElement extends XmlElement {
   /**
    * Gets the value associated with this element. If the value contains a placeholder only, it will be resolved.
    */

--- a/java/ql/lib/semmle/code/xml/WebXML.qll
+++ b/java/ql/lib/semmle/code/xml/WebXML.qll
@@ -11,9 +11,9 @@ deprecated predicate isWebXMLIncluded = isWebXmlIncluded/0;
 /**
  * A deployment descriptor file, typically called `web.xml`.
  */
-class WebXmlFile extends XMLFile {
+class WebXmlFile extends XmlFile {
   WebXmlFile() {
-    count(XMLElement e | e = this.getAChild()) = 1 and
+    count(XmlElement e | e = this.getAChild()) = 1 and
     this.getAChild().getName() = "web-app"
   }
 
@@ -37,7 +37,7 @@ deprecated class WebXMLFile = WebXmlFile;
 /**
  * An XML element in a `WebXMLFile`.
  */
-class WebXmlElement extends XMLElement {
+class WebXmlElement extends XmlElement {
   WebXmlElement() { this.getFile() instanceof WebXmlFile }
 
   /**

--- a/java/ql/lib/semmle/code/xml/XML.qll
+++ b/java/ql/lib/semmle/code/xml/XML.qll
@@ -36,12 +36,12 @@ class XmlLocatable extends @xmllocatable, TXmlLocatable {
 deprecated class XMLLocatable = XmlLocatable;
 
 /**
- * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
+ * An `XmlParent` is either an `XmlElement` or an `XmlFile`,
  * both of which can contain other elements.
  */
 class XmlParent extends @xmlparent {
   XmlParent() {
-    // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
+    // explicitly restrict `this` to be either an `XmlElement` or an `XmlFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
   }

--- a/java/ql/lib/semmle/code/xml/XML.qll
+++ b/java/ql/lib/semmle/code/xml/XML.qll
@@ -132,7 +132,7 @@ class XmlFile extends XmlParent, File {
   XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
-  XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
+  XmlDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
 /** DEPRECATED: Alias for XmlFile */
@@ -149,7 +149,7 @@ deprecated class XMLFile = XmlFile;
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XmlLocatable, @xmldtd {
+class XmlDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -173,6 +173,9 @@ class XMLDTD extends XmlLocatable, @xmldtd {
     result = this.getRoot() + " SYSTEM '" + this.getSystemId() + "'"
   }
 }
+
+/** DEPRECATED: Alias for XmlDTD */
+deprecated class XMLDTD = XmlDTD;
 
 /**
  * An XML element in an XML file.

--- a/java/ql/lib/semmle/code/xml/XML.qll
+++ b/java/ql/lib/semmle/code/xml/XML.qll
@@ -8,7 +8,7 @@ private class TXmlLocatable =
   @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
-class XMLLocatable extends @xmllocatable, TXmlLocatable {
+class XmlLocatable extends @xmllocatable, TXmlLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -32,12 +32,15 @@ class XMLLocatable extends @xmllocatable, TXmlLocatable {
   string toString() { none() } // overridden in subclasses
 }
 
+/** DEPRECATED: Alias for XmlLocatable */
+deprecated class XMLLocatable = XmlLocatable;
+
 /**
  * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
  * both of which can contain other elements.
  */
-class XMLParent extends @xmlparent {
-  XMLParent() {
+class XmlParent extends @xmlparent {
+  XmlParent() {
     // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
@@ -50,28 +53,28 @@ class XMLParent extends @xmlparent {
   string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
-  XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }
+  XmlFile getFile() { result = this or xmlElements(this, _, _, _, result) }
 
   /** Gets the child element at a specified index of this XML parent. */
-  XMLElement getChild(int index) { xmlElements(result, _, this, index, _) }
+  XmlElement getChild(int index) { xmlElements(result, _, this, index, _) }
 
   /** Gets a child element of this XML parent. */
-  XMLElement getAChild() { xmlElements(result, _, this, _, _) }
+  XmlElement getAChild() { xmlElements(result, _, this, _, _) }
 
   /** Gets a child element of this XML parent with the given `name`. */
-  XMLElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
+  XmlElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
 
   /** Gets a comment that is a child of this XML parent. */
-  XMLComment getAComment() { xmlComments(result, _, this, _) }
+  XmlComment getAComment() { xmlComments(result, _, this, _) }
 
   /** Gets a character sequence that is a child of this XML parent. */
-  XMLCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
+  XmlCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
 
-  /** Gets the depth in the tree. (Overridden in XMLElement.) */
+  /** Gets the depth in the tree. (Overridden in XmlElement.) */
   int getDepth() { result = 0 }
 
   /** Gets the number of child XML elements of this XML parent. */
-  int getNumberOfChildren() { result = count(XMLElement e | xmlElements(e, _, this, _, _)) }
+  int getNumberOfChildren() { result = count(XmlElement e | xmlElements(e, _, this, _, _)) }
 
   /** Gets the number of places in the body of this XML parent where text occurs. */
   int getNumberOfCharacterSets() { result = count(int pos | xmlChars(_, _, this, pos, _, _)) }
@@ -92,9 +95,12 @@ class XMLParent extends @xmlparent {
   string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlParent */
+deprecated class XMLParent = XmlParent;
+
 /** An XML file. */
-class XMLFile extends XMLParent, File {
-  XMLFile() { xmlEncoding(this, _) }
+class XmlFile extends XmlParent, File {
+  XmlFile() { xmlEncoding(this, _) }
 
   /** Gets a printable representation of this XML file. */
   override string toString() { result = this.getName() }
@@ -120,14 +126,17 @@ class XMLFile extends XMLParent, File {
   string getEncoding() { xmlEncoding(this, result) }
 
   /** Gets the XML file itself. */
-  override XMLFile getFile() { result = this }
+  override XmlFile getFile() { result = this }
 
   /** Gets a top-most element in an XML file. */
-  XMLElement getARootElement() { result = this.getAChild() }
+  XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
+
+/** DEPRECATED: Alias for XmlFile */
+deprecated class XMLFile = XmlFile;
 
 /**
  * An XML document type definition (DTD).
@@ -140,7 +149,7 @@ class XMLFile extends XMLParent, File {
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XMLLocatable, @xmldtd {
+class XMLDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -154,7 +163,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
   predicate isPublic() { not xmlDTDs(this, _, "", _, _) }
 
   /** Gets the parent of this DTD. */
-  XMLParent getParent() { xmlDTDs(this, _, _, _, result) }
+  XmlParent getParent() { xmlDTDs(this, _, _, _, result) }
 
   override string toString() {
     this.isPublic() and
@@ -176,7 +185,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
  * </manifest>
  * ```
  */
-class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
+class XmlElement extends @xmlelement, XmlParent, XmlLocatable {
   /** Holds if this XML element has the given `name`. */
   predicate hasName(string name) { name = this.getName() }
 
@@ -184,10 +193,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string getName() { xmlElements(this, result, _, _, _) }
 
   /** Gets the XML file in which this XML element occurs. */
-  override XMLFile getFile() { xmlElements(this, _, _, _, result) }
+  override XmlFile getFile() { xmlElements(this, _, _, _, result) }
 
   /** Gets the parent of this XML element. */
-  XMLParent getParent() { xmlElements(this, _, result, _, _) }
+  XmlParent getParent() { xmlElements(this, _, result, _, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getIndex() { xmlElements(this, _, _, result, _) }
@@ -196,7 +205,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this XML element, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getElementPositionIndex() { xmlElements(this, _, _, result, _) }
@@ -205,10 +214,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override int getDepth() { result = this.getParent().getDepth() + 1 }
 
   /** Gets an XML attribute of this XML element. */
-  XMLAttribute getAnAttribute() { result.getElement() = this }
+  XmlAttribute getAnAttribute() { result.getElement() = this }
 
   /** Gets the attribute with the specified `name`, if any. */
-  XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
+  XmlAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
   predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
@@ -220,6 +229,9 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlElement */
+deprecated class XMLElement = XmlElement;
+
 /**
  * An attribute that occurs inside an XML element.
  *
@@ -230,18 +242,18 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
  * android:versionCode="1"
  * ```
  */
-class XMLAttribute extends @xmlattribute, XMLLocatable {
+class XmlAttribute extends @xmlattribute, XmlLocatable {
   /** Gets the name of this attribute. */
   string getName() { xmlAttrs(this, _, result, _, _, _) }
 
   /** Gets the XML element to which this attribute belongs. */
-  XMLElement getElement() { xmlAttrs(this, result, _, _, _, _) }
+  XmlElement getElement() { xmlAttrs(this, result, _, _, _, _) }
 
   /** Holds if this attribute has a namespace. */
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this attribute, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the value of this attribute. */
   string getValue() { xmlAttrs(this, _, _, result, _, _) }
@@ -249,6 +261,9 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
   /** Gets a printable representation of this XML attribute. */
   override string toString() { result = this.getName() + "=" + this.getValue() }
 }
+
+/** DEPRECATED: Alias for XmlAttribute */
+deprecated class XMLAttribute = XmlAttribute;
 
 /**
  * A namespace used in an XML file.
@@ -259,7 +274,7 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
  * xmlns:android="http://schemas.android.com/apk/res/android"
  * ```
  */
-class XMLNamespace extends XMLLocatable, @xmlnamespace {
+class XmlNamespace extends XmlLocatable, @xmlnamespace {
   /** Gets the prefix of this namespace. */
   string getPrefix() { xmlNs(this, result, _, _) }
 
@@ -276,6 +291,9 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
   }
 }
 
+/** DEPRECATED: Alias for XmlNamespace */
+deprecated class XMLNamespace = XmlNamespace;
+
 /**
  * A comment in an XML file.
  *
@@ -285,16 +303,19 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
  * <!-- This is a comment. -->
  * ```
  */
-class XMLComment extends @xmlcomment, XMLLocatable {
+class XmlComment extends @xmlcomment, XmlLocatable {
   /** Gets the text content of this XML comment. */
   string getText() { xmlComments(this, result, _, _) }
 
   /** Gets the parent of this XML comment. */
-  XMLParent getParent() { xmlComments(this, _, result, _) }
+  XmlParent getParent() { xmlComments(this, _, result, _) }
 
   /** Gets a printable representation of this XML comment. */
   override string toString() { result = this.getText() }
 }
+
+/** DEPRECATED: Alias for XmlComment */
+deprecated class XMLComment = XmlComment;
 
 /**
  * A sequence of characters that occurs between opening and
@@ -306,12 +327,12 @@ class XMLComment extends @xmlcomment, XMLLocatable {
  * <content>This is a sequence of characters.</content>
  * ```
  */
-class XMLCharacters extends @xmlcharacters, XMLLocatable {
+class XmlCharacters extends @xmlcharacters, XmlLocatable {
   /** Gets the content of this character sequence. */
   string getCharacters() { xmlChars(this, result, _, _, _, _) }
 
   /** Gets the parent of this character sequence. */
-  XMLParent getParent() { xmlChars(this, _, result, _, _, _) }
+  XmlParent getParent() { xmlChars(this, _, result, _, _, _) }
 
   /** Holds if this character sequence is CDATA. */
   predicate isCDATA() { xmlChars(this, _, _, _, 1, _) }
@@ -319,3 +340,6 @@ class XMLCharacters extends @xmlcharacters, XMLLocatable {
   /** Gets a printable representation of this XML character sequence. */
   override string toString() { result = this.getCharacters() }
 }
+
+/** DEPRECATED: Alias for XmlCharacters */
+deprecated class XMLCharacters = XmlCharacters;

--- a/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.ql
@@ -38,7 +38,7 @@ predicate dead(RefType dead) {
   // Exclude results that have a `main` method.
   not dead.getAMethod().hasName("main") and
   // Exclude results that are referenced in XML files.
-  not exists(XMLAttribute xla | xla.getValue() = dead.getQualifiedName()) and
+  not exists(XmlAttribute xla | xla.getValue() = dead.getQualifiedName()) and
   // Exclude type variables.
   not dead instanceof BoundedType and
   // Exclude JUnit tests.

--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
@@ -44,7 +44,7 @@ class ListType extends RefType {
   }
 }
 
-/** Holds if the specified `method` uses MyBatis Mapper XMLElement `mmxx`. */
+/** Holds if the specified `method` uses MyBatis Mapper XmlElement `mmxx`. */
 predicate myBatisMapperXmlElementFromMethod(Method method, MyBatisMapperXmlElement mmxx) {
   exists(MyBatisMapperSqlOperation mbmxe | mbmxe.getMapperMethod() = method |
     mbmxe.getAChild*() = mmxx
@@ -68,7 +68,7 @@ predicate myBatisSqlOperationAnnotationFromMethod(Method method, IbatisSqlOperat
 }
 
 /** Gets a `#{...}` or `${...}` expression argument in XML element `xmle`. */
-string getAMybatisXmlSetValue(XMLElement xmle) {
+string getAMybatisXmlSetValue(XmlElement xmle) {
   result = xmle.getTextValue().regexpFind("(#|\\$)\\{[^\\}]*\\}", _, _)
 }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-555/PasswordInConfigurationFile.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-555/PasswordInConfigurationFile.ql
@@ -32,13 +32,13 @@ predicate hasEmbeddedPassword(string value) {
   )
 }
 
-from XMLAttribute nameAttr
+from XmlAttribute nameAttr
 where
   nameAttr.getName().toLowerCase() in ["password", "pwd"] and
   not isNotPassword(nameAttr.getValue().trim()) // Attribute name "password" or "pwd"
   or
   exists(
-    XMLAttribute valueAttr // name/value pair like <property name="password" value="mysecret"/>
+    XmlAttribute valueAttr // name/value pair like <property name="password" value="mysecret"/>
   |
     valueAttr.getElement() = nameAttr.getElement() and
     nameAttr.getName().toLowerCase() = "name" and

--- a/java/ql/src/experimental/semmle/code/xml/StrutsXML.qll
+++ b/java/ql/src/experimental/semmle/code/xml/StrutsXML.qll
@@ -3,9 +3,9 @@ import java
 /**
  * A deployment descriptor file, typically called `struts.xml`.
  */
-class StrutsXmlFile extends XMLFile {
+class StrutsXmlFile extends XmlFile {
   StrutsXmlFile() {
-    count(XMLElement e | e = this.getAChild()) = 1 and
+    count(XmlElement e | e = this.getAChild()) = 1 and
     this.getAChild().getName() = "struts"
   }
 }
@@ -16,7 +16,7 @@ deprecated class StrutsXMLFile = StrutsXmlFile;
 /**
  * An XML element in a `StrutsXMLFile`.
  */
-class StrutsXmlElement extends XMLElement {
+class StrutsXmlElement extends XmlElement {
   StrutsXmlElement() { this.getFile() instanceof StrutsXmlFile }
 
   /**

--- a/java/ql/src/external/Clover.qll
+++ b/java/ql/src/external/Clover.qll
@@ -7,14 +7,14 @@ import java
  * top-level children (usually, in fact, there is only one) is
  * a tag with the name "coverage".
  */
-class CloverReport extends XMLFile {
+class CloverReport extends XmlFile {
   CloverReport() { this.getAChild().getName() = "coverage" }
 }
 
 /**
  * The Clover "coverage" tag contains one or more "projects".
  */
-class CloverCoverage extends XMLElement {
+class CloverCoverage extends XmlElement {
   CloverCoverage() {
     this.getParent() instanceof CloverReport and
     this.getName() = "coverage"
@@ -29,7 +29,7 @@ class CloverCoverage extends XMLElement {
  * contains various numbers, aggregated to the different levels. They are
  * all subclasses of this class, to share code.
  */
-abstract class CloverMetricsContainer extends XMLElement {
+abstract class CloverMetricsContainer extends XmlElement {
   /** Gets the Clover `metrics` child element for this element. */
   CloverMetrics getMetrics() { result = this.getAChild() }
 }
@@ -38,7 +38,7 @@ abstract class CloverMetricsContainer extends XMLElement {
  * A "metrics" element contains a range of numbers for the current
  * aggregation level.
  */
-class CloverMetrics extends XMLElement {
+class CloverMetrics extends XmlElement {
   CloverMetrics() {
     this.getParent() instanceof CloverMetricsContainer and
     this.getName() = "metrics"

--- a/java/ql/src/semmle/code/xml/MyBatisMapperXML.qll
+++ b/java/ql/src/semmle/code/xml/MyBatisMapperXML.qll
@@ -7,9 +7,9 @@ import java
 /**
  * MyBatis Mapper XML file.
  */
-class MyBatisMapperXmlFile extends XMLFile {
+class MyBatisMapperXmlFile extends XmlFile {
   MyBatisMapperXmlFile() {
-    count(XMLElement e | e = this.getAChild()) = 1 and
+    count(XmlElement e | e = this.getAChild()) = 1 and
     this.getAChild().getName() = "mapper"
   }
 }
@@ -20,7 +20,7 @@ deprecated class MyBatisMapperXMLFile = MyBatisMapperXmlFile;
 /**
  * An XML element in a `MyBatisMapperXMLFile`.
  */
-class MyBatisMapperXmlElement extends XMLElement {
+class MyBatisMapperXmlElement extends XmlElement {
   MyBatisMapperXmlElement() { this.getFile() instanceof MyBatisMapperXmlFile }
 
   /**

--- a/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
@@ -21,14 +21,14 @@ private class KtExpectationComment extends KtComment, ExpectationComment {
   override string getContents() { result = this.getText().suffix(2).trim() }
 }
 
-private class XmlExpectationComment extends ExpectationComment instanceof XMLComment {
-  override string getContents() { result = this.(XMLComment).getText().trim() }
+private class XmlExpectationComment extends ExpectationComment instanceof XmlComment {
+  override string getContents() { result = this.(XmlComment).getText().trim() }
 
-  override Location getLocation() { result = this.(XMLComment).getLocation() }
+  override Location getLocation() { result = this.(XmlComment).getLocation() }
 
   override predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
-    this.(XMLComment).hasLocationInfo(path, sl, sc, el, ec)
+    this.(XmlComment).hasLocationInfo(path, sl, sc, el, ec)
   }
 
-  override string toString() { result = this.(XMLComment).toString() }
+  override string toString() { result = this.(XmlComment).toString() }
 }

--- a/java/ql/test/library-tests/xml/XMLTest.ql
+++ b/java/ql/test/library-tests/xml/XMLTest.ql
@@ -8,7 +8,7 @@ class XmlTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasXmlResult" and
-    exists(XMLAttribute a |
+    exists(XmlAttribute a |
       a.getLocation() = location and
       element = a.toString() and
       value = ""

--- a/javascript/ql/lib/change-notes/2022-08-22-xml-rename.md
+++ b/javascript/ql/lib/change-notes/2022-08-22-xml-rename.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Classes/predicates that had upper-case acronym XML in their name have been renamed to Xml to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/javascript/ql/lib/semmle/javascript/XML.qll
+++ b/javascript/ql/lib/semmle/javascript/XML.qll
@@ -36,12 +36,12 @@ class XmlLocatable extends @xmllocatable, TXmlLocatable {
 deprecated class XMLLocatable = XmlLocatable;
 
 /**
- * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
+ * An `XmlParent` is either an `XmlElement` or an `XmlFile`,
  * both of which can contain other elements.
  */
 class XmlParent extends @xmlparent {
   XmlParent() {
-    // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
+    // explicitly restrict `this` to be either an `XmlElement` or an `XmlFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
   }

--- a/javascript/ql/lib/semmle/javascript/XML.qll
+++ b/javascript/ql/lib/semmle/javascript/XML.qll
@@ -132,7 +132,7 @@ class XmlFile extends XmlParent, File {
   XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
-  XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
+  XmlDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
 /** DEPRECATED: Alias for XmlFile */
@@ -149,7 +149,7 @@ deprecated class XMLFile = XmlFile;
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XmlLocatable, @xmldtd {
+class XmlDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -173,6 +173,9 @@ class XMLDTD extends XmlLocatable, @xmldtd {
     result = this.getRoot() + " SYSTEM '" + this.getSystemId() + "'"
   }
 }
+
+/** DEPRECATED: Alias for XmlDTD */
+deprecated class XMLDTD = XmlDTD;
 
 /**
  * An XML element in an XML file.

--- a/javascript/ql/lib/semmle/javascript/XML.qll
+++ b/javascript/ql/lib/semmle/javascript/XML.qll
@@ -8,7 +8,7 @@ private class TXmlLocatable =
   @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
-class XMLLocatable extends @xmllocatable, TXmlLocatable {
+class XmlLocatable extends @xmllocatable, TXmlLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -32,12 +32,15 @@ class XMLLocatable extends @xmllocatable, TXmlLocatable {
   string toString() { none() } // overridden in subclasses
 }
 
+/** DEPRECATED: Alias for XmlLocatable */
+deprecated class XMLLocatable = XmlLocatable;
+
 /**
  * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
  * both of which can contain other elements.
  */
-class XMLParent extends @xmlparent {
-  XMLParent() {
+class XmlParent extends @xmlparent {
+  XmlParent() {
     // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
@@ -50,28 +53,28 @@ class XMLParent extends @xmlparent {
   string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
-  XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }
+  XmlFile getFile() { result = this or xmlElements(this, _, _, _, result) }
 
   /** Gets the child element at a specified index of this XML parent. */
-  XMLElement getChild(int index) { xmlElements(result, _, this, index, _) }
+  XmlElement getChild(int index) { xmlElements(result, _, this, index, _) }
 
   /** Gets a child element of this XML parent. */
-  XMLElement getAChild() { xmlElements(result, _, this, _, _) }
+  XmlElement getAChild() { xmlElements(result, _, this, _, _) }
 
   /** Gets a child element of this XML parent with the given `name`. */
-  XMLElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
+  XmlElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
 
   /** Gets a comment that is a child of this XML parent. */
-  XMLComment getAComment() { xmlComments(result, _, this, _) }
+  XmlComment getAComment() { xmlComments(result, _, this, _) }
 
   /** Gets a character sequence that is a child of this XML parent. */
-  XMLCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
+  XmlCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
 
-  /** Gets the depth in the tree. (Overridden in XMLElement.) */
+  /** Gets the depth in the tree. (Overridden in XmlElement.) */
   int getDepth() { result = 0 }
 
   /** Gets the number of child XML elements of this XML parent. */
-  int getNumberOfChildren() { result = count(XMLElement e | xmlElements(e, _, this, _, _)) }
+  int getNumberOfChildren() { result = count(XmlElement e | xmlElements(e, _, this, _, _)) }
 
   /** Gets the number of places in the body of this XML parent where text occurs. */
   int getNumberOfCharacterSets() { result = count(int pos | xmlChars(_, _, this, pos, _, _)) }
@@ -92,9 +95,12 @@ class XMLParent extends @xmlparent {
   string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlParent */
+deprecated class XMLParent = XmlParent;
+
 /** An XML file. */
-class XMLFile extends XMLParent, File {
-  XMLFile() { xmlEncoding(this, _) }
+class XmlFile extends XmlParent, File {
+  XmlFile() { xmlEncoding(this, _) }
 
   /** Gets a printable representation of this XML file. */
   override string toString() { result = this.getName() }
@@ -120,14 +126,17 @@ class XMLFile extends XMLParent, File {
   string getEncoding() { xmlEncoding(this, result) }
 
   /** Gets the XML file itself. */
-  override XMLFile getFile() { result = this }
+  override XmlFile getFile() { result = this }
 
   /** Gets a top-most element in an XML file. */
-  XMLElement getARootElement() { result = this.getAChild() }
+  XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
+
+/** DEPRECATED: Alias for XmlFile */
+deprecated class XMLFile = XmlFile;
 
 /**
  * An XML document type definition (DTD).
@@ -140,7 +149,7 @@ class XMLFile extends XMLParent, File {
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XMLLocatable, @xmldtd {
+class XMLDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -154,7 +163,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
   predicate isPublic() { not xmlDTDs(this, _, "", _, _) }
 
   /** Gets the parent of this DTD. */
-  XMLParent getParent() { xmlDTDs(this, _, _, _, result) }
+  XmlParent getParent() { xmlDTDs(this, _, _, _, result) }
 
   override string toString() {
     this.isPublic() and
@@ -176,7 +185,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
  * </manifest>
  * ```
  */
-class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
+class XmlElement extends @xmlelement, XmlParent, XmlLocatable {
   /** Holds if this XML element has the given `name`. */
   predicate hasName(string name) { name = this.getName() }
 
@@ -184,10 +193,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string getName() { xmlElements(this, result, _, _, _) }
 
   /** Gets the XML file in which this XML element occurs. */
-  override XMLFile getFile() { xmlElements(this, _, _, _, result) }
+  override XmlFile getFile() { xmlElements(this, _, _, _, result) }
 
   /** Gets the parent of this XML element. */
-  XMLParent getParent() { xmlElements(this, _, result, _, _) }
+  XmlParent getParent() { xmlElements(this, _, result, _, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getIndex() { xmlElements(this, _, _, result, _) }
@@ -196,7 +205,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this XML element, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getElementPositionIndex() { xmlElements(this, _, _, result, _) }
@@ -205,10 +214,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override int getDepth() { result = this.getParent().getDepth() + 1 }
 
   /** Gets an XML attribute of this XML element. */
-  XMLAttribute getAnAttribute() { result.getElement() = this }
+  XmlAttribute getAnAttribute() { result.getElement() = this }
 
   /** Gets the attribute with the specified `name`, if any. */
-  XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
+  XmlAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
   predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
@@ -220,6 +229,9 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlElement */
+deprecated class XMLElement = XmlElement;
+
 /**
  * An attribute that occurs inside an XML element.
  *
@@ -230,18 +242,18 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
  * android:versionCode="1"
  * ```
  */
-class XMLAttribute extends @xmlattribute, XMLLocatable {
+class XmlAttribute extends @xmlattribute, XmlLocatable {
   /** Gets the name of this attribute. */
   string getName() { xmlAttrs(this, _, result, _, _, _) }
 
   /** Gets the XML element to which this attribute belongs. */
-  XMLElement getElement() { xmlAttrs(this, result, _, _, _, _) }
+  XmlElement getElement() { xmlAttrs(this, result, _, _, _, _) }
 
   /** Holds if this attribute has a namespace. */
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this attribute, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the value of this attribute. */
   string getValue() { xmlAttrs(this, _, _, result, _, _) }
@@ -249,6 +261,9 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
   /** Gets a printable representation of this XML attribute. */
   override string toString() { result = this.getName() + "=" + this.getValue() }
 }
+
+/** DEPRECATED: Alias for XmlAttribute */
+deprecated class XMLAttribute = XmlAttribute;
 
 /**
  * A namespace used in an XML file.
@@ -259,7 +274,7 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
  * xmlns:android="http://schemas.android.com/apk/res/android"
  * ```
  */
-class XMLNamespace extends XMLLocatable, @xmlnamespace {
+class XmlNamespace extends XmlLocatable, @xmlnamespace {
   /** Gets the prefix of this namespace. */
   string getPrefix() { xmlNs(this, result, _, _) }
 
@@ -276,6 +291,9 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
   }
 }
 
+/** DEPRECATED: Alias for XmlNamespace */
+deprecated class XMLNamespace = XmlNamespace;
+
 /**
  * A comment in an XML file.
  *
@@ -285,16 +303,19 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
  * <!-- This is a comment. -->
  * ```
  */
-class XMLComment extends @xmlcomment, XMLLocatable {
+class XmlComment extends @xmlcomment, XmlLocatable {
   /** Gets the text content of this XML comment. */
   string getText() { xmlComments(this, result, _, _) }
 
   /** Gets the parent of this XML comment. */
-  XMLParent getParent() { xmlComments(this, _, result, _) }
+  XmlParent getParent() { xmlComments(this, _, result, _) }
 
   /** Gets a printable representation of this XML comment. */
   override string toString() { result = this.getText() }
 }
+
+/** DEPRECATED: Alias for XmlComment */
+deprecated class XMLComment = XmlComment;
 
 /**
  * A sequence of characters that occurs between opening and
@@ -306,12 +327,12 @@ class XMLComment extends @xmlcomment, XMLLocatable {
  * <content>This is a sequence of characters.</content>
  * ```
  */
-class XMLCharacters extends @xmlcharacters, XMLLocatable {
+class XmlCharacters extends @xmlcharacters, XmlLocatable {
   /** Gets the content of this character sequence. */
   string getCharacters() { xmlChars(this, result, _, _, _, _) }
 
   /** Gets the parent of this character sequence. */
-  XMLParent getParent() { xmlChars(this, _, result, _, _, _) }
+  XmlParent getParent() { xmlChars(this, _, result, _, _, _) }
 
   /** Holds if this character sequence is CDATA. */
   predicate isCDATA() { xmlChars(this, _, _, _, 1, _) }
@@ -319,3 +340,6 @@ class XMLCharacters extends @xmlcharacters, XMLLocatable {
   /** Gets a printable representation of this XML character sequence. */
   override string toString() { result = this.getCharacters() }
 }
+
+/** DEPRECATED: Alias for XmlCharacters */
+deprecated class XMLCharacters = XmlCharacters;

--- a/javascript/ql/test/library-tests/XML/tests.ql
+++ b/javascript/ql/test/library-tests/XML/tests.ql
@@ -1,28 +1,28 @@
 import javascript
 
-query predicate xmlAttribute(XMLAttribute attr, XMLElement element, string name, string value) {
+query predicate xmlAttribute(XmlAttribute attr, XmlElement element, string name, string value) {
   attr.getElement() = element and
   attr.getName() = name and
   attr.getValue() = value
 }
 
-query predicate xmlComment(XMLComment c, string text) { text = c.getText() }
+query predicate xmlComment(XmlComment c, string text) { text = c.getText() }
 
-query predicate xmlElement_getAnAttribute(XMLElement e, XMLAttribute attr) {
+query predicate xmlElement_getAnAttribute(XmlElement e, XmlAttribute attr) {
   attr = e.getAnAttribute()
 }
 
-query predicate xmlElement(XMLElement elt, string name, XMLParent parent, int index, XMLFile file) {
+query predicate xmlElement(XmlElement elt, string name, XmlParent parent, int index, XmlFile file) {
   name = elt.getName() and
   parent = elt.getParent() and
   index = elt.getIndex() and
   file = elt.getFile()
 }
 
-query predicate xmlFile(XMLFile f) { any() }
+query predicate xmlFile(XmlFile f) { any() }
 
-query predicate xmlLocatable(XMLLocatable x) { any() }
+query predicate xmlLocatable(XmlLocatable x) { any() }
 
-query predicate xmlParent_getChild(XMLParent p, int i, XMLElement child) { child = p.getChild(i) }
+query predicate xmlParent_getChild(XmlParent p, int i, XmlElement child) { child = p.getChild(i) }
 
-query predicate xmlParent_getTextValue(XMLParent p, string text) { p.getTextValue() = text }
+query predicate xmlParent_getTextValue(XmlParent p, string text) { p.getTextValue() = text }

--- a/python/ql/lib/change-notes/2022-08-22-xml-rename.md
+++ b/python/ql/lib/change-notes/2022-08-22-xml-rename.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Classes/predicates that had upper-case acronym XML in their name have been renamed to Xml to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/python/ql/lib/semmle/python/xml/XML.qll
+++ b/python/ql/lib/semmle/python/xml/XML.qll
@@ -36,12 +36,12 @@ class XmlLocatable extends @xmllocatable, TXmlLocatable {
 deprecated class XMLLocatable = XmlLocatable;
 
 /**
- * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
+ * An `XmlParent` is either an `XmlElement` or an `XmlFile`,
  * both of which can contain other elements.
  */
 class XmlParent extends @xmlparent {
   XmlParent() {
-    // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
+    // explicitly restrict `this` to be either an `XmlElement` or an `XmlFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
   }

--- a/python/ql/lib/semmle/python/xml/XML.qll
+++ b/python/ql/lib/semmle/python/xml/XML.qll
@@ -132,7 +132,7 @@ class XmlFile extends XmlParent, File {
   XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
-  XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
+  XmlDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
 /** DEPRECATED: Alias for XmlFile */
@@ -149,7 +149,7 @@ deprecated class XMLFile = XmlFile;
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XmlLocatable, @xmldtd {
+class XmlDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -173,6 +173,9 @@ class XMLDTD extends XmlLocatable, @xmldtd {
     result = this.getRoot() + " SYSTEM '" + this.getSystemId() + "'"
   }
 }
+
+/** DEPRECATED: Alias for XmlDTD */
+deprecated class XMLDTD = XmlDTD;
 
 /**
  * An XML element in an XML file.

--- a/python/ql/lib/semmle/python/xml/XML.qll
+++ b/python/ql/lib/semmle/python/xml/XML.qll
@@ -8,7 +8,7 @@ private class TXmlLocatable =
   @xmldtd or @xmlelement or @xmlattribute or @xmlnamespace or @xmlcomment or @xmlcharacters;
 
 /** An XML element that has a location. */
-class XMLLocatable extends @xmllocatable, TXmlLocatable {
+class XmlLocatable extends @xmllocatable, TXmlLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
@@ -32,12 +32,15 @@ class XMLLocatable extends @xmllocatable, TXmlLocatable {
   string toString() { none() } // overridden in subclasses
 }
 
+/** DEPRECATED: Alias for XmlLocatable */
+deprecated class XMLLocatable = XmlLocatable;
+
 /**
  * An `XMLParent` is either an `XMLElement` or an `XMLFile`,
  * both of which can contain other elements.
  */
-class XMLParent extends @xmlparent {
-  XMLParent() {
+class XmlParent extends @xmlparent {
+  XmlParent() {
     // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
     // the type `@xmlparent` currently also includes non-XML files
     this instanceof @xmlelement or xmlEncoding(this, _)
@@ -50,28 +53,28 @@ class XMLParent extends @xmlparent {
   string getName() { none() } // overridden in subclasses
 
   /** Gets the file to which this XML parent belongs. */
-  XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }
+  XmlFile getFile() { result = this or xmlElements(this, _, _, _, result) }
 
   /** Gets the child element at a specified index of this XML parent. */
-  XMLElement getChild(int index) { xmlElements(result, _, this, index, _) }
+  XmlElement getChild(int index) { xmlElements(result, _, this, index, _) }
 
   /** Gets a child element of this XML parent. */
-  XMLElement getAChild() { xmlElements(result, _, this, _, _) }
+  XmlElement getAChild() { xmlElements(result, _, this, _, _) }
 
   /** Gets a child element of this XML parent with the given `name`. */
-  XMLElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
+  XmlElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
 
   /** Gets a comment that is a child of this XML parent. */
-  XMLComment getAComment() { xmlComments(result, _, this, _) }
+  XmlComment getAComment() { xmlComments(result, _, this, _) }
 
   /** Gets a character sequence that is a child of this XML parent. */
-  XMLCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
+  XmlCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
 
-  /** Gets the depth in the tree. (Overridden in XMLElement.) */
+  /** Gets the depth in the tree. (Overridden in XmlElement.) */
   int getDepth() { result = 0 }
 
   /** Gets the number of child XML elements of this XML parent. */
-  int getNumberOfChildren() { result = count(XMLElement e | xmlElements(e, _, this, _, _)) }
+  int getNumberOfChildren() { result = count(XmlElement e | xmlElements(e, _, this, _, _)) }
 
   /** Gets the number of places in the body of this XML parent where text occurs. */
   int getNumberOfCharacterSets() { result = count(int pos | xmlChars(_, _, this, pos, _, _)) }
@@ -92,9 +95,12 @@ class XMLParent extends @xmlparent {
   string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlParent */
+deprecated class XMLParent = XmlParent;
+
 /** An XML file. */
-class XMLFile extends XMLParent, File {
-  XMLFile() { xmlEncoding(this, _) }
+class XmlFile extends XmlParent, File {
+  XmlFile() { xmlEncoding(this, _) }
 
   /** Gets a printable representation of this XML file. */
   override string toString() { result = this.getName() }
@@ -120,14 +126,17 @@ class XMLFile extends XMLParent, File {
   string getEncoding() { xmlEncoding(this, result) }
 
   /** Gets the XML file itself. */
-  override XMLFile getFile() { result = this }
+  override XmlFile getFile() { result = this }
 
   /** Gets a top-most element in an XML file. */
-  XMLElement getARootElement() { result = this.getAChild() }
+  XmlElement getARootElement() { result = this.getAChild() }
 
   /** Gets a DTD associated with this XML file. */
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
+
+/** DEPRECATED: Alias for XmlFile */
+deprecated class XMLFile = XmlFile;
 
 /**
  * An XML document type definition (DTD).
@@ -140,7 +149,7 @@ class XMLFile extends XMLParent, File {
  * <!ELEMENT lastName (#PCDATA)>
  * ```
  */
-class XMLDTD extends XMLLocatable, @xmldtd {
+class XMLDTD extends XmlLocatable, @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
@@ -154,7 +163,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
   predicate isPublic() { not xmlDTDs(this, _, "", _, _) }
 
   /** Gets the parent of this DTD. */
-  XMLParent getParent() { xmlDTDs(this, _, _, _, result) }
+  XmlParent getParent() { xmlDTDs(this, _, _, _, result) }
 
   override string toString() {
     this.isPublic() and
@@ -176,7 +185,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
  * </manifest>
  * ```
  */
-class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
+class XmlElement extends @xmlelement, XmlParent, XmlLocatable {
   /** Holds if this XML element has the given `name`. */
   predicate hasName(string name) { name = this.getName() }
 
@@ -184,10 +193,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string getName() { xmlElements(this, result, _, _, _) }
 
   /** Gets the XML file in which this XML element occurs. */
-  override XMLFile getFile() { xmlElements(this, _, _, _, result) }
+  override XmlFile getFile() { xmlElements(this, _, _, _, result) }
 
   /** Gets the parent of this XML element. */
-  XMLParent getParent() { xmlElements(this, _, result, _, _) }
+  XmlParent getParent() { xmlElements(this, _, result, _, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getIndex() { xmlElements(this, _, _, result, _) }
@@ -196,7 +205,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this XML element, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the index of this XML element among its parent's children. */
   int getElementPositionIndex() { xmlElements(this, _, _, result, _) }
@@ -205,10 +214,10 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override int getDepth() { result = this.getParent().getDepth() + 1 }
 
   /** Gets an XML attribute of this XML element. */
-  XMLAttribute getAnAttribute() { result.getElement() = this }
+  XmlAttribute getAnAttribute() { result.getElement() = this }
 
   /** Gets the attribute with the specified `name`, if any. */
-  XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
+  XmlAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
   predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
@@ -220,6 +229,9 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string toString() { result = this.getName() }
 }
 
+/** DEPRECATED: Alias for XmlElement */
+deprecated class XMLElement = XmlElement;
+
 /**
  * An attribute that occurs inside an XML element.
  *
@@ -230,18 +242,18 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
  * android:versionCode="1"
  * ```
  */
-class XMLAttribute extends @xmlattribute, XMLLocatable {
+class XmlAttribute extends @xmlattribute, XmlLocatable {
   /** Gets the name of this attribute. */
   string getName() { xmlAttrs(this, _, result, _, _, _) }
 
   /** Gets the XML element to which this attribute belongs. */
-  XMLElement getElement() { xmlAttrs(this, result, _, _, _, _) }
+  XmlElement getElement() { xmlAttrs(this, result, _, _, _, _) }
 
   /** Holds if this attribute has a namespace. */
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** Gets the namespace of this attribute, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
+  XmlNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** Gets the value of this attribute. */
   string getValue() { xmlAttrs(this, _, _, result, _, _) }
@@ -249,6 +261,9 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
   /** Gets a printable representation of this XML attribute. */
   override string toString() { result = this.getName() + "=" + this.getValue() }
 }
+
+/** DEPRECATED: Alias for XmlAttribute */
+deprecated class XMLAttribute = XmlAttribute;
 
 /**
  * A namespace used in an XML file.
@@ -259,7 +274,7 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
  * xmlns:android="http://schemas.android.com/apk/res/android"
  * ```
  */
-class XMLNamespace extends XMLLocatable, @xmlnamespace {
+class XmlNamespace extends XmlLocatable, @xmlnamespace {
   /** Gets the prefix of this namespace. */
   string getPrefix() { xmlNs(this, result, _, _) }
 
@@ -276,6 +291,9 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
   }
 }
 
+/** DEPRECATED: Alias for XmlNamespace */
+deprecated class XMLNamespace = XmlNamespace;
+
 /**
  * A comment in an XML file.
  *
@@ -285,16 +303,19 @@ class XMLNamespace extends XMLLocatable, @xmlnamespace {
  * <!-- This is a comment. -->
  * ```
  */
-class XMLComment extends @xmlcomment, XMLLocatable {
+class XmlComment extends @xmlcomment, XmlLocatable {
   /** Gets the text content of this XML comment. */
   string getText() { xmlComments(this, result, _, _) }
 
   /** Gets the parent of this XML comment. */
-  XMLParent getParent() { xmlComments(this, _, result, _) }
+  XmlParent getParent() { xmlComments(this, _, result, _) }
 
   /** Gets a printable representation of this XML comment. */
   override string toString() { result = this.getText() }
 }
+
+/** DEPRECATED: Alias for XmlComment */
+deprecated class XMLComment = XmlComment;
 
 /**
  * A sequence of characters that occurs between opening and
@@ -306,12 +327,12 @@ class XMLComment extends @xmlcomment, XMLLocatable {
  * <content>This is a sequence of characters.</content>
  * ```
  */
-class XMLCharacters extends @xmlcharacters, XMLLocatable {
+class XmlCharacters extends @xmlcharacters, XmlLocatable {
   /** Gets the content of this character sequence. */
   string getCharacters() { xmlChars(this, result, _, _, _, _) }
 
   /** Gets the parent of this character sequence. */
-  XMLParent getParent() { xmlChars(this, _, result, _, _, _) }
+  XmlParent getParent() { xmlChars(this, _, result, _, _, _) }
 
   /** Holds if this character sequence is CDATA. */
   predicate isCDATA() { xmlChars(this, _, _, _, 1, _) }
@@ -319,3 +340,6 @@ class XMLCharacters extends @xmlcharacters, XMLLocatable {
   /** Gets a printable representation of this XML character sequence. */
   override string toString() { result = this.getCharacters() }
 }
+
+/** DEPRECATED: Alias for XmlCharacters */
+deprecated class XMLCharacters = XmlCharacters;

--- a/python/tools/recorded-call-graph-metrics/ql/lib/BytecodeExpr.qll
+++ b/python/tools/recorded-call-graph-metrics/ql/lib/BytecodeExpr.qll
@@ -1,6 +1,6 @@
 import python
 
-abstract class XmlBytecodeExpr extends XMLElement { }
+abstract class XmlBytecodeExpr extends XmlElement { }
 
 /** DEPRECATED: Alias for XmlBytecodeExpr */
 deprecated class XMLBytecodeExpr = XmlBytecodeExpr;

--- a/python/tools/recorded-call-graph-metrics/ql/lib/RecordedCalls.qll
+++ b/python/tools/recorded-call-graph-metrics/ql/lib/RecordedCalls.qll
@@ -4,7 +4,7 @@ import semmle.python.objects.Callables
 import lib.BytecodeExpr
 
 /** The XML data for a recorded call (includes all data). */
-class XmlRecordedCall extends XMLElement {
+class XmlRecordedCall extends XmlElement {
   XmlRecordedCall() { this.hasName("recorded_call") }
 
   /** Gets the XML data for the call. */
@@ -61,7 +61,7 @@ class XmlRecordedCall extends XMLElement {
 deprecated class XMLRecordedCall = XmlRecordedCall;
 
 /** The XML data for the call part a recorded call. */
-class XmlCall extends XMLElement {
+class XmlCall extends XmlElement {
   XmlCall() { this.hasName("Call") }
 
   string get_filename_data() { result = this.getAChild("filename").getTextValue() }
@@ -114,7 +114,7 @@ class XmlCall extends XMLElement {
 deprecated class XMLCall = XmlCall;
 
 /** The XML data for the callee part a recorded call. */
-abstract class XmlCallee extends XMLElement { }
+abstract class XmlCallee extends XmlElement { }
 
 /** DEPRECATED: Alias for XmlCallee */
 deprecated class XMLCallee = XmlCallee;


### PR DESCRIPTION
[Acronyms should use normal PascalCase/camelCase](https://github.com/github/codeql/blob/main/docs/ql-style-guide.md#naming).  

written automatically using my patching utility 

The CI here is failing, and that is intended. Look at the CI checks in the internal PR (see the first backref below).  

I've also deleted a dead method in [java/kotlin-extractor/src/main/kotlin/utils/List.kt](https://github.com/github/codeql/pull/10073/commits/98acb1db01fb0574a1ba7ef3a4f520e16d66a616#diff-b2dd6f8c69711edb07aa0cbbc5686fe64c73958188af34e90807439c60423d75), because that method being dead caused the internal CI to fail. 

This PR has to be merged at the same time as the internal PR. 