### PR TITLE
Java: Add support for androidx.fragment.app.Fragment

### DIFF
--- a/java/ql/lib/change-notes/2022-08-19-androidx-fragments.md
+++ b/java/ql/lib/change-notes/2022-08-19-androidx-fragments.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The class `AndroidFragment` now also models the Android Jetpack version of the `Fragment` class (`androidx.fragment.app.Fragment`).

--- a/java/ql/lib/semmle/code/java/frameworks/android/Fragment.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Fragment.qll
@@ -4,7 +4,9 @@ import java
 
 /** The class `android.app.Fragment`. */
 class AndroidFragment extends Class {
-  AndroidFragment() { this.getAnAncestor().hasQualifiedName("android.app", "Fragment") }
+  AndroidFragment() {
+    this.getAnAncestor().hasQualifiedName(["android.app", "androidx.fragment.app"], "Fragment")
+  }
 }
 
 /** The method `instantiate` of the class `android.app.Fragment`. */

--- a/java/ql/test/library-tests/frameworks/android/fragments/TestFragment.java
+++ b/java/ql/test/library-tests/frameworks/android/fragments/TestFragment.java
@@ -1,0 +1,6 @@
+import androidx.fragment.app.Fragment;
+
+public class TestFragment extends Fragment {
+    class SecondFragment extends android.app.Fragment {
+    }
+}

--- a/java/ql/test/library-tests/frameworks/android/fragments/options
+++ b/java/ql/test/library-tests/frameworks/android/fragments/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/google-android-9.0.0

--- a/java/ql/test/library-tests/frameworks/android/fragments/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/fragments/test.expected
@@ -1,0 +1,2 @@
+| TestFragment.java:3:14:3:25 | TestFragment |
+| TestFragment.java:4:11:4:24 | SecondFragment |

--- a/java/ql/test/library-tests/frameworks/android/fragments/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/fragments/test.ql
@@ -1,0 +1,6 @@
+import java
+import semmle.code.java.frameworks.android.Fragment
+
+from AndroidFragment f
+where f.getFile().getBaseName() = "TestFragment.java"
+select f

--- a/java/ql/test/library-tests/frameworks/android/sources/TestActivityAndFragment.java
+++ b/java/ql/test/library-tests/frameworks/android/sources/TestActivityAndFragment.java
@@ -1,7 +1,7 @@
 import android.app.Activity;
-import android.app.Fragment;
 import android.content.Intent;
 import android.os.Bundle;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
 public class TestActivityAndFragment extends Activity {

--- a/java/ql/test/query-tests/security/CWE-470/MainActivity.java
+++ b/java/ql/test/query-tests/security/CWE-470/MainActivity.java
@@ -1,11 +1,7 @@
 package com.example.myapp;
 
-import android.app.Fragment;
 import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.Button;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentTransaction;
 

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/ActivityCompat.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/ActivityCompat.java
@@ -1,0 +1,49 @@
+// Generated automatically from androidx.core.app.ActivityCompat for testing purposes
+
+package androidx.core.app;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.DragEvent;
+import android.view.View;
+import androidx.core.app.SharedElementCallback;
+import androidx.core.content.ContextCompat;
+import androidx.core.view.DragAndDropPermissionsCompat;
+
+public class ActivityCompat extends ContextCompat
+{
+    protected ActivityCompat(){}
+    public static <T extends View> T requireViewById(Activity p0, int p1){ return null; }
+    public static ActivityCompat.PermissionCompatDelegate getPermissionCompatDelegate(){ return null; }
+    public static DragAndDropPermissionsCompat requestDragAndDropPermissions(Activity p0, DragEvent p1){ return null; }
+    public static Uri getReferrer(Activity p0){ return null; }
+    public static boolean invalidateOptionsMenu(Activity p0){ return false; }
+    public static boolean shouldShowRequestPermissionRationale(Activity p0, String p1){ return false; }
+    public static void finishAffinity(Activity p0){}
+    public static void finishAfterTransition(Activity p0){}
+    public static void postponeEnterTransition(Activity p0){}
+    public static void recreate(Activity p0){}
+    public static void requestPermissions(Activity p0, String[] p1, int p2){}
+    public static void setEnterSharedElementCallback(Activity p0, SharedElementCallback p1){}
+    public static void setExitSharedElementCallback(Activity p0, SharedElementCallback p1){}
+    public static void setPermissionCompatDelegate(ActivityCompat.PermissionCompatDelegate p0){}
+    public static void startActivityForResult(Activity p0, Intent p1, int p2, Bundle p3){}
+    public static void startIntentSenderForResult(Activity p0, IntentSender p1, int p2, Intent p3, int p4, int p5, int p6, Bundle p7){}
+    public static void startPostponedEnterTransition(Activity p0){}
+    static public interface OnRequestPermissionsResultCallback
+    {
+        void onRequestPermissionsResult(int p0, String[] p1, int[] p2);
+    }
+    static public interface PermissionCompatDelegate
+    {
+        boolean onActivityResult(Activity p0, int p1, int p2, Intent p3);
+        boolean requestPermissions(Activity p0, String[] p1, int p2);
+    }
+    static public interface RequestPermissionsRequestCodeValidator
+    {
+        void validateRequestPermissionsRequestCode(int p0);
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/SharedElementCallback.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/SharedElementCallback.java
@@ -1,0 +1,27 @@
+// Generated automatically from androidx.core.app.SharedElementCallback for testing purposes
+
+package androidx.core.app;
+
+import android.content.Context;
+import android.graphics.Matrix;
+import android.graphics.RectF;
+import android.os.Parcelable;
+import android.view.View;
+import java.util.List;
+import java.util.Map;
+
+abstract public class SharedElementCallback
+{
+    public Parcelable onCaptureSharedElementSnapshot(View p0, Matrix p1, RectF p2){ return null; }
+    public SharedElementCallback(){}
+    public View onCreateSnapshotView(Context p0, Parcelable p1){ return null; }
+    public void onMapSharedElements(List<String> p0, Map<String, View> p1){}
+    public void onRejectSharedElements(List<View> p0){}
+    public void onSharedElementEnd(List<String> p0, List<View> p1, List<View> p2){}
+    public void onSharedElementStart(List<String> p0, List<View> p1, List<View> p2){}
+    public void onSharedElementsArrived(List<String> p0, List<View> p1, SharedElementCallback.OnSharedElementsReadyListener p2){}
+    static public interface OnSharedElementsReadyListener
+    {
+        void onSharedElementsReady();
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/content/ContextCompat.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/content/ContextCompat.java
@@ -1,0 +1,35 @@
+// Generated automatically from androidx.core.content.ContextCompat for testing purposes
+
+package androidx.core.content;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.ColorStateList;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import java.io.File;
+import java.util.concurrent.Executor;
+
+public class ContextCompat
+{
+    protected ContextCompat(){}
+    public static <T> T getSystemService(Context p0, Class<T> p1){ return null; }
+    public static ColorStateList getColorStateList(Context p0, int p1){ return null; }
+    public static Context createDeviceProtectedStorageContext(Context p0){ return null; }
+    public static Drawable getDrawable(Context p0, int p1){ return null; }
+    public static Executor getMainExecutor(Context p0){ return null; }
+    public static File getCodeCacheDir(Context p0){ return null; }
+    public static File getDataDir(Context p0){ return null; }
+    public static File getNoBackupFilesDir(Context p0){ return null; }
+    public static File[] getExternalCacheDirs(Context p0){ return null; }
+    public static File[] getExternalFilesDirs(Context p0, String p1){ return null; }
+    public static File[] getObbDirs(Context p0){ return null; }
+    public static String getSystemServiceName(Context p0, Class<? extends Object> p1){ return null; }
+    public static boolean isDeviceProtectedStorage(Context p0){ return false; }
+    public static boolean startActivities(Context p0, Intent[] p1){ return false; }
+    public static boolean startActivities(Context p0, Intent[] p1, Bundle p2){ return false; }
+    public static int checkSelfPermission(Context p0, String p1){ return 0; }
+    public static int getColor(Context p0, int p1){ return 0; }
+    public static void startActivity(Context p0, Intent p1, Bundle p2){}
+    public static void startForegroundService(Context p0, Intent p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/view/DragAndDropPermissionsCompat.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/view/DragAndDropPermissionsCompat.java
@@ -1,0 +1,13 @@
+// Generated automatically from androidx.core.view.DragAndDropPermissionsCompat for testing purposes
+
+package androidx.core.view;
+
+import android.app.Activity;
+import android.view.DragEvent;
+
+public class DragAndDropPermissionsCompat
+{
+    protected DragAndDropPermissionsCompat() {}
+    public static DragAndDropPermissionsCompat request(Activity p0, DragEvent p1){ return null; }
+    public void release(){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/BackStackRecord.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/BackStackRecord.java
@@ -1,0 +1,37 @@
+// Generated automatically from androidx.fragment.app.BackStackRecord for testing purposes
+
+package androidx.fragment.app;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.Lifecycle;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+
+class BackStackRecord extends FragmentTransaction implements FragmentManager.BackStackEntry, FragmentManager.OpGenerator
+{
+    protected BackStackRecord() {}
+    public CharSequence getBreadCrumbShortTitle(){ return null; }
+    public CharSequence getBreadCrumbTitle(){ return null; }
+    public FragmentTransaction detach(Fragment p0){ return null; }
+    public FragmentTransaction hide(Fragment p0){ return null; }
+    public FragmentTransaction remove(Fragment p0){ return null; }
+    public FragmentTransaction setMaxLifecycle(Fragment p0, Lifecycle.State p1){ return null; }
+    public FragmentTransaction setPrimaryNavigationFragment(Fragment p0){ return null; }
+    public FragmentTransaction show(Fragment p0){ return null; }
+    public String getName(){ return null; }
+    public String toString(){ return null; }
+    public boolean generateOps(ArrayList<BackStackRecord> p0, ArrayList<Boolean> p1){ return false; }
+    public boolean isEmpty(){ return false; }
+    public int commit(){ return 0; }
+    public int commitAllowingStateLoss(){ return 0; }
+    public int getBreadCrumbShortTitleRes(){ return 0; }
+    public int getBreadCrumbTitleRes(){ return 0; }
+    public int getId(){ return 0; }
+    public void commitNow(){}
+    public void commitNowAllowingStateLoss(){}
+    public void dump(String p0, PrintWriter p1){}
+    public void dump(String p0, PrintWriter p1, boolean p2){}
+    public void runOnCommitRunnables(){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/Fragment.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/Fragment.java
@@ -1,0 +1,175 @@
+// Generated automatically from androidx.fragment.app.Fragment for testing purposes
+
+package androidx.fragment.app;
+
+import android.animation.Animator;
+import android.app.Activity;
+import android.content.ComponentCallbacks;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.util.AttributeSet;
+import android.view.ContextMenu;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.animation.Animation;
+import androidx.core.app.SharedElementCallback;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.HasDefaultViewModelProviderFactory;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelStore;
+import androidx.lifecycle.ViewModelStoreOwner;
+import androidx.loader.app.LoaderManager;
+import androidx.savedstate.SavedStateRegistry;
+import androidx.savedstate.SavedStateRegistryOwner;
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
+import java.util.concurrent.TimeUnit;
+
+public class Fragment implements ComponentCallbacks, HasDefaultViewModelProviderFactory, LifecycleOwner, SavedStateRegistryOwner, View.OnCreateContextMenuListener, ViewModelStoreOwner
+{
+    public Animation onCreateAnimation(int p0, boolean p1, int p2){ return null; }
+    public Animator onCreateAnimator(int p0, boolean p1, int p2){ return null; }
+    public Context getContext(){ return null; }
+    public Fragment(){}
+    public Fragment(int p0){}
+    public LayoutInflater getLayoutInflater(Bundle p0){ return null; }
+    public LayoutInflater onGetLayoutInflater(Bundle p0){ return null; }
+    public Lifecycle getLifecycle(){ return null; }
+    public LifecycleOwner getViewLifecycleOwner(){ return null; }
+    public LoaderManager getLoaderManager(){ return null; }
+    public Object getEnterTransition(){ return null; }
+    public Object getExitTransition(){ return null; }
+    public Object getReenterTransition(){ return null; }
+    public Object getReturnTransition(){ return null; }
+    public Object getSharedElementEnterTransition(){ return null; }
+    public Object getSharedElementReturnTransition(){ return null; }
+    public String toString(){ return null; }
+    public View getView(){ return null; }
+    public View onCreateView(LayoutInflater p0, ViewGroup p1, Bundle p2){ return null; }
+    public ViewModelProvider.Factory getDefaultViewModelProviderFactory(){ return null; }
+    public ViewModelStore getViewModelStore(){ return null; }
+    public boolean getAllowEnterTransitionOverlap(){ return false; }
+    public boolean getAllowReturnTransitionOverlap(){ return false; }
+    public boolean getUserVisibleHint(){ return false; }
+    public boolean onContextItemSelected(MenuItem p0){ return false; }
+    public boolean onOptionsItemSelected(MenuItem p0){ return false; }
+    public boolean shouldShowRequestPermissionRationale(String p0){ return false; }
+    public final Bundle getArguments(){ return null; }
+    public final Bundle requireArguments(){ return null; }
+    public final CharSequence getText(int p0){ return null; }
+    public final Context requireContext(){ return null; }
+    public final Fragment getParentFragment(){ return null; }
+    public final Fragment getTargetFragment(){ return null; }
+    public final Fragment requireParentFragment(){ return null; }
+    public final FragmentActivity getActivity(){ return null; }
+    public final FragmentActivity requireActivity(){ return null; }
+    public final FragmentManager getChildFragmentManager(){ return null; }
+    public final FragmentManager getFragmentManager(){ return null; }
+    public final FragmentManager getParentFragmentManager(){ return null; }
+    public final FragmentManager requireFragmentManager(){ return null; }
+    public final LayoutInflater getLayoutInflater(){ return null; }
+    public final Object getHost(){ return null; }
+    public final Object requireHost(){ return null; }
+    public final Resources getResources(){ return null; }
+    public final SavedStateRegistry getSavedStateRegistry(){ return null; }
+    public final String getString(int p0){ return null; }
+    public final String getString(int p0, Object... p1){ return null; }
+    public final String getTag(){ return null; }
+    public final View requireView(){ return null; }
+    public final boolean equals(Object p0){ return false; }
+    public final boolean getRetainInstance(){ return false; }
+    public final boolean hasOptionsMenu(){ return false; }
+    public final boolean isAdded(){ return false; }
+    public final boolean isDetached(){ return false; }
+    public final boolean isHidden(){ return false; }
+    public final boolean isInLayout(){ return false; }
+    public final boolean isMenuVisible(){ return false; }
+    public final boolean isRemoving(){ return false; }
+    public final boolean isResumed(){ return false; }
+    public final boolean isStateSaved(){ return false; }
+    public final boolean isVisible(){ return false; }
+    public final int getId(){ return 0; }
+    public final int getTargetRequestCode(){ return 0; }
+    public final int hashCode(){ return 0; }
+    public final void postponeEnterTransition(long p0, TimeUnit p1){}
+    public final void requestPermissions(String[] p0, int p1){}
+    public static Fragment instantiate(Context p0, String p1){ return null; }
+    public static Fragment instantiate(Context p0, String p1, Bundle p2){ return null; }
+    public void dump(String p0, FileDescriptor p1, PrintWriter p2, String[] p3){}
+    public void onActivityCreated(Bundle p0){}
+    public void onActivityResult(int p0, int p1, Intent p2){}
+    public void onAttach(Activity p0){}
+    public void onAttach(Context p0){}
+    public void onAttachFragment(Fragment p0){}
+    public void onConfigurationChanged(Configuration p0){}
+    public void onCreate(Bundle p0){}
+    public void onCreateContextMenu(ContextMenu p0, View p1, ContextMenu.ContextMenuInfo p2){}
+    public void onCreateOptionsMenu(Menu p0, MenuInflater p1){}
+    public void onDestroy(){}
+    public void onDestroyOptionsMenu(){}
+    public void onDestroyView(){}
+    public void onDetach(){}
+    public void onHiddenChanged(boolean p0){}
+    public void onInflate(Activity p0, AttributeSet p1, Bundle p2){}
+    public void onInflate(Context p0, AttributeSet p1, Bundle p2){}
+    public void onLowMemory(){}
+    public void onMultiWindowModeChanged(boolean p0){}
+    public void onOptionsMenuClosed(Menu p0){}
+    public void onPause(){}
+    public void onPictureInPictureModeChanged(boolean p0){}
+    public void onPrepareOptionsMenu(Menu p0){}
+    public void onPrimaryNavigationFragmentChanged(boolean p0){}
+    public void onRequestPermissionsResult(int p0, String[] p1, int[] p2){}
+    public void onResume(){}
+    public void onSaveInstanceState(Bundle p0){}
+    public void onStart(){}
+    public void onStop(){}
+    public void onViewCreated(View p0, Bundle p1){}
+    public void onViewStateRestored(Bundle p0){}
+    public void postponeEnterTransition(){}
+    public void registerForContextMenu(View p0){}
+    public void setAllowEnterTransitionOverlap(boolean p0){}
+    public void setAllowReturnTransitionOverlap(boolean p0){}
+    public void setArguments(Bundle p0){}
+    public void setEnterSharedElementCallback(SharedElementCallback p0){}
+    public void setEnterTransition(Object p0){}
+    public void setExitSharedElementCallback(SharedElementCallback p0){}
+    public void setExitTransition(Object p0){}
+    public void setHasOptionsMenu(boolean p0){}
+    public void setInitialSavedState(Fragment.SavedState p0){}
+    public void setMenuVisibility(boolean p0){}
+    public void setReenterTransition(Object p0){}
+    public void setRetainInstance(boolean p0){}
+    public void setReturnTransition(Object p0){}
+    public void setSharedElementEnterTransition(Object p0){}
+    public void setSharedElementReturnTransition(Object p0){}
+    public void setTargetFragment(Fragment p0, int p1){}
+    public void setUserVisibleHint(boolean p0){}
+    public void startActivity(Intent p0){}
+    public void startActivity(Intent p0, Bundle p1){}
+    public void startActivityForResult(Intent p0, int p1){}
+    public void startActivityForResult(Intent p0, int p1, Bundle p2){}
+    public void startIntentSenderForResult(IntentSender p0, int p1, Intent p2, int p3, int p4, int p5, Bundle p6){}
+    public void startPostponedEnterTransition(){}
+    public void unregisterForContextMenu(View p0){}
+    static public class SavedState implements Parcelable
+    {
+        protected SavedState() {}
+        public int describeContents(){ return 0; }
+        public static Parcelable.Creator<Fragment.SavedState> CREATOR = null;
+        public void writeToParcel(Parcel p0, int p1){}
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentActivity.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentActivity.java
@@ -1,83 +1,68 @@
-/*
- * Copyright 2018 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
+// Generated automatically from androidx.fragment.app.FragmentActivity for testing purposes
 
 package androidx.fragment.app;
 
-import java.io.FileDescriptor;
-import java.io.PrintWriter;
-import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.util.AttributeSet;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
-import androidx.activity.ComponentActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.app.SharedElementCallback;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.loader.app.LoaderManager;
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
 
-public class FragmentActivity extends ComponentActivity {
-        public FragmentActivity() {}
-
-        public FragmentActivity(int contentLayoutId) {}
-
-        public void supportFinishAfterTransition() {}
-
-        public void supportPostponeEnterTransition() {}
-
-        public void supportStartPostponedEnterTransition() {}
-
-        public void onMultiWindowModeChanged(boolean isInMultiWindowMode) {}
-
-        public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {}
-
-        public void onConfigurationChanged(Configuration newConfig) {}
-
-        public View onCreateView(View parent, String name, Context context, AttributeSet attrs) {
-                return null;
-        }
-
-        public View onCreateView(String name, Context context, AttributeSet attrs) {
-                return null;
-        }
-
-        public void onLowMemory() {}
-
-        public void onStateNotSaved() {}
-
-        public void supportInvalidateOptionsMenu() {}
-
-        public void dump(String prefix, FileDescriptor fd, PrintWriter writer, String[] args) {}
-
-        public void onAttachFragment(Fragment fragment) {}
-
-        public FragmentManager getSupportFragmentManager() {
-                return null;
-        }
-
-        public final void validateRequestPermissionsRequestCode(int requestCode) {}
-
-        @Override
-        public void onRequestPermissionsResult(int requestCode, String[] permissions,
-                        int[] grantResults) {}
-
-        public void startActivityFromFragment(Fragment fragment, Intent intent, int requestCode) {}
-
-        public void startActivityFromFragment(Fragment fragment, Intent intent, int requestCode,
-                        Bundle options) {}
-
-        public void startIntentSenderFromFragment(Fragment fragment, IntentSender intent,
-                        int requestCode, Intent fillInIntent, int flagsMask, int flagsValues,
-                        int extraFlags, Bundle options) throws IntentSender.SendIntentException {}
-
+public class FragmentActivity implements ActivityCompat.OnRequestPermissionsResultCallback, ActivityCompat.RequestPermissionsRequestCodeValidator
+{
+    protected boolean onPrepareOptionsPanel(View p0, Menu p1){ return false; }
+    protected void onActivityResult(int p0, int p1, Intent p2){}
+    protected void onCreate(Bundle p0){}
+    protected void onDestroy(){}
+    protected void onNewIntent(Intent p0){}
+    protected void onPause(){}
+    protected void onPostResume(){}
+    protected void onResume(){}
+    protected void onResumeFragments(){}
+    protected void onSaveInstanceState(Bundle p0){}
+    protected void onStart(){}
+    protected void onStop(){}
+    public FragmentActivity(){}
+    public FragmentActivity(int p0){}
+    public FragmentManager getSupportFragmentManager(){ return null; }
+    public LoaderManager getSupportLoaderManager(){ return null; }
+    public View onCreateView(String p0, Context p1, AttributeSet p2){ return null; }
+    public View onCreateView(View p0, String p1, Context p2, AttributeSet p3){ return null; }
+    public boolean onCreatePanelMenu(int p0, Menu p1){ return false; }
+    public boolean onMenuItemSelected(int p0, MenuItem p1){ return false; }
+    public boolean onPreparePanel(int p0, View p1, Menu p2){ return false; }
+    public final void validateRequestPermissionsRequestCode(int p0){}
+    public void dump(String p0, FileDescriptor p1, PrintWriter p2, String[] p3){}
+    public void onAttachFragment(Fragment p0){}
+    public void onConfigurationChanged(Configuration p0){}
+    public void onLowMemory(){}
+    public void onMultiWindowModeChanged(boolean p0){}
+    public void onPanelClosed(int p0, Menu p1){}
+    public void onPictureInPictureModeChanged(boolean p0){}
+    public void onRequestPermissionsResult(int p0, String[] p1, int[] p2){}
+    public void onStateNotSaved(){}
+    public void setEnterSharedElementCallback(SharedElementCallback p0){}
+    public void setExitSharedElementCallback(SharedElementCallback p0){}
+    public void startActivityForResult(Intent p0, int p1){}
+    public void startActivityForResult(Intent p0, int p1, Bundle p2){}
+    public void startActivityFromFragment(Fragment p0, Intent p1, int p2){}
+    public void startActivityFromFragment(Fragment p0, Intent p1, int p2, Bundle p3){}
+    public void startIntentSenderForResult(IntentSender p0, int p1, Intent p2, int p3, int p4, int p5){}
+    public void startIntentSenderForResult(IntentSender p0, int p1, Intent p2, int p3, int p4, int p5, Bundle p6){}
+    public void startIntentSenderFromFragment(Fragment p0, IntentSender p1, int p2, Intent p3, int p4, int p5, int p6, Bundle p7){}
+    public void supportFinishAfterTransition(){}
+    public void supportInvalidateOptionsMenu(){}
+    public void supportPostponeEnterTransition(){}
+    public void supportStartPostponedEnterTransition(){}
 }

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentActivity.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentActivity.java
@@ -2,6 +2,8 @@
 
 package androidx.fragment.app;
 
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -11,19 +13,15 @@ import android.util.AttributeSet;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import androidx.activity.ComponentActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.SharedElementCallback;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
 import androidx.loader.app.LoaderManager;
-import java.io.FileDescriptor;
-import java.io.PrintWriter;
 
-public class FragmentActivity implements ActivityCompat.OnRequestPermissionsResultCallback, ActivityCompat.RequestPermissionsRequestCodeValidator
+public class FragmentActivity extends ComponentActivity implements ActivityCompat.OnRequestPermissionsResultCallback, ActivityCompat.RequestPermissionsRequestCodeValidator
 {
     protected boolean onPrepareOptionsPanel(View p0, Menu p1){ return false; }
     protected void onActivityResult(int p0, int p1, Intent p2){}
-    protected void onCreate(Bundle p0){}
     protected void onDestroy(){}
     protected void onNewIntent(Intent p0){}
     protected void onPause(){}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentFactory.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentFactory.java
@@ -1,0 +1,12 @@
+// Generated automatically from androidx.fragment.app.FragmentFactory for testing purposes
+
+package androidx.fragment.app;
+
+import androidx.fragment.app.Fragment;
+
+public class FragmentFactory
+{
+    public Fragment instantiate(ClassLoader p0, String p1){ return null; }
+    public FragmentFactory(){}
+    public static Class<? extends Fragment> loadFragmentClass(ClassLoader p0, String p1){ return null; }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentManager.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentManager.java
@@ -1,160 +1,174 @@
-/*
- * Copyright 2018 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
+// Generated automatically from androidx.fragment.app.FragmentManager for testing purposes
 
 package androidx.fragment.app;
 
-import java.util.List;
-import android.app.Fragment;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
+import androidx.fragment.app.BackStackRecord;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentFactory;
+import androidx.fragment.app.FragmentTransaction;
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 
-public abstract class FragmentManager {
-  public static void enableDebugLogging(boolean enabled) {}
+abstract public class FragmentManager {
+    abstract static public class FragmentLifecycleCallbacks {
+        public FragmentLifecycleCallbacks() {}
 
-  public static boolean isLoggingEnabled(int level) {
-    return false;
-  }
+        public void onFragmentActivityCreated(FragmentManager p0, Fragment p1, Bundle p2) {}
 
-  public interface BackStackEntry {
-    int getId();
+        public void onFragmentAttached(FragmentManager p0, Fragment p1, Context p2) {}
 
-    String getName();
+        public void onFragmentCreated(FragmentManager p0, Fragment p1, Bundle p2) {}
 
-    int getBreadCrumbTitleRes();
+        public void onFragmentDestroyed(FragmentManager p0, Fragment p1) {}
 
-    int getBreadCrumbShortTitleRes();
+        public void onFragmentDetached(FragmentManager p0, Fragment p1) {}
 
-    CharSequence getBreadCrumbTitle();
+        public void onFragmentPaused(FragmentManager p0, Fragment p1) {}
 
-    CharSequence getBreadCrumbShortTitle();
+        public void onFragmentPreAttached(FragmentManager p0, Fragment p1, Context p2) {}
 
-  }
-  public interface OnBackStackChangedListener {
-    void onBackStackChanged();
+        public void onFragmentPreCreated(FragmentManager p0, Fragment p1, Bundle p2) {}
 
-  }
-  public abstract static class FragmentLifecycleCallbacks {
-    public void onFragmentPreAttached(FragmentManager fm, Fragment f, Context context) {}
+        public void onFragmentResumed(FragmentManager p0, Fragment p1) {}
 
-    public void onFragmentAttached(FragmentManager fm, Fragment f, Context context) {}
+        public void onFragmentSaveInstanceState(FragmentManager p0, Fragment p1, Bundle p2) {}
 
-    public void onFragmentPreCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {}
+        public void onFragmentStarted(FragmentManager p0, Fragment p1) {}
 
-    public void onFragmentCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {}
+        public void onFragmentStopped(FragmentManager p0, Fragment p1) {}
 
-    public void onFragmentActivityCreated(FragmentManager fm, Fragment f,
-        Bundle savedInstanceState) {}
+        public void onFragmentViewCreated(FragmentManager p0, Fragment p1, View p2, Bundle p3) {}
 
-    public void onFragmentViewCreated(FragmentManager fm, Fragment f, View v,
-        Bundle savedInstanceState) {}
+        public void onFragmentViewDestroyed(FragmentManager p0, Fragment p1) {}
+    }
 
-    public void onFragmentStarted(FragmentManager fm, Fragment f) {}
+    public Fragment findFragmentById(int p0) {
+        return null;
+    }
 
-    public void onFragmentResumed(FragmentManager fm, Fragment f) {}
+    public Fragment findFragmentByTag(String p0) {
+        return null;
+    }
 
-    public void onFragmentPaused(FragmentManager fm, Fragment f) {}
+    public Fragment getFragment(Bundle p0, String p1) {
+        return null;
+    }
 
-    public void onFragmentStopped(FragmentManager fm, Fragment f) {}
+    public Fragment getPrimaryNavigationFragment() {
+        return null;
+    }
 
-    public void onFragmentSaveInstanceState(FragmentManager fm, Fragment f, Bundle outState) {}
+    public Fragment.SavedState saveFragmentInstanceState(Fragment p0) {
+        return null;
+    }
 
-    public void onFragmentViewDestroyed(FragmentManager fm, Fragment f) {}
+    public FragmentFactory getFragmentFactory() {
+        return null;
+    }
 
-    public void onFragmentDestroyed(FragmentManager fm, Fragment f) {}
+    public FragmentManager() {}
 
-    public void onFragmentDetached(FragmentManager fm, Fragment f) {}
+    public FragmentManager.BackStackEntry getBackStackEntryAt(int p0) {
+        return null;
+    }
 
-  }
+    public FragmentTransaction beginTransaction() {
+        return null;
+    }
 
-  public FragmentTransaction openTransaction() {
-    return null;
-  }
+    public FragmentTransaction openTransaction() {
+        return null;
+    }
 
-  public FragmentTransaction beginTransaction() {
-    return null;
-  }
+    public List<Fragment> getFragments() {
+        return null;
+    }
 
-  public boolean executePendingTransactions() {
-    return false;
-  }
+    public String toString() {
+        return null;
+    }
 
-  public void restoreBackStack(String name) {}
+    public boolean executePendingTransactions() {
+        return false;
+    }
 
-  public void saveBackStack(String name) {}
+    public boolean isDestroyed() {
+        return false;
+    }
 
-  public void popBackStack() {}
+    public boolean isStateSaved() {
+        return false;
+    }
 
-  public boolean popBackStackImmediate() {
-    return false;
-  }
+    public boolean popBackStackImmediate() {
+        return false;
+    }
 
-  public void popBackStack(final String name, final int flags) {}
+    public boolean popBackStackImmediate(String p0, int p1) {
+        return false;
+    }
 
-  public boolean popBackStackImmediate(String name, int flags) {
-    return false;
-  }
+    public boolean popBackStackImmediate(int p0, int p1) {
+        return false;
+    }
 
-  public void popBackStack(final int id, final int flags) {}
+    public int getBackStackEntryCount() {
+        return 0;
+    }
 
-  public boolean popBackStackImmediate(int id, int flags) {
-    return false;
-  }
+    public static <F extends Fragment> F findFragment(View p0) {
+        return null;
+    }
 
-  public int getBackStackEntryCount() {
-    return 0;
-  }
+    public static int POP_BACK_STACK_INCLUSIVE = 0;
 
-  public BackStackEntry getBackStackEntryAt(int index) {
-    return null;
-  }
+    public static void enableDebugLogging(boolean p0) {}
 
-  public void addOnBackStackChangedListener(OnBackStackChangedListener listener) {}
+    public void addOnBackStackChangedListener(FragmentManager.OnBackStackChangedListener p0) {}
 
-  public void removeOnBackStackChangedListener(OnBackStackChangedListener listener) {}
+    public void dump(String p0, FileDescriptor p1, PrintWriter p2, String[] p3) {}
 
-  public final void setFragmentResult(String requestKey, Bundle result) {}
+    public void popBackStack() {}
 
-  public final void clearFragmentResult(String requestKey) {}
+    public void popBackStack(String p0, int p1) {}
 
-  public final void clearFragmentResultListener(String requestKey) {}
+    public void popBackStack(int p0, int p1) {}
 
-  public void putFragment(Bundle bundle, String key, Fragment fragment) {}
+    public void putFragment(Bundle p0, String p1, Fragment p2) {}
 
-  public Fragment getFragment(Bundle bundle, String key) {
-    return null;
-  }
+    public void registerFragmentLifecycleCallbacks(FragmentManager.FragmentLifecycleCallbacks p0,
+            boolean p1) {}
 
-  public static <F extends Fragment> F findFragment(View view) {
-    return null;
-  }
+    public void removeOnBackStackChangedListener(FragmentManager.OnBackStackChangedListener p0) {}
 
-  public List<Fragment> getFragments() {
-    return null;
-  }
+    public void setFragmentFactory(FragmentFactory p0) {}
 
-  public Fragment.SavedState saveFragmentInstanceState(Fragment fragment) {
-    return null;
-  }
+    public void unregisterFragmentLifecycleCallbacks(
+            FragmentManager.FragmentLifecycleCallbacks p0) {}
 
-  public boolean isDestroyed() {
-    return false;
-  }
+    static public interface BackStackEntry {
+        CharSequence getBreadCrumbShortTitle();
 
-  @Override
-  public String toString() {
-    return null;
-  }
+        CharSequence getBreadCrumbTitle();
 
+        String getName();
+
+        int getBreadCrumbShortTitleRes();
+
+        int getBreadCrumbTitleRes();
+
+        int getId();
+    }
+    static public interface OnBackStackChangedListener {
+        void onBackStackChanged();
+    }
+
+    static public interface OpGenerator {
+        boolean generateOps(ArrayList<BackStackRecord> records, ArrayList<Boolean> isRecordPop);
+    }
 }

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentTransaction.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentTransaction.java
@@ -1,165 +1,57 @@
-/*
- * Copyright 2018 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
+// Generated automatically from androidx.fragment.app.FragmentTransaction for testing purposes
 
 package androidx.fragment.app;
 
-import android.app.Fragment;
 import android.os.Bundle;
 import android.view.View;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 
-public abstract class FragmentTransaction {
-  public FragmentTransaction() {}
-
-  public final FragmentTransaction add(Class<? extends Fragment> fragmentClass, Bundle args,
-      String tag) {
-    return null;
-  }
-
-  public FragmentTransaction add(Fragment fragment, String tag) {
-    return null;
-  }
-
-  public final FragmentTransaction add(int containerViewId, Class<? extends Fragment> fragmentClass,
-      Bundle args) {
-    return null;
-  }
-
-  public FragmentTransaction add(int containerViewId, Fragment fragment) {
-    return null;
-  }
-
-  public final FragmentTransaction add(int containerViewId, Class<? extends Fragment> fragmentClass,
-      Bundle args, String tag) {
-    return null;
-  }
-
-  public FragmentTransaction add(int containerViewId, Fragment fragment, String tag) {
-    return null;
-  }
-
-  public final FragmentTransaction replace(int containerViewId,
-      Class<? extends Fragment> fragmentClass, Bundle args) {
-    return null;
-  }
-
-  public FragmentTransaction replace(int containerViewId, Fragment fragment) {
-    return null;
-  }
-
-  public final FragmentTransaction replace(int containerViewId,
-      Class<? extends Fragment> fragmentClass, Bundle args, String tag) {
-    return null;
-  }
-
-  public FragmentTransaction replace(int containerViewId, Fragment fragment, String tag) {
-    return null;
-  }
-
-  public FragmentTransaction remove(Fragment fragment) {
-    return null;
-  }
-
-  public FragmentTransaction hide(Fragment fragment) {
-    return null;
-  }
-
-  public FragmentTransaction show(Fragment fragment) {
-    return null;
-  }
-
-  public FragmentTransaction detach(Fragment fragment) {
-    return null;
-  }
-
-  public FragmentTransaction attach(Fragment fragment) {
-    return null;
-  }
-
-  public FragmentTransaction setPrimaryNavigationFragment(Fragment fragment) {
-    return null;
-  }
-
-  public boolean isEmpty() {
-    return false;
-  }
-
-  public FragmentTransaction setCustomAnimations(int enter, int exit) {
-    return null;
-  }
-
-  public FragmentTransaction setCustomAnimations(int enter, int exit, int popEnter, int popExit) {
-    return null;
-  }
-
-  public FragmentTransaction addSharedElement(View sharedElement, String name) {
-    return null;
-  }
-
-  public FragmentTransaction setTransition(int transition) {
-    return null;
-  }
-
-  public FragmentTransaction setTransitionStyle(int styleRes) {
-    return null;
-  }
-
-  public FragmentTransaction addToBackStack(String name) {
-    return null;
-  }
-
-  public boolean isAddToBackStackAllowed() {
-    return false;
-  }
-
-  public FragmentTransaction disallowAddToBackStack() {
-    return null;
-  }
-
-  public FragmentTransaction setBreadCrumbTitle(int res) {
-    return null;
-  }
-
-  public FragmentTransaction setBreadCrumbTitle(CharSequence text) {
-    return null;
-  }
-
-  public FragmentTransaction setBreadCrumbShortTitle(int res) {
-    return null;
-  }
-
-  public FragmentTransaction setBreadCrumbShortTitle(CharSequence text) {
-    return null;
-  }
-
-  public FragmentTransaction setReorderingAllowed(boolean reorderingAllowed) {
-    return null;
-  }
-
-  public FragmentTransaction setAllowOptimization(boolean allowOptimization) {
-    return null;
-  }
-
-  public FragmentTransaction runOnCommit(Runnable runnable) {
-    return null;
-  }
-
-  public abstract int commit();
-
-  public abstract int commitAllowingStateLoss();
-
-  public abstract void commitNow();
-
-  public abstract void commitNowAllowingStateLoss();
-
+abstract public class FragmentTransaction
+{
+    public FragmentTransaction add(Fragment p0, String p1){ return null; }
+    public FragmentTransaction add(int p0, Fragment p1){ return null; }
+    public FragmentTransaction add(int p0, Fragment p1, String p2){ return null; }
+    public FragmentTransaction addSharedElement(View p0, String p1){ return null; }
+    public FragmentTransaction addToBackStack(String p0){ return null; }
+    public FragmentTransaction attach(Fragment p0){ return null; }
+    public FragmentTransaction detach(Fragment p0){ return null; }
+    public FragmentTransaction disallowAddToBackStack(){ return null; }
+    public FragmentTransaction hide(Fragment p0){ return null; }
+    public FragmentTransaction remove(Fragment p0){ return null; }
+    public FragmentTransaction replace(int p0, Fragment p1){ return null; }
+    public FragmentTransaction replace(int p0, Fragment p1, String p2){ return null; }
+    public FragmentTransaction runOnCommit(Runnable p0){ return null; }
+    public FragmentTransaction setAllowOptimization(boolean p0){ return null; }
+    public FragmentTransaction setBreadCrumbShortTitle(CharSequence p0){ return null; }
+    public FragmentTransaction setBreadCrumbShortTitle(int p0){ return null; }
+    public FragmentTransaction setBreadCrumbTitle(CharSequence p0){ return null; }
+    public FragmentTransaction setBreadCrumbTitle(int p0){ return null; }
+    public FragmentTransaction setCustomAnimations(int p0, int p1){ return null; }
+    public FragmentTransaction setCustomAnimations(int p0, int p1, int p2, int p3){ return null; }
+    public FragmentTransaction setMaxLifecycle(Fragment p0, Lifecycle.State p1){ return null; }
+    public FragmentTransaction setPrimaryNavigationFragment(Fragment p0){ return null; }
+    public FragmentTransaction setReorderingAllowed(boolean p0){ return null; }
+    public FragmentTransaction setTransition(int p0){ return null; }
+    public FragmentTransaction setTransitionStyle(int p0){ return null; }
+    public FragmentTransaction show(Fragment p0){ return null; }
+    public FragmentTransaction(){}
+    public abstract int commit();
+    public abstract int commitAllowingStateLoss();
+    public abstract void commitNow();
+    public abstract void commitNowAllowingStateLoss();
+    public boolean isAddToBackStackAllowed(){ return false; }
+    public boolean isEmpty(){ return false; }
+    public final FragmentTransaction add(Class<? extends Fragment> p0, Bundle p1, String p2){ return null; }
+    public final FragmentTransaction add(int p0, Class<? extends Fragment> p1, Bundle p2){ return null; }
+    public final FragmentTransaction add(int p0, Class<? extends Fragment> p1, Bundle p2, String p3){ return null; }
+    public final FragmentTransaction replace(int p0, Class<? extends Fragment> p1, Bundle p2){ return null; }
+    public final FragmentTransaction replace(int p0, Class<? extends Fragment> p1, Bundle p2, String p3){ return null; }
+    public static int TRANSIT_ENTER_MASK = 0;
+    public static int TRANSIT_EXIT_MASK = 0;
+    public static int TRANSIT_FRAGMENT_CLOSE = 0;
+    public static int TRANSIT_FRAGMENT_FADE = 0;
+    public static int TRANSIT_FRAGMENT_OPEN = 0;
+    public static int TRANSIT_NONE = 0;
+    public static int TRANSIT_UNSET = 0;
 }

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/HasDefaultViewModelProviderFactory.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/HasDefaultViewModelProviderFactory.java
@@ -1,0 +1,10 @@
+// Generated automatically from androidx.lifecycle.HasDefaultViewModelProviderFactory for testing purposes
+
+package androidx.lifecycle;
+
+import androidx.lifecycle.ViewModelProvider;
+
+public interface HasDefaultViewModelProviderFactory
+{
+    ViewModelProvider.Factory getDefaultViewModelProviderFactory();
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/Lifecycle.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/Lifecycle.java
@@ -1,0 +1,29 @@
+// Generated automatically from androidx.lifecycle.Lifecycle for testing purposes
+
+package androidx.lifecycle;
+
+import androidx.lifecycle.LifecycleObserver;
+
+abstract public class Lifecycle
+{
+    public Lifecycle(){}
+    public abstract Lifecycle.State getCurrentState();
+    public abstract void addObserver(LifecycleObserver p0);
+    public abstract void removeObserver(LifecycleObserver p0);
+    static public enum Event
+    {
+        ON_ANY, ON_CREATE, ON_DESTROY, ON_PAUSE, ON_RESUME, ON_START, ON_STOP;
+        private Event() {}
+        public Lifecycle.State getTargetState(){ return null; }
+        public static Lifecycle.Event downFrom(Lifecycle.State p0){ return null; }
+        public static Lifecycle.Event downTo(Lifecycle.State p0){ return null; }
+        public static Lifecycle.Event upFrom(Lifecycle.State p0){ return null; }
+        public static Lifecycle.Event upTo(Lifecycle.State p0){ return null; }
+    }
+    static public enum State
+    {
+        CREATED, DESTROYED, INITIALIZED, RESUMED, STARTED;
+        private State() {}
+        public boolean isAtLeast(Lifecycle.State p0){ return false; }
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/LifecycleObserver.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/LifecycleObserver.java
@@ -1,0 +1,8 @@
+// Generated automatically from androidx.lifecycle.LifecycleObserver for testing purposes
+
+package androidx.lifecycle;
+
+
+public interface LifecycleObserver
+{
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/LifecycleOwner.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/LifecycleOwner.java
@@ -1,0 +1,10 @@
+// Generated automatically from androidx.lifecycle.LifecycleOwner for testing purposes
+
+package androidx.lifecycle;
+
+import androidx.lifecycle.Lifecycle;
+
+public interface LifecycleOwner
+{
+    Lifecycle getLifecycle();
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/ViewModel.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/ViewModel.java
@@ -1,0 +1,10 @@
+// Generated automatically from androidx.lifecycle.ViewModel for testing purposes
+
+package androidx.lifecycle;
+
+
+abstract public class ViewModel
+{
+    protected void onCleared(){}
+    public ViewModel(){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/ViewModelProvider.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/ViewModelProvider.java
@@ -1,0 +1,21 @@
+// Generated automatically from androidx.lifecycle.ViewModelProvider for testing purposes
+
+package androidx.lifecycle;
+
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelStore;
+import androidx.lifecycle.ViewModelStoreOwner;
+
+public class ViewModelProvider
+{
+    protected ViewModelProvider() {}
+    public <T extends ViewModel> T get(Class<T> p0){ return null; }
+    public <T extends ViewModel> T get(String p0, Class<T> p1){ return null; }
+    public ViewModelProvider(ViewModelStore p0, ViewModelProvider.Factory p1){}
+    public ViewModelProvider(ViewModelStoreOwner p0){}
+    public ViewModelProvider(ViewModelStoreOwner p0, ViewModelProvider.Factory p1){}
+    static public interface Factory
+    {
+        <T extends ViewModel> T create(Class<T> p0);
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/ViewModelStore.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/ViewModelStore.java
@@ -1,0 +1,10 @@
+// Generated automatically from androidx.lifecycle.ViewModelStore for testing purposes
+
+package androidx.lifecycle;
+
+
+public class ViewModelStore
+{
+    public ViewModelStore(){}
+    public final void clear(){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/ViewModelStoreOwner.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/lifecycle/ViewModelStoreOwner.java
@@ -1,0 +1,10 @@
+// Generated automatically from androidx.lifecycle.ViewModelStoreOwner for testing purposes
+
+package androidx.lifecycle;
+
+import androidx.lifecycle.ViewModelStore;
+
+public interface ViewModelStoreOwner
+{
+    ViewModelStore getViewModelStore();
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/loader/app/LoaderManager.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/loader/app/LoaderManager.java
@@ -1,0 +1,8 @@
+// Generated automatically from androidx.loader.app.LoaderManager for testing purposes
+
+package androidx.loader.app;
+
+
+public class LoaderManager {
+    protected LoaderManager() {}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/savedstate/SavedStateRegistry.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/savedstate/SavedStateRegistry.java
@@ -1,0 +1,23 @@
+// Generated automatically from androidx.savedstate.SavedStateRegistry for testing purposes
+
+package androidx.savedstate;
+
+import android.os.Bundle;
+import androidx.savedstate.SavedStateRegistryOwner;
+
+public class SavedStateRegistry
+{
+    public Bundle consumeRestoredStateForKey(String p0){ return null; }
+    public boolean isRestored(){ return false; }
+    public void registerSavedStateProvider(String p0, SavedStateRegistry.SavedStateProvider p1){}
+    public void runOnNextRecreation(Class<? extends SavedStateRegistry.AutoRecreated> p0){}
+    public void unregisterSavedStateProvider(String p0){}
+    static public interface AutoRecreated
+    {
+        void onRecreated(SavedStateRegistryOwner p0);
+    }
+    static public interface SavedStateProvider
+    {
+        Bundle saveState();
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/savedstate/SavedStateRegistryOwner.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/savedstate/SavedStateRegistryOwner.java
@@ -1,0 +1,11 @@
+// Generated automatically from androidx.savedstate.SavedStateRegistryOwner for testing purposes
+
+package androidx.savedstate;
+
+import androidx.lifecycle.LifecycleOwner;
+import androidx.savedstate.SavedStateRegistry;
+
+public interface SavedStateRegistryOwner extends LifecycleOwner
+{
+    SavedStateRegistry getSavedStateRegistry();
+}


### PR DESCRIPTION
`android.app.Fragment` is [deprecated](https://developer.android.com/reference/android/app/Fragment). This PR adds support for the new version, [`androidx.fragment.app.Fragment`](https://developer.android.com/reference/androidx/fragment/app/Fragment.html), which should help with our Android analysis by detecting more fragments.