### PR TITLE
Kotlin: Add AnyDbType

### DIFF
--- a/java/kotlin-extractor/generate_dbscheme.py
+++ b/java/kotlin-extractor/generate_dbscheme.py
@@ -171,13 +171,12 @@ with open('src/main/kotlin/KotlinExtractorDbScheme.kt', 'w') as kt:
             for num, typ in mapping:
                 genTable(kt, relname, columns, enum, kind, num, typ)
 
+    kt.write('sealed interface AnyDbType\n')
     for typ in sorted(supertypes):
-        kt.write('sealed interface Db' + upperFirst(typ))
+        kt.write('sealed interface Db' + upperFirst(typ) + ': AnyDbType')
         # Sorting makes the output deterministic.
         names = sorted(supertypes[typ])
-        if names:
-            kt.write(': ')
-            kt.write(', '.join(map(lambda name: 'Db' + upperFirst(name), names)))
+        kt.write(''.join(map(lambda name: ', Db' + upperFirst(name), names)))
         kt.write('\n')
     for alias in sorted(type_aliases):
         kt.write('typealias Db' + upperFirst(alias) + ' = Db' + upperFirst(type_aliases[alias]) + '\n')

--- a/java/kotlin-extractor/src/main/kotlin/Label.kt
+++ b/java/kotlin-extractor/src/main/kotlin/Label.kt
@@ -6,8 +6,8 @@ import java.io.StringWriter
 /**
  * This represents a label (`#...`) in a TRAP file.
  */
-interface Label<T> {
-    fun <U> cast(): Label<U> {
+interface Label<T: AnyDbType> {
+    fun <U: AnyDbType> cast(): Label<U> {
         @Suppress("UNCHECKED_CAST")
         return this as Label<U>
     }
@@ -17,7 +17,7 @@ interface Label<T> {
  * The label `#i`, e.g. `#123`. Most labels we generate are of this
  * form.
  */
-class IntLabel<T>(val i: Int): Label<T> {
+class IntLabel<T: AnyDbType>(val i: Int): Label<T> {
     override fun toString(): String = "#$i"
 }
 
@@ -26,6 +26,6 @@ class IntLabel<T>(val i: Int): Label<T> {
  * shared between different components (e.g. when both the interceptor
  * and the extractor need to refer to the same label).
  */
-class StringLabel<T>(val name: String): Label<T> {
+class StringLabel<T: AnyDbType>(val name: String): Label<T> {
     override fun toString(): String = "#$name"
 }

--- a/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
+++ b/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
@@ -26,7 +26,7 @@ class TrapLabelManager {
     private var nextInt: Int = 100
 
     /** Returns a fresh label. */
-    fun <T> getFreshLabel(): Label<T> {
+    fun <T: AnyDbType> getFreshLabel(): Label<T> {
         return IntLabel(nextInt++)
     }
 
@@ -64,7 +64,7 @@ open class TrapWriter (protected val loggerBase: LoggerBase, val lm: TrapLabelMa
      * `getLabelFor` instead, which allows non-existent labels to be
      * initialised.
      */
-    fun <T> getExistingLabelFor(key: String): Label<T>? {
+    fun <T: AnyDbType> getExistingLabelFor(key: String): Label<T>? {
         return lm.labelMapping.get(key)?.cast<T>()
     }
     /**
@@ -73,7 +73,7 @@ open class TrapWriter (protected val loggerBase: LoggerBase, val lm: TrapLabelMa
      * is run on it, and it is returned.
      */
     @JvmOverloads // Needed so Java can call a method with an optional argument
-    fun <T> getLabelFor(key: String, initialise: (Label<T>) -> Unit = {}): Label<T> {
+    fun <T: AnyDbType> getLabelFor(key: String, initialise: (Label<T>) -> Unit = {}): Label<T> {
         val maybeLabel: Label<T>? = getExistingLabelFor(key)
         if(maybeLabel == null) {
             val label: Label<T> = lm.getFreshLabel()
@@ -89,7 +89,7 @@ open class TrapWriter (protected val loggerBase: LoggerBase, val lm: TrapLabelMa
     /**
      * Returns a label for a fresh ID (i.e. a new label bound to `*`).
      */
-    fun <T> getFreshIdLabel(): Label<T> {
+    fun <T: AnyDbType> getFreshIdLabel(): Label<T> {
         val label: Label<T> = lm.getFreshLabel()
         writeTrap("$label = *\n")
         return label

--- a/java/kotlin-extractor/src/main/kotlin/utils/TypeResults.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/TypeResults.kt
@@ -12,8 +12,8 @@ package com.github.codeql
  * `shortName` is a Java primitive name (e.g. "int"), a class short name with Java-style type arguments ("InnerClass<E>" or
  * "OuterClass<ConcreteArgument>" or "OtherClass<? extends Bound>") or an array ("componentShortName[]").
  */
-data class TypeResultGeneric<SignatureType,out LabelType>(val id: Label<out LabelType>, val signature: SignatureType, val shortName: String) {
-    fun <U> cast(): TypeResult<U> {
+data class TypeResultGeneric<SignatureType,out LabelType: AnyDbType>(val id: Label<out LabelType>, val signature: SignatureType, val shortName: String) {
+    fun <U: AnyDbType> cast(): TypeResult<U> {
         @Suppress("UNCHECKED_CAST")
         return this as TypeResult<U>
     }
@@ -25,6 +25,6 @@ typealias TypeResultWithoutSignature<T> = TypeResultGeneric<Unit,T>
 typealias TypeResults = TypeResultsGeneric<String>
 typealias TypeResultsWithoutSignatures = TypeResultsGeneric<Unit>
 
-fun <T> TypeResult<T>.forgetSignature(): TypeResultWithoutSignature<T> {
+fun <T: AnyDbType> TypeResult<T>.forgetSignature(): TypeResultWithoutSignature<T> {
     return TypeResultWithoutSignature(this.id, Unit, this.shortName)
 }


### PR DESCRIPTION
All DbType* types extend it, and `Label`s require their argument to be a subtype of it.

This gives us a little more type-safety / compiler-checked-documentation, but also I think it will make it easier to write a "cast is safe" internal query.