### PR TITLE
C++: Remove CP in `cpp/command-line-injection`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -19,6 +19,7 @@ import semmle.code.cpp.security.Security
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.ir.IR
 import semmle.code.cpp.ir.dataflow.TaintTracking
+import semmle.code.cpp.ir.dataflow.TaintTracking2
 import semmle.code.cpp.security.FlowSources
 import semmle.code.cpp.models.implementations.Strcat
 import DataFlow::PathGraph
@@ -83,6 +84,32 @@ class ExecState extends DataFlow::FlowState {
   DataFlow::Node getFstNode() { result = fst }
 
   DataFlow::Node getSndNode() { result = snd }
+
+  /** Holds if this is a possible `ExecState` for `sink`. */
+  predicate isFeasibleForSink(DataFlow::Node sink) {
+    any(ExecStateConfiguration conf).hasFlow(snd, sink)
+  }
+}
+
+/**
+ * A `TaintTracking` configuration that's used to find the relevant `ExecState`s for a
+ * given sink. This avoids a cartesian product between all sinks and all `ExecState`s in
+ * `ExecTaintConfiguration::isSink`.
+ */
+class ExecStateConfiguration extends TaintTracking2::Configuration {
+  ExecStateConfiguration() { this = "ExecStateConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(ExecState state | state.getSndNode() = source)
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    shellCommand(sinkAsArgumentIndirection(sink), _)
+  }
+
+  override predicate isSanitizerOut(DataFlow::Node node) {
+    isSink(node, _) // Prevent duplicates along a call chain, since `shellCommand` will include wrappers
+  }
 }
 
 class ExecTaintConfiguration extends TaintTracking::Configuration {
@@ -94,8 +121,8 @@ class ExecTaintConfiguration extends TaintTracking::Configuration {
   }
 
   override predicate isSink(DataFlow::Node sink, DataFlow::FlowState state) {
-    shellCommand(sinkAsArgumentIndirection(sink), _) and
-    state instanceof ExecState
+    any(ExecStateConfiguration conf).isSink(sink) and
+    state.(ExecState).isFeasibleForSink(sink)
   }
 
   override predicate isAdditionalTaintStep(


### PR DESCRIPTION
Prior to this PR, the sink in `ExecTaintConfiguration` was a cartesian product between all concatenation-like functions and all shell-command executing functions (😱) This PR introduces another taint tracking configuration that limits the possible flow states to only those that are relevant for a given sink.

Here are some numbers from Samate:

On `main`:
```
Tuple counts for DataFlowImpl#9021cc4c::sinkNode#fff/3@1ba010mo after 17.3s:
  48709004  ~6%     {3} r1 = SCAN num#DataFlowImpl#9021cc4c::TNodeNormal#ff OUTPUT In.0, "ExecTaintConfiguration", In.1 'node'
  10846     ~0%     {2} r2 = JOIN r1 WITH ExecTainted#91000ffb::ExecTaintConfiguration::isSink#dispred#cpe#2#f ON FIRST 1 OUTPUT "ExecTaintConfiguration", Lhs.2 'node'
  235097896 ~0%     {3} r3 = JOIN r2 WITH project#ExecTainted#91000ffb::ExecState#fff#3 CARTESIAN PRODUCT OUTPUT "ExecTaintConfiguration", Lhs.1 'node', Rhs.0
  235097896 ~0%     {3} r4 = r3 AND NOT DataFlowImpl#9021cc4c::stateBarrier#fff(Lhs.1 'node', Lhs.2 'state', "ExecTaintConfiguration")
  235097896 ~2%     {3} r5 = SCAN r4 OUTPUT In.1 'node', In.2 'state', "ExecTaintConfiguration"
                    return r5
```

On this PR:
```
[2022-08-21 16:34:58] Evaluated non-recursive predicate DataFlowImpl#9021cc4c::sinkNode#fff@aa41362f in 1ms (size: 4188).
Evaluated relational algebra for predicate DataFlowImpl#9021cc4c::sinkNode#fff@aa41362f with tuple counts:
        4188  ~1%    {3} r1 = JOIN num#DataFlowImpl#9021cc4c::TNodeNormal#ff WITH ExecTainted#91000ffb::ExecTaintConfiguration::isSink#dispred#cpe#23#ff ON FIRST 1 OUTPUT "ExecTaintConfigurationAAA", Lhs.1, Rhs.1
        4188  ~1%    {3} r2 = r1 AND NOT DataFlowImpl#9021cc4c::stateBarrier#fff(Lhs.1, Lhs.2, "ExecTaintConfigurationAAA")
        4188  ~0%    {3} r3 = SCAN r2 OUTPUT In.1, In.2, "ExecTaintConfigurationAAA"
                     return r3
```