### PR TITLE
Ruby: Perf fix for trackUseNode.

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -619,7 +619,7 @@ module API {
       exists(TypeBackTracker tb |
         result = mid.track(tmid, t) and
         pragma[only_bind_into](result) = useCandRev(pragma[only_bind_into](tb)) and
-        pragma[only_bind_out](t) = tb.getACompatibleTypeTracker()
+        pragma[only_bind_out](t) = pragma[only_bind_into](tb).getACompatibleTypeTracker()
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -613,7 +613,9 @@ module API {
     }
 
     pragma[nomagic]
-    private DataFlow::Node useNodeStep(DataFlow::LocalSourceNode mid, TypeTracker tmid, TypeTracker t) {
+    private DataFlow::Node useNodeStep(
+      DataFlow::LocalSourceNode mid, TypeTracker tmid, TypeTracker t
+    ) {
       exists(TypeBackTracker tb |
         result = mid.track(tmid, t) and
         pragma[only_bind_into](result) = useCandRev(pragma[only_bind_into](tb)) and

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -606,11 +606,18 @@ module API {
       result = useCandRev() and
       t.start()
       or
-      exists(TypeTracker t2, DataFlow::LocalSourceNode mid, TypeBackTracker tb |
+      exists(TypeTracker t2, DataFlow::LocalSourceNode mid |
         mid = trackUseNode(src, t2) and
-        result = mid.track(t2, t) and
-        pragma[only_bind_out](result) = useCandRev(tb) and
-        pragma[only_bind_out](t) = pragma[only_bind_out](tb).getACompatibleTypeTracker()
+        result = useNodeStep(mid, t2, t)
+      )
+    }
+
+    pragma[nomagic]
+    private DataFlow::Node useNodeStep(DataFlow::LocalSourceNode mid, TypeTracker tmid, TypeTracker t) {
+      exists(TypeBackTracker tb |
+        result = mid.track(tmid, t) and
+        pragma[only_bind_into](result) = useCandRev(pragma[only_bind_into](tb)) and
+        pragma[only_bind_out](t) = tb.getACompatibleTypeTracker()
       )
     }
 


### PR DESCRIPTION
Let's see if this does the trick. The problem was the following join-order:
```
Evaluated recursive predicate ApiGraphs#3116a2f3::API::Impl::trackUseNode#2#fff@ce9ac9do in 51821ms on iteration 43 (delta size: 4222306).
Evaluated relational algebra for predicate ApiGraphs#3116a2f3::API::Impl::trackUseNode#2#fff@ce9ac9do on iteration 43 running pipeline standard with tuple counts:
          3770177   ~0%    {3} r1 = SCAN ApiGraphs#3116a2f3::API::Impl::trackUseNode#2#fff#prev_delta OUTPUT In.2, In.0, In.1
        461567525  ~64%    {5} r2 = JOIN r1 WITH ApiGraphs#3116a2f3::API::Impl::trackUseNode#2#fff#join_rhs ON FIRST 1 OUTPUT Lhs.2, Rhs.3, Rhs.2, Rhs.1, Lhs.1
         10791924  ~66%    {5} r3 = JOIN r2 WITH TypeTracker#6f8aa30b::Cached::append#2#fff ON FIRST 3 OUTPUT Lhs.3, Lhs.1, Lhs.4, Lhs.1, Lhs.2
          4936050  ~21%    {5} r4 = r3 AND NOT ApiGraphs#3116a2f3::API::Impl::trackUseNode#2#fff#prev(Lhs.2, Lhs.4, Lhs.0)
          4936050  ~21%    {3} r5 = SCAN r4 OUTPUT In.2, In.4, In.0
                           return r5
```
which was clearly joining `append` too late.