### PR TITLE
Java: Add some type-based sanitizers to SensitiveInfoLog.ql.

### DIFF
--- a/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
@@ -17,6 +17,14 @@ class CredentialExpr extends Expr {
   }
 }
 
+/** An instantiation of a (reflexive, transitive) subtype of `java.lang.reflect.Type`. */
+private class TypeType extends RefType {
+  pragma[nomagic]
+  TypeType() {
+    this.getSourceDeclaration().getASourceSupertype*().hasQualifiedName("java.lang.reflect", "Type")
+  }
+}
+
 /** A data-flow configuration for identifying potentially-sensitive data flowing to a log output. */
 class SensitiveLoggerConfiguration extends TaintTracking::Configuration {
   SensitiveLoggerConfiguration() { this = "SensitiveLoggerConfiguration" }
@@ -26,7 +34,11 @@ class SensitiveLoggerConfiguration extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) { sinkNode(sink, "logging") }
 
   override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer.asExpr() instanceof LiveLiteral
+    sanitizer.asExpr() instanceof LiveLiteral or
+    sanitizer.getType() instanceof PrimitiveType or
+    sanitizer.getType() instanceof BoxedType or
+    sanitizer.getType() instanceof NumberType or
+    sanitizer.getType() instanceof TypeType
   }
 
   override predicate isSanitizerIn(Node node) { isSource(node) }

--- a/java/ql/src/change-notes/2022-08-18-sensitive-log-sanitizer.md
+++ b/java/ql/src/change-notes/2022-08-18-sensitive-log-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Improved sanitizers for `java/sensitive-log`, which removes some false positives and improves performance a bit.


### PR DESCRIPTION
The source definition is rather ad-hoc in this query, so filtering nodes based on some safe types can help remove FPs.