### PR TITLE
Go: don't use WriteNode for channel writes

### DIFF
--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
@@ -167,20 +167,10 @@ module ControlFlow {
     }
 
     /**
-     * Holds if this node writes `rhs` to `channel`.
-     */
-    predicate writesToChannel(DataFlow::ExprNode channel, DataFlow::ExprNode rhs) {
-      exists(SendStmt send |
-        send.getChannel() = channel.asExpr() and
-        send.getValue() = rhs.asExpr()
-      )
-    }
-
-    /**
      * Holds if this node sets any field or element of `base` to `rhs`.
      */
     predicate writesComponent(DataFlow::Node base, DataFlow::Node rhs) {
-      writesElement(base, _, rhs) or writesField(base, _, rhs) or writesToChannel(base, rhs)
+      writesElement(base, _, rhs) or writesField(base, _, rhs)
     }
   }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/ContainerFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/ContainerFlow.qll
@@ -24,7 +24,9 @@ predicate containerStoreStep(Node node1, Node node2, Content c) {
   )
   or
   c instanceof CollectionContent and
-  exists(Write w | w.writesToChannel(node2, node1))
+  exists(SendStmt send |
+    send.getChannel() = node2.(ExprNode).asExpr() and send.getValue() = node1.(ExprNode).asExpr()
+  )
   or
   c instanceof MapKeyContent and
   node2.getType() instanceof MapType and

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -634,7 +634,10 @@ module Public {
     predicate isReceiverOf(MethodDecl m) { parm.isReceiverOf(m) }
   }
 
-  private Node getADirectlyWrittenNode() { exists(Write w | w.writesComponent(result, _)) }
+  private Node getADirectlyWrittenNode() {
+    exists(Write w | w.writesComponent(result, _)) or
+    result = DataFlow::exprNode(any(SendStmt s).getChannel())
+  }
 
   private DataFlow::Node getAccessPathPredecessor(DataFlow::Node node) {
     result = node.(PointerDereferenceNode).getOperand()

--- a/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.expected
@@ -1,0 +1,22 @@
+edges
+| test.go:9:10:9:12 | selection of c [collection] : string | test.go:9:8:9:12 | <-... |
+| test.go:13:16:13:16 | definition of s [pointer, c, collection] : string | test.go:16:3:16:3 | s [pointer, c, collection] : string |
+| test.go:15:11:15:18 | call to source : string | test.go:16:10:16:13 | data : string |
+| test.go:16:3:16:3 | implicit dereference [c, collection] : string | test.go:13:16:13:16 | definition of s [pointer, c, collection] : string |
+| test.go:16:3:16:3 | implicit dereference [c, collection] : string | test.go:16:3:16:5 | selection of c [collection] : string |
+| test.go:16:3:16:3 | s [pointer, c, collection] : string | test.go:16:3:16:3 | implicit dereference [c, collection] : string |
+| test.go:16:3:16:5 | selection of c [collection] : string | test.go:9:10:9:12 | selection of c [collection] : string |
+| test.go:16:3:16:5 | selection of c [collection] : string | test.go:16:3:16:3 | implicit dereference [c, collection] : string |
+| test.go:16:10:16:13 | data : string | test.go:16:3:16:5 | selection of c [collection] : string |
+nodes
+| test.go:9:8:9:12 | <-... | semmle.label | <-... |
+| test.go:9:10:9:12 | selection of c [collection] : string | semmle.label | selection of c [collection] : string |
+| test.go:13:16:13:16 | definition of s [pointer, c, collection] : string | semmle.label | definition of s [pointer, c, collection] : string |
+| test.go:15:11:15:18 | call to source : string | semmle.label | call to source : string |
+| test.go:16:3:16:3 | implicit dereference [c, collection] : string | semmle.label | implicit dereference [c, collection] : string |
+| test.go:16:3:16:3 | s [pointer, c, collection] : string | semmle.label | s [pointer, c, collection] : string |
+| test.go:16:3:16:5 | selection of c [collection] : string | semmle.label | selection of c [collection] : string |
+| test.go:16:10:16:13 | data : string | semmle.label | data : string |
+subpaths
+#select
+| test.go:15:11:15:18 | call to source : string | test.go:15:11:15:18 | call to source : string | test.go:9:8:9:12 | <-... | path |

--- a/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.expected
@@ -1,22 +1,22 @@
 edges
-| test.go:9:10:9:12 | selection of c [collection] : string | test.go:9:8:9:12 | <-... |
-| test.go:13:16:13:16 | definition of s [pointer, c, collection] : string | test.go:16:3:16:3 | s [pointer, c, collection] : string |
-| test.go:15:11:15:18 | call to source : string | test.go:16:10:16:13 | data : string |
-| test.go:16:3:16:3 | implicit dereference [c, collection] : string | test.go:13:16:13:16 | definition of s [pointer, c, collection] : string |
-| test.go:16:3:16:3 | implicit dereference [c, collection] : string | test.go:16:3:16:5 | selection of c [collection] : string |
-| test.go:16:3:16:3 | s [pointer, c, collection] : string | test.go:16:3:16:3 | implicit dereference [c, collection] : string |
-| test.go:16:3:16:5 | selection of c [collection] : string | test.go:9:10:9:12 | selection of c [collection] : string |
-| test.go:16:3:16:5 | selection of c [collection] : string | test.go:16:3:16:3 | implicit dereference [c, collection] : string |
-| test.go:16:10:16:13 | data : string | test.go:16:3:16:5 | selection of c [collection] : string |
+| test.go:9:9:9:11 | selection of c [collection] : string | test.go:9:7:9:11 | <-... |
+| test.go:13:16:13:16 | definition of s [pointer, c, collection] : string | test.go:16:2:16:2 | s [pointer, c, collection] : string |
+| test.go:15:10:15:17 | call to source : string | test.go:16:9:16:12 | data : string |
+| test.go:16:2:16:2 | implicit dereference [c, collection] : string | test.go:13:16:13:16 | definition of s [pointer, c, collection] : string |
+| test.go:16:2:16:2 | implicit dereference [c, collection] : string | test.go:16:2:16:4 | selection of c [collection] : string |
+| test.go:16:2:16:2 | s [pointer, c, collection] : string | test.go:16:2:16:2 | implicit dereference [c, collection] : string |
+| test.go:16:2:16:4 | selection of c [collection] : string | test.go:9:9:9:11 | selection of c [collection] : string |
+| test.go:16:2:16:4 | selection of c [collection] : string | test.go:16:2:16:2 | implicit dereference [c, collection] : string |
+| test.go:16:9:16:12 | data : string | test.go:16:2:16:4 | selection of c [collection] : string |
 nodes
-| test.go:9:8:9:12 | <-... | semmle.label | <-... |
-| test.go:9:10:9:12 | selection of c [collection] : string | semmle.label | selection of c [collection] : string |
+| test.go:9:7:9:11 | <-... | semmle.label | <-... |
+| test.go:9:9:9:11 | selection of c [collection] : string | semmle.label | selection of c [collection] : string |
 | test.go:13:16:13:16 | definition of s [pointer, c, collection] : string | semmle.label | definition of s [pointer, c, collection] : string |
-| test.go:15:11:15:18 | call to source : string | semmle.label | call to source : string |
-| test.go:16:3:16:3 | implicit dereference [c, collection] : string | semmle.label | implicit dereference [c, collection] : string |
-| test.go:16:3:16:3 | s [pointer, c, collection] : string | semmle.label | s [pointer, c, collection] : string |
-| test.go:16:3:16:5 | selection of c [collection] : string | semmle.label | selection of c [collection] : string |
-| test.go:16:10:16:13 | data : string | semmle.label | data : string |
+| test.go:15:10:15:17 | call to source : string | semmle.label | call to source : string |
+| test.go:16:2:16:2 | implicit dereference [c, collection] : string | semmle.label | implicit dereference [c, collection] : string |
+| test.go:16:2:16:2 | s [pointer, c, collection] : string | semmle.label | s [pointer, c, collection] : string |
+| test.go:16:2:16:4 | selection of c [collection] : string | semmle.label | selection of c [collection] : string |
+| test.go:16:9:16:12 | data : string | semmle.label | data : string |
 subpaths
 #select
-| test.go:15:11:15:18 | call to source : string | test.go:15:11:15:18 | call to source : string | test.go:9:8:9:12 | <-... | path |
+| test.go:15:10:15:17 | call to source : string | test.go:15:10:15:17 | call to source : string | test.go:9:7:9:11 | <-... | path |

--- a/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.go
@@ -1,26 +1,26 @@
 package test
 
 type State struct {
-  c chan string
+	c chan string
 }
 
 func handler(s *State) {
 
-  sink(<-s.c)
+	sink(<-s.c)
 
 }
 
 func requester(s *State) {
 
-  data := source()
-  s.c <- data
+	data := source()
+	s.c <- data
 
 }
 
 func source() string {
 
-  return "tainted"
+	return "tainted"
 
 }
 
-func sink(s string) { }
+func sink(s string) {}

--- a/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.go
@@ -1,0 +1,26 @@
+package test
+
+type State struct {
+  c chan string
+}
+
+func handler(s *State) {
+
+  sink(<-s.c)
+
+}
+
+func requester(s *State) {
+
+  data := source()
+  s.c <- data
+
+}
+
+func source() string {
+
+  return "tainted"
+
+}
+
+func sink(s string) { }

--- a/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ChannelField/test.ql
@@ -1,0 +1,18 @@
+import go
+import DataFlow::PathGraph
+
+class TestConfig extends DataFlow::Configuration {
+  TestConfig() { this = "test config" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source.(DataFlow::CallNode).getTarget().getName() = "source"
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    sink = any(DataFlow::CallNode c | c.getTarget().getName() = "sink").getAnArgument()
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, TestConfig c
+where c.hasFlowPath(source, sink)
+select source, source, sink, "path"


### PR DESCRIPTION
I overlooked the fact that this has a WriteInstruction, which wasn't bound in the channel-write case, but somehow the evaluator discarded the implied cartesian product until last night's performance evaluation.

Rather than try to cram channel writes into WriteInstruction, just handle them as their own beast.