### PR TITLE
C++: Improve performance of `cpp/cleartext-storage-buffer`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -267,8 +267,6 @@ private predicate instrStrictlyDominates(Instruction i1, Instruction i2) {
   i1.getBlock().strictlyDominates(i2.getBlock())
   or
   exists(IRBlock block, int index1, int index2 |
-    block = i1.getBlock() and
-    block = i2.getBlock() and
     block.getInstruction(index1) = i1 and
     block.getInstruction(index2) = i2 and
     index1 < index2
@@ -282,7 +280,6 @@ predicate jumpInto(GlobalOrNamespaceVariable v, Node n1, Node n2) {
     // Only do a jump step if there is no write that is guaranteed to
     // overwrite the global variable.
     not exists(StoreInstruction anotherStore |
-      store != anotherStore and
       writesToGlobal(anotherStore, v) and
       instrStrictlyPostDominates(anotherStore, store)
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -279,7 +279,7 @@ predicate jumpInto(GlobalOrNamespaceVariable v, Node n1, Node n2) {
   exists(StoreInstruction store |
     store = n1.asInstruction() and
     writesToGlobal(store, v) and
-    // Only do a jump step if there is no write that is guarenteed to
+    // Only do a jump step if there is no write that is guaranteed to
     // overwrite the global variable.
     not exists(StoreInstruction anotherStore |
       store != anotherStore and

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
@@ -26,6 +26,10 @@ class ToBufferConfiguration extends TaintTracking::Configuration {
 
   override predicate isSource(DataFlow::Node source) { source instanceof FlowSource }
 
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.asExpr().getUnspecifiedType() instanceof IntegralType
+  }
+
   override predicate isSink(DataFlow::Node sink) {
     exists(BufferWrite::BufferWrite w | w.getASource() = sink.asExpr())
   }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -346,7 +346,7 @@ namespace FlowThroughGlobals {
   int taintAndCall() {
     globalVar = source();
     calledAfterTaint();
-    sink(globalVar); // $ ast ir=333:17 ir=347:17
+    sink(globalVar); // $ ast,ir
   }
 }
 


### PR DESCRIPTION
This PR contains two unrelated performance fixes to prevent the `cpp/cleartext-storage-buffer` query from blowing up some strange codebases.

The first one is a general fix to global variable dataflow: We prune the relation so that we don't consider `use2(x)` to be a jump step from the global variable to the use of `x` in:
```c
int x;

void test1() {
  use1(x); // This is a jump step.
  x = 42;
  use2(x); // But this is no longer a jump step.
}
```
and similarly, for writes to global variables we only register the "final" write as a write to the global variable. So for instance, `x = 42` in:
```c
int x;

void test2() {
  x = 42; // No longer a jump step.
  x = 99; // This is still a jump step, though.
}
```

The second performance fix is to block flow through integral typed expressions in the query. We have used similar sanitizers in other queries to fix FPs, so this is a natural thing to do in this query as well, and it seems to dramatically improve the query's performance.