### PR TITLE
Java: Add CWE-1333 tag to Java ReDoS queries

### DIFF
--- a/java/ql/src/Security/CWE/CWE-730/PolynomialReDoS.ql
+++ b/java/ql/src/Security/CWE/CWE-730/PolynomialReDoS.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id java/polynomial-redos
  * @tags security
+ *       external/cwe/cwe-1333
  *       external/cwe/cwe-730
  *       external/cwe/cwe-400
  */

--- a/java/ql/src/Security/CWE/CWE-730/ReDoS.ql
+++ b/java/ql/src/Security/CWE/CWE-730/ReDoS.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @id java/redos
  * @tags security
+ *       external/cwe/cwe-1333
  *       external/cwe/cwe-730
  *       external/cwe/cwe-400
  */

--- a/java/ql/src/change-notes/2022-08-23-redos-cwe-1333.md
+++ b/java/ql/src/change-notes/2022-08-23-redos-cwe-1333.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* The queries `java/redos` and `java/polynomial-redos` now have a tag for CWE-1333. 


### PR DESCRIPTION
All ReDoS queries in other languages had this tag, so it makes sense for the Java versions to have it too.