### PR TITLE
Java: Move sink-constraints into the configuration in NumericCastTainted.ql.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-681/NumericCastTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-681/NumericCastTainted.ql
@@ -23,7 +23,8 @@ private class NumericCastFlowConfig extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
 
   override predicate isSink(DataFlow::Node sink) {
-    sink.asExpr() = any(NumericNarrowingCastExpr cast).getExpr()
+    sink.asExpr() = any(NumericNarrowingCastExpr cast).getExpr() and
+    sink.asExpr() instanceof VarAccess
   }
 
   override predicate isSanitizer(DataFlow::Node node) {
@@ -31,18 +32,17 @@ private class NumericCastFlowConfig extends TaintTracking::Configuration {
     castCheck(node.asExpr()) or
     node.getType() instanceof SmallType or
     smallExpr(node.asExpr()) or
-    node.getEnclosingCallable() instanceof HashCodeMethod
+    node.getEnclosingCallable() instanceof HashCodeMethod or
+    exists(RightShiftOp e | e.getShiftedVariable().getAnAccess() = node.asExpr())
   }
 }
 
 from
   DataFlow::PathNode source, DataFlow::PathNode sink, NumericNarrowingCastExpr exp,
-  VarAccess tainted, NumericCastFlowConfig conf
+  NumericCastFlowConfig conf
 where
-  exp.getExpr() = tainted and
-  sink.getNode().asExpr() = tainted and
-  conf.hasFlowPath(source, sink) and
-  not exists(RightShiftOp e | e.getShiftedVariable() = tainted.getVariable())
+  sink.getNode().asExpr() = exp.getExpr() and
+  conf.hasFlowPath(source, sink)
 select exp, source, sink,
   "$@ flows to here and is cast to a narrower type, potentially causing truncation.",
   source.getNode(), "User-provided value"


### PR DESCRIPTION
The exclusion of right-shifted variables on sinks is probably better as a sanitizer, so move it there. That should help performance a bit and possibly also remove some FPs.

Also, there was a somewhat arbitrary-looking restriction that the sink has to be a variable access. I'm not going to consider whether that restriction ought to lifted (it's probably fine to keep), but we might as well make it explicit and move it into the configuration to gain some performance.