### PR TITLE
C++: Add a sanitizer to `cpp/cleartext-storage-buffer`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
@@ -26,6 +26,10 @@ class ToBufferConfiguration extends TaintTracking::Configuration {
 
   override predicate isSource(DataFlow::Node source) { source instanceof FlowSource }
 
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.asExpr().getUnspecifiedType() instanceof IntegralType
+  }
+
   override predicate isSink(DataFlow::Node sink) {
     exists(BufferWrite::BufferWrite w | w.getASource() = sink.asExpr())
   }

--- a/cpp/ql/src/change-notes/2022-08-22-cleartext-buffer-write-sanitizer.md
+++ b/cpp/ql/src/change-notes/2022-08-22-cleartext-buffer-write-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Cleartext storage of sensitive information in buffer" (`cpp/cleartext-storage-buffer`) query has been improved to produce fewer false positives.


### PR DESCRIPTION
This is the easy part of https://github.com/github/codeql/pull/10117:
> The second performance fix is to block flow through integral typed expressions in the query. We have used similar sanitizers in other queries to fix FPs, so this is a natural thing to do in this query as well, and it seems to dramatically improve the query's performance.

I pulled this out to a separate PR so it's not needlessly delayed by the unrelated `jumpStep` change.