### PR TITLE
JS: precise flow through calls to `.apply()`

### DIFF
--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -261,14 +261,12 @@ private module ArrayDataFlow {
   /**
    * A step for creating an array and storing the elements in the array.
    */
-  private class ArrayCreationStep extends DataFlow::SharedFlowStep {
+  private class ArrayCreationStep extends PreCallGraphStep {
     override predicate storeStep(DataFlow::Node element, DataFlow::SourceNode obj, string prop) {
       exists(DataFlow::ArrayCreationNode array, int i |
         element = array.getElement(i) and
         obj = array and
-        if array = any(PromiseAllCreation c).getArrayNode()
-        then prop = arrayElement(i)
-        else prop = arrayElement()
+        prop = arrayElement(i)
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -344,6 +344,14 @@ private module ArrayLibraries {
     result = DataFlow::globalVarRef("Array").getAMemberCall("from")
     or
     result = DataFlow::moduleImport("array-from").getACall()
+    or
+    // Array.prototype.slice.call acts the same as Array.from, and is sometimes used with e.g. the arguments object.
+    result =
+      DataFlow::globalVarRef("Array")
+          .getAPropertyRead("prototype")
+          .getAPropertyRead("slice")
+          .getAMethodCall("call") and
+    result.getNumArgument() = 1
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/lib/semmle/javascript/PackageExports.qll
@@ -11,7 +11,7 @@ private import semmle.javascript.internal.CachedStages
  * Gets a parameter that is a library input to a top-level package.
  */
 cached
-DataFlow::SourceNode getALibraryInputParameter() {
+DataFlow::Node getALibraryInputParameter() {
   Stages::Taint::ref() and
   exists(int bound, DataFlow::FunctionNode func |
     func = getAValueExportedByPackage().getABoundFunctionValue(bound)
@@ -19,6 +19,8 @@ DataFlow::SourceNode getALibraryInputParameter() {
     result = func.getParameter(any(int arg | arg >= bound))
     or
     result = getAnArgumentsRead(func.getFunction())
+    or
+    result = func.getFunction().getArgumentsVariable().getAnAccess().flow()
   )
 }
 

--- a/javascript/ql/lib/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/lib/semmle/javascript/PackageExports.qll
@@ -18,31 +18,7 @@ DataFlow::Node getALibraryInputParameter() {
   |
     result = func.getParameter(any(int arg | arg >= bound))
     or
-    result = getAnArgumentsRead(func.getFunction())
-    or
     result = func.getFunction().getArgumentsVariable().getAnAccess().flow()
-  )
-}
-
-private DataFlow::SourceNode getAnArgumentsRead(Function func) {
-  exists(DataFlow::PropRead read |
-    not read.getPropertyName() = "length" and
-    result = read
-  |
-    read.getBase() = func.getArgumentsVariable().getAnAccess().flow()
-    or
-    exists(DataFlow::MethodCallNode call |
-      call =
-        DataFlow::globalVarRef("Array")
-            .getAPropertyRead("prototype")
-            .getAPropertyRead("slice")
-            .getAMethodCall("call")
-      or
-      call = DataFlow::globalVarRef("Array").getAMethodCall("from")
-    |
-      call.getArgument(0) = func.getArgumentsVariable().getAnAccess().flow() and
-      call.flowsTo(read.getBase())
-    )
   )
 }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
@@ -1030,6 +1030,32 @@ module DataFlow {
   }
 
   /**
+   * A data flow node representing the arguments object given to a function.
+   */
+  class ReflectiveParametersNode extends DataFlow::Node, TReflectiveParametersNode {
+    Function function;
+
+    ReflectiveParametersNode() { this = TReflectiveParametersNode(function) }
+
+    override string toString() { result = "the arguments object of " + function.describe() }
+
+    override predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      function.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    override BasicBlock getBasicBlock() { result = function.getEntry().getBasicBlock() }
+
+    /**
+     * Gets the function corresponding to this reflektive parameters node.
+     */
+    Function getFunction() { result = function }
+
+    override File getFile() { result = function.getFile() }
+  }
+
+  /**
    * A data flow node representing the exceptions thrown by the callee of an invocation.
    */
   class ExceptionalInvocationReturnNode extends DataFlow::Node, TExceptionalInvocationReturnNode {
@@ -1627,6 +1653,26 @@ module DataFlow {
     exists(Function f | not f.isAsyncOrGenerator() |
       DataFlow::functionReturnNode(succ, f) and pred = valueNode(f.getAReturnedExpr())
     )
+    or
+    // from a reflective params node to a reference to the arguments object.
+    exists(DataFlow::ReflectiveParametersNode params, Function f | f = params.getFunction() |
+      succ = f.getArgumentsVariable().getAnAccess().flow() and
+      pred = params
+    )
+  }
+
+  /**
+   * A step from a reflective parameter node to each parameter.
+   */
+  private class ReflectiveParamsStep extends PreCallGraphStep {
+    override predicate loadStep(DataFlow::Node obj, DataFlow::Node element, string prop) {
+      exists(DataFlow::ReflectiveParametersNode params, DataFlow::FunctionNode f, int i |
+        f.getFunction() = params.getFunction() and
+        obj = params and
+        prop = i + "" and
+        element = f.getParameter(i)
+      )
+    }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
@@ -1037,7 +1037,7 @@ module DataFlow {
 
     ReflectiveParametersNode() { this = TReflectiveParametersNode(function) }
 
-    override string toString() { result = "the arguments object of " + function.describe() }
+    override string toString() { result = "'arguments' object of " + function.describe() }
 
     override predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -1048,7 +1048,7 @@ module DataFlow {
     override BasicBlock getBasicBlock() { result = function.getEntry().getBasicBlock() }
 
     /**
-     * Gets the function corresponding to this reflektive parameters node.
+     * Gets the function whose `arguments` object is represented by this node.
      */
     Function getFunction() { result = function }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
@@ -1661,9 +1661,7 @@ module DataFlow {
     )
   }
 
-  /**
-   * A step from a reflective parameter node to each parameter.
-   */
+  /** A load step from a reflective parameter node to each parameter. */
   private class ReflectiveParamsStep extends PreCallGraphStep {
     override predicate loadStep(DataFlow::Node obj, DataFlow::Node element, string prop) {
       exists(DataFlow::ReflectiveParametersNode params, DataFlow::FunctionNode f, int i |
@@ -1671,6 +1669,17 @@ module DataFlow {
         obj = params and
         prop = i + "" and
         element = f.getParameter(i)
+      )
+    }
+  }
+
+  /** A taint step from the reflective parameters node to any parameter. */
+  private class ReflectiveParamsTaintStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node obj, DataFlow::Node element) {
+      exists(DataFlow::ReflectiveParametersNode params, DataFlow::FunctionNode f |
+        f.getFunction() = params.getFunction() and
+        obj = params and
+        element = f.getAParameter()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
@@ -332,6 +332,8 @@ module SourceNode {
       or
       // Include return nodes because they model the implicit Promise creation in async functions.
       DataFlow::functionReturnNode(this, _)
+      or
+      this instanceof DataFlow::ReflectiveParametersNode
     }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowNode.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowNode.qll
@@ -31,4 +31,5 @@ newtype TNode =
   TExceptionalFunctionReturnNode(Function f) or
   TExceptionalInvocationReturnNode(InvokeExpr e) or
   TGlobalAccessPathRoot() or
-  TTemplatePlaceholderTag(Templating::TemplatePlaceholderTag tag)
+  TTemplatePlaceholderTag(Templating::TemplatePlaceholderTag tag) or
+  TReflectiveParametersNode(Function f)

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -224,6 +224,14 @@ private module CachedSteps {
       or
       arg = invk.(DataFlow::PropWrite).getRhs() and
       parm = DataFlow::parameterNode(f.getParameter(0))
+      or
+      calls(invk, f) and
+      exists(MethodCallExpr apply |
+        invk = DataFlow::reflectiveCallNode(apply) and
+        apply.getMethodName() = "apply" and
+        arg = apply.getArgument(1).flow()
+      ) and
+      parm.(DataFlow::ReflectiveParametersNode).getFunction() = f
     )
     or
     exists(DataFlow::Node callback, int i, Parameter p, Function target |

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutingAssignmentCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutingAssignmentCustomizations.qll
@@ -68,7 +68,7 @@ module PrototypePollutingAssignment {
   /**
    * A parameter of an exported function, seen as a source prototype-polluting assignment.
    */
-  class ExternalInputSource extends Source, DataFlow::SourceNode {
+  class ExternalInputSource extends Source {
     ExternalInputSource() { this = Exports::getALibraryInputParameter() }
 
     override string describe() { result = "library input" }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeCodeConstructionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeCodeConstructionCustomizations.qll
@@ -21,11 +21,11 @@ module UnsafeCodeConstruction {
   /**
    * A parameter of an exported function, seen as a source.
    */
-  class ExternalInputSource extends Source, DataFlow::ParameterNode {
+  class ExternalInputSource extends Source {
     ExternalInputSource() {
       this = Exports::getALibraryInputParameter() and
       // permit parameters that clearly are intended to contain executable code.
-      not this.getName() = "code"
+      not this.(DataFlow::ParameterNode).getName() = "code"
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeHtmlConstructionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeHtmlConstructionCustomizations.qll
@@ -22,7 +22,7 @@ module UnsafeHtmlConstruction {
   /**
    * A parameter of an exported function, seen as a source for usnafe HTML constructed from input.
    */
-  class ExternalInputSource extends Source, DataFlow::ParameterNode {
+  class ExternalInputSource extends Source {
     ExternalInputSource() {
       this = Exports::getALibraryInputParameter() and
       // An AMD-style module sometimes loads the jQuery library in a way which looks like library input.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
@@ -49,7 +49,7 @@ module UnsafeShellCommandConstruction {
   /**
    * A parameter of an exported function, seen as a source for shell command constructed from library input.
    */
-  class ExternalInputSource extends Source, DataFlow::SourceNode {
+  class ExternalInputSource extends Source {
     ExternalInputSource() {
       this = Exports::getALibraryInputParameter() and
       not (

--- a/javascript/ql/lib/semmle/javascript/security/regexp/PolynomialReDoSCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/regexp/PolynomialReDoSCustomizations.qll
@@ -138,7 +138,7 @@ module PolynomialReDoS {
   /**
    * A parameter of an exported function, seen as a source for polynomial-redos.
    */
-  class ExternalInputSource extends Source, DataFlow::SourceNode {
+  class ExternalInputSource extends Source {
     ExternalInputSource() { this = Exports::getALibraryInputParameter() }
 
     override string getKind() { result = "library" }

--- a/javascript/ql/test/library-tests/DataFlow/tests.expected
+++ b/javascript/ql/test/library-tests/DataFlow/tests.expected
@@ -15,16 +15,16 @@ basicBlock
 | arguments.js:1:1:12:4 | (functi ... );\\n})() | arguments.js:1:1:1:0 | entry node of <toplevel> |
 | arguments.js:1:1:12:4 | exceptional return of (functi ... );\\n})() | arguments.js:1:1:1:0 | entry node of <toplevel> |
 | arguments.js:1:2:1:1 | this | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
+| arguments.js:1:2:12:1 | 'arguments' object of anonymous function | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:1:2:12:1 | exceptional return of anonymous function | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:1:2:12:1 | functio ... , 3);\\n} | arguments.js:1:1:1:0 | entry node of <toplevel> |
 | arguments.js:1:2:12:1 | return of anonymous function | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
-| arguments.js:1:2:12:1 | the arguments object of anonymous function | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:2:5:2:4 | this | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
 | arguments.js:2:5:2:5 | arguments | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
+| arguments.js:2:5:10:5 | 'arguments' object of function f | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
 | arguments.js:2:5:10:5 | exceptional return of function f | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
 | arguments.js:2:5:10:5 | functio ... ;\\n    } | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:2:5:10:5 | return of function f | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
-| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
 | arguments.js:2:14:2:14 | f | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:2:14:2:14 | f | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:2:16:2:16 | x | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
@@ -68,10 +68,10 @@ basicBlock
 | arguments.js:11:13:11:13 | 3 | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | eval.js:1:1:1:0 | this | eval.js:1:1:1:0 | entry node of <toplevel> |
 | eval.js:1:1:1:0 | this | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
+| eval.js:1:1:5:1 | 'arguments' object of function k | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
 | eval.js:1:1:5:1 | exceptional return of function k | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
 | eval.js:1:1:5:1 | functio ... eval`\\n} | eval.js:1:1:1:0 | entry node of <toplevel> |
 | eval.js:1:1:5:1 | return of function k | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
-| eval.js:1:1:5:1 | the arguments object of function k | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
 | eval.js:1:10:1:10 | k | eval.js:1:1:1:0 | entry node of <toplevel> |
 | eval.js:2:7:2:7 | x | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
 | eval.js:2:7:2:12 | x | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
@@ -88,19 +88,19 @@ basicBlock
 | sources.js:1:5:1:12 | (x => x) | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:1:6:1:6 | x | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:1:6:1:6 | x | sources.js:1:6:1:5 | entry node of x => x |
+| sources.js:1:6:1:11 | 'arguments' object of anonymous function | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:1:6:1:11 | exceptional return of anonymous function | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:1:6:1:11 | return of anonymous function | sources.js:1:6:1:5 | entry node of x => x |
-| sources.js:1:6:1:11 | the arguments object of anonymous function | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:1:6:1:11 | x => x | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:1:11:1:11 | x | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:3:1:5:2 | (functi ... +19;\\n}) | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:3:1:5:6 | (functi ... \\n})(23) | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:3:1:5:6 | exceptional return of (functi ... \\n})(23) | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:3:2:3:1 | this | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
+| sources.js:3:2:5:1 | 'arguments' object of anonymous function | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:3:2:5:1 | exceptional return of anonymous function | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:3:2:5:1 | functio ... x+19;\\n} | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:3:2:5:1 | return of anonymous function | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
-| sources.js:3:2:5:1 | the arguments object of anonymous function | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:3:11:3:11 | x | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:3:11:3:11 | x | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:4:10:4:10 | x | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
@@ -109,10 +109,10 @@ basicBlock
 | sources.js:5:4:5:5 | 23 | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:7:1:7:3 | /x/ | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:9:1:9:0 | this | sources.js:9:1:9:0 | entry node of functio ... ey; }\\n} |
+| sources.js:9:1:12:1 | 'arguments' object of function foo | sources.js:9:1:9:0 | entry node of functio ... ey; }\\n} |
 | sources.js:9:1:12:1 | exceptional return of function foo | sources.js:12:2:12:1 | exit node of functio ... ey; }\\n} |
 | sources.js:9:1:12:1 | functio ... ey; }\\n} | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:9:1:12:1 | return of function foo | sources.js:12:2:12:1 | exit node of functio ... ey; }\\n} |
-| sources.js:9:1:12:1 | the arguments object of function foo | sources.js:9:1:9:0 | entry node of functio ... ey; }\\n} |
 | sources.js:9:10:9:12 | foo | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:9:14:9:18 | array | sources.js:9:1:9:0 | entry node of functio ... ey; }\\n} |
 | sources.js:9:14:9:18 | array | sources.js:9:1:9:0 | entry node of functio ... ey; }\\n} |
@@ -146,10 +146,10 @@ basicBlock
 | tst2.ts:4:3:4:3 | x | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:7:1:7:0 | A | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
 | tst2.ts:7:1:7:0 | this | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
+| tst2.ts:7:1:9:1 | 'arguments' object of function setX | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
 | tst2.ts:7:1:9:1 | exceptional return of function setX | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
 | tst2.ts:7:1:9:1 | functio ... = 23;\\n} | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:7:1:9:1 | return of function setX | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
-| tst2.ts:7:1:9:1 | the arguments object of function setX | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
 | tst2.ts:7:10:7:13 | setX | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:7:10:7:13 | setX | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:8:3:8:3 | A | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
@@ -167,6 +167,7 @@ basicBlock
 | tst2.ts:13:7:13:16 | StringList | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:13:26:13:29 | List | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:13:26:13:37 | List<string> | tst2.ts:1:1:1:0 | entry node of <toplevel> |
+| tst2.ts:13:39:13:38 | 'arguments' object of default constructor of class StringList | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | (...arg ... rgs); } | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:13:39:13:38 | ...args | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | args | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
@@ -180,7 +181,6 @@ basicBlock
 | tst2.ts:13:39:13:38 | return of default constructor of class StringList | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | super | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | super(...args) | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
-| tst2.ts:13:39:13:38 | the arguments object of default constructor of class StringList | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | this | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst.js:1:1:1:0 | this | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:1:1:1:1 | x | tst.js:1:1:1:0 | entry node of <toplevel> |
@@ -229,10 +229,10 @@ basicBlock
 | tst.js:16:1:20:9 | (functi ... ("arg") | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:16:1:20:9 | exceptional return of (functi ... ("arg") | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:16:2:16:1 | this | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
+| tst.js:16:2:20:1 | 'arguments' object of function f | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
 | tst.js:16:2:20:1 | exceptional return of function f | tst.js:20:2:20:1 | exit node of functio ... n "";\\n} |
 | tst.js:16:2:20:1 | functio ... n "";\\n} | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:16:2:20:1 | return of function f | tst.js:20:2:20:1 | exit node of functio ... n "";\\n} |
-| tst.js:16:2:20:1 | the arguments object of function f | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
 | tst.js:16:11:16:11 | f | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
 | tst.js:16:13:16:13 | a | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
 | tst.js:16:13:16:13 | a | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
@@ -263,17 +263,17 @@ basicBlock
 | tst.js:28:1:30:3 | (() =>\\n ... les\\n)() | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:28:1:30:3 | exceptional return of (() =>\\n ... les\\n)() | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:28:2:28:1 | x | tst.js:28:2:28:1 | entry node of () =>\\n  x |
+| tst.js:28:2:29:3 | 'arguments' object of anonymous function | tst.js:28:2:28:1 | entry node of () =>\\n  x |
 | tst.js:28:2:29:3 | () =>\\n  x | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:28:2:29:3 | exceptional return of anonymous function | tst.js:28:2:28:1 | entry node of () =>\\n  x |
 | tst.js:28:2:29:3 | return of anonymous function | tst.js:28:2:28:1 | entry node of () =>\\n  x |
-| tst.js:28:2:29:3 | the arguments object of anonymous function | tst.js:28:2:28:1 | entry node of () =>\\n  x |
 | tst.js:29:3:29:3 | x | tst.js:28:2:28:1 | entry node of () =>\\n  x |
 | tst.js:32:1:32:0 | this | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
 | tst.js:32:1:32:0 | x | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
+| tst.js:32:1:34:1 | 'arguments' object of function g | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
 | tst.js:32:1:34:1 | exceptional return of function g | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
 | tst.js:32:1:34:1 | functio ... ables\\n} | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:32:1:34:1 | return of function g | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
-| tst.js:32:1:34:1 | the arguments object of function g | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
 | tst.js:32:10:32:10 | g | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:32:10:32:10 | g | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:32:12:32:12 | b | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
@@ -294,10 +294,10 @@ basicBlock
 | tst.js:39:3:41:3 | m() {\\n    this;\\n  } | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:39:3:41:3 | m() {\\n    this;\\n  } | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:39:4:39:3 | this | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
+| tst.js:39:4:41:3 | 'arguments' object of method m | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
 | tst.js:39:4:41:3 | () {\\n    this;\\n  } | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:39:4:41:3 | exceptional return of method m | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
 | tst.js:39:4:41:3 | return of method m | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
-| tst.js:39:4:41:3 | the arguments object of method m | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
 | tst.js:40:5:40:8 | this | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
 | tst.js:43:1:43:1 | o | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:43:1:43:3 | o.x | tst.js:16:1:20:10 | (functi ... "arg"); |
@@ -319,10 +319,10 @@ basicBlock
 | tst.js:50:3:53:3 | constru ... et`\\n  } | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:50:3:53:3 | constru ... et`\\n  } | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:50:14:50:13 | this | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
+| tst.js:50:14:53:3 | 'arguments' object of constructor of class A | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:50:14:53:3 | () {\\n   ... et`\\n  } | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:50:14:53:3 | exceptional return of constructor of class A | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:50:14:53:3 | return of constructor of class A | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
-| tst.js:50:14:53:3 | the arguments object of constructor of class A | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:51:5:51:9 | super | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:51:5:51:13 | exceptional return of super(42) | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:51:5:51:13 | super(42) | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
@@ -346,10 +346,10 @@ basicBlock
 | tst.js:62:1:62:4 | o::g | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:62:4:62:4 | g | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:64:1:64:0 | this | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
+| tst.js:64:1:67:1 | 'arguments' object of function h | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
 | tst.js:64:1:67:1 | exceptional return of function h | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
 | tst.js:64:1:67:1 | functio ... lysed\\n} | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:64:1:67:1 | return of function h | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
-| tst.js:64:1:67:1 | the arguments object of function h | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
 | tst.js:64:11:64:11 | h | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:64:11:64:11 | h | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:65:3:65:10 | yield 42 | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
@@ -370,10 +370,10 @@ basicBlock
 | tst.js:69:6:69:9 | next | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:69:11:69:12 | 23 | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:71:1:71:0 | this | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
+| tst.js:71:1:73:1 | 'arguments' object of function k | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
 | tst.js:71:1:73:1 | async f ... lysed\\n} | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:71:1:73:1 | exceptional return of function k | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
 | tst.js:71:1:73:1 | return of function k | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
-| tst.js:71:1:73:1 | the arguments object of function k | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
 | tst.js:71:16:71:16 | k | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:72:3:72:11 | await p() | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
 | tst.js:72:9:72:9 | p | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
@@ -413,10 +413,10 @@ basicBlock
 | tst.js:87:1:96:2 | (functi ... r: 0\\n}) | tst.js:85:5:85:28 | vs2 = ( ...  o) v ) |
 | tst.js:87:1:96:2 | exceptional return of (functi ... r: 0\\n}) | tst.js:85:5:85:28 | vs2 = ( ...  o) v ) |
 | tst.js:87:2:87:1 | this | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
+| tst.js:87:2:92:1 | 'arguments' object of anonymous function | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:2:92:1 | exceptional return of anonymous function | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:2:92:1 | functio ...  + z;\\n} | tst.js:85:5:85:28 | vs2 = ( ...  o) v ) |
 | tst.js:87:2:92:1 | return of anonymous function | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
-| tst.js:87:2:92:1 | the arguments object of anonymous function | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:11:87:24 | o | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:11:87:24 | x | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:11:87:24 | { p: x, ...o } | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
@@ -467,10 +467,10 @@ basicBlock
 | tst.js:98:1:103:17 | (functi ... 3, 0 ]) | tst.js:85:5:85:28 | vs2 = ( ...  o) v ) |
 | tst.js:98:1:103:17 | exceptional return of (functi ... 3, 0 ]) | tst.js:85:5:85:28 | vs2 = ( ...  o) v ) |
 | tst.js:98:2:98:1 | this | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
+| tst.js:98:2:103:1 | 'arguments' object of anonymous function | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:2:103:1 | exceptional return of anonymous function | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:2:103:1 | functio ...  + z;\\n} | tst.js:85:5:85:28 | vs2 = ( ...  o) v ) |
 | tst.js:98:2:103:1 | return of anonymous function | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
-| tst.js:98:2:103:1 | the arguments object of anonymous function | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:11:98:24 | [ x, ...rest ] | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:11:98:24 | rest | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:11:98:24 | x | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
@@ -509,10 +509,10 @@ basicBlock
 | tst.js:105:6:105:6 | y | tst.js:105:6:105:6 | y |
 | tst.js:107:1:113:2 | (functi ... v2c;\\n}) | tst.js:107:1:113:3 | (functi ... 2c;\\n}); |
 | tst.js:107:2:107:1 | this | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
+| tst.js:107:2:113:1 | 'arguments' object of anonymous function | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:107:2:113:1 | exceptional return of anonymous function | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:107:2:113:1 | functio ...  v2c;\\n} | tst.js:107:1:113:3 | (functi ... 2c;\\n}); |
 | tst.js:107:2:113:1 | return of anonymous function | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
-| tst.js:107:2:113:1 | the arguments object of anonymous function | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:108:6:108:32 | {v1a, v ...  = o1c} | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:108:6:108:38 | v1a | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:108:6:108:38 | v1b | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
@@ -936,12 +936,12 @@ flowStep
 | arguments.js:2:5:2:5 | arguments | arguments.js:4:28:4:36 | arguments |
 | arguments.js:2:5:2:5 | arguments | arguments.js:5:25:5:33 | arguments |
 | arguments.js:2:5:2:5 | arguments | arguments.js:6:20:6:28 | arguments |
+| arguments.js:2:5:10:5 | 'arguments' object of function f | arguments.js:4:28:4:36 | arguments |
+| arguments.js:2:5:10:5 | 'arguments' object of function f | arguments.js:5:25:5:33 | arguments |
+| arguments.js:2:5:10:5 | 'arguments' object of function f | arguments.js:6:20:6:28 | arguments |
+| arguments.js:2:5:10:5 | 'arguments' object of function f | arguments.js:8:9:8:17 | arguments |
+| arguments.js:2:5:10:5 | 'arguments' object of function f | arguments.js:9:27:9:35 | arguments |
 | arguments.js:2:5:10:5 | functio ... ;\\n    } | arguments.js:2:14:2:14 | f |
-| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:4:28:4:36 | arguments |
-| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:5:25:5:33 | arguments |
-| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:6:20:6:28 | arguments |
-| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:8:9:8:17 | arguments |
-| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:9:27:9:35 | arguments |
 | arguments.js:2:14:2:14 | f | arguments.js:11:5:11:5 | f |
 | arguments.js:2:16:2:16 | x | arguments.js:2:16:2:16 | x |
 | arguments.js:2:16:2:16 | x | arguments.js:3:24:3:24 | x |
@@ -1444,13 +1444,13 @@ sources
 | arguments.js:1:1:1:0 | this |
 | arguments.js:1:1:12:4 | (functi ... );\\n})() |
 | arguments.js:1:2:1:1 | this |
+| arguments.js:1:2:12:1 | 'arguments' object of anonymous function |
 | arguments.js:1:2:12:1 | functio ... , 3);\\n} |
 | arguments.js:1:2:12:1 | return of anonymous function |
-| arguments.js:1:2:12:1 | the arguments object of anonymous function |
 | arguments.js:2:5:2:4 | this |
+| arguments.js:2:5:10:5 | 'arguments' object of function f |
 | arguments.js:2:5:10:5 | functio ... ;\\n    } |
 | arguments.js:2:5:10:5 | return of function f |
-| arguments.js:2:5:10:5 | the arguments object of function f |
 | arguments.js:2:16:2:16 | x |
 | arguments.js:4:28:4:39 | arguments[0] |
 | arguments.js:5:25:5:36 | arguments[1] |
@@ -1460,9 +1460,9 @@ sources
 | arguments.js:11:5:11:14 | f(1, 2, 3) |
 | eval.js:1:1:1:0 | this |
 | eval.js:1:1:1:0 | this |
+| eval.js:1:1:5:1 | 'arguments' object of function k |
 | eval.js:1:1:5:1 | functio ... eval`\\n} |
 | eval.js:1:1:5:1 | return of function k |
-| eval.js:1:1:5:1 | the arguments object of function k |
 | eval.js:3:3:3:6 | eval |
 | eval.js:3:3:3:16 | eval("x = 23") |
 | eval.js:3:8:3:15 | "x = 23" |
@@ -1470,20 +1470,20 @@ sources
 | sources.js:1:1:1:0 | this |
 | sources.js:1:1:1:12 | new (x => x) |
 | sources.js:1:6:1:6 | x |
+| sources.js:1:6:1:11 | 'arguments' object of anonymous function |
 | sources.js:1:6:1:11 | return of anonymous function |
-| sources.js:1:6:1:11 | the arguments object of anonymous function |
 | sources.js:1:6:1:11 | x => x |
 | sources.js:3:1:5:6 | (functi ... \\n})(23) |
 | sources.js:3:2:3:1 | this |
+| sources.js:3:2:5:1 | 'arguments' object of anonymous function |
 | sources.js:3:2:5:1 | functio ... x+19;\\n} |
 | sources.js:3:2:5:1 | return of anonymous function |
-| sources.js:3:2:5:1 | the arguments object of anonymous function |
 | sources.js:3:11:3:11 | x |
 | sources.js:7:1:7:3 | /x/ |
 | sources.js:9:1:9:0 | this |
+| sources.js:9:1:12:1 | 'arguments' object of function foo |
 | sources.js:9:1:12:1 | functio ... ey; }\\n} |
 | sources.js:9:1:12:1 | return of function foo |
-| sources.js:9:1:12:1 | the arguments object of function foo |
 | sources.js:9:14:9:18 | array |
 | sources.js:10:12:10:14 | key |
 | sources.js:11:12:11:18 | { key } |
@@ -1491,18 +1491,18 @@ sources
 | tst2.ts:1:1:1:0 | this |
 | tst2.ts:3:3:3:8 | setX() |
 | tst2.ts:7:1:7:0 | this |
+| tst2.ts:7:1:9:1 | 'arguments' object of function setX |
 | tst2.ts:7:1:9:1 | functio ... = 23;\\n} |
 | tst2.ts:7:1:9:1 | return of function setX |
-| tst2.ts:7:1:9:1 | the arguments object of function setX |
 | tst2.ts:8:3:8:5 | A.x |
 | tst2.ts:11:11:11:13 | A.x |
 | tst2.ts:13:1:13:40 | class S ... ing> {} |
 | tst2.ts:13:26:13:29 | List |
+| tst2.ts:13:39:13:38 | 'arguments' object of default constructor of class StringList |
 | tst2.ts:13:39:13:38 | (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | args |
 | tst2.ts:13:39:13:38 | return of default constructor of class StringList |
 | tst2.ts:13:39:13:38 | super(...args) |
-| tst2.ts:13:39:13:38 | the arguments object of default constructor of class StringList |
 | tst2.ts:13:39:13:38 | this |
 | tst.js:1:1:1:0 | this |
 | tst.js:1:1:1:24 | import  ... m 'fs'; |
@@ -1511,9 +1511,9 @@ sources
 | tst.js:4:9:4:12 | "hi" |
 | tst.js:16:1:20:9 | (functi ... ("arg") |
 | tst.js:16:2:16:1 | this |
+| tst.js:16:2:20:1 | 'arguments' object of function f |
 | tst.js:16:2:20:1 | functio ... n "";\\n} |
 | tst.js:16:2:20:1 | return of function f |
-| tst.js:16:2:20:1 | the arguments object of function f |
 | tst.js:16:13:16:13 | a |
 | tst.js:17:7:17:10 | Math |
 | tst.js:17:7:17:17 | Math.random |
@@ -1522,20 +1522,20 @@ sources
 | tst.js:20:4:20:8 | "arg" |
 | tst.js:22:7:22:18 | readFileSync |
 | tst.js:28:1:30:3 | (() =>\\n ... les\\n)() |
+| tst.js:28:2:29:3 | 'arguments' object of anonymous function |
 | tst.js:28:2:29:3 | () =>\\n  x |
 | tst.js:28:2:29:3 | return of anonymous function |
-| tst.js:28:2:29:3 | the arguments object of anonymous function |
 | tst.js:32:1:32:0 | this |
+| tst.js:32:1:34:1 | 'arguments' object of function g |
 | tst.js:32:1:34:1 | functio ... ables\\n} |
 | tst.js:32:1:34:1 | return of function g |
-| tst.js:32:1:34:1 | the arguments object of function g |
 | tst.js:32:12:32:12 | b |
 | tst.js:35:1:35:7 | g(true) |
 | tst.js:37:9:42:1 | {\\n  x:  ... ;\\n  }\\n} |
 | tst.js:39:4:39:3 | this |
+| tst.js:39:4:41:3 | 'arguments' object of method m |
 | tst.js:39:4:41:3 | () {\\n    this;\\n  } |
 | tst.js:39:4:41:3 | return of method m |
-| tst.js:39:4:41:3 | the arguments object of method m |
 | tst.js:43:1:43:3 | o.x |
 | tst.js:44:1:44:3 | o.m |
 | tst.js:44:1:44:5 | o.m() |
@@ -1545,9 +1545,9 @@ sources
 | tst.js:49:1:54:1 | class A ... `\\n  }\\n} |
 | tst.js:49:17:49:17 | B |
 | tst.js:50:14:50:13 | this |
+| tst.js:50:14:53:3 | 'arguments' object of constructor of class A |
 | tst.js:50:14:53:3 | () {\\n   ... et`\\n  } |
 | tst.js:50:14:53:3 | return of constructor of class A |
-| tst.js:50:14:53:3 | the arguments object of constructor of class A |
 | tst.js:51:5:51:13 | super(42) |
 | tst.js:58:1:58:3 | tag |
 | tst.js:58:1:58:13 | tag `x: ${x}` |
@@ -1555,18 +1555,18 @@ sources
 | tst.js:61:3:61:5 | o.m |
 | tst.js:62:1:62:4 | o::g |
 | tst.js:64:1:64:0 | this |
+| tst.js:64:1:67:1 | 'arguments' object of function h |
 | tst.js:64:1:67:1 | functio ... lysed\\n} |
 | tst.js:64:1:67:1 | return of function h |
-| tst.js:64:1:67:1 | the arguments object of function h |
 | tst.js:65:3:65:10 | yield 42 |
 | tst.js:66:13:66:25 | function.sent |
 | tst.js:68:12:68:14 | h() |
 | tst.js:69:1:69:9 | iter.next |
 | tst.js:69:1:69:13 | iter.next(23) |
 | tst.js:71:1:71:0 | this |
+| tst.js:71:1:73:1 | 'arguments' object of function k |
 | tst.js:71:1:73:1 | async f ... lysed\\n} |
 | tst.js:71:1:73:1 | return of function k |
-| tst.js:71:1:73:1 | the arguments object of function k |
 | tst.js:72:3:72:11 | await p() |
 | tst.js:72:9:72:9 | p |
 | tst.js:72:9:72:11 | p() |
@@ -1577,9 +1577,9 @@ sources
 | tst.js:85:11:85:28 | ( for (v of o) v ) |
 | tst.js:87:1:96:2 | (functi ... r: 0\\n}) |
 | tst.js:87:2:87:1 | this |
+| tst.js:87:2:92:1 | 'arguments' object of anonymous function |
 | tst.js:87:2:92:1 | functio ...  + z;\\n} |
 | tst.js:87:2:92:1 | return of anonymous function |
-| tst.js:87:2:92:1 | the arguments object of anonymous function |
 | tst.js:87:11:87:24 | { p: x, ...o } |
 | tst.js:87:13:87:16 | p: x |
 | tst.js:87:22:87:22 | ...o |
@@ -1588,9 +1588,9 @@ sources
 | tst.js:92:4:96:1 | {\\n  p:  ...  r: 0\\n} |
 | tst.js:98:1:103:17 | (functi ... 3, 0 ]) |
 | tst.js:98:2:98:1 | this |
+| tst.js:98:2:103:1 | 'arguments' object of anonymous function |
 | tst.js:98:2:103:1 | functio ...  + z;\\n} |
 | tst.js:98:2:103:1 | return of anonymous function |
-| tst.js:98:2:103:1 | the arguments object of anonymous function |
 | tst.js:98:11:98:24 | [ x, ...rest ] |
 | tst.js:98:13:98:13 | x |
 | tst.js:98:19:98:22 | ...rest |
@@ -1598,9 +1598,9 @@ sources
 | tst.js:101:7:101:7 | z |
 | tst.js:103:4:103:16 | [ 19, 23, 0 ] |
 | tst.js:107:2:107:1 | this |
+| tst.js:107:2:113:1 | 'arguments' object of anonymous function |
 | tst.js:107:2:113:1 | functio ...  v2c;\\n} |
 | tst.js:107:2:113:1 | return of anonymous function |
-| tst.js:107:2:113:1 | the arguments object of anonymous function |
 | tst.js:108:7:108:9 | v1a |
 | tst.js:108:12:108:20 | v1b = o1b |
 | tst.js:108:18:108:20 | o1b |

--- a/javascript/ql/test/library-tests/DataFlow/tests.expected
+++ b/javascript/ql/test/library-tests/DataFlow/tests.expected
@@ -18,11 +18,13 @@ basicBlock
 | arguments.js:1:2:12:1 | exceptional return of anonymous function | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:1:2:12:1 | functio ... , 3);\\n} | arguments.js:1:1:1:0 | entry node of <toplevel> |
 | arguments.js:1:2:12:1 | return of anonymous function | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
+| arguments.js:1:2:12:1 | the arguments object of anonymous function | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:2:5:2:4 | this | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
 | arguments.js:2:5:2:5 | arguments | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
 | arguments.js:2:5:10:5 | exceptional return of function f | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
 | arguments.js:2:5:10:5 | functio ... ;\\n    } | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:2:5:10:5 | return of function f | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
+| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
 | arguments.js:2:14:2:14 | f | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:2:14:2:14 | f | arguments.js:1:2:1:1 | entry node of functio ... , 3);\\n} |
 | arguments.js:2:16:2:16 | x | arguments.js:2:5:2:4 | entry node of functio ... ;\\n    } |
@@ -69,6 +71,7 @@ basicBlock
 | eval.js:1:1:5:1 | exceptional return of function k | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
 | eval.js:1:1:5:1 | functio ... eval`\\n} | eval.js:1:1:1:0 | entry node of <toplevel> |
 | eval.js:1:1:5:1 | return of function k | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
+| eval.js:1:1:5:1 | the arguments object of function k | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
 | eval.js:1:10:1:10 | k | eval.js:1:1:1:0 | entry node of <toplevel> |
 | eval.js:2:7:2:7 | x | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
 | eval.js:2:7:2:12 | x | eval.js:1:1:1:0 | entry node of functio ... eval`\\n} |
@@ -87,6 +90,7 @@ basicBlock
 | sources.js:1:6:1:6 | x | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:1:6:1:11 | exceptional return of anonymous function | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:1:6:1:11 | return of anonymous function | sources.js:1:6:1:5 | entry node of x => x |
+| sources.js:1:6:1:11 | the arguments object of anonymous function | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:1:6:1:11 | x => x | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:1:11:1:11 | x | sources.js:1:6:1:5 | entry node of x => x |
 | sources.js:3:1:5:2 | (functi ... +19;\\n}) | sources.js:1:1:1:0 | entry node of <toplevel> |
@@ -96,6 +100,7 @@ basicBlock
 | sources.js:3:2:5:1 | exceptional return of anonymous function | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:3:2:5:1 | functio ... x+19;\\n} | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:3:2:5:1 | return of anonymous function | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
+| sources.js:3:2:5:1 | the arguments object of anonymous function | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:3:11:3:11 | x | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:3:11:3:11 | x | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
 | sources.js:4:10:4:10 | x | sources.js:3:2:3:1 | entry node of functio ... x+19;\\n} |
@@ -107,6 +112,7 @@ basicBlock
 | sources.js:9:1:12:1 | exceptional return of function foo | sources.js:12:2:12:1 | exit node of functio ... ey; }\\n} |
 | sources.js:9:1:12:1 | functio ... ey; }\\n} | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:9:1:12:1 | return of function foo | sources.js:12:2:12:1 | exit node of functio ... ey; }\\n} |
+| sources.js:9:1:12:1 | the arguments object of function foo | sources.js:9:1:9:0 | entry node of functio ... ey; }\\n} |
 | sources.js:9:10:9:12 | foo | sources.js:1:1:1:0 | entry node of <toplevel> |
 | sources.js:9:14:9:18 | array | sources.js:9:1:9:0 | entry node of functio ... ey; }\\n} |
 | sources.js:9:14:9:18 | array | sources.js:9:1:9:0 | entry node of functio ... ey; }\\n} |
@@ -143,6 +149,7 @@ basicBlock
 | tst2.ts:7:1:9:1 | exceptional return of function setX | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
 | tst2.ts:7:1:9:1 | functio ... = 23;\\n} | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:7:1:9:1 | return of function setX | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
+| tst2.ts:7:1:9:1 | the arguments object of function setX | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
 | tst2.ts:7:10:7:13 | setX | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:7:10:7:13 | setX | tst2.ts:1:1:1:0 | entry node of <toplevel> |
 | tst2.ts:8:3:8:3 | A | tst2.ts:7:1:7:0 | entry node of functio ... = 23;\\n} |
@@ -173,6 +180,7 @@ basicBlock
 | tst2.ts:13:39:13:38 | return of default constructor of class StringList | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | super | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | super(...args) | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
+| tst2.ts:13:39:13:38 | the arguments object of default constructor of class StringList | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | this | tst2.ts:13:39:13:38 | entry node of (...arg ... rgs); } |
 | tst.js:1:1:1:0 | this | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:1:1:1:1 | x | tst.js:1:1:1:0 | entry node of <toplevel> |
@@ -224,6 +232,7 @@ basicBlock
 | tst.js:16:2:20:1 | exceptional return of function f | tst.js:20:2:20:1 | exit node of functio ... n "";\\n} |
 | tst.js:16:2:20:1 | functio ... n "";\\n} | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:16:2:20:1 | return of function f | tst.js:20:2:20:1 | exit node of functio ... n "";\\n} |
+| tst.js:16:2:20:1 | the arguments object of function f | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
 | tst.js:16:11:16:11 | f | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
 | tst.js:16:13:16:13 | a | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
 | tst.js:16:13:16:13 | a | tst.js:16:2:16:1 | entry node of functio ... n "";\\n} |
@@ -257,12 +266,14 @@ basicBlock
 | tst.js:28:2:29:3 | () =>\\n  x | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:28:2:29:3 | exceptional return of anonymous function | tst.js:28:2:28:1 | entry node of () =>\\n  x |
 | tst.js:28:2:29:3 | return of anonymous function | tst.js:28:2:28:1 | entry node of () =>\\n  x |
+| tst.js:28:2:29:3 | the arguments object of anonymous function | tst.js:28:2:28:1 | entry node of () =>\\n  x |
 | tst.js:29:3:29:3 | x | tst.js:28:2:28:1 | entry node of () =>\\n  x |
 | tst.js:32:1:32:0 | this | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
 | tst.js:32:1:32:0 | x | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
 | tst.js:32:1:34:1 | exceptional return of function g | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
 | tst.js:32:1:34:1 | functio ... ables\\n} | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:32:1:34:1 | return of function g | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
+| tst.js:32:1:34:1 | the arguments object of function g | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
 | tst.js:32:10:32:10 | g | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:32:10:32:10 | g | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:32:12:32:12 | b | tst.js:32:1:32:0 | entry node of functio ... ables\\n} |
@@ -286,6 +297,7 @@ basicBlock
 | tst.js:39:4:41:3 | () {\\n    this;\\n  } | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:39:4:41:3 | exceptional return of method m | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
 | tst.js:39:4:41:3 | return of method m | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
+| tst.js:39:4:41:3 | the arguments object of method m | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
 | tst.js:40:5:40:8 | this | tst.js:39:4:39:3 | entry node of () {\\n    this;\\n  } |
 | tst.js:43:1:43:1 | o | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:43:1:43:3 | o.x | tst.js:16:1:20:10 | (functi ... "arg"); |
@@ -310,6 +322,7 @@ basicBlock
 | tst.js:50:14:53:3 | () {\\n   ... et`\\n  } | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:50:14:53:3 | exceptional return of constructor of class A | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:50:14:53:3 | return of constructor of class A | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
+| tst.js:50:14:53:3 | the arguments object of constructor of class A | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:51:5:51:9 | super | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:51:5:51:13 | exceptional return of super(42) | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
 | tst.js:51:5:51:13 | super(42) | tst.js:50:14:50:13 | entry node of () {\\n   ... et`\\n  } |
@@ -336,6 +349,7 @@ basicBlock
 | tst.js:64:1:67:1 | exceptional return of function h | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
 | tst.js:64:1:67:1 | functio ... lysed\\n} | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:64:1:67:1 | return of function h | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
+| tst.js:64:1:67:1 | the arguments object of function h | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
 | tst.js:64:11:64:11 | h | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:64:11:64:11 | h | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:65:3:65:10 | yield 42 | tst.js:64:1:64:0 | entry node of functio ... lysed\\n} |
@@ -359,6 +373,7 @@ basicBlock
 | tst.js:71:1:73:1 | async f ... lysed\\n} | tst.js:16:1:20:10 | (functi ... "arg"); |
 | tst.js:71:1:73:1 | exceptional return of function k | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
 | tst.js:71:1:73:1 | return of function k | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
+| tst.js:71:1:73:1 | the arguments object of function k | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
 | tst.js:71:16:71:16 | k | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:72:3:72:11 | await p() | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
 | tst.js:72:9:72:9 | p | tst.js:71:1:71:0 | entry node of async f ... lysed\\n} |
@@ -401,6 +416,7 @@ basicBlock
 | tst.js:87:2:92:1 | exceptional return of anonymous function | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:2:92:1 | functio ...  + z;\\n} | tst.js:85:5:85:28 | vs2 = ( ...  o) v ) |
 | tst.js:87:2:92:1 | return of anonymous function | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
+| tst.js:87:2:92:1 | the arguments object of anonymous function | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:11:87:24 | o | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:11:87:24 | x | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
 | tst.js:87:11:87:24 | { p: x, ...o } | tst.js:87:2:87:1 | entry node of functio ...  + z;\\n} |
@@ -454,6 +470,7 @@ basicBlock
 | tst.js:98:2:103:1 | exceptional return of anonymous function | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:2:103:1 | functio ...  + z;\\n} | tst.js:85:5:85:28 | vs2 = ( ...  o) v ) |
 | tst.js:98:2:103:1 | return of anonymous function | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
+| tst.js:98:2:103:1 | the arguments object of anonymous function | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:11:98:24 | [ x, ...rest ] | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:11:98:24 | rest | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
 | tst.js:98:11:98:24 | x | tst.js:98:2:98:1 | entry node of functio ...  + z;\\n} |
@@ -495,6 +512,7 @@ basicBlock
 | tst.js:107:2:113:1 | exceptional return of anonymous function | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:107:2:113:1 | functio ...  v2c;\\n} | tst.js:107:1:113:3 | (functi ... 2c;\\n}); |
 | tst.js:107:2:113:1 | return of anonymous function | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
+| tst.js:107:2:113:1 | the arguments object of anonymous function | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:108:6:108:32 | {v1a, v ...  = o1c} | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:108:6:108:38 | v1a | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
 | tst.js:108:6:108:38 | v1b | tst.js:107:2:107:1 | entry node of functio ...  v2c;\\n} |
@@ -919,6 +937,11 @@ flowStep
 | arguments.js:2:5:2:5 | arguments | arguments.js:5:25:5:33 | arguments |
 | arguments.js:2:5:2:5 | arguments | arguments.js:6:20:6:28 | arguments |
 | arguments.js:2:5:10:5 | functio ... ;\\n    } | arguments.js:2:14:2:14 | f |
+| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:4:28:4:36 | arguments |
+| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:5:25:5:33 | arguments |
+| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:6:20:6:28 | arguments |
+| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:8:9:8:17 | arguments |
+| arguments.js:2:5:10:5 | the arguments object of function f | arguments.js:9:27:9:35 | arguments |
 | arguments.js:2:14:2:14 | f | arguments.js:11:5:11:5 | f |
 | arguments.js:2:16:2:16 | x | arguments.js:2:16:2:16 | x |
 | arguments.js:2:16:2:16 | x | arguments.js:3:24:3:24 | x |
@@ -1423,9 +1446,11 @@ sources
 | arguments.js:1:2:1:1 | this |
 | arguments.js:1:2:12:1 | functio ... , 3);\\n} |
 | arguments.js:1:2:12:1 | return of anonymous function |
+| arguments.js:1:2:12:1 | the arguments object of anonymous function |
 | arguments.js:2:5:2:4 | this |
 | arguments.js:2:5:10:5 | functio ... ;\\n    } |
 | arguments.js:2:5:10:5 | return of function f |
+| arguments.js:2:5:10:5 | the arguments object of function f |
 | arguments.js:2:16:2:16 | x |
 | arguments.js:4:28:4:39 | arguments[0] |
 | arguments.js:5:25:5:36 | arguments[1] |
@@ -1437,6 +1462,7 @@ sources
 | eval.js:1:1:1:0 | this |
 | eval.js:1:1:5:1 | functio ... eval`\\n} |
 | eval.js:1:1:5:1 | return of function k |
+| eval.js:1:1:5:1 | the arguments object of function k |
 | eval.js:3:3:3:6 | eval |
 | eval.js:3:3:3:16 | eval("x = 23") |
 | eval.js:3:8:3:15 | "x = 23" |
@@ -1445,16 +1471,19 @@ sources
 | sources.js:1:1:1:12 | new (x => x) |
 | sources.js:1:6:1:6 | x |
 | sources.js:1:6:1:11 | return of anonymous function |
+| sources.js:1:6:1:11 | the arguments object of anonymous function |
 | sources.js:1:6:1:11 | x => x |
 | sources.js:3:1:5:6 | (functi ... \\n})(23) |
 | sources.js:3:2:3:1 | this |
 | sources.js:3:2:5:1 | functio ... x+19;\\n} |
 | sources.js:3:2:5:1 | return of anonymous function |
+| sources.js:3:2:5:1 | the arguments object of anonymous function |
 | sources.js:3:11:3:11 | x |
 | sources.js:7:1:7:3 | /x/ |
 | sources.js:9:1:9:0 | this |
 | sources.js:9:1:12:1 | functio ... ey; }\\n} |
 | sources.js:9:1:12:1 | return of function foo |
+| sources.js:9:1:12:1 | the arguments object of function foo |
 | sources.js:9:14:9:18 | array |
 | sources.js:10:12:10:14 | key |
 | sources.js:11:12:11:18 | { key } |
@@ -1464,6 +1493,7 @@ sources
 | tst2.ts:7:1:7:0 | this |
 | tst2.ts:7:1:9:1 | functio ... = 23;\\n} |
 | tst2.ts:7:1:9:1 | return of function setX |
+| tst2.ts:7:1:9:1 | the arguments object of function setX |
 | tst2.ts:8:3:8:5 | A.x |
 | tst2.ts:11:11:11:13 | A.x |
 | tst2.ts:13:1:13:40 | class S ... ing> {} |
@@ -1472,6 +1502,7 @@ sources
 | tst2.ts:13:39:13:38 | args |
 | tst2.ts:13:39:13:38 | return of default constructor of class StringList |
 | tst2.ts:13:39:13:38 | super(...args) |
+| tst2.ts:13:39:13:38 | the arguments object of default constructor of class StringList |
 | tst2.ts:13:39:13:38 | this |
 | tst.js:1:1:1:0 | this |
 | tst.js:1:1:1:24 | import  ... m 'fs'; |
@@ -1482,6 +1513,7 @@ sources
 | tst.js:16:2:16:1 | this |
 | tst.js:16:2:20:1 | functio ... n "";\\n} |
 | tst.js:16:2:20:1 | return of function f |
+| tst.js:16:2:20:1 | the arguments object of function f |
 | tst.js:16:13:16:13 | a |
 | tst.js:17:7:17:10 | Math |
 | tst.js:17:7:17:17 | Math.random |
@@ -1492,15 +1524,18 @@ sources
 | tst.js:28:1:30:3 | (() =>\\n ... les\\n)() |
 | tst.js:28:2:29:3 | () =>\\n  x |
 | tst.js:28:2:29:3 | return of anonymous function |
+| tst.js:28:2:29:3 | the arguments object of anonymous function |
 | tst.js:32:1:32:0 | this |
 | tst.js:32:1:34:1 | functio ... ables\\n} |
 | tst.js:32:1:34:1 | return of function g |
+| tst.js:32:1:34:1 | the arguments object of function g |
 | tst.js:32:12:32:12 | b |
 | tst.js:35:1:35:7 | g(true) |
 | tst.js:37:9:42:1 | {\\n  x:  ... ;\\n  }\\n} |
 | tst.js:39:4:39:3 | this |
 | tst.js:39:4:41:3 | () {\\n    this;\\n  } |
 | tst.js:39:4:41:3 | return of method m |
+| tst.js:39:4:41:3 | the arguments object of method m |
 | tst.js:43:1:43:3 | o.x |
 | tst.js:44:1:44:3 | o.m |
 | tst.js:44:1:44:5 | o.m() |
@@ -1512,6 +1547,7 @@ sources
 | tst.js:50:14:50:13 | this |
 | tst.js:50:14:53:3 | () {\\n   ... et`\\n  } |
 | tst.js:50:14:53:3 | return of constructor of class A |
+| tst.js:50:14:53:3 | the arguments object of constructor of class A |
 | tst.js:51:5:51:13 | super(42) |
 | tst.js:58:1:58:3 | tag |
 | tst.js:58:1:58:13 | tag `x: ${x}` |
@@ -1521,6 +1557,7 @@ sources
 | tst.js:64:1:64:0 | this |
 | tst.js:64:1:67:1 | functio ... lysed\\n} |
 | tst.js:64:1:67:1 | return of function h |
+| tst.js:64:1:67:1 | the arguments object of function h |
 | tst.js:65:3:65:10 | yield 42 |
 | tst.js:66:13:66:25 | function.sent |
 | tst.js:68:12:68:14 | h() |
@@ -1529,6 +1566,7 @@ sources
 | tst.js:71:1:71:0 | this |
 | tst.js:71:1:73:1 | async f ... lysed\\n} |
 | tst.js:71:1:73:1 | return of function k |
+| tst.js:71:1:73:1 | the arguments object of function k |
 | tst.js:72:3:72:11 | await p() |
 | tst.js:72:9:72:9 | p |
 | tst.js:72:9:72:11 | p() |
@@ -1541,6 +1579,7 @@ sources
 | tst.js:87:2:87:1 | this |
 | tst.js:87:2:92:1 | functio ...  + z;\\n} |
 | tst.js:87:2:92:1 | return of anonymous function |
+| tst.js:87:2:92:1 | the arguments object of anonymous function |
 | tst.js:87:11:87:24 | { p: x, ...o } |
 | tst.js:87:13:87:16 | p: x |
 | tst.js:87:22:87:22 | ...o |
@@ -1551,6 +1590,7 @@ sources
 | tst.js:98:2:98:1 | this |
 | tst.js:98:2:103:1 | functio ...  + z;\\n} |
 | tst.js:98:2:103:1 | return of anonymous function |
+| tst.js:98:2:103:1 | the arguments object of anonymous function |
 | tst.js:98:11:98:24 | [ x, ...rest ] |
 | tst.js:98:13:98:13 | x |
 | tst.js:98:19:98:22 | ...rest |
@@ -1560,6 +1600,7 @@ sources
 | tst.js:107:2:107:1 | this |
 | tst.js:107:2:113:1 | functio ...  v2c;\\n} |
 | tst.js:107:2:113:1 | return of anonymous function |
+| tst.js:107:2:113:1 | the arguments object of anonymous function |
 | tst.js:108:7:108:9 | v1a |
 | tst.js:108:12:108:20 | v1b = o1b |
 | tst.js:108:18:108:20 | o1b |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/tests.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/tests.expected
@@ -14,6 +14,7 @@ dataFlow
 | callback.js:16:14:16:21 | "source" | callback.js:13:14:13:14 | x |
 | callback.js:17:15:17:23 | "source2" | callback.js:13:14:13:14 | x |
 | callback.js:27:15:27:23 | "source3" | callback.js:13:14:13:14 | x |
+| destructuring.js:2:16:2:24 | "tainted" | destructuring.js:5:14:5:20 | tainted |
 | destructuring.js:2:16:2:24 | "tainted" | destructuring.js:9:15:9:22 | tainted2 |
 | destructuring.js:19:15:19:23 | "tainted" | destructuring.js:14:15:14:15 | p |
 | destructuring.js:20:15:20:28 | "also tainted" | destructuring.js:15:15:15:15 | r |
@@ -201,6 +202,7 @@ germanFlow
 | callback.js:17:15:17:23 | "source2" | callback.js:13:14:13:14 | x |
 | callback.js:27:15:27:23 | "source3" | callback.js:13:14:13:14 | x |
 | custom.js:1:14:1:26 | "verschmutzt" | custom.js:2:15:2:20 | quelle |
+| destructuring.js:2:16:2:24 | "tainted" | destructuring.js:5:14:5:20 | tainted |
 | destructuring.js:2:16:2:24 | "tainted" | destructuring.js:9:15:9:22 | tainted2 |
 | destructuring.js:19:15:19:23 | "tainted" | destructuring.js:14:15:14:15 | p |
 | destructuring.js:20:15:20:28 | "also tainted" | destructuring.js:15:15:15:15 | r |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -1,15 +1,15 @@
 typeInferenceMismatch
-| call-apply.js:25:14:25:21 | source() | call-apply.js:1:1:3:1 | the arguments object of function foo1 |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:5:1:7:1 | the arguments object of function foo2 |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:10:10:10:30 | reflective call |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:14:10:14:40 | reflective call |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:21:1:23:1 | the arguments object of function foo1_sink |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:27:6:27:32 | reflective call |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:30:6:30:35 | reflective call |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:31:6:31:35 | reflective call |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:62:3:64:3 | the arguments object of function sinkArguments1 |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:65:3:67:3 | the arguments object of function sinkArguments0 |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:69:3:72:3 | the arguments object of function fowardArguments |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:3:1:5:1 | the arguments object of function foo1 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:7:1:9:1 | the arguments object of function foo2 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:12:10:12:30 | reflective call |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:16:10:16:40 | reflective call |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:23:1:25:1 | the arguments object of function foo1_sink |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:29:6:29:32 | reflective call |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:32:6:32:35 | reflective call |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:33:6:33:35 | reflective call |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:64:3:66:3 | the arguments object of function sinkArguments1 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:67:3:69:3 | the arguments object of function sinkArguments0 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:71:3:74:3 | the arguments object of function fowardArguments |
 | destruct.js:20:7:20:14 | source() | destruct.js:13:14:13:19 | [a, b] |
 #select
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
@@ -52,16 +52,16 @@ typeInferenceMismatch
 | bound-function.js:45:10:45:17 | source() | bound-function.js:45:6:45:18 | id3(source()) |
 | bound-function.js:49:12:49:19 | source() | bound-function.js:54:6:54:14 | source0() |
 | bound-function.js:49:12:49:19 | source() | bound-function.js:55:6:55:14 | source1() |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:22:8:22:11 | arg1 |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:27:6:27:32 | foo1.ca ... ce, "") |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:30:6:30:35 | foo1.ap ... e, ""]) |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:31:6:31:35 | foo2.ap ... e, ""]) |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:38:6:38:29 | foo1_ap ... e, ""]) |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:44:6:44:28 | foo1_ca ... e, ""]) |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:45:6:45:28 | foo1_ca ... ource]) |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:63:10:63:21 | arguments[1] |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:66:10:66:21 | arguments[0] |
-| call-apply.js:85:17:85:24 | source() | call-apply.js:82:8:82:11 | this |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:24:8:24:11 | arg1 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:29:6:29:32 | foo1.ca ... ce, "") |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:32:6:32:35 | foo1.ap ... e, ""]) |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:33:6:33:35 | foo2.ap ... e, ""]) |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:40:6:40:29 | foo1_ap ... e, ""]) |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:46:6:46:28 | foo1_ca ... e, ""]) |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:47:6:47:28 | foo1_ca ... ource]) |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:65:10:65:21 | arguments[1] |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:68:10:68:21 | arguments[0] |
+| call-apply.js:87:17:87:24 | source() | call-apply.js:84:8:84:11 | this |
 | callbacks.js:4:6:4:13 | source() | callbacks.js:34:27:34:27 | x |
 | callbacks.js:4:6:4:13 | source() | callbacks.js:35:27:35:27 | x |
 | callbacks.js:5:6:5:13 | source() | callbacks.js:34:27:34:27 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -1,4 +1,14 @@
 typeInferenceMismatch
+| call-apply.js:25:14:25:21 | source() | call-apply.js:1:1:3:1 | the arguments object of function foo1 |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:5:1:7:1 | the arguments object of function foo2 |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:10:10:10:30 | reflective call |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:14:10:14:40 | reflective call |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:21:1:23:1 | the arguments object of function foo1_sink |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:27:6:27:32 | reflective call |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:30:6:30:35 | reflective call |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:62:3:64:3 | the arguments object of function sinkArguments1 |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:65:3:67:3 | the arguments object of function sinkArguments0 |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:69:3:72:3 | the arguments object of function fowardArguments |
 | destruct.js:20:7:20:14 | source() | destruct.js:13:14:13:19 | [a, b] |
 #select
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
@@ -12,6 +22,19 @@ typeInferenceMismatch
 | array-mutation.js:31:33:31:40 | source() | array-mutation.js:32:8:32:8 | h |
 | array-mutation.js:35:36:35:43 | source() | array-mutation.js:36:8:36:8 | i |
 | array-mutation.js:39:17:39:24 | source() | array-mutation.js:40:8:40:8 | j |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:17:8:17:13 | arr[1] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:22:8:22:13 | arr[6] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:27:8:27:13 | arr[0] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:28:8:28:13 | arr[1] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:33:8:33:13 | arr[0] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:34:8:34:13 | arr[1] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:35:8:35:13 | arr[2] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:36:8:36:13 | arr[3] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:37:8:37:13 | arr[4] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:38:8:38:13 | arr[5] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:43:10:43:15 | arr[i] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:55:10:55:15 | arr[i] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:61:10:61:13 | item |
 | arrays.js:2:15:2:22 | source() | arrays.js:5:10:5:20 | arrify(foo) |
 | arrays.js:2:15:2:22 | source() | arrays.js:8:10:8:22 | arrayIfy(foo) |
 | arrays.js:2:15:2:22 | source() | arrays.js:11:10:11:28 | union(["bla"], foo) |
@@ -28,6 +51,14 @@ typeInferenceMismatch
 | bound-function.js:45:10:45:17 | source() | bound-function.js:45:6:45:18 | id3(source()) |
 | bound-function.js:49:12:49:19 | source() | bound-function.js:54:6:54:14 | source0() |
 | bound-function.js:49:12:49:19 | source() | bound-function.js:55:6:55:14 | source1() |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:22:8:22:11 | arg1 |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:27:6:27:32 | foo1.ca ... ce, "") |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:30:6:30:35 | foo1.ap ... e, ""]) |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:44:6:44:28 | foo1_ca ... e, ""]) |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:45:6:45:28 | foo1_ca ... ource]) |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:63:10:63:21 | arguments[1] |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:66:10:66:21 | arguments[0] |
+| call-apply.js:85:17:85:24 | source() | call-apply.js:82:8:82:11 | this |
 | callbacks.js:4:6:4:13 | source() | callbacks.js:34:27:34:27 | x |
 | callbacks.js:4:6:4:13 | source() | callbacks.js:35:27:35:27 | x |
 | callbacks.js:5:6:5:13 | source() | callbacks.js:34:27:34:27 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -1,15 +1,15 @@
 typeInferenceMismatch
-| call-apply.js:27:14:27:21 | source() | call-apply.js:3:1:5:1 | the arguments object of function foo1 |
-| call-apply.js:27:14:27:21 | source() | call-apply.js:7:1:9:1 | the arguments object of function foo2 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:3:1:5:1 | 'arguments' object of function foo1 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:7:1:9:1 | 'arguments' object of function foo2 |
 | call-apply.js:27:14:27:21 | source() | call-apply.js:12:10:12:30 | reflective call |
 | call-apply.js:27:14:27:21 | source() | call-apply.js:16:10:16:40 | reflective call |
-| call-apply.js:27:14:27:21 | source() | call-apply.js:23:1:25:1 | the arguments object of function foo1_sink |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:23:1:25:1 | 'arguments' object of function foo1_sink |
 | call-apply.js:27:14:27:21 | source() | call-apply.js:29:6:29:32 | reflective call |
 | call-apply.js:27:14:27:21 | source() | call-apply.js:32:6:32:35 | reflective call |
 | call-apply.js:27:14:27:21 | source() | call-apply.js:33:6:33:35 | reflective call |
-| call-apply.js:27:14:27:21 | source() | call-apply.js:64:3:66:3 | the arguments object of function sinkArguments1 |
-| call-apply.js:27:14:27:21 | source() | call-apply.js:67:3:69:3 | the arguments object of function sinkArguments0 |
-| call-apply.js:27:14:27:21 | source() | call-apply.js:71:3:74:3 | the arguments object of function fowardArguments |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:64:3:66:3 | 'arguments' object of function sinkArguments1 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:67:3:69:3 | 'arguments' object of function sinkArguments0 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:71:3:74:3 | 'arguments' object of function fowardArguments |
 | destruct.js:20:7:20:14 | source() | destruct.js:13:14:13:19 | [a, b] |
 #select
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -6,6 +6,7 @@ typeInferenceMismatch
 | call-apply.js:25:14:25:21 | source() | call-apply.js:21:1:23:1 | the arguments object of function foo1_sink |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:27:6:27:32 | reflective call |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:30:6:30:35 | reflective call |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:31:6:31:35 | reflective call |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:62:3:64:3 | the arguments object of function sinkArguments1 |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:65:3:67:3 | the arguments object of function sinkArguments0 |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:69:3:72:3 | the arguments object of function fowardArguments |
@@ -54,6 +55,8 @@ typeInferenceMismatch
 | call-apply.js:25:14:25:21 | source() | call-apply.js:22:8:22:11 | arg1 |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:27:6:27:32 | foo1.ca ... ce, "") |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:30:6:30:35 | foo1.ap ... e, ""]) |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:31:6:31:35 | foo2.ap ... e, ""]) |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:38:6:38:29 | foo1_ap ... e, ""]) |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:44:6:44:28 | foo1_ca ... e, ""]) |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:45:6:45:28 | foo1_ca ... ource]) |
 | call-apply.js:25:14:25:21 | source() | call-apply.js:63:10:63:21 | arguments[1] |

--- a/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
@@ -1,5 +1,12 @@
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | advanced-callgraph.js:2:13:2:20 | source() | advanced-callgraph.js:6:22:6:22 | v |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:17:8:17:13 | arr[1] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:22:8:22:13 | arr[6] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:28:8:28:13 | arr[1] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:34:8:34:13 | arr[1] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:43:10:43:15 | arr[i] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:55:10:55:15 | arr[i] |
+| arrays-init.js:2:16:2:23 | source() | arrays-init.js:61:10:61:13 | item |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:4:8:4:8 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:7:10:7:10 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:10:10:10:10 | x |
@@ -12,6 +19,12 @@
 | bound-function.js:45:10:45:17 | source() | bound-function.js:45:6:45:18 | id3(source()) |
 | bound-function.js:49:12:49:19 | source() | bound-function.js:54:6:54:14 | source0() |
 | bound-function.js:49:12:49:19 | source() | bound-function.js:55:6:55:14 | source1() |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:22:8:22:11 | arg1 |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:27:6:27:32 | foo1.ca ... ce, "") |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:30:6:30:35 | foo1.ap ... e, ""]) |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:44:6:44:28 | foo1_ca ... e, ""]) |
+| call-apply.js:25:14:25:21 | source() | call-apply.js:66:10:66:21 | arguments[0] |
+| call-apply.js:85:17:85:24 | source() | call-apply.js:82:8:82:11 | this |
 | callbacks.js:4:6:4:13 | source() | callbacks.js:34:27:34:27 | x |
 | callbacks.js:4:6:4:13 | source() | callbacks.js:35:27:35:27 | x |
 | callbacks.js:5:6:5:13 | source() | callbacks.js:34:27:34:27 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
@@ -19,12 +19,12 @@
 | bound-function.js:45:10:45:17 | source() | bound-function.js:45:6:45:18 | id3(source()) |
 | bound-function.js:49:12:49:19 | source() | bound-function.js:54:6:54:14 | source0() |
 | bound-function.js:49:12:49:19 | source() | bound-function.js:55:6:55:14 | source1() |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:22:8:22:11 | arg1 |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:27:6:27:32 | foo1.ca ... ce, "") |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:30:6:30:35 | foo1.ap ... e, ""]) |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:44:6:44:28 | foo1_ca ... e, ""]) |
-| call-apply.js:25:14:25:21 | source() | call-apply.js:66:10:66:21 | arguments[0] |
-| call-apply.js:85:17:85:24 | source() | call-apply.js:82:8:82:11 | this |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:24:8:24:11 | arg1 |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:29:6:29:32 | foo1.ca ... ce, "") |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:32:6:32:35 | foo1.ap ... e, ""]) |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:46:6:46:28 | foo1_ca ... e, ""]) |
+| call-apply.js:27:14:27:21 | source() | call-apply.js:68:10:68:21 | arguments[0] |
+| call-apply.js:87:17:87:24 | source() | call-apply.js:84:8:84:11 | this |
 | callbacks.js:4:6:4:13 | source() | callbacks.js:34:27:34:27 | x |
 | callbacks.js:4:6:4:13 | source() | callbacks.js:35:27:35:27 | x |
 | callbacks.js:5:6:5:13 | source() | callbacks.js:34:27:34:27 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/arrays-init.js
+++ b/javascript/ql/test/library-tests/TaintTracking/arrays-init.js
@@ -1,0 +1,63 @@
+(function () {
+  let source = source();
+
+  var str = "FALSE"; 
+
+  console.log("=== access by index (init by ctor) ===");
+  var arr = new Array(2);
+  arr[0] = str;
+  arr[1] = source;
+  arr[2] = 'b';
+  arr[3] = 'c';
+  arr[4] = 'd';
+  arr[5] = 'e';
+  arr[6] = source;
+
+  sink(arr[0]);       // OK
+  sink(arr[1]);       // NOT OK
+  sink(arr[2]);       // OK
+  sink(arr[3]);       // OK
+  sink(arr[4]);       // OK
+  sink(arr[5]);       // OK
+  sink(arr[6]);       // NOT OK
+  sink(str);          // OK
+
+  console.log("=== access by index (init by [...]) ===");
+  var arr = [str, source];
+  sink(arr[0]);       // OK
+  sink(arr[1]);       // NOT OK
+  sink(str);          // OK
+
+  console.log("=== access by index (init by [...], array.lenght > 5) ===");
+  var arr = [str, source, 'b', 'c', 'd', source];
+  sink(arr[0]);      // OK
+  sink(arr[1]);      // NOT OK
+  sink(arr[2]);      // OK
+  sink(arr[3]);      // OK
+  sink(arr[4]);      // OK
+  sink(arr[5]);      // NOT OK - but not flagged [INCONSISTENCY]
+
+  console.log("=== access in for (init by [...]) ===");
+  var arr = [str, source];
+  for (let i = 0; i < arr.length; i++) {
+    sink(arr[i]);    // NOT OK
+  }
+
+  console.log("=== access in for (init by [...]) w/o source ===");
+  var arr = [str, 'a'];
+  for (let i = 0; i < arr.length; i++) {
+    sink(arr[i]);    // OK
+  }
+
+  console.log("=== access in for (init by [...], array.lenght > 5) ===");
+  var arr = [str, 'a', 'b', 'c', 'd', source];
+  for (let i = 0; i < arr.length; i++) {
+    sink(arr[i]);    // NOT OK
+  }
+
+  console.log("=== access in forof (init by [...]) ===");
+  var arr = [str, source];
+  for (const item of arr) {
+    sink(item);       // NOT OK    
+  }
+}());

--- a/javascript/ql/test/library-tests/TaintTracking/call-apply.js
+++ b/javascript/ql/test/library-tests/TaintTracking/call-apply.js
@@ -1,0 +1,85 @@
+function foo1(arg1, arg2) {
+  return arg1;
+}
+
+function foo2(arg1, arg2) {
+  return arg2;
+}
+
+function foo1_apply(arr) {
+  return foo1.apply(this, arr);
+}
+
+function foo1_call(arr) {
+  return foo1.call(this, arr[0], arr[1]);
+}
+
+function foo1_apply_sink(arr) {
+  foo1_sink.apply(this, arr);
+}
+
+function foo1_sink(arg1, arg2) {
+  sink(arg1); // NOT OK
+}
+
+var source = source();
+
+sink(foo1.call(null, source, "")); // NOT OK
+sink(foo2.call(null, source, "")); // OK
+
+sink(foo1.apply(null, [source, ""])); // NOT OK
+sink(foo2.apply(null, [source, ""])); // OK
+
+// doesn't work due to fundamental limitations of our dataflow analysis.
+// exactly (and I mean exactly) the same thing happens in the below `obj.foo` example.
+// in general we don't track flow that first goes through a call, and then a return, unless we can summarize it. 
+// in the other examples we can summarize the flow, because it's quite simple, but here we can't.
+// (try to read the QLDoc in the top of `Configuration.qll`, that might help). 
+sink(foo1_apply([source, ""])); // NOT OK - but not flagged [INCONSISTENCY]
+
+foo1_apply_sink([source, ""]); // This works, because we don't need a return after a call (the sink is inside the called function).
+
+sink(foo1_apply.apply(["", source])); // OK
+
+sink(foo1_call([source, ""])); // NOT OK
+sink(foo1_call(["", source])); // OK
+
+
+var obj = {
+  foo: source(),
+  bar: "safe"
+};
+
+function foo(x) {
+  return bar(x);
+}
+function bar(x) {
+  return x.foo;
+}
+sink(foo(obj)); // NOT OK - but not flagged [INCONSISTENCY]
+
+function argumentsObject() {
+  function sinkArguments1() {
+    sink(arguments[1]); // OK
+  }
+  function sinkArguments0() {
+    sink(arguments[0]); // NOT OK
+  }
+  
+  function fowardArguments() {
+    sinkArguments1.apply(this, arguments);
+    sinkArguments0.apply(this, arguments);
+  }
+  
+  fowardArguments.apply(this, [source, ""]);
+}
+
+function sinksThis() {
+  sinksThis2.apply(this, arguments);
+}
+
+function sinksThis2() {
+  sink(this); // NOT OK
+}
+
+sinksThis.apply(source(), []);

--- a/javascript/ql/test/library-tests/TaintTracking/call-apply.js
+++ b/javascript/ql/test/library-tests/TaintTracking/call-apply.js
@@ -1,3 +1,5 @@
+import * as foolib from 'foolib';
+
 function foo1(arg1, arg2) {
   return arg1;
 }

--- a/javascript/ql/test/library-tests/frameworks/Collections/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Collections/test.expected
@@ -24,6 +24,7 @@ typeTracking
 | tst.js:2:16:2:23 | source() | tst.js:29:14:29:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:33:14:33:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:37:14:37:14 | e |
+| tst.js:2:16:2:23 | source() | tst.js:41:14:41:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:45:14:45:14 | e |
 | tst.js:2:16:2:23 | source() | tst.js:53:8:53:21 | map.get("key") |
 | tst.js:2:16:2:23 | source() | tst.js:59:8:59:22 | map2.get("foo") |

--- a/javascript/ql/test/library-tests/frameworks/Collections/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/Collections/tst.js
@@ -39,7 +39,7 @@
   }
 
   for (const e of new Set([source])) {
-	sink(e); // NOT OK (not caught by type-tracking, as it doesn't include array steps).
+	sink(e); // NOT OK
   }
 
   for (const e of new Set(set)) {

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/UnpromotedRouteHandlerCandidate.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/UnpromotedRouteHandlerCandidate.expected
@@ -1,5 +1,4 @@
 | src/hapi.js:1:1:1:30 | functio ... t, h){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
-| src/iterated-handlers.js:4:2:4:22 | functio ...  res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/route-objects.js:7:19:7:38 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/route-objects.js:8:12:10:5 | (req, res) {\\n\\n    } | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/route-objects.js:20:16:22:9 | (req, r ...       } | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/tests.expected
@@ -16,6 +16,7 @@ routeHandler
 | src/exported-middleware-attacher.js:2:13:2:32 | function(req, res){} |
 | src/handler-in-property.js:5:14:5:33 | function(req, res){} |
 | src/handler-in-property.js:12:18:12:37 | function(req, res){} |
+| src/iterated-handlers.js:4:2:4:22 | functio ...  res){} |
 | src/middleware-attacher-getter.js:4:17:4:36 | function(req, res){} |
 | src/middleware-attacher-getter.js:19:19:19:38 | function(req, res){} |
 | src/middleware-attacher-getter.js:29:32:29:51 | function(req, res){} |

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialBackTracking.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialBackTracking.expected
@@ -32,6 +32,7 @@
 | lib/lib.js:1:15:1:16 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
 | lib/lib.js:8:3:8:4 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
 | lib/lib.js:28:3:28:4 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
+| lib/lib.js:36:3:36:4 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
 | lib/moduleLib/moduleLib.js:2:3:2:4 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
 | lib/otherLib/js/src/index.js:2:3:2:4 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
 | lib/snapdragon.js:7:28:7:29 | a* | Strings starting with 'a' and with many repetitions of 'a' can start matching anywhere after the start of the preceeding aa*$ |

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialReDoS.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialReDoS.expected
@@ -22,6 +22,12 @@ nodes
 | lib/lib.js:27:10:27:19 | id("safe") |
 | lib/lib.js:28:13:28:13 | y |
 | lib/lib.js:28:13:28:13 | y |
+| lib/lib.js:32:32:32:40 | arguments |
+| lib/lib.js:32:32:32:40 | arguments |
+| lib/lib.js:35:1:37:1 | the arguments object of function usedWithArguments |
+| lib/lib.js:35:28:35:31 | name |
+| lib/lib.js:36:13:36:16 | name |
+| lib/lib.js:36:13:36:16 | name |
 | lib/moduleLib/moduleLib.js:1:28:1:31 | name |
 | lib/moduleLib/moduleLib.js:1:28:1:31 | name |
 | lib/moduleLib/moduleLib.js:2:13:2:16 | name |
@@ -238,6 +244,11 @@ edges
 | lib/lib.js:27:6:27:19 | y | lib/lib.js:28:13:28:13 | y |
 | lib/lib.js:27:6:27:19 | y | lib/lib.js:28:13:28:13 | y |
 | lib/lib.js:27:10:27:19 | id("safe") | lib/lib.js:27:6:27:19 | y |
+| lib/lib.js:32:32:32:40 | arguments | lib/lib.js:35:1:37:1 | the arguments object of function usedWithArguments |
+| lib/lib.js:32:32:32:40 | arguments | lib/lib.js:35:1:37:1 | the arguments object of function usedWithArguments |
+| lib/lib.js:35:1:37:1 | the arguments object of function usedWithArguments | lib/lib.js:35:28:35:31 | name |
+| lib/lib.js:35:28:35:31 | name | lib/lib.js:36:13:36:16 | name |
+| lib/lib.js:35:28:35:31 | name | lib/lib.js:36:13:36:16 | name |
 | lib/moduleLib/moduleLib.js:1:28:1:31 | name | lib/moduleLib/moduleLib.js:2:13:2:16 | name |
 | lib/moduleLib/moduleLib.js:1:28:1:31 | name | lib/moduleLib/moduleLib.js:2:13:2:16 | name |
 | lib/moduleLib/moduleLib.js:1:28:1:31 | name | lib/moduleLib/moduleLib.js:2:13:2:16 | name |
@@ -428,6 +439,7 @@ edges
 | lib/indirect.js:2:5:2:17 | /k*h/.test(x) | lib/indirect.js:1:32:1:32 | x | lib/indirect.js:2:16:2:16 | x | This $@ that depends on $@ may run slow on strings with many repetitions of 'k'. | lib/indirect.js:2:6:2:7 | k* | regular expression | lib/indirect.js:1:32:1:32 | x | library input |
 | lib/lib.js:4:2:4:18 | regexp.test(name) | lib/lib.js:3:28:3:31 | name | lib/lib.js:4:14:4:17 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/lib.js:1:15:1:16 | a* | regular expression | lib/lib.js:3:28:3:31 | name | library input |
 | lib/lib.js:8:2:8:17 | /f*g/.test(name) | lib/lib.js:7:19:7:22 | name | lib/lib.js:8:13:8:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/lib.js:8:3:8:4 | f* | regular expression | lib/lib.js:7:19:7:22 | name | library input |
+| lib/lib.js:36:2:36:17 | /f*g/.test(name) | lib/lib.js:32:32:32:40 | arguments | lib/lib.js:36:13:36:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/lib.js:36:3:36:4 | f* | regular expression | lib/lib.js:32:32:32:40 | arguments | library input |
 | lib/moduleLib/moduleLib.js:2:2:2:17 | /a*b/.test(name) | lib/moduleLib/moduleLib.js:1:28:1:31 | name | lib/moduleLib/moduleLib.js:2:13:2:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/moduleLib/moduleLib.js:2:3:2:4 | a* | regular expression | lib/moduleLib/moduleLib.js:1:28:1:31 | name | library input |
 | lib/otherLib/js/src/index.js:2:2:2:17 | /a*b/.test(name) | lib/otherLib/js/src/index.js:1:28:1:31 | name | lib/otherLib/js/src/index.js:2:13:2:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/otherLib/js/src/index.js:2:3:2:4 | a* | regular expression | lib/otherLib/js/src/index.js:1:28:1:31 | name | library input |
 | lib/snapdragon.js:7:15:7:32 | this.match(/aa*$/) | lib/snapdragon.js:3:34:3:38 | input | lib/snapdragon.js:7:15:7:18 | this | This $@ that depends on $@ may run slow on strings starting with 'a' and with many repetitions of 'a'. | lib/snapdragon.js:7:28:7:29 | a* | regular expression | lib/snapdragon.js:3:34:3:38 | input | library input |

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialReDoS.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialReDoS.expected
@@ -24,7 +24,7 @@ nodes
 | lib/lib.js:28:13:28:13 | y |
 | lib/lib.js:32:32:32:40 | arguments |
 | lib/lib.js:32:32:32:40 | arguments |
-| lib/lib.js:35:1:37:1 | the arguments object of function usedWithArguments |
+| lib/lib.js:35:1:37:1 | 'arguments' object of function usedWithArguments |
 | lib/lib.js:35:28:35:31 | name |
 | lib/lib.js:36:13:36:16 | name |
 | lib/lib.js:36:13:36:16 | name |
@@ -244,9 +244,9 @@ edges
 | lib/lib.js:27:6:27:19 | y | lib/lib.js:28:13:28:13 | y |
 | lib/lib.js:27:6:27:19 | y | lib/lib.js:28:13:28:13 | y |
 | lib/lib.js:27:10:27:19 | id("safe") | lib/lib.js:27:6:27:19 | y |
-| lib/lib.js:32:32:32:40 | arguments | lib/lib.js:35:1:37:1 | the arguments object of function usedWithArguments |
-| lib/lib.js:32:32:32:40 | arguments | lib/lib.js:35:1:37:1 | the arguments object of function usedWithArguments |
-| lib/lib.js:35:1:37:1 | the arguments object of function usedWithArguments | lib/lib.js:35:28:35:31 | name |
+| lib/lib.js:32:32:32:40 | arguments | lib/lib.js:35:1:37:1 | 'arguments' object of function usedWithArguments |
+| lib/lib.js:32:32:32:40 | arguments | lib/lib.js:35:1:37:1 | 'arguments' object of function usedWithArguments |
+| lib/lib.js:35:1:37:1 | 'arguments' object of function usedWithArguments | lib/lib.js:35:28:35:31 | name |
 | lib/lib.js:35:28:35:31 | name | lib/lib.js:36:13:36:16 | name |
 | lib/lib.js:35:28:35:31 | name | lib/lib.js:36:13:36:16 | name |
 | lib/moduleLib/moduleLib.js:1:28:1:31 | name | lib/moduleLib/moduleLib.js:2:13:2:16 | name |

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/lib.js
@@ -28,4 +28,12 @@ module.exports.safe = function (x) {
 	/f*g/.test(y); // OK
 }
 
+module.exports.useArguments = function () {
+	usedWithArguments.apply(this, arguments);
+}
+
+function usedWithArguments(name) {
+	/f*g/.test(name); // NOT OK - bit not yet recognized [INCONSITENCY]
+}
+
 module.exports.snapdragon = require("./snapdragon")

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/lib.js
@@ -33,7 +33,7 @@ module.exports.useArguments = function () {
 }
 
 function usedWithArguments(name) {
-	/f*g/.test(name); // NOT OK - bit not yet recognized [INCONSITENCY]
+	/f*g/.test(name); // NOT OK
 }
 
 module.exports.snapdragon = require("./snapdragon")

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
@@ -26,6 +26,8 @@ nodes
 | lib.js:15:7:15:10 | path |
 | lib.js:15:7:15:13 | path[0] |
 | lib.js:20:7:20:25 | path |
+| lib.js:20:14:20:22 | arguments |
+| lib.js:20:14:20:22 | arguments |
 | lib.js:20:14:20:25 | arguments[1] |
 | lib.js:20:14:20:25 | arguments[1] |
 | lib.js:22:3:22:14 | obj[path[0]] |
@@ -45,7 +47,12 @@ nodes
 | lib.js:34:3:34:14 | obj[path[0]] |
 | lib.js:34:7:34:10 | path |
 | lib.js:34:7:34:13 | path[0] |
+| lib.js:38:9:38:36 | args |
+| lib.js:38:16:38:36 | Array.f ... uments) |
+| lib.js:38:27:38:35 | arguments |
+| lib.js:38:27:38:35 | arguments |
 | lib.js:40:7:40:20 | path |
+| lib.js:40:14:40:17 | args |
 | lib.js:40:14:40:20 | args[1] |
 | lib.js:40:14:40:20 | args[1] |
 | lib.js:42:3:42:14 | obj[path[0]] |
@@ -71,6 +78,8 @@ nodes
 | lib.js:70:17:70:20 | path |
 | lib.js:70:17:70:23 | path[0] |
 | lib.js:83:7:83:25 | path |
+| lib.js:83:14:83:22 | arguments |
+| lib.js:83:14:83:22 | arguments |
 | lib.js:83:14:83:25 | arguments[1] |
 | lib.js:83:14:83:25 | arguments[1] |
 | lib.js:86:7:86:26 | proto |
@@ -89,6 +98,8 @@ nodes
 | lib.js:95:3:95:12 | maybeProto |
 | lib.js:95:3:95:12 | maybeProto |
 | lib.js:104:7:104:24 | one |
+| lib.js:104:13:104:21 | arguments |
+| lib.js:104:13:104:21 | arguments |
 | lib.js:104:13:104:24 | arguments[1] |
 | lib.js:104:13:104:24 | arguments[1] |
 | lib.js:108:3:108:10 | obj[one] |
@@ -183,6 +194,8 @@ edges
 | lib.js:15:7:15:13 | path[0] | lib.js:15:3:15:14 | obj[path[0]] |
 | lib.js:15:7:15:13 | path[0] | lib.js:15:3:15:14 | obj[path[0]] |
 | lib.js:20:7:20:25 | path | lib.js:22:7:22:10 | path |
+| lib.js:20:14:20:22 | arguments | lib.js:20:14:20:25 | arguments[1] |
+| lib.js:20:14:20:22 | arguments | lib.js:20:14:20:25 | arguments[1] |
 | lib.js:20:14:20:25 | arguments[1] | lib.js:20:7:20:25 | path |
 | lib.js:20:14:20:25 | arguments[1] | lib.js:20:7:20:25 | path |
 | lib.js:22:7:22:10 | path | lib.js:22:7:22:13 | path[0] |
@@ -199,7 +212,12 @@ edges
 | lib.js:34:7:34:10 | path | lib.js:34:7:34:13 | path[0] |
 | lib.js:34:7:34:13 | path[0] | lib.js:34:3:34:14 | obj[path[0]] |
 | lib.js:34:7:34:13 | path[0] | lib.js:34:3:34:14 | obj[path[0]] |
+| lib.js:38:9:38:36 | args | lib.js:40:14:40:17 | args |
+| lib.js:38:16:38:36 | Array.f ... uments) | lib.js:38:9:38:36 | args |
+| lib.js:38:27:38:35 | arguments | lib.js:38:16:38:36 | Array.f ... uments) |
+| lib.js:38:27:38:35 | arguments | lib.js:38:16:38:36 | Array.f ... uments) |
 | lib.js:40:7:40:20 | path | lib.js:42:7:42:10 | path |
+| lib.js:40:14:40:17 | args | lib.js:40:14:40:20 | args[1] |
 | lib.js:40:14:40:20 | args[1] | lib.js:40:7:40:20 | path |
 | lib.js:40:14:40:20 | args[1] | lib.js:40:7:40:20 | path |
 | lib.js:42:7:42:10 | path | lib.js:42:7:42:13 | path[0] |
@@ -222,6 +240,8 @@ edges
 | lib.js:70:17:70:23 | path[0] | lib.js:70:13:70:24 | obj[path[0]] |
 | lib.js:70:17:70:23 | path[0] | lib.js:70:13:70:24 | obj[path[0]] |
 | lib.js:83:7:83:25 | path | lib.js:86:19:86:22 | path |
+| lib.js:83:14:83:22 | arguments | lib.js:83:14:83:25 | arguments[1] |
+| lib.js:83:14:83:22 | arguments | lib.js:83:14:83:25 | arguments[1] |
 | lib.js:83:14:83:25 | arguments[1] | lib.js:83:7:83:25 | path |
 | lib.js:83:14:83:25 | arguments[1] | lib.js:83:7:83:25 | path |
 | lib.js:86:7:86:26 | proto | lib.js:87:10:87:14 | proto |
@@ -238,6 +258,8 @@ edges
 | lib.js:91:20:91:28 | obj[path] | lib.js:91:7:91:28 | maybeProto |
 | lib.js:91:24:91:27 | path | lib.js:91:20:91:28 | obj[path] |
 | lib.js:104:7:104:24 | one | lib.js:108:7:108:9 | one |
+| lib.js:104:13:104:21 | arguments | lib.js:104:13:104:24 | arguments[1] |
+| lib.js:104:13:104:21 | arguments | lib.js:104:13:104:24 | arguments[1] |
 | lib.js:104:13:104:24 | arguments[1] | lib.js:104:7:104:24 | one |
 | lib.js:104:13:104:24 | arguments[1] | lib.js:104:7:104:24 | one |
 | lib.js:108:7:108:9 | one | lib.js:108:3:108:10 | obj[one] |
@@ -299,12 +321,16 @@ edges
 #select
 | lib.js:6:7:6:9 | obj | lib.js:1:43:1:46 | path | lib.js:6:7:6:9 | obj | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:1:43:1:46 | path | library input |
 | lib.js:15:3:15:14 | obj[path[0]] | lib.js:14:38:14:41 | path | lib.js:15:3:15:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:14:38:14:41 | path | library input |
+| lib.js:22:3:22:14 | obj[path[0]] | lib.js:20:14:20:22 | arguments | lib.js:22:3:22:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:20:14:20:22 | arguments | library input |
 | lib.js:22:3:22:14 | obj[path[0]] | lib.js:20:14:20:25 | arguments[1] | lib.js:22:3:22:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:20:14:20:25 | arguments[1] | library input |
 | lib.js:26:10:26:21 | obj[path[0]] | lib.js:25:44:25:47 | path | lib.js:26:10:26:21 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:25:44:25:47 | path | library input |
 | lib.js:34:3:34:14 | obj[path[0]] | lib.js:32:14:32:20 | args[1] | lib.js:34:3:34:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:32:14:32:20 | args[1] | library input |
+| lib.js:42:3:42:14 | obj[path[0]] | lib.js:38:27:38:35 | arguments | lib.js:42:3:42:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:38:27:38:35 | arguments | library input |
 | lib.js:42:3:42:14 | obj[path[0]] | lib.js:40:14:40:20 | args[1] | lib.js:42:3:42:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:40:14:40:20 | args[1] | library input |
 | lib.js:70:13:70:24 | obj[path[0]] | lib.js:59:18:59:18 | s | lib.js:70:13:70:24 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:59:18:59:18 | s | library input |
+| lib.js:87:10:87:14 | proto | lib.js:83:14:83:22 | arguments | lib.js:87:10:87:14 | proto | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:83:14:83:22 | arguments | library input |
 | lib.js:87:10:87:14 | proto | lib.js:83:14:83:25 | arguments[1] | lib.js:87:10:87:14 | proto | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:83:14:83:25 | arguments[1] | library input |
+| lib.js:108:3:108:10 | obj[one] | lib.js:104:13:104:21 | arguments | lib.js:108:3:108:10 | obj[one] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:104:13:104:21 | arguments | library input |
 | lib.js:108:3:108:10 | obj[one] | lib.js:104:13:104:24 | arguments[1] | lib.js:108:3:108:10 | obj[one] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:104:13:104:24 | arguments[1] | library input |
 | lib.js:119:13:119:24 | obj[path[0]] | lib.js:118:29:118:32 | path | lib.js:119:13:119:24 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:118:29:118:32 | path | library input |
 | sublib/sub.js:2:3:2:14 | obj[path[0]] | sublib/sub.js:1:37:1:40 | path | sublib/sub.js:2:3:2:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | sublib/sub.js:1:37:1:40 | path | library input |

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
@@ -29,7 +29,6 @@ nodes
 | lib.js:20:14:20:22 | arguments |
 | lib.js:20:14:20:22 | arguments |
 | lib.js:20:14:20:25 | arguments[1] |
-| lib.js:20:14:20:25 | arguments[1] |
 | lib.js:22:3:22:14 | obj[path[0]] |
 | lib.js:22:3:22:14 | obj[path[0]] |
 | lib.js:22:7:22:10 | path |
@@ -40,8 +39,12 @@ nodes
 | lib.js:26:10:26:21 | obj[path[0]] |
 | lib.js:26:14:26:17 | path |
 | lib.js:26:14:26:20 | path[0] |
+| lib.js:30:9:30:52 | args |
+| lib.js:30:16:30:52 | Array.p ... uments) |
+| lib.js:30:43:30:51 | arguments |
+| lib.js:30:43:30:51 | arguments |
 | lib.js:32:7:32:20 | path |
-| lib.js:32:14:32:20 | args[1] |
+| lib.js:32:14:32:17 | args |
 | lib.js:32:14:32:20 | args[1] |
 | lib.js:34:3:34:14 | obj[path[0]] |
 | lib.js:34:3:34:14 | obj[path[0]] |
@@ -53,7 +56,6 @@ nodes
 | lib.js:38:27:38:35 | arguments |
 | lib.js:40:7:40:20 | path |
 | lib.js:40:14:40:17 | args |
-| lib.js:40:14:40:20 | args[1] |
 | lib.js:40:14:40:20 | args[1] |
 | lib.js:42:3:42:14 | obj[path[0]] |
 | lib.js:42:3:42:14 | obj[path[0]] |
@@ -81,7 +83,6 @@ nodes
 | lib.js:83:14:83:22 | arguments |
 | lib.js:83:14:83:22 | arguments |
 | lib.js:83:14:83:25 | arguments[1] |
-| lib.js:83:14:83:25 | arguments[1] |
 | lib.js:86:7:86:26 | proto |
 | lib.js:86:15:86:26 | obj[path[0]] |
 | lib.js:86:19:86:22 | path |
@@ -100,7 +101,6 @@ nodes
 | lib.js:104:7:104:24 | one |
 | lib.js:104:13:104:21 | arguments |
 | lib.js:104:13:104:21 | arguments |
-| lib.js:104:13:104:24 | arguments[1] |
 | lib.js:104:13:104:24 | arguments[1] |
 | lib.js:108:3:108:10 | obj[one] |
 | lib.js:108:3:108:10 | obj[one] |
@@ -197,7 +197,6 @@ edges
 | lib.js:20:14:20:22 | arguments | lib.js:20:14:20:25 | arguments[1] |
 | lib.js:20:14:20:22 | arguments | lib.js:20:14:20:25 | arguments[1] |
 | lib.js:20:14:20:25 | arguments[1] | lib.js:20:7:20:25 | path |
-| lib.js:20:14:20:25 | arguments[1] | lib.js:20:7:20:25 | path |
 | lib.js:22:7:22:10 | path | lib.js:22:7:22:13 | path[0] |
 | lib.js:22:7:22:13 | path[0] | lib.js:22:3:22:14 | obj[path[0]] |
 | lib.js:22:7:22:13 | path[0] | lib.js:22:3:22:14 | obj[path[0]] |
@@ -206,8 +205,12 @@ edges
 | lib.js:26:14:26:17 | path | lib.js:26:14:26:20 | path[0] |
 | lib.js:26:14:26:20 | path[0] | lib.js:26:10:26:21 | obj[path[0]] |
 | lib.js:26:14:26:20 | path[0] | lib.js:26:10:26:21 | obj[path[0]] |
+| lib.js:30:9:30:52 | args | lib.js:32:14:32:17 | args |
+| lib.js:30:16:30:52 | Array.p ... uments) | lib.js:30:9:30:52 | args |
+| lib.js:30:43:30:51 | arguments | lib.js:30:16:30:52 | Array.p ... uments) |
+| lib.js:30:43:30:51 | arguments | lib.js:30:16:30:52 | Array.p ... uments) |
 | lib.js:32:7:32:20 | path | lib.js:34:7:34:10 | path |
-| lib.js:32:14:32:20 | args[1] | lib.js:32:7:32:20 | path |
+| lib.js:32:14:32:17 | args | lib.js:32:14:32:20 | args[1] |
 | lib.js:32:14:32:20 | args[1] | lib.js:32:7:32:20 | path |
 | lib.js:34:7:34:10 | path | lib.js:34:7:34:13 | path[0] |
 | lib.js:34:7:34:13 | path[0] | lib.js:34:3:34:14 | obj[path[0]] |
@@ -218,7 +221,6 @@ edges
 | lib.js:38:27:38:35 | arguments | lib.js:38:16:38:36 | Array.f ... uments) |
 | lib.js:40:7:40:20 | path | lib.js:42:7:42:10 | path |
 | lib.js:40:14:40:17 | args | lib.js:40:14:40:20 | args[1] |
-| lib.js:40:14:40:20 | args[1] | lib.js:40:7:40:20 | path |
 | lib.js:40:14:40:20 | args[1] | lib.js:40:7:40:20 | path |
 | lib.js:42:7:42:10 | path | lib.js:42:7:42:13 | path[0] |
 | lib.js:42:7:42:13 | path[0] | lib.js:42:3:42:14 | obj[path[0]] |
@@ -243,7 +245,6 @@ edges
 | lib.js:83:14:83:22 | arguments | lib.js:83:14:83:25 | arguments[1] |
 | lib.js:83:14:83:22 | arguments | lib.js:83:14:83:25 | arguments[1] |
 | lib.js:83:14:83:25 | arguments[1] | lib.js:83:7:83:25 | path |
-| lib.js:83:14:83:25 | arguments[1] | lib.js:83:7:83:25 | path |
 | lib.js:86:7:86:26 | proto | lib.js:87:10:87:14 | proto |
 | lib.js:86:7:86:26 | proto | lib.js:87:10:87:14 | proto |
 | lib.js:86:15:86:26 | obj[path[0]] | lib.js:86:7:86:26 | proto |
@@ -260,7 +261,6 @@ edges
 | lib.js:104:7:104:24 | one | lib.js:108:7:108:9 | one |
 | lib.js:104:13:104:21 | arguments | lib.js:104:13:104:24 | arguments[1] |
 | lib.js:104:13:104:21 | arguments | lib.js:104:13:104:24 | arguments[1] |
-| lib.js:104:13:104:24 | arguments[1] | lib.js:104:7:104:24 | one |
 | lib.js:104:13:104:24 | arguments[1] | lib.js:104:7:104:24 | one |
 | lib.js:108:7:108:9 | one | lib.js:108:3:108:10 | obj[one] |
 | lib.js:108:7:108:9 | one | lib.js:108:3:108:10 | obj[one] |
@@ -322,16 +322,12 @@ edges
 | lib.js:6:7:6:9 | obj | lib.js:1:43:1:46 | path | lib.js:6:7:6:9 | obj | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:1:43:1:46 | path | library input |
 | lib.js:15:3:15:14 | obj[path[0]] | lib.js:14:38:14:41 | path | lib.js:15:3:15:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:14:38:14:41 | path | library input |
 | lib.js:22:3:22:14 | obj[path[0]] | lib.js:20:14:20:22 | arguments | lib.js:22:3:22:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:20:14:20:22 | arguments | library input |
-| lib.js:22:3:22:14 | obj[path[0]] | lib.js:20:14:20:25 | arguments[1] | lib.js:22:3:22:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:20:14:20:25 | arguments[1] | library input |
 | lib.js:26:10:26:21 | obj[path[0]] | lib.js:25:44:25:47 | path | lib.js:26:10:26:21 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:25:44:25:47 | path | library input |
-| lib.js:34:3:34:14 | obj[path[0]] | lib.js:32:14:32:20 | args[1] | lib.js:34:3:34:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:32:14:32:20 | args[1] | library input |
+| lib.js:34:3:34:14 | obj[path[0]] | lib.js:30:43:30:51 | arguments | lib.js:34:3:34:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:30:43:30:51 | arguments | library input |
 | lib.js:42:3:42:14 | obj[path[0]] | lib.js:38:27:38:35 | arguments | lib.js:42:3:42:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:38:27:38:35 | arguments | library input |
-| lib.js:42:3:42:14 | obj[path[0]] | lib.js:40:14:40:20 | args[1] | lib.js:42:3:42:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:40:14:40:20 | args[1] | library input |
 | lib.js:70:13:70:24 | obj[path[0]] | lib.js:59:18:59:18 | s | lib.js:70:13:70:24 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:59:18:59:18 | s | library input |
 | lib.js:87:10:87:14 | proto | lib.js:83:14:83:22 | arguments | lib.js:87:10:87:14 | proto | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:83:14:83:22 | arguments | library input |
-| lib.js:87:10:87:14 | proto | lib.js:83:14:83:25 | arguments[1] | lib.js:87:10:87:14 | proto | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:83:14:83:25 | arguments[1] | library input |
 | lib.js:108:3:108:10 | obj[one] | lib.js:104:13:104:21 | arguments | lib.js:108:3:108:10 | obj[one] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:104:13:104:21 | arguments | library input |
-| lib.js:108:3:108:10 | obj[one] | lib.js:104:13:104:24 | arguments[1] | lib.js:108:3:108:10 | obj[one] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:104:13:104:24 | arguments[1] | library input |
 | lib.js:119:13:119:24 | obj[path[0]] | lib.js:118:29:118:32 | path | lib.js:119:13:119:24 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:118:29:118:32 | path | library input |
 | sublib/sub.js:2:3:2:14 | obj[path[0]] | sublib/sub.js:1:37:1:40 | path | sublib/sub.js:2:3:2:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | sublib/sub.js:1:37:1:40 | path | library input |
 | tst.js:8:5:8:17 | object[taint] | tst.js:5:24:5:37 | req.query.data | tst.js:8:5:8:17 | object[taint] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |


### PR DESCRIPTION
For some context see this external contribution that never got merged: https://github.com/github/codeql/pull/6559 

The [improve performance of global dataflow by inlining a step predicate](https://github.com/github/codeql/commit/354eca001fa2715e62b0fb8c09e3273ff669d5c1) commit got the predicate from 4m8s to 1m36s on `bwip-js`.  

[An evaluation looks good](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/myApply__nightly-old__code-scanning/reports). There are a few new results, and the performance looks good.  
(The new `js/unsafe-jquery-plugin` results are from the new `arguments` node, the others are from the improved flow through arrays).  

In an earlier evaluation I did a comparison where I disabled `ReflectiveParametersNode`: https://github.com/github/codeql-dca-main/tree/data/erik-krogh/myApply-no-parms-node-nightly-codescanning/reports 
The query-suite is bigger, so it finds more results.   
If you look at the `alert-meta-comparison` in the two evaluations you can see that most of the new flow doesn't have anything to do with `ReflectiveParametersNode`.   
(Library inputs worked slightly different back when I did that evaluation, so those numbers are off).  

/cc @yuske This is inspired by your attempt to do the same thing: https://github.com/github/codeql/pull/6559 