### PR TITLE
Kotlin: fix array iterator extraction

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -2177,7 +2177,7 @@ open class KotlinFileExtractor(
                         extractRawMethodAccess(getter, c, callable, parent, idx, enclosingStmt, listOf(), null, ext, typeArguments)
                     }
                 }
-                isFunction(target, "kotlin", "(some array type)", { isArrayType(it) }, "iterator") && c.origin == IrStatementOrigin.FOR_LOOP_ITERATOR -> {
+                isFunction(target, "kotlin", "(some array type)", { isArrayType(it) }, "iterator") -> {
                     findTopLevelFunctionOrWarn("kotlin.jvm.internal.iterator", "kotlin.jvm.internal.ArrayIteratorKt", c)?.let { iteratorFn ->
                         val dispatchReceiver = c.dispatchReceiver
                         if (dispatchReceiver == null) {

--- a/java/ql/test/kotlin/library-tests/arrays/arrayIterators.expected
+++ b/java/ql/test/kotlin/library-tests/arrays/arrayIterators.expected
@@ -1,6 +1,6 @@
 | arrayIterators.kt:6:15:6:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
 | arrayIterators.kt:7:15:7:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
 | arrayIterators.kt:8:15:8:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
-| arrayIterators.kt:10:16:10:25 | iterator(...) | iterator() | kotlin.Array<Integer> |
-| arrayIterators.kt:11:16:11:25 | iterator(...) | iterator() | kotlin.IntArray |
-| arrayIterators.kt:12:16:12:25 | iterator(...) | iterator() | kotlin.BooleanArray |
+| arrayIterators.kt:10:16:10:25 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
+| arrayIterators.kt:11:16:11:25 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
+| arrayIterators.kt:12:16:12:25 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |

--- a/java/ql/test/kotlin/library-tests/arrays/arrayIterators.expected
+++ b/java/ql/test/kotlin/library-tests/arrays/arrayIterators.expected
@@ -1,0 +1,6 @@
+| arrayIterators.kt:6:15:6:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
+| arrayIterators.kt:7:15:7:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
+| arrayIterators.kt:8:15:8:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
+| arrayIterators.kt:10:16:10:25 | iterator(...) | iterator() | kotlin.Array<Integer> |
+| arrayIterators.kt:11:16:11:25 | iterator(...) | iterator() | kotlin.IntArray |
+| arrayIterators.kt:12:16:12:25 | iterator(...) | iterator() | kotlin.BooleanArray |

--- a/java/ql/test/kotlin/library-tests/arrays/arrayIterators.expected
+++ b/java/ql/test/kotlin/library-tests/arrays/arrayIterators.expected
@@ -1,6 +1,6 @@
 | arrayIterators.kt:6:15:6:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
-| arrayIterators.kt:7:15:7:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
-| arrayIterators.kt:8:15:8:15 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
+| arrayIterators.kt:7:15:7:15 | iterator(...) | iterator(int[]) | kotlin.jvm.internal.ArrayIteratorsKt |
+| arrayIterators.kt:8:15:8:15 | iterator(...) | iterator(boolean[]) | kotlin.jvm.internal.ArrayIteratorsKt |
 | arrayIterators.kt:10:16:10:25 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
-| arrayIterators.kt:11:16:11:25 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
-| arrayIterators.kt:12:16:12:25 | iterator(...) | iterator(java.lang.Object[]) | kotlin.jvm.internal.ArrayIteratorKt |
+| arrayIterators.kt:11:16:11:25 | iterator(...) | iterator(int[]) | kotlin.jvm.internal.ArrayIteratorsKt |
+| arrayIterators.kt:12:16:12:25 | iterator(...) | iterator(boolean[]) | kotlin.jvm.internal.ArrayIteratorsKt |

--- a/java/ql/test/kotlin/library-tests/arrays/arrayIterators.kt
+++ b/java/ql/test/kotlin/library-tests/arrays/arrayIterators.kt
@@ -1,0 +1,13 @@
+fun test(
+    a: Array<Int>,
+    b: IntArray,
+    c: BooleanArray) {
+
+    for (i in a) { }
+    for (i in b) { }
+    for (i in c) { }
+
+    val i1 = a.iterator()
+    val i2 = b.iterator()
+    val i3 = c.iterator()
+}

--- a/java/ql/test/kotlin/library-tests/arrays/arrayIterators.ql
+++ b/java/ql/test/kotlin/library-tests/arrays/arrayIterators.ql
@@ -1,0 +1,10 @@
+import java
+
+query predicate iterator(MethodAccess ma, string mn, string t) {
+  exists(Method m |
+    ma.getMethod() = m and
+    m.getName() = "iterator" and
+    mn = m.getSignature() and
+    t = ma.getMethod().getDeclaringType().getQualifiedName()
+  )
+}

--- a/java/ql/test/kotlin/library-tests/arrays/test.expected
+++ b/java/ql/test/kotlin/library-tests/arrays/test.expected
@@ -18,6 +18,7 @@ sourceSignatures
 | arrayCreations.kt:27:24:27:38 | invoke | invoke(int) |
 | arrayGetsSets.kt:1:1:22:1 | arrayGetSet | arrayGetSet(int[],short[],byte[],long[],float[],double[],boolean[],char[],java.lang.Object[]) |
 | arrayGetsSets.kt:24:1:41:1 | arrayGetSetInPlace | arrayGetSetInPlace(int[],long[],float[],double[]) |
+| arrayIterators.kt:1:1:13:1 | test | test(java.lang.Integer[],int[],boolean[]) |
 | primitiveArrays.kt:3:1:7:1 | Test | Test() |
 | primitiveArrays.kt:5:3:5:123 | test | test(java.lang.Integer[],java.lang.Integer[],int[],java.lang.Integer[][],java.lang.Integer[][],int[][]) |
 #select


### PR DESCRIPTION
This PR fixes the extraction of calls to `Array::iterator` function. These iterators were only extracted correctly in `for` loops before. Additionally, iterators of arrays of primitive types are also fixed. 