### PR TITLE
Go: fix tracing spec for windows

### DIFF
--- a/go/codeql-tools/tracing-config.lua
+++ b/go/codeql-tools/tracing-config.lua
@@ -10,7 +10,7 @@ function RegisterExtractorPack()
 
     }
     if OperatingSystem == 'windows' then
-        goExtractor = goExtractor .. 'go-extractor.exe'
+        goExtractor = goExtractor .. '.exe'
         patterns = {
             CreatePatternMatcher({'^go%-autobuilder%.exe$'}, MatchCompilerName,
                                  nil, {trace = false}),


### PR DESCRIPTION
This should fix errors like:
```
[T 17:40:07 5848] Unable to invoke extractor using command line ""C:\hostedtoolcache\windows\CodeQL\0.0.0-20220811\x64\codeql\go\tools\win64\go-extractorgo-extractor.exe" --mimic "c:\hostedtoolcache\windows\go\1.19.0\x64\bin\go.exe" build main.go".
```