### PR TITLE
Add missing security tags

### DIFF
--- a/go/ql/src/Security/CWE-322/InsecureHostKeyCallback.ql
+++ b/go/ql/src/Security/CWE-322/InsecureHostKeyCallback.ql
@@ -3,9 +3,11 @@
  * @description Detects insecure SSL client configurations with an implementation of the `HostKeyCallback` that accepts all host keys.
  * @kind path-problem
  * @problem.severity warning
+ * @security-severity 8.2
  * @precision high
  * @id go/insecure-hostkeycallback
  * @tags security
+ *       external/cwe/cwe-322
  */
 
 import go

--- a/go/ql/src/change-notes/2022-08-29-add-security-severity.md
+++ b/go/ql/src/change-notes/2022-08-29-add-security-severity.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* Added the `security-severity` tag and CWE tag to the `go/insecure-hostkeycallback` query.

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbContainerInterference.ql
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbContainerInterference.ql
@@ -7,7 +7,6 @@
  *              Such operations could interfere with the EJB container's operation.
  * @kind problem
  * @problem.severity error
- * @security-severity 5.8
  * @precision low
  * @id java/ejb/container-interference
  * @tags reliability

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbFileIO.ql
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbFileIO.ql
@@ -5,7 +5,6 @@
  *              for enterprise components.
  * @kind problem
  * @problem.severity error
- * @security-severity 5.8
  * @precision low
  * @id java/ejb/file-io
  * @tags reliability

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbNative.ql
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbNative.ql
@@ -4,7 +4,6 @@
  *              Such use could compromise security and system stability.
  * @kind problem
  * @problem.severity error
- * @security-severity 5.8
  * @precision low
  * @id java/ejb/native-code
  * @tags reliability

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbReflection.ql
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbReflection.ql
@@ -4,7 +4,6 @@
  *              as this could compromise security.
  * @kind problem
  * @problem.severity error
- * @security-severity 5.8
  * @precision low
  * @id java/ejb/reflection
  * @tags external/cwe/cwe-573

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSecurityConfiguration.ql
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSecurityConfiguration.ql
@@ -5,7 +5,6 @@
  *              This functionality is reserved for the EJB container for security reasons.
  * @kind problem
  * @problem.severity error
- * @security-severity 5.8
  * @precision low
  * @id java/ejb/security-configuration-access
  * @tags external/cwe/cwe-573

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSerialization.ql
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSerialization.ql
@@ -4,7 +4,6 @@
  *              the Java serialization protocol, since their use could compromise security.
  * @kind problem
  * @problem.severity error
- * @security-severity 5.8
  * @precision low
  * @id java/ejb/substitution-in-serialization
  * @tags external/cwe/cwe-573

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSetSocketOrUrlFactory.ql
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSetSocketOrUrlFactory.ql
@@ -4,7 +4,7 @@
  *              or the stream handler factory used by URL. Such operations could
  *              compromise security or interfere with the EJB container's operation.
  * @kind problem
- * @security-severity 5.8
+ * @problem.severity error
  * @precision low
  * @id java/ejb/socket-or-stream-handler-factory
  * @tags reliability

--- a/java/ql/src/Frameworks/JavaEE/EJB/EjbSetSocketOrUrlFactory.ql
+++ b/java/ql/src/Frameworks/JavaEE/EJB/EjbSetSocketOrUrlFactory.ql
@@ -4,7 +4,6 @@
  *              or the stream handler factory used by URL. Such operations could
  *              compromise security or interfere with the EJB container's operation.
  * @kind problem
- * @problem.severity error
  * @security-severity 5.8
  * @precision low
  * @id java/ejb/socket-or-stream-handler-factory

--- a/java/ql/src/change-notes/2022-08-29-remove-security-tag.md
+++ b/java/ql/src/change-notes/2022-08-29-remove-security-tag.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* Removed the `security` tag from several queries not in the `Security/` folder that also had missing `@security-severity` tags.

--- a/java/ql/src/change-notes/2022-08-29-remove-security-tag.md
+++ b/java/ql/src/change-notes/2022-08-29-remove-security-tag.md
@@ -1,4 +1,4 @@
 ---
 category: queryMetadata
 ---
-* Removed the `security` tag from several queries not in the `Security/` folder that also had missing `@security-severity` tags.
+* Removed the `@security-severity` tag from several queries not in the `Security/` folder that also had missing `security` tags.

--- a/python/ql/src/Security/CWE-730/PolynomialReDoS.ql
+++ b/python/ql/src/Security/CWE-730/PolynomialReDoS.ql
@@ -4,6 +4,7 @@
  *              to match may be vulnerable to denial-of-service attacks.
  * @kind path-problem
  * @problem.severity warning
+ * @security-severity 7.5
  * @precision high
  * @id py/polynomial-redos
  * @tags security

--- a/python/ql/src/Security/CWE-730/ReDoS.ql
+++ b/python/ql/src/Security/CWE-730/ReDoS.ql
@@ -5,6 +5,7 @@
  *              attacks.
  * @kind problem
  * @problem.severity error
+ * @security-severity 7.5
  * @precision high
  * @id py/redos
  * @tags security

--- a/python/ql/src/Security/CWE-730/RegexInjection.ql
+++ b/python/ql/src/Security/CWE-730/RegexInjection.ql
@@ -5,6 +5,7 @@
  *              exponential time on certain inputs.
  * @kind path-problem
  * @problem.severity error
+ * @security-severity 7.5
  * @precision high
  * @id py/regex-injection
  * @tags security

--- a/python/ql/src/change-notes/2022-08-29-missing-security-severity.md
+++ b/python/ql/src/change-notes/2022-08-29-missing-security-severity.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* Added the `security-severity` tag the `py/redos`, `py/polynomial-redos`, and `py/regex-injection` queries.


### PR DESCRIPTION
I stumbled upon a query that had a missing `@tag security`.  
So I took a look at the results of `ql/missing-security-metadata`, and added the missing tags were I could.  

[There still some queries with missing @security-severity](https://github.com/github/codeql/security/code-scanning?query=pr%3A10180+tool%3ACodeQL+is%3Aopen+rule%3Aql%2Fmissing-security-metadata), but they are also not tagged with any CWEs, so I'm not sure what to set the value to.  