### PR TITLE
QL: remove consistency errors related to resolving multiple predicates from parameterized modules

### DIFF
--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -521,6 +521,9 @@ class ClasslessPredicate extends TClasslessPredicate, Predicate, ModuleDeclarati
   }
 
   override predicate isPrivate() { Predicate.super.isPrivate() }
+
+  /** Holds if this classless predicate is a signature predicate with no body. */
+  predicate isSignature() { not exists(this.getBody()) }
 }
 
 /**

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -211,7 +211,7 @@ module PredConsistency {
     c > 1 and
     resolvePredicateExpr(pe, p) and
     // parameterized modules are expected to resolve to multiple.
-    not exists(Predicate sig | not exists(sig.getBody()) and resolvePredicateExpr(pe, sig))
+    not exists(ClasslessPredicate sig | not sig.isSignature() and resolvePredicateExpr(pe, sig))
   }
 
   query predicate multipleResolveCall(Call call, int c, PredicateOrBuiltin p) {
@@ -227,6 +227,6 @@ module PredConsistency {
     c > 1 and
     resolveCall(call, p) and
     // parameterized modules are expected to resolve to multiple.
-    not exists(Predicate sig | not exists(sig.getBody()) and resolveCall(call, sig))
+    not exists(ClasslessPredicate sig | not sig.isSignature() and resolveCall(call, sig))
   }
 }

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -209,7 +209,9 @@ module PredConsistency {
         not exists(p0.getAlias())
       ) and
     c > 1 and
-    resolvePredicateExpr(pe, p)
+    resolvePredicateExpr(pe, p) and
+    // parameterized modules are expected to resolve to multiple.
+    not exists(Predicate sig | not exists(sig.getBody()) and resolvePredicateExpr(pe, sig))
   }
 
   query predicate multipleResolveCall(Call call, int c, PredicateOrBuiltin p) {


### PR DESCRIPTION
Predicate references in prameterized modules will resolve to multiple predicates, that's a feature (for now).  
This fixes a FP in the consistency test related to that.  