### PR TITLE
RB: introduce the cached stages pattern for Ruby

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/AST.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/AST.qll
@@ -6,6 +6,7 @@ private import codeql.ruby.ast.internal.Pattern
 private import codeql.ruby.ast.internal.Variable
 private import codeql.ruby.AST as AST
 private import Synthesis
+private import codeql.ruby.internal.CachedStages
 
 module MethodName {
   predicate range(Ruby::UnderscoreMethodName g) {
@@ -649,6 +650,7 @@ private module Cached {
 
   cached
   predicate lhsExpr(AST::Expr e) {
+    Stages::AST::ref() and
     explicitAssignmentNode(toGenerated(e), _)
     or
     implicitAssignmentNode(toGenerated(e))

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Erb.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Erb.qll
@@ -1,6 +1,7 @@
 import codeql.Locations
 private import TreeSitter
 private import codeql.ruby.ast.Erb
+private import codeql.ruby.internal.CachedStages
 
 cached
 private module Cached {
@@ -20,13 +21,21 @@ private module Cached {
    */
   cached
   Erb::AstNode toGenerated(ErbAstNode n) {
-    n = TCommentDirective(result) or
-    n = TDirective(result) or
-    n = TGraphqlDirective(result) or
-    n = TOutputDirective(result) or
-    n = TTemplate(result) or
-    n = TToken(result) or
-    n = TComment(result) or
+    Stages::AST::ref() and
+    n = TCommentDirective(result)
+    or
+    n = TDirective(result)
+    or
+    n = TGraphqlDirective(result)
+    or
+    n = TOutputDirective(result)
+    or
+    n = TTemplate(result)
+    or
+    n = TToken(result)
+    or
+    n = TComment(result)
+    or
     n = TCode(result)
   }
 

--- a/ruby/ql/lib/codeql/ruby/controlflow/BasicBlocks.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/BasicBlocks.qll
@@ -8,6 +8,7 @@ private import codeql.ruby.controlflow.ControlFlowGraph
 private import internal.ControlFlowGraphImpl
 private import CfgNodes
 private import SuccessorTypes
+private import codeql.ruby.internal.CachedStages
 
 /**
  * A basic block, that is, a maximal straight-line sequence of control flow nodes
@@ -302,6 +303,7 @@ private module Cached {
    */
   cached
   JoinBlockPredecessor getJoinBlockPredecessor(JoinBlock jb, int i) {
+    Stages::CFG::ref() and
     result =
       rank[i + 1](JoinBlockPredecessor jbp |
         jbp = jb.getAPredecessor()

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -8,6 +8,7 @@ private import codeql.ruby.ast.internal.Literal
 private import ControlFlowGraph
 private import internal.ControlFlowGraphImpl
 private import internal.Splitting
+private import codeql.ruby.internal.CachedStages
 
 /** An entry node for a given scope. */
 class EntryNode extends CfgNode, TEntryNode {
@@ -185,6 +186,7 @@ abstract private class ChildMapping extends AstNode {
    */
   cached
   predicate hasCfgChild(AstNode child, CfgNode cfn, CfgNode cfnChild) {
+    Stages::CFG::ref() and
     this.reachesBasicBlock(child, cfn, cfnChild.getBasicBlock()) and
     cfnChild.getNode() = desugar(child)
   }

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImpl.qll
@@ -40,6 +40,7 @@ private import codeql.ruby.ast.internal.Variable
 private import codeql.ruby.controlflow.ControlFlowGraph
 private import Completion
 import ControlFlowGraphImplShared
+private import codeql.ruby.internal.CachedStages
 
 abstract class CfgScopeImpl extends AstNode {
   abstract predicate entry(AstNode first);
@@ -1448,7 +1449,7 @@ cached
 private module Cached {
   cached
   newtype TSuccessorType =
-    TSuccessorSuccessor() or
+    TSuccessorSuccessor() { Stages::CFG::ref() } or
     TBooleanSuccessor(boolean b) { b in [false, true] } or
     TEmptinessSuccessor(boolean isEmpty) { isEmpty in [false, true] } or
     TMatchingSuccessor(boolean isMatch) { isMatch in [false, true] } or

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/Splitting.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/Splitting.qll
@@ -7,23 +7,19 @@ private import Completion
 private import ControlFlowGraphImpl
 private import SuccessorTypes
 private import codeql.ruby.controlflow.ControlFlowGraph
+private import codeql.ruby.internal.CachedStages
 
 cached
-private module Cached {
-  cached
-  newtype TSplitKind =
-    TConditionalCompletionSplitKind() { forceCachingInSameStage() } or
-    TEnsureSplitKind(int nestLevel) { nestLevel = any(Trees::BodyStmtTree t).getNestLevel() }
+newtype TSplitKind =
+  TConditionalCompletionSplitKind() { forceCachingInSameStage() and Stages::CFG::ref() } or
+  TEnsureSplitKind(int nestLevel) { nestLevel = any(Trees::BodyStmtTree t).getNestLevel() }
 
-  cached
-  newtype TSplit =
-    TConditionalCompletionSplit(ConditionalCompletion c) or
-    TEnsureSplit(EnsureSplitting::EnsureSplitType type, int nestLevel) {
-      nestLevel = any(Trees::BodyStmtTree t).getNestLevel()
-    }
-}
-
-import Cached
+cached
+newtype TSplit =
+  TConditionalCompletionSplit(ConditionalCompletion c) { Stages::CFG::ref() } or
+  TEnsureSplit(EnsureSplitting::EnsureSplitType type, int nestLevel) {
+    nestLevel = any(Trees::BodyStmtTree t).getNestLevel()
+  }
 
 /** A split for a control flow node. */
 class Split extends TSplit {

--- a/ruby/ql/lib/codeql/ruby/dataflow/RemoteFlowSources.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/RemoteFlowSources.qll
@@ -6,6 +6,7 @@
 private import codeql.ruby.dataflow.internal.DataFlowPublic as DataFlow
 // Need to import since frameworks can extend `RemoteFlowSource::Range`
 private import codeql.ruby.Frameworks
+private import codeql.ruby.internal.CachedStages
 
 /**
  * A data flow source of remote user input.
@@ -13,13 +14,11 @@ private import codeql.ruby.Frameworks
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `RemoteFlowSource::Range` instead.
  */
-class RemoteFlowSource extends DataFlow::Node {
-  RemoteFlowSource::Range self;
-
-  RemoteFlowSource() { this = self }
-
+cached
+class RemoteFlowSource extends DataFlow::Node instanceof RemoteFlowSource::Range {
   /** Gets a string that describes the type of this remote flow source. */
-  string getSourceType() { result = self.getSourceType() }
+  cached
+  string getSourceType() { Stages::Taint::ref() and result = super.getSourceType() }
 }
 
 /** Provides a class for modeling new sources of remote user input. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -6,6 +6,7 @@ private import codeql.ruby.typetracking.TypeTracker
 private import codeql.ruby.dataflow.SSA
 private import FlowSummaryImpl as FlowSummaryImpl
 private import SsaImpl as SsaImpl
+private import codeql.ruby.internal.CachedStages
 
 /**
  * An element, viewed as a node in a data flow graph. Either an expression
@@ -20,11 +21,13 @@ class Node extends TNode {
 
   /** Gets a textual representation of this node. */
   cached
-  final string toString() { result = this.(NodeImpl).toStringImpl() }
+  final string toString() { result = this.(NodeImpl).toStringImpl() and Stages::DataFlow::ref() }
 
   /** Gets the location of this node. */
   cached
-  final Location getLocation() { result = this.(NodeImpl).getLocationImpl() }
+  final Location getLocation() {
+    result = this.(NodeImpl).getLocationImpl() and Stages::DataFlow::ref()
+  }
 
   /**
    * Holds if this element is at the specified location.

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -4,6 +4,7 @@ private import codeql.ruby.AST
 private import codeql.ruby.CFG
 private import codeql.ruby.ast.Variable
 private import CfgNodes::ExprNodes
+private import codeql.ruby.internal.CachedStages
 
 /** Holds if `v` is uninitialized at index `i` in entry block `bb`. */
 predicate uninitializedWrite(EntryBasicBlock bb, int i, LocalVariable v) {
@@ -171,6 +172,7 @@ private module Cached {
    */
   cached
   predicate variableWriteActual(BasicBlock bb, int i, LocalVariable v, VariableWriteAccess write) {
+    Stages::CFG::ref() and
     exists(AstNode n |
       write.getVariable() = v and
       n = bb.getNode(i).getNode()

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -62,8 +62,10 @@ private CfgNodes::ExprNodes::VariableWriteAccessCfgNode variablesInPattern(
 
 cached
 private module Cached {
+  private import codeql.ruby.internal.CachedStages
+
   cached
-  predicate forceCachingInSameStage() { any() }
+  predicate forceCachingInSameStage() { Stages::Taint::ref() }
 
   /**
    * Holds if the additional step from `nodeFrom` to `nodeTo` should be included

--- a/ruby/ql/lib/codeql/ruby/internal/CachedStages.qll
+++ b/ruby/ql/lib/codeql/ruby/internal/CachedStages.qll
@@ -35,8 +35,8 @@ module Stages {
    */
   cached
   module AST {
-    private import codeql.ruby.AST as AST1
-    private import codeql.ruby.ast.internal.AST as AST2
+    private import codeql.ruby.AST as Ast1
+    private import codeql.ruby.ast.internal.AST as Ast2
     private import codeql.ruby.ast.internal.Erb as Erb
 
     /**
@@ -54,13 +54,13 @@ module Stages {
     predicate backref() {
       1 = 1
       or
-      exists(any(AST1::AstNode a).getEnclosingModule())
+      exists(any(Ast1::AstNode a).getEnclosingModule())
       or
-      AST2::lhsExpr(_)
+      Ast2::lhsExpr(_)
       or
       exists(Erb::toGenerated(_))
       or
-      exists(any(AST1::AstNode a).toString())
+      exists(any(Ast1::AstNode a).toString())
     }
   }
 
@@ -70,11 +70,11 @@ module Stages {
    */
   cached
   module CFG {
-    private import codeql.ruby.controlflow.internal.ControlFlowGraphImpl as CFGImpl
-    private import codeql.ruby.controlflow.internal.Splitting as CFGSplitting
-    private import codeql.ruby.controlflow.BasicBlocks as CFGBasicBlocks
+    private import codeql.ruby.controlflow.internal.ControlFlowGraphImpl as CfgImpl
+    private import codeql.ruby.controlflow.internal.Splitting as CfgSplitting
+    private import codeql.ruby.controlflow.BasicBlocks as CfgBasicBlocks
     private import codeql.ruby.dataflow.internal.SsaImpl as SsaImpl
-    private import codeql.ruby.controlflow.CfgNodes as CFGNodes
+    private import codeql.ruby.controlflow.CfgNodes as CfgNodes
 
     /**
      * Always holds.
@@ -91,17 +91,17 @@ module Stages {
     predicate backref() {
       1 = 1
       or
-      exists(CFGImpl::TSuccessorType a)
+      exists(CfgImpl::TSuccessorType a)
       or
-      exists(CFGSplitting::TSplitKind a)
+      exists(CfgSplitting::TSplitKind a)
       or
-      exists(CFGSplitting::TSplit a)
+      exists(CfgSplitting::TSplit a)
       or
-      exists(any(CFGBasicBlocks::JoinBlock b).getJoinBlockPredecessor(_))
+      exists(any(CfgBasicBlocks::JoinBlock b).getJoinBlockPredecessor(_))
       or
       SsaImpl::variableWriteActual(_, _, _, _)
       or
-      exists(any(CFGNodes::ExprNodes::AssignExprCfgNode a).getLhs())
+      exists(any(CfgNodes::ExprNodes::AssignExprCfgNode a).getLhs())
     }
   }
 

--- a/ruby/ql/lib/codeql/ruby/internal/CachedStages.qll
+++ b/ruby/ql/lib/codeql/ruby/internal/CachedStages.qll
@@ -1,0 +1,182 @@
+/**
+ * INTERNAL: Do not use.
+ *
+ * The purpose of this file is to control which cached predicates belong to the same stage.
+ *
+ * Combining stages can improve performance as we are more likely to reuse shared, non-cached predicates.
+ *
+ * To make a predicate `p` belong to a stage `A`:
+ * - make `p` depend on `A::ref()`, and
+ * - make `A::backref()` depend on `p`.
+ *
+ * Since `A` is a cached module, `ref` and `backref` must be in the same stage, and the dependency
+ * chain above thus forces `p` to be in that stage as well.
+ *
+ * With these two predicates in a `cached module` we ensure that all the cached predicates will be in a single stage at runtime.
+ *
+ * Grouping stages can cause unnecessary computation, as a concrete query might not depend on
+ * all the cached predicates in a stage.
+ * Care should therefore be taken not to combine two stages, if it is likely that a query only depend
+ * on some but not all the cached predicates in the combined stage.
+ */
+
+/**
+ * Contains a `cached module` for each stage.
+ * Each `cached module` ensures that predicates that are supposed to be in the same stage, are in the same stage.
+ *
+ * Each `cached module` contain two predicates:
+ * The first, `ref`, always holds, and is referenced from `cached` predicates.
+ * The second, `backref`, contains references to the same `cached` predicates.
+ * The `backref` predicate starts with `1 = 1 or` to ensure that the predicate will be optimized down to a constant by the optimizer.
+ */
+module Stages {
+  /**
+   * The `AST` stage.
+   */
+  cached
+  module AST {
+    private import codeql.ruby.AST as AST1
+    private import codeql.ruby.ast.internal.AST as AST2
+    private import codeql.ruby.ast.internal.Erb as Erb
+
+    /**
+     * Always holds.
+     * Ensures that a predicate is evaluated as part of the Ast stage.
+     */
+    cached
+    predicate ref() { 1 = 1 }
+
+    /**
+     * DONT USE!
+     * Contains references to each predicate that use the above `ref` predicate.
+     */
+    cached
+    predicate backref() {
+      1 = 1
+      or
+      exists(any(AST1::AstNode a).getEnclosingModule())
+      or
+      AST2::lhsExpr(_)
+      or
+      exists(Erb::toGenerated(_))
+      or
+      exists(any(AST1::AstNode a).toString())
+    }
+  }
+
+  /**
+   * The `CFG` stage.
+   * Computes predicates based on the CFG.
+   */
+  cached
+  module CFG {
+    private import codeql.ruby.controlflow.internal.ControlFlowGraphImpl as CFGImpl
+    private import codeql.ruby.controlflow.internal.Splitting as CFGSplitting
+    private import codeql.ruby.controlflow.BasicBlocks as CFGBasicBlocks
+    private import codeql.ruby.dataflow.internal.SsaImpl as SsaImpl
+    private import codeql.ruby.controlflow.CfgNodes as CFGNodes
+
+    /**
+     * Always holds.
+     * Ensures that a predicate is evaluated as part of the Ast stage.
+     */
+    cached
+    predicate ref() { 1 = 1 }
+
+    /**
+     * DONT USE!
+     * Contains references to each predicate that use the above `ref` predicate.
+     */
+    cached
+    predicate backref() {
+      1 = 1
+      or
+      exists(CFGImpl::TSuccessorType a)
+      or
+      exists(CFGSplitting::TSplitKind a)
+      or
+      exists(CFGSplitting::TSplit a)
+      or
+      exists(any(CFGBasicBlocks::JoinBlock b).getJoinBlockPredecessor(_))
+      or
+      SsaImpl::variableWriteActual(_, _, _, _)
+      or
+      exists(any(CFGNodes::ExprNodes::AssignExprCfgNode a).getLhs())
+    }
+  }
+
+  /**
+   * The `DataFlow` stage.
+   * The DataFlow stages already included both lots of DataFlow and API-graphs without the collapsing that happens here.
+   */
+  cached
+  module DataFlow {
+    private import codeql.ruby.ApiGraphs::API as ApiGraphs
+    private import codeql.ruby.dataflow.internal.DataFlowPublic as DataFlowPublic
+
+    /**
+     * Always holds.
+     * Ensures that a predicate is evaluated as part of the Ast stage.
+     */
+    cached
+    predicate ref() { 1 = 1 }
+
+    /**
+     * DONT USE!
+     * Contains references to each predicate that use the above `ref` predicate.
+     */
+    cached
+    predicate backref() {
+      1 = 1
+      or
+      exists(
+        ApiGraphs::root()
+            .getMember(_)
+            .getAMember()
+            .getMethod(_)
+            .getReturn(_)
+            .getReturn()
+            .getParameter(_)
+            .getKeywordParameter(_)
+            .getBlock()
+            .getAnImmediateSubclass()
+            .getAValueReachableFromSource()
+      )
+      or
+      exists(ApiGraphs::root().getMember(_).getAMethodCall(_))
+      or
+      exists(any(DataFlowPublic::Node n).toString())
+      or
+      exists(any(DataFlowPublic::Node n).getLocation())
+    }
+  }
+
+  /**
+   * The `Taint` stage.
+   */
+  cached
+  module Taint {
+    private import codeql.ruby.dataflow.RemoteFlowSources as RemoteFlowSources
+    private import codeql.ruby.dataflow.internal.TaintTrackingPublic as TaintTrackingPublic
+
+    /**
+     * Always holds.
+     * Ensures that a predicate is evaluated as part of the Ast stage.
+     */
+    cached
+    predicate ref() { 1 = 1 }
+
+    /**
+     * DONT USE!
+     * Contains references to each predicate that use the above `ref` predicate.
+     */
+    cached
+    predicate backref() {
+      1 = 1
+      or
+      exists(any(RemoteFlowSources::RemoteFlowSource r).getSourceType())
+      or
+      TaintTrackingPublic::localTaintStep(_, _)
+    }
+  }
+}


### PR DESCRIPTION
When you look at the changes and relate that to how the CodeQL evaluator works, then you might think that there should be no performance change at all from these changes.   

But there is: [Evaluation shows ~1.5% performance increase](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/rbPerf__nightly__code-scanning__6/reports).  

The change there to be less stages at compile time, which can cause more predicates to be compiled together, which might allow the optimizer to share more intermediate results. 
That's probably not the whole explanation, but it might be some of it. 
At least that's what I think. I haven't been able to confirm why it's faster, just that it definitely is faster. 

There are some drawbacks:  
 - More cached predicates are evaluated together, meaning that in some cases predicates will be computed without their result ever being used. 
 - It's more code.   
 
 So I'll leave it to the Ruby team whether you want this PR merged or not. 