### PR TITLE
JavaScript: Update to TypeScript 4.8

### DIFF
--- a/docs/codeql/support/reusables/versions-compilers.rst
+++ b/docs/codeql/support/reusables/versions-compilers.rst
@@ -23,7 +23,7 @@
    JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [6]_"
    Python,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10",Not applicable,``.py``
    Ruby [7]_,"up to 3.0.2",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
-   TypeScript [8]_,"2.6-4.7",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
+   TypeScript [8]_,"2.6-4.8",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
 
 .. container:: footnote-group
 

--- a/javascript/extractor/lib/typescript/package.json
+++ b/javascript/extractor/lib/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-parser-wrapper",
     "private": true,
     "dependencies": {
-        "typescript": "4.7.2"
+        "typescript": "4.8.2"
     },
     "scripts": {
         "build": "tsc --project tsconfig.json",

--- a/javascript/extractor/lib/typescript/src/ast_extractor.ts
+++ b/javascript/extractor/lib/typescript/src/ast_extractor.ts
@@ -202,6 +202,12 @@ export function augmentAst(ast: AugmentedSourceFile, code: string, project: Proj
             }
         }
 
+        // This PR: https://github.com/microsoft/TypeScript/pull/50343/ changed how illegal decorators are stored, this hack reverts it.
+        // Those decorator uses are syntax errors, but people use them anyway.
+        if ((node as any).illegalDecorators) {
+            (node as any).decorators = (node as any).illegalDecorators;
+        }
+
         if (typeChecker != null && insideConditionalTypes === 0) {
             if (isTypedNode(node)) {
                 let contextualType = isContextuallyTypedNode(node)

--- a/javascript/extractor/lib/typescript/src/ast_extractor.ts
+++ b/javascript/extractor/lib/typescript/src/ast_extractor.ts
@@ -202,12 +202,6 @@ export function augmentAst(ast: AugmentedSourceFile, code: string, project: Proj
             }
         }
 
-        // This PR: https://github.com/microsoft/TypeScript/pull/50343/ changed how illegal decorators are stored, this hack reverts it.
-        // Those decorator uses are syntax errors, but people use them anyway.
-        if ((node as any).illegalDecorators) {
-            (node as any).decorators = (node as any).illegalDecorators;
-        }
-
         if (typeChecker != null && insideConditionalTypes === 0) {
             if (isTypedNode(node)) {
                 let contextualType = isContextuallyTypedNode(node)

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -241,7 +241,7 @@ const astProperties: string[] = [
     "constructor",
     "declarationList",
     "declarations",
-    "decorators",
+    "illegalDecorators",
     "default",
     "delete",
     "dotDotDotToken",

--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -947,7 +947,7 @@ export class TypeTable {
    * Returns a unique string for the given call/constructor signature.
    */
   private getSignatureString(kind: ts.SignatureKind, signature: AugmentedSignature): string {
-    let modifiers : ts.ModifiersArray = signature.getDeclaration()?.modifiers;
+    let modifiers  = signature.getDeclaration()?.modifiers;
     let isAbstract = modifiers && modifiers.filter(modifier => modifier.kind == ts.SyntaxKind.AbstractKeyword).length > 0
 
     let parameters = signature.getParameters();

--- a/javascript/extractor/lib/typescript/yarn.lock
+++ b/javascript/extractor/lib/typescript/yarn.lock
@@ -6,7 +6,7 @@
   version "12.7.11"
   resolved node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446
 
-typescript@4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
-  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+typescript@4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -41,7 +41,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2022-07-11";
+  public static final String EXTRACTOR_VERSION = "2022-08-25";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
@@ -1151,7 +1151,7 @@ public class TypeScriptASTConverter {
             loc,
             hasModifier(node, "ConstKeyword"),
             hasModifier(node, "DeclareKeyword"),
-            convertChildrenNotNull(node, "decorators"),
+            convertChildrenNotNull(node, "illegalDecorators"), // as of https://github.com/microsoft/TypeScript/pull/50343/ the property is called `illegalDecorators` instead of `decorators`
             convertChild(node, "name"),
             convertChildren(node, "members"));
     attachSymbolInformation(enumDeclaration, node);

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
@@ -976,8 +976,9 @@ public class TypeScriptASTConverter {
             hasDeclareKeyword,
             hasAbstractKeyword);
     attachSymbolInformation(classDecl.getClassDef(), node);
-    if (node.has("decorators")) {
-      classDecl.addDecorators(convertChildren(node, "decorators"));
+    List<Decorator> decorators = getDecorators(node);
+    if (!decorators.isEmpty()) {
+      classDecl.addDecorators(decorators);
       advanceUntilAfter(loc, classDecl.getDecorators());
     }
     Node exportedDecl = fixExports(loc, classDecl);
@@ -987,6 +988,17 @@ public class TypeScriptASTConverter {
           exportedDecl.getLoc(), new ClassExpression(classDecl.getLoc(), classDecl.getClassDef()));
     }
     return exportedDecl;
+  }
+
+  List<Decorator> getDecorators(JsonObject node) throws ParseError {
+    List<Decorator> result = new ArrayList<>();
+    for (JsonElement elt : getChildIterable(node, "modifiers")) {
+      JsonObject modifier = elt.getAsJsonObject();
+      if (hasKind(modifier, "Decorator")) {
+        result.add((Decorator) convertNode(modifier));
+      }
+    }
+    return result;
   }
 
   private Node convertCommaListExpression(JsonObject node, SourceLocation loc) throws ParseError {
@@ -1041,7 +1053,7 @@ public class TypeScriptASTConverter {
   private List<DecoratorList> convertParameterDecorators(JsonObject function) throws ParseError {
     List<DecoratorList> decoratorLists = new ArrayList<>();
     for (JsonElement parameter : getProperParameters(function)) {
-      decoratorLists.add(makeDecoratorList(parameter.getAsJsonObject().get("decorators")));
+      decoratorLists.add(makeDecoratorList(parameter.getAsJsonObject().get("modifiers")));
     }
     return decoratorLists;
   }
@@ -1664,8 +1676,9 @@ public class TypeScriptASTConverter {
     FunctionExpression method = convertImplicitFunction(node, loc);
     MethodDefinition methodDefinition =
         new MethodDefinition(loc, flags, methodKind, convertChild(node, "name"), method);
-    if (node.has("decorators")) {
-      methodDefinition.addDecorators(convertChildren(node, "decorators"));
+    List<Decorator> decorators = getDecorators(node);
+    if (!decorators.isEmpty()) {
+      methodDefinition.addDecorators(decorators);
       advanceUntilAfter(loc, methodDefinition.getDecorators());
     }
     return methodDefinition;
@@ -2079,8 +2092,9 @@ public class TypeScriptASTConverter {
             convertChild(node, "name"),
             convertChild(node, "initializer"),
             convertChildAsType(node, "type"));
-    if (node.has("decorators")) {
-      fieldDefinition.addDecorators(convertChildren(node, "decorators"));
+    List<Decorator> decorators = getDecorators(node);
+    if (!decorators.isEmpty()) {
+      fieldDefinition.addDecorators(decorators);
       advanceUntilAfter(loc, fieldDefinition.getDecorators());
     }
     return fieldDefinition;

--- a/javascript/ql/lib/change-notes/2022-05-24-typescript-4-8.md
+++ b/javascript/ql/lib/change-notes/2022-05-24-typescript-4-8.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* Added support for TypeScript 4.8.

--- a/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
@@ -99,6 +99,7 @@ nodes
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
@@ -132,6 +133,9 @@ nodes
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (TypeParameters) | semmle.label | (TypeParameters) |
+| file://:0:0:0:0 | (TypeParameters) | semmle.label | (TypeParameters) |
 | file://:0:0:0:0 | (TypeParameters) | semmle.label | (TypeParameters) |
 | file://:0:0:0:0 | (TypeParameters) | semmle.label | (TypeParameters) |
 | file://:0:0:0:0 | (TypeParameters) | semmle.label | (TypeParameters) |
@@ -1381,8 +1385,47 @@ nodes
 | tst.ts:374:13:374:26 | [DotExpr] B.resolvedFile | semmle.label | [DotExpr] B.resolvedFile |
 | tst.ts:374:13:374:28 | [MethodCallExpr] B.resolvedFile() | semmle.label | [MethodCallExpr] B.resolvedFile() |
 | tst.ts:374:15:374:26 | [Label] resolvedFile | semmle.label | [Label] resolvedFile |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | semmle.label | [NamespaceDeclaration] module ... ; } |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | semmle.order | 84 |
+| tst.ts:379:8:379:11 | [VarDecl] TS48 | semmle.label | [VarDecl] TS48 |
+| tst.ts:381:5:381:73 | [TypeAliasDeclaration,TypeDefinition] type So ... never; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type So ... never; |
+| tst.ts:381:10:381:16 | [Identifier] SomeNum | semmle.label | [Identifier] SomeNum |
+| tst.ts:381:20:381:24 | [LiteralTypeExpr] "100" | semmle.label | [LiteralTypeExpr] "100" |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | semmle.label | [ConditionalTypeExpr] "100" e ... : never |
+| tst.ts:381:34:381:60 | [TemplateLiteralTypeExpr] `${infe ... umber}` | semmle.label | [TemplateLiteralTypeExpr] `${infe ... umber}` |
+| tst.ts:381:37:381:58 | [InferTypeExpr] infer U ... number | semmle.label | [InferTypeExpr] infer U ... number |
+| tst.ts:381:43:381:43 | [Identifier] U | semmle.label | [Identifier] U |
+| tst.ts:381:43:381:58 | [TypeParameter] U extends number | semmle.label | [TypeParameter] U extends number |
+| tst.ts:381:53:381:58 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
+| tst.ts:381:64:381:64 | [LocalTypeAccess] U | semmle.label | [LocalTypeAccess] U |
+| tst.ts:381:68:381:72 | [KeywordTypeExpr] never | semmle.label | [KeywordTypeExpr] never |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | semmle.label | [FunctionDeclStmt] declare ... T): T; |
+| tst.ts:383:22:383:35 | [VarDecl] chooseRandomly | semmle.label | [VarDecl] chooseRandomly |
+| tst.ts:383:37:383:37 | [Identifier] T | semmle.label | [Identifier] T |
+| tst.ts:383:37:383:37 | [TypeParameter] T | semmle.label | [TypeParameter] T |
+| tst.ts:383:40:383:40 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
+| tst.ts:383:43:383:43 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
+| tst.ts:383:46:383:46 | [SimpleParameter] y | semmle.label | [SimpleParameter] y |
+| tst.ts:383:49:383:49 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
+| tst.ts:383:53:383:53 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
+| tst.ts:385:5:385:74 | [DeclStmt] let [a, ... ye!"]); | semmle.label | [DeclStmt] let [a, ... ye!"]); |
+| tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | semmle.label | [ArrayPattern] [a, b, c] |
+| tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | semmle.label | [VariableDeclarator] [a, b, ... bye!"]) |
+| tst.ts:385:10:385:10 | [VarDecl] a | semmle.label | [VarDecl] a |
+| tst.ts:385:13:385:13 | [VarDecl] b | semmle.label | [VarDecl] b |
+| tst.ts:385:16:385:16 | [VarDecl] c | semmle.label | [VarDecl] c |
+| tst.ts:385:21:385:34 | [VarRef] chooseRandomly | semmle.label | [VarRef] chooseRandomly |
+| tst.ts:385:21:385:73 | [CallExpr] chooseR ... bye!"]) | semmle.label | [CallExpr] chooseR ... bye!"]) |
+| tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | semmle.label | [ArrayExpr] [42, true, "hi!"] |
+| tst.ts:385:37:385:38 | [Literal] 42 | semmle.label | [Literal] 42 |
+| tst.ts:385:41:385:44 | [Literal] true | semmle.label | [Literal] true |
+| tst.ts:385:47:385:51 | [Literal] "hi!" | semmle.label | [Literal] "hi!" |
+| tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | semmle.label | [ArrayExpr] [0, false, "bye!"] |
+| tst.ts:385:56:385:56 | [Literal] 0 | semmle.label | [Literal] 0 |
+| tst.ts:385:59:385:63 | [Literal] false | semmle.label | [Literal] false |
+| tst.ts:385:66:385:71 | [Literal] "bye!" | semmle.label | [Literal] "bye!" |
 | tstModuleCJS.cts:1:1:3:1 | [ExportDeclaration] export ... 'b'; } | semmle.label | [ExportDeclaration] export ... 'b'; } |
-| tstModuleCJS.cts:1:1:3:1 | [ExportDeclaration] export ... 'b'; } | semmle.order | 84 |
+| tstModuleCJS.cts:1:1:3:1 | [ExportDeclaration] export ... 'b'; } | semmle.order | 85 |
 | tstModuleCJS.cts:1:8:3:1 | [FunctionDeclStmt] functio ... 'b'; } | semmle.label | [FunctionDeclStmt] functio ... 'b'; } |
 | tstModuleCJS.cts:1:17:1:28 | [VarDecl] tstModuleCJS | semmle.label | [VarDecl] tstModuleCJS |
 | tstModuleCJS.cts:1:33:1:35 | [LiteralTypeExpr] 'a' | semmle.label | [LiteralTypeExpr] 'a' |
@@ -1400,7 +1443,7 @@ nodes
 | tstModuleCJS.cts:2:34:2:36 | [Literal] 'a' | semmle.label | [Literal] 'a' |
 | tstModuleCJS.cts:2:40:2:42 | [Literal] 'b' | semmle.label | [Literal] 'b' |
 | tstModuleES.mts:1:1:3:1 | [ExportDeclaration] export ... 'b'; } | semmle.label | [ExportDeclaration] export ... 'b'; } |
-| tstModuleES.mts:1:1:3:1 | [ExportDeclaration] export ... 'b'; } | semmle.order | 85 |
+| tstModuleES.mts:1:1:3:1 | [ExportDeclaration] export ... 'b'; } | semmle.order | 86 |
 | tstModuleES.mts:1:16:3:1 | [FunctionDeclStmt] functio ... 'b'; } | semmle.label | [FunctionDeclStmt] functio ... 'b'; } |
 | tstModuleES.mts:1:25:1:35 | [VarDecl] tstModuleES | semmle.label | [VarDecl] tstModuleES |
 | tstModuleES.mts:1:40:1:42 | [LiteralTypeExpr] 'a' | semmle.label | [LiteralTypeExpr] 'a' |
@@ -1418,7 +1461,7 @@ nodes
 | tstModuleES.mts:2:34:2:36 | [Literal] 'a' | semmle.label | [Literal] 'a' |
 | tstModuleES.mts:2:40:2:42 | [Literal] 'b' | semmle.label | [Literal] 'b' |
 | tstSuffixA.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.label | [ExportDeclaration] export ... .ts'; } |
-| tstSuffixA.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.order | 86 |
+| tstSuffixA.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.order | 87 |
 | tstSuffixA.ts:1:8:3:1 | [FunctionDeclStmt] functio ... .ts'; } | semmle.label | [FunctionDeclStmt] functio ... .ts'; } |
 | tstSuffixA.ts:1:17:1:28 | [VarDecl] resolvedFile | semmle.label | [VarDecl] resolvedFile |
 | tstSuffixA.ts:1:33:1:47 | [LiteralTypeExpr] 'tstSuffixA.ts' | semmle.label | [LiteralTypeExpr] 'tstSuffixA.ts' |
@@ -1426,7 +1469,7 @@ nodes
 | tstSuffixA.ts:2:5:2:27 | [ReturnStmt] return ... xA.ts'; | semmle.label | [ReturnStmt] return ... xA.ts'; |
 | tstSuffixA.ts:2:12:2:26 | [Literal] 'tstSuffixA.ts' | semmle.label | [Literal] 'tstSuffixA.ts' |
 | tstSuffixB.ios.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.label | [ExportDeclaration] export ... .ts'; } |
-| tstSuffixB.ios.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.order | 87 |
+| tstSuffixB.ios.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.order | 88 |
 | tstSuffixB.ios.ts:1:8:3:1 | [FunctionDeclStmt] functio ... .ts'; } | semmle.label | [FunctionDeclStmt] functio ... .ts'; } |
 | tstSuffixB.ios.ts:1:17:1:28 | [VarDecl] resolvedFile | semmle.label | [VarDecl] resolvedFile |
 | tstSuffixB.ios.ts:1:33:1:51 | [LiteralTypeExpr] 'tstSuffixB.ios.ts' | semmle.label | [LiteralTypeExpr] 'tstSuffixB.ios.ts' |
@@ -1434,7 +1477,7 @@ nodes
 | tstSuffixB.ios.ts:2:5:2:31 | [ReturnStmt] return ... os.ts'; | semmle.label | [ReturnStmt] return ... os.ts'; |
 | tstSuffixB.ios.ts:2:12:2:30 | [Literal] 'tstSuffixB.ios.ts' | semmle.label | [Literal] 'tstSuffixB.ios.ts' |
 | tstSuffixB.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.label | [ExportDeclaration] export ... .ts'; } |
-| tstSuffixB.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.order | 88 |
+| tstSuffixB.ts:1:1:3:1 | [ExportDeclaration] export ... .ts'; } | semmle.order | 89 |
 | tstSuffixB.ts:1:8:3:1 | [FunctionDeclStmt] functio ... .ts'; } | semmle.label | [FunctionDeclStmt] functio ... .ts'; } |
 | tstSuffixB.ts:1:17:1:28 | [VarDecl] resolvedFile | semmle.label | [VarDecl] resolvedFile |
 | tstSuffixB.ts:1:33:1:47 | [LiteralTypeExpr] 'tstSuffixB.ts' | semmle.label | [LiteralTypeExpr] 'tstSuffixB.ts' |
@@ -1442,16 +1485,16 @@ nodes
 | tstSuffixB.ts:2:5:2:27 | [ReturnStmt] return ... xB.ts'; | semmle.label | [ReturnStmt] return ... xB.ts'; |
 | tstSuffixB.ts:2:12:2:26 | [Literal] 'tstSuffixB.ts' | semmle.label | [Literal] 'tstSuffixB.ts' |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type B = boolean; |
-| type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | semmle.order | 89 |
+| type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | semmle.order | 90 |
 | type_alias.ts:1:6:1:6 | [Identifier] B | semmle.label | [Identifier] B |
 | type_alias.ts:1:10:1:16 | [KeywordTypeExpr] boolean | semmle.label | [KeywordTypeExpr] boolean |
 | type_alias.ts:3:1:3:9 | [DeclStmt] var b = ... | semmle.label | [DeclStmt] var b = ... |
-| type_alias.ts:3:1:3:9 | [DeclStmt] var b = ... | semmle.order | 90 |
+| type_alias.ts:3:1:3:9 | [DeclStmt] var b = ... | semmle.order | 91 |
 | type_alias.ts:3:5:3:5 | [VarDecl] b | semmle.label | [VarDecl] b |
 | type_alias.ts:3:5:3:8 | [VariableDeclarator] b: B | semmle.label | [VariableDeclarator] b: B |
 | type_alias.ts:3:8:3:8 | [LocalTypeAccess] B | semmle.label | [LocalTypeAccess] B |
 | type_alias.ts:5:1:5:50 | [TypeAliasDeclaration,TypeDefinition] type Va ... ay<T>>; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Va ... ay<T>>; |
-| type_alias.ts:5:1:5:50 | [TypeAliasDeclaration,TypeDefinition] type Va ... ay<T>>; | semmle.order | 91 |
+| type_alias.ts:5:1:5:50 | [TypeAliasDeclaration,TypeDefinition] type Va ... ay<T>>; | semmle.order | 92 |
 | type_alias.ts:5:6:5:17 | [Identifier] ValueOrArray | semmle.label | [Identifier] ValueOrArray |
 | type_alias.ts:5:19:5:19 | [Identifier] T | semmle.label | [Identifier] T |
 | type_alias.ts:5:19:5:19 | [TypeParameter] T | semmle.label | [TypeParameter] T |
@@ -1463,14 +1506,14 @@ nodes
 | type_alias.ts:5:34:5:48 | [GenericTypeExpr] ValueOrArray<T> | semmle.label | [GenericTypeExpr] ValueOrArray<T> |
 | type_alias.ts:5:47:5:47 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
 | type_alias.ts:7:1:7:28 | [DeclStmt] var c = ... | semmle.label | [DeclStmt] var c = ... |
-| type_alias.ts:7:1:7:28 | [DeclStmt] var c = ... | semmle.order | 92 |
+| type_alias.ts:7:1:7:28 | [DeclStmt] var c = ... | semmle.order | 93 |
 | type_alias.ts:7:5:7:5 | [VarDecl] c | semmle.label | [VarDecl] c |
 | type_alias.ts:7:5:7:27 | [VariableDeclarator] c: Valu ... number> | semmle.label | [VariableDeclarator] c: Valu ... number> |
 | type_alias.ts:7:8:7:19 | [LocalTypeAccess] ValueOrArray | semmle.label | [LocalTypeAccess] ValueOrArray |
 | type_alias.ts:7:8:7:27 | [GenericTypeExpr] ValueOrArray<number> | semmle.label | [GenericTypeExpr] ValueOrArray<number> |
 | type_alias.ts:7:21:7:26 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
 | type_alias.ts:9:1:15:13 | [TypeAliasDeclaration,TypeDefinition] type Js ... Json[]; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Js ... Json[]; |
-| type_alias.ts:9:1:15:13 | [TypeAliasDeclaration,TypeDefinition] type Js ... Json[]; | semmle.order | 93 |
+| type_alias.ts:9:1:15:13 | [TypeAliasDeclaration,TypeDefinition] type Js ... Json[]; | semmle.order | 94 |
 | type_alias.ts:9:6:9:9 | [Identifier] Json | semmle.label | [Identifier] Json |
 | type_alias.ts:10:5:15:12 | [UnionTypeExpr] \| strin ... Json[] | semmle.label | [UnionTypeExpr] \| strin ... Json[] |
 | type_alias.ts:10:7:10:12 | [KeywordTypeExpr] string | semmle.label | [KeywordTypeExpr] string |
@@ -1486,12 +1529,12 @@ nodes
 | type_alias.ts:15:7:15:10 | [LocalTypeAccess] Json | semmle.label | [LocalTypeAccess] Json |
 | type_alias.ts:15:7:15:12 | [ArrayTypeExpr] Json[] | semmle.label | [ArrayTypeExpr] Json[] |
 | type_alias.ts:17:1:17:15 | [DeclStmt] var json = ... | semmle.label | [DeclStmt] var json = ... |
-| type_alias.ts:17:1:17:15 | [DeclStmt] var json = ... | semmle.order | 94 |
+| type_alias.ts:17:1:17:15 | [DeclStmt] var json = ... | semmle.order | 95 |
 | type_alias.ts:17:5:17:8 | [VarDecl] json | semmle.label | [VarDecl] json |
 | type_alias.ts:17:5:17:14 | [VariableDeclarator] json: Json | semmle.label | [VariableDeclarator] json: Json |
 | type_alias.ts:17:11:17:14 | [LocalTypeAccess] Json | semmle.label | [LocalTypeAccess] Json |
 | type_alias.ts:19:1:21:57 | [TypeAliasDeclaration,TypeDefinition] type Vi ... ode[]]; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Vi ... ode[]]; |
-| type_alias.ts:19:1:21:57 | [TypeAliasDeclaration,TypeDefinition] type Vi ... ode[]]; | semmle.order | 95 |
+| type_alias.ts:19:1:21:57 | [TypeAliasDeclaration,TypeDefinition] type Vi ... ode[]]; | semmle.order | 96 |
 | type_alias.ts:19:6:19:16 | [Identifier] VirtualNode | semmle.label | [Identifier] VirtualNode |
 | type_alias.ts:20:5:21:56 | [UnionTypeExpr] \| strin ... Node[]] | semmle.label | [UnionTypeExpr] \| strin ... Node[]] |
 | type_alias.ts:20:7:20:12 | [KeywordTypeExpr] string | semmle.label | [KeywordTypeExpr] string |
@@ -1507,7 +1550,7 @@ nodes
 | type_alias.ts:21:43:21:53 | [LocalTypeAccess] VirtualNode | semmle.label | [LocalTypeAccess] VirtualNode |
 | type_alias.ts:21:43:21:55 | [ArrayTypeExpr] VirtualNode[] | semmle.label | [ArrayTypeExpr] VirtualNode[] |
 | type_alias.ts:23:1:27:6 | [DeclStmt] const myNode = ... | semmle.label | [DeclStmt] const myNode = ... |
-| type_alias.ts:23:1:27:6 | [DeclStmt] const myNode = ... | semmle.order | 96 |
+| type_alias.ts:23:1:27:6 | [DeclStmt] const myNode = ... | semmle.order | 97 |
 | type_alias.ts:23:7:23:12 | [VarDecl] myNode | semmle.label | [VarDecl] myNode |
 | type_alias.ts:23:7:27:5 | [VariableDeclarator] myNode: ... ] ] | semmle.label | [VariableDeclarator] myNode: ... ] ] |
 | type_alias.ts:23:15:23:25 | [LocalTypeAccess] VirtualNode | semmle.label | [LocalTypeAccess] VirtualNode |
@@ -1532,12 +1575,12 @@ nodes
 | type_alias.ts:26:23:26:36 | [Literal] "second-child" | semmle.label | [Literal] "second-child" |
 | type_alias.ts:26:41:26:62 | [Literal] "I'm the second child" | semmle.label | [Literal] "I'm the second child" |
 | type_definition_objects.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.label | [ImportDeclaration] import ... dummy"; |
-| type_definition_objects.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.order | 97 |
+| type_definition_objects.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.order | 98 |
 | type_definition_objects.ts:1:8:1:17 | [ImportSpecifier] * as dummy | semmle.label | [ImportSpecifier] * as dummy |
 | type_definition_objects.ts:1:13:1:17 | [VarDecl] dummy | semmle.label | [VarDecl] dummy |
 | type_definition_objects.ts:1:24:1:32 | [Literal] "./dummy" | semmle.label | [Literal] "./dummy" |
 | type_definition_objects.ts:3:1:3:17 | [ExportDeclaration] export class C {} | semmle.label | [ExportDeclaration] export class C {} |
-| type_definition_objects.ts:3:1:3:17 | [ExportDeclaration] export class C {} | semmle.order | 98 |
+| type_definition_objects.ts:3:1:3:17 | [ExportDeclaration] export class C {} | semmle.order | 99 |
 | type_definition_objects.ts:3:8:3:17 | [ClassDefinition,TypeDefinition] class C {} | semmle.label | [ClassDefinition,TypeDefinition] class C {} |
 | type_definition_objects.ts:3:14:3:14 | [VarDecl] C | semmle.label | [VarDecl] C |
 | type_definition_objects.ts:3:16:3:15 | [BlockStmt] {} | semmle.label | [BlockStmt] {} |
@@ -1545,36 +1588,36 @@ nodes
 | type_definition_objects.ts:3:16:3:15 | [FunctionExpr] () {} | semmle.label | [FunctionExpr] () {} |
 | type_definition_objects.ts:3:16:3:15 | [Label] constructor | semmle.label | [Label] constructor |
 | type_definition_objects.ts:4:1:4:17 | [DeclStmt] let classObj = ... | semmle.label | [DeclStmt] let classObj = ... |
-| type_definition_objects.ts:4:1:4:17 | [DeclStmt] let classObj = ... | semmle.order | 99 |
+| type_definition_objects.ts:4:1:4:17 | [DeclStmt] let classObj = ... | semmle.order | 100 |
 | type_definition_objects.ts:4:5:4:12 | [VarDecl] classObj | semmle.label | [VarDecl] classObj |
 | type_definition_objects.ts:4:5:4:16 | [VariableDeclarator] classObj = C | semmle.label | [VariableDeclarator] classObj = C |
 | type_definition_objects.ts:4:16:4:16 | [VarRef] C | semmle.label | [VarRef] C |
 | type_definition_objects.ts:6:1:6:16 | [ExportDeclaration] export enum E {} | semmle.label | [ExportDeclaration] export enum E {} |
-| type_definition_objects.ts:6:1:6:16 | [ExportDeclaration] export enum E {} | semmle.order | 100 |
+| type_definition_objects.ts:6:1:6:16 | [ExportDeclaration] export enum E {} | semmle.order | 101 |
 | type_definition_objects.ts:6:8:6:16 | [EnumDeclaration,TypeDefinition] enum E {} | semmle.label | [EnumDeclaration,TypeDefinition] enum E {} |
 | type_definition_objects.ts:6:13:6:13 | [VarDecl] E | semmle.label | [VarDecl] E |
 | type_definition_objects.ts:7:1:7:16 | [DeclStmt] let enumObj = ... | semmle.label | [DeclStmt] let enumObj = ... |
-| type_definition_objects.ts:7:1:7:16 | [DeclStmt] let enumObj = ... | semmle.order | 101 |
+| type_definition_objects.ts:7:1:7:16 | [DeclStmt] let enumObj = ... | semmle.order | 102 |
 | type_definition_objects.ts:7:5:7:11 | [VarDecl] enumObj | semmle.label | [VarDecl] enumObj |
 | type_definition_objects.ts:7:5:7:15 | [VariableDeclarator] enumObj = E | semmle.label | [VariableDeclarator] enumObj = E |
 | type_definition_objects.ts:7:15:7:15 | [VarRef] E | semmle.label | [VarRef] E |
 | type_definition_objects.ts:9:1:9:22 | [ExportDeclaration] export ... e N {;} | semmle.label | [ExportDeclaration] export ... e N {;} |
-| type_definition_objects.ts:9:1:9:22 | [ExportDeclaration] export ... e N {;} | semmle.order | 102 |
+| type_definition_objects.ts:9:1:9:22 | [ExportDeclaration] export ... e N {;} | semmle.order | 103 |
 | type_definition_objects.ts:9:8:9:22 | [NamespaceDeclaration] namespace N {;} | semmle.label | [NamespaceDeclaration] namespace N {;} |
 | type_definition_objects.ts:9:18:9:18 | [VarDecl] N | semmle.label | [VarDecl] N |
 | type_definition_objects.ts:9:21:9:21 | [EmptyStmt] ; | semmle.label | [EmptyStmt] ; |
 | type_definition_objects.ts:10:1:10:21 | [DeclStmt] let namespaceObj = ... | semmle.label | [DeclStmt] let namespaceObj = ... |
-| type_definition_objects.ts:10:1:10:21 | [DeclStmt] let namespaceObj = ... | semmle.order | 103 |
+| type_definition_objects.ts:10:1:10:21 | [DeclStmt] let namespaceObj = ... | semmle.order | 104 |
 | type_definition_objects.ts:10:5:10:16 | [VarDecl] namespaceObj | semmle.label | [VarDecl] namespaceObj |
 | type_definition_objects.ts:10:5:10:20 | [VariableDeclarator] namespaceObj = N | semmle.label | [VariableDeclarator] namespaceObj = N |
 | type_definition_objects.ts:10:20:10:20 | [VarRef] N | semmle.label | [VarRef] N |
 | type_definitions.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.label | [ImportDeclaration] import ... dummy"; |
-| type_definitions.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.order | 104 |
+| type_definitions.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.order | 105 |
 | type_definitions.ts:1:8:1:17 | [ImportSpecifier] * as dummy | semmle.label | [ImportSpecifier] * as dummy |
 | type_definitions.ts:1:13:1:17 | [VarDecl] dummy | semmle.label | [VarDecl] dummy |
 | type_definitions.ts:1:24:1:32 | [Literal] "./dummy" | semmle.label | [Literal] "./dummy" |
 | type_definitions.ts:3:1:5:1 | [InterfaceDeclaration,TypeDefinition] interfa ... x: S; } | semmle.label | [InterfaceDeclaration,TypeDefinition] interfa ... x: S; } |
-| type_definitions.ts:3:1:5:1 | [InterfaceDeclaration,TypeDefinition] interfa ... x: S; } | semmle.order | 105 |
+| type_definitions.ts:3:1:5:1 | [InterfaceDeclaration,TypeDefinition] interfa ... x: S; } | semmle.order | 106 |
 | type_definitions.ts:3:11:3:11 | [Identifier] I | semmle.label | [Identifier] I |
 | type_definitions.ts:3:13:3:13 | [Identifier] S | semmle.label | [Identifier] S |
 | type_definitions.ts:3:13:3:13 | [TypeParameter] S | semmle.label | [TypeParameter] S |
@@ -1582,14 +1625,14 @@ nodes
 | type_definitions.ts:4:3:4:7 | [FieldDeclaration] x: S; | semmle.label | [FieldDeclaration] x: S; |
 | type_definitions.ts:4:6:4:6 | [LocalTypeAccess] S | semmle.label | [LocalTypeAccess] S |
 | type_definitions.ts:6:1:6:16 | [DeclStmt] let i = ... | semmle.label | [DeclStmt] let i = ... |
-| type_definitions.ts:6:1:6:16 | [DeclStmt] let i = ... | semmle.order | 106 |
+| type_definitions.ts:6:1:6:16 | [DeclStmt] let i = ... | semmle.order | 107 |
 | type_definitions.ts:6:5:6:5 | [VarDecl] i | semmle.label | [VarDecl] i |
 | type_definitions.ts:6:5:6:16 | [VariableDeclarator] i: I<number> | semmle.label | [VariableDeclarator] i: I<number> |
 | type_definitions.ts:6:8:6:8 | [LocalTypeAccess] I | semmle.label | [LocalTypeAccess] I |
 | type_definitions.ts:6:8:6:16 | [GenericTypeExpr] I<number> | semmle.label | [GenericTypeExpr] I<number> |
 | type_definitions.ts:6:10:6:15 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
 | type_definitions.ts:8:1:10:1 | [ClassDefinition,TypeDefinition] class C ... x: T } | semmle.label | [ClassDefinition,TypeDefinition] class C ... x: T } |
-| type_definitions.ts:8:1:10:1 | [ClassDefinition,TypeDefinition] class C ... x: T } | semmle.order | 107 |
+| type_definitions.ts:8:1:10:1 | [ClassDefinition,TypeDefinition] class C ... x: T } | semmle.order | 108 |
 | type_definitions.ts:8:7:8:7 | [VarDecl] C | semmle.label | [VarDecl] C |
 | type_definitions.ts:8:8:8:7 | [BlockStmt] {} | semmle.label | [BlockStmt] {} |
 | type_definitions.ts:8:8:8:7 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | semmle.label | [ClassInitializedMember,ConstructorDefinition] constructor() {} |
@@ -1601,14 +1644,14 @@ nodes
 | type_definitions.ts:9:3:9:6 | [FieldDeclaration] x: T | semmle.label | [FieldDeclaration] x: T |
 | type_definitions.ts:9:6:9:6 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
 | type_definitions.ts:11:1:11:17 | [DeclStmt] let c = ... | semmle.label | [DeclStmt] let c = ... |
-| type_definitions.ts:11:1:11:17 | [DeclStmt] let c = ... | semmle.order | 108 |
+| type_definitions.ts:11:1:11:17 | [DeclStmt] let c = ... | semmle.order | 109 |
 | type_definitions.ts:11:5:11:5 | [VarDecl] c | semmle.label | [VarDecl] c |
 | type_definitions.ts:11:5:11:16 | [VariableDeclarator] c: C<number> | semmle.label | [VariableDeclarator] c: C<number> |
 | type_definitions.ts:11:8:11:8 | [LocalTypeAccess] C | semmle.label | [LocalTypeAccess] C |
 | type_definitions.ts:11:8:11:16 | [GenericTypeExpr] C<number> | semmle.label | [GenericTypeExpr] C<number> |
 | type_definitions.ts:11:10:11:15 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
 | type_definitions.ts:13:1:15:1 | [EnumDeclaration,TypeDefinition] enum Co ... blue } | semmle.label | [EnumDeclaration,TypeDefinition] enum Co ... blue } |
-| type_definitions.ts:13:1:15:1 | [EnumDeclaration,TypeDefinition] enum Co ... blue } | semmle.order | 109 |
+| type_definitions.ts:13:1:15:1 | [EnumDeclaration,TypeDefinition] enum Co ... blue } | semmle.order | 110 |
 | type_definitions.ts:13:6:13:10 | [VarDecl] Color | semmle.label | [VarDecl] Color |
 | type_definitions.ts:14:3:14:5 | [EnumMember,TypeDefinition] red | semmle.label | [EnumMember,TypeDefinition] red |
 | type_definitions.ts:14:3:14:5 | [VarDecl] red | semmle.label | [VarDecl] red |
@@ -1617,29 +1660,29 @@ nodes
 | type_definitions.ts:14:15:14:18 | [EnumMember,TypeDefinition] blue | semmle.label | [EnumMember,TypeDefinition] blue |
 | type_definitions.ts:14:15:14:18 | [VarDecl] blue | semmle.label | [VarDecl] blue |
 | type_definitions.ts:16:1:16:17 | [DeclStmt] let color = ... | semmle.label | [DeclStmt] let color = ... |
-| type_definitions.ts:16:1:16:17 | [DeclStmt] let color = ... | semmle.order | 110 |
+| type_definitions.ts:16:1:16:17 | [DeclStmt] let color = ... | semmle.order | 111 |
 | type_definitions.ts:16:5:16:9 | [VarDecl] color | semmle.label | [VarDecl] color |
 | type_definitions.ts:16:5:16:16 | [VariableDeclarator] color: Color | semmle.label | [VariableDeclarator] color: Color |
 | type_definitions.ts:16:12:16:16 | [LocalTypeAccess] Color | semmle.label | [LocalTypeAccess] Color |
 | type_definitions.ts:18:1:18:33 | [EnumDeclaration,TypeDefinition] enum En ... ember } | semmle.label | [EnumDeclaration,TypeDefinition] enum En ... ember } |
-| type_definitions.ts:18:1:18:33 | [EnumDeclaration,TypeDefinition] enum En ... ember } | semmle.order | 111 |
+| type_definitions.ts:18:1:18:33 | [EnumDeclaration,TypeDefinition] enum En ... ember } | semmle.order | 112 |
 | type_definitions.ts:18:6:18:22 | [VarDecl] EnumWithOneMember | semmle.label | [VarDecl] EnumWithOneMember |
 | type_definitions.ts:18:26:18:31 | [EnumMember,TypeDefinition] member | semmle.label | [EnumMember,TypeDefinition] member |
 | type_definitions.ts:18:26:18:31 | [VarDecl] member | semmle.label | [VarDecl] member |
 | type_definitions.ts:19:1:19:25 | [DeclStmt] let e = ... | semmle.label | [DeclStmt] let e = ... |
-| type_definitions.ts:19:1:19:25 | [DeclStmt] let e = ... | semmle.order | 112 |
+| type_definitions.ts:19:1:19:25 | [DeclStmt] let e = ... | semmle.order | 113 |
 | type_definitions.ts:19:5:19:5 | [VarDecl] e | semmle.label | [VarDecl] e |
 | type_definitions.ts:19:5:19:24 | [VariableDeclarator] e: EnumWithOneMember | semmle.label | [VariableDeclarator] e: EnumWithOneMember |
 | type_definitions.ts:19:8:19:24 | [LocalTypeAccess] EnumWithOneMember | semmle.label | [LocalTypeAccess] EnumWithOneMember |
 | type_definitions.ts:21:1:21:20 | [TypeAliasDeclaration,TypeDefinition] type Alias<T> = T[]; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Alias<T> = T[]; |
-| type_definitions.ts:21:1:21:20 | [TypeAliasDeclaration,TypeDefinition] type Alias<T> = T[]; | semmle.order | 113 |
+| type_definitions.ts:21:1:21:20 | [TypeAliasDeclaration,TypeDefinition] type Alias<T> = T[]; | semmle.order | 114 |
 | type_definitions.ts:21:6:21:10 | [Identifier] Alias | semmle.label | [Identifier] Alias |
 | type_definitions.ts:21:12:21:12 | [Identifier] T | semmle.label | [Identifier] T |
 | type_definitions.ts:21:12:21:12 | [TypeParameter] T | semmle.label | [TypeParameter] T |
 | type_definitions.ts:21:17:21:17 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
 | type_definitions.ts:21:17:21:19 | [ArrayTypeExpr] T[] | semmle.label | [ArrayTypeExpr] T[] |
 | type_definitions.ts:22:1:22:39 | [DeclStmt] let aliasForNumberArray = ... | semmle.label | [DeclStmt] let aliasForNumberArray = ... |
-| type_definitions.ts:22:1:22:39 | [DeclStmt] let aliasForNumberArray = ... | semmle.order | 114 |
+| type_definitions.ts:22:1:22:39 | [DeclStmt] let aliasForNumberArray = ... | semmle.order | 115 |
 | type_definitions.ts:22:5:22:23 | [VarDecl] aliasForNumberArray | semmle.label | [VarDecl] aliasForNumberArray |
 | type_definitions.ts:22:5:22:38 | [VariableDeclarator] aliasFo ... number> | semmle.label | [VariableDeclarator] aliasFo ... number> |
 | type_definitions.ts:22:26:22:30 | [LocalTypeAccess] Alias | semmle.label | [LocalTypeAccess] Alias |
@@ -1794,6 +1837,10 @@ edges
 | file://:0:0:0:0 | (Arguments) | tst.ts:370:13:370:28 | [MethodCallExpr] A.resolvedFile() | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | tst.ts:374:13:374:28 | [MethodCallExpr] B.resolvedFile() | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | tst.ts:374:13:374:28 | [MethodCallExpr] B.resolvedFile() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | semmle.order | 1 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:14:17:14:17 | [SimpleParameter] x | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:14:17:14:17 | [SimpleParameter] x | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:14:28:14:28 | [SimpleParameter] y | semmle.label | 1 |
@@ -1866,6 +1913,10 @@ edges
 | file://:0:0:0:0 | (Parameters) | tst.ts:344:9:344:13 | [SimpleParameter] value | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:349:9:349:13 | [SimpleParameter] value | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:349:9:349:13 | [SimpleParameter] value | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:383:40:383:40 | [SimpleParameter] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:383:40:383:40 | [SimpleParameter] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:383:46:383:46 | [SimpleParameter] y | semmle.label | 1 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:383:46:383:46 | [SimpleParameter] y | semmle.order | 1 |
 | file://:0:0:0:0 | (Parameters) | type_alias.ts:14:10:14:17 | [SimpleParameter] property | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | type_alias.ts:14:10:14:17 | [SimpleParameter] property | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | type_alias.ts:21:19:21:21 | [SimpleParameter] key | semmle.label | 0 |
@@ -1884,6 +1935,10 @@ edges
 | file://:0:0:0:0 | (TypeParameters) | tst.ts:332:20:332:35 | [TypeParameter] S extends string | semmle.order | 0 |
 | file://:0:0:0:0 | (TypeParameters) | tst.ts:342:17:342:24 | [TypeParameter] in out T | semmle.label | 0 |
 | file://:0:0:0:0 | (TypeParameters) | tst.ts:342:17:342:24 | [TypeParameter] in out T | semmle.order | 0 |
+| file://:0:0:0:0 | (TypeParameters) | tst.ts:381:43:381:58 | [TypeParameter] U extends number | semmle.label | 0 |
+| file://:0:0:0:0 | (TypeParameters) | tst.ts:381:43:381:58 | [TypeParameter] U extends number | semmle.order | 0 |
+| file://:0:0:0:0 | (TypeParameters) | tst.ts:383:37:383:37 | [TypeParameter] T | semmle.label | 0 |
+| file://:0:0:0:0 | (TypeParameters) | tst.ts:383:37:383:37 | [TypeParameter] T | semmle.order | 0 |
 | file://:0:0:0:0 | (TypeParameters) | type_alias.ts:5:19:5:19 | [TypeParameter] T | semmle.label | 0 |
 | file://:0:0:0:0 | (TypeParameters) | type_alias.ts:5:19:5:19 | [TypeParameter] T | semmle.order | 0 |
 | file://:0:0:0:0 | (TypeParameters) | type_definitions.ts:3:13:3:13 | [TypeParameter] S | semmle.label | 0 |
@@ -4078,6 +4133,76 @@ edges
 | tst.ts:374:13:374:26 | [DotExpr] B.resolvedFile | tst.ts:374:15:374:26 | [Label] resolvedFile | semmle.order | 2 |
 | tst.ts:374:13:374:28 | [MethodCallExpr] B.resolvedFile() | tst.ts:374:13:374:26 | [DotExpr] B.resolvedFile | semmle.label | 0 |
 | tst.ts:374:13:374:28 | [MethodCallExpr] B.resolvedFile() | tst.ts:374:13:374:26 | [DotExpr] B.resolvedFile | semmle.order | 0 |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | tst.ts:379:8:379:11 | [VarDecl] TS48 | semmle.label | 1 |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | tst.ts:379:8:379:11 | [VarDecl] TS48 | semmle.order | 1 |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | tst.ts:381:5:381:73 | [TypeAliasDeclaration,TypeDefinition] type So ... never; | semmle.label | 2 |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | tst.ts:381:5:381:73 | [TypeAliasDeclaration,TypeDefinition] type So ... never; | semmle.order | 2 |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | semmle.label | 3 |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | semmle.order | 3 |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | tst.ts:385:5:385:74 | [DeclStmt] let [a, ... ye!"]); | semmle.label | 4 |
+| tst.ts:379:1:386:1 | [NamespaceDeclaration] module ... ; } | tst.ts:385:5:385:74 | [DeclStmt] let [a, ... ye!"]); | semmle.order | 4 |
+| tst.ts:381:5:381:73 | [TypeAliasDeclaration,TypeDefinition] type So ... never; | tst.ts:381:10:381:16 | [Identifier] SomeNum | semmle.label | 1 |
+| tst.ts:381:5:381:73 | [TypeAliasDeclaration,TypeDefinition] type So ... never; | tst.ts:381:10:381:16 | [Identifier] SomeNum | semmle.order | 1 |
+| tst.ts:381:5:381:73 | [TypeAliasDeclaration,TypeDefinition] type So ... never; | tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | semmle.label | 2 |
+| tst.ts:381:5:381:73 | [TypeAliasDeclaration,TypeDefinition] type So ... never; | tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | semmle.order | 2 |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | tst.ts:381:20:381:24 | [LiteralTypeExpr] "100" | semmle.label | 1 |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | tst.ts:381:20:381:24 | [LiteralTypeExpr] "100" | semmle.order | 1 |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | tst.ts:381:34:381:60 | [TemplateLiteralTypeExpr] `${infe ... umber}` | semmle.label | 2 |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | tst.ts:381:34:381:60 | [TemplateLiteralTypeExpr] `${infe ... umber}` | semmle.order | 2 |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | tst.ts:381:64:381:64 | [LocalTypeAccess] U | semmle.label | 3 |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | tst.ts:381:64:381:64 | [LocalTypeAccess] U | semmle.order | 3 |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | tst.ts:381:68:381:72 | [KeywordTypeExpr] never | semmle.label | 4 |
+| tst.ts:381:20:381:72 | [ConditionalTypeExpr] "100" e ... : never | tst.ts:381:68:381:72 | [KeywordTypeExpr] never | semmle.order | 4 |
+| tst.ts:381:34:381:60 | [TemplateLiteralTypeExpr] `${infe ... umber}` | tst.ts:381:37:381:58 | [InferTypeExpr] infer U ... number | semmle.label | 1 |
+| tst.ts:381:34:381:60 | [TemplateLiteralTypeExpr] `${infe ... umber}` | tst.ts:381:37:381:58 | [InferTypeExpr] infer U ... number | semmle.order | 1 |
+| tst.ts:381:37:381:58 | [InferTypeExpr] infer U ... number | file://:0:0:0:0 | (TypeParameters) | semmle.label | -100 |
+| tst.ts:381:37:381:58 | [InferTypeExpr] infer U ... number | file://:0:0:0:0 | (TypeParameters) | semmle.order | -100 |
+| tst.ts:381:43:381:58 | [TypeParameter] U extends number | tst.ts:381:43:381:43 | [Identifier] U | semmle.label | 1 |
+| tst.ts:381:43:381:58 | [TypeParameter] U extends number | tst.ts:381:43:381:43 | [Identifier] U | semmle.order | 1 |
+| tst.ts:381:43:381:58 | [TypeParameter] U extends number | tst.ts:381:53:381:58 | [KeywordTypeExpr] number | semmle.label | 2 |
+| tst.ts:381:43:381:58 | [TypeParameter] U extends number | tst.ts:381:53:381:58 | [KeywordTypeExpr] number | semmle.order | 2 |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | file://:0:0:0:0 | (TypeParameters) | semmle.label | 2 |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | file://:0:0:0:0 | (TypeParameters) | semmle.order | 2 |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | tst.ts:383:22:383:35 | [VarDecl] chooseRandomly | semmle.label | 0 |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | tst.ts:383:22:383:35 | [VarDecl] chooseRandomly | semmle.order | 0 |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | tst.ts:383:53:383:53 | [LocalTypeAccess] T | semmle.label | 4 |
+| tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | tst.ts:383:53:383:53 | [LocalTypeAccess] T | semmle.order | 4 |
+| tst.ts:383:37:383:37 | [TypeParameter] T | tst.ts:383:37:383:37 | [Identifier] T | semmle.label | 1 |
+| tst.ts:383:37:383:37 | [TypeParameter] T | tst.ts:383:37:383:37 | [Identifier] T | semmle.order | 1 |
+| tst.ts:383:40:383:40 | [SimpleParameter] x | tst.ts:383:43:383:43 | [LocalTypeAccess] T | semmle.label | 0 |
+| tst.ts:383:40:383:40 | [SimpleParameter] x | tst.ts:383:43:383:43 | [LocalTypeAccess] T | semmle.order | 0 |
+| tst.ts:383:46:383:46 | [SimpleParameter] y | tst.ts:383:49:383:49 | [LocalTypeAccess] T | semmle.label | 0 |
+| tst.ts:383:46:383:46 | [SimpleParameter] y | tst.ts:383:49:383:49 | [LocalTypeAccess] T | semmle.order | 0 |
+| tst.ts:385:5:385:74 | [DeclStmt] let [a, ... ye!"]); | tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | semmle.label | 1 |
+| tst.ts:385:5:385:74 | [DeclStmt] let [a, ... ye!"]); | tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | semmle.order | 1 |
+| tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | tst.ts:385:10:385:10 | [VarDecl] a | semmle.label | 1 |
+| tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | tst.ts:385:10:385:10 | [VarDecl] a | semmle.order | 1 |
+| tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | tst.ts:385:13:385:13 | [VarDecl] b | semmle.label | 2 |
+| tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | tst.ts:385:13:385:13 | [VarDecl] b | semmle.order | 2 |
+| tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | tst.ts:385:16:385:16 | [VarDecl] c | semmle.label | 3 |
+| tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | tst.ts:385:16:385:16 | [VarDecl] c | semmle.order | 3 |
+| tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | semmle.label | 1 |
+| tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | semmle.order | 1 |
+| tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | tst.ts:385:21:385:73 | [CallExpr] chooseR ... bye!"]) | semmle.label | 2 |
+| tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | tst.ts:385:21:385:73 | [CallExpr] chooseR ... bye!"]) | semmle.order | 2 |
+| tst.ts:385:21:385:73 | [CallExpr] chooseR ... bye!"]) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| tst.ts:385:21:385:73 | [CallExpr] chooseR ... bye!"]) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| tst.ts:385:21:385:73 | [CallExpr] chooseR ... bye!"]) | tst.ts:385:21:385:34 | [VarRef] chooseRandomly | semmle.label | 0 |
+| tst.ts:385:21:385:73 | [CallExpr] chooseR ... bye!"]) | tst.ts:385:21:385:34 | [VarRef] chooseRandomly | semmle.order | 0 |
+| tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | tst.ts:385:37:385:38 | [Literal] 42 | semmle.label | 1 |
+| tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | tst.ts:385:37:385:38 | [Literal] 42 | semmle.order | 1 |
+| tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | tst.ts:385:41:385:44 | [Literal] true | semmle.label | 2 |
+| tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | tst.ts:385:41:385:44 | [Literal] true | semmle.order | 2 |
+| tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | tst.ts:385:47:385:51 | [Literal] "hi!" | semmle.label | 3 |
+| tst.ts:385:36:385:52 | [ArrayExpr] [42, true, "hi!"] | tst.ts:385:47:385:51 | [Literal] "hi!" | semmle.order | 3 |
+| tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | tst.ts:385:56:385:56 | [Literal] 0 | semmle.label | 1 |
+| tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | tst.ts:385:56:385:56 | [Literal] 0 | semmle.order | 1 |
+| tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | tst.ts:385:59:385:63 | [Literal] false | semmle.label | 2 |
+| tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | tst.ts:385:59:385:63 | [Literal] false | semmle.order | 2 |
+| tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | tst.ts:385:66:385:71 | [Literal] "bye!" | semmle.label | 3 |
+| tst.ts:385:55:385:72 | [ArrayExpr] [0, false, "bye!"] | tst.ts:385:66:385:71 | [Literal] "bye!" | semmle.order | 3 |
 | tstModuleCJS.cts:1:1:3:1 | [ExportDeclaration] export ... 'b'; } | tstModuleCJS.cts:1:8:3:1 | [FunctionDeclStmt] functio ... 'b'; } | semmle.label | 1 |
 | tstModuleCJS.cts:1:1:3:1 | [ExportDeclaration] export ... 'b'; } | tstModuleCJS.cts:1:8:3:1 | [FunctionDeclStmt] functio ... 'b'; } | semmle.order | 1 |
 | tstModuleCJS.cts:1:8:3:1 | [FunctionDeclStmt] functio ... 'b'; } | tstModuleCJS.cts:1:17:1:28 | [VarDecl] tstModuleCJS | semmle.label | 0 |

--- a/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
@@ -441,7 +441,7 @@ getExprType
 | tst.ts:320:19:320:29 | toLowerCase | () => string |
 | tst.ts:325:7:325:14 | ErrorMap | { new (entries?: readonly (readonly [string, Er... |
 | tst.ts:325:18:325:20 | Map | MapConstructor |
-| tst.ts:325:18:325:35 | Map<string, Error> | any |
+| tst.ts:325:18:325:35 | Map<string, Error> | { new (entries?: readonly (readonly [string, Er... |
 | tst.ts:327:7:327:14 | errorMap | Map<string, Error> |
 | tst.ts:327:18:327:31 | new ErrorMap() | Map<string, Error> |
 | tst.ts:327:22:327:29 | ErrorMap | { new (entries?: readonly (readonly [string, Er... |
@@ -502,6 +502,23 @@ getExprType
 | tst.ts:374:13:374:26 | B.resolvedFile | () => "tstSuffixB.ios.ts" |
 | tst.ts:374:13:374:28 | B.resolvedFile() | "tstSuffixB.ios.ts" |
 | tst.ts:374:15:374:26 | resolvedFile | () => "tstSuffixB.ios.ts" |
+| tst.ts:379:8:379:11 | TS48 | typeof TS48 in library-tests/TypeScript/Types/tst.ts |
+| tst.ts:383:22:383:35 | chooseRandomly | <T>(x: T, y: T) => T |
+| tst.ts:383:40:383:40 | x | T |
+| tst.ts:383:46:383:46 | y | T |
+| tst.ts:385:10:385:10 | a | number |
+| tst.ts:385:13:385:13 | b | boolean |
+| tst.ts:385:16:385:16 | c | string |
+| tst.ts:385:21:385:34 | chooseRandomly | <T>(x: T, y: T) => T |
+| tst.ts:385:21:385:73 | chooseR ... bye!"]) | [number, boolean, string] |
+| tst.ts:385:36:385:52 | [42, true, "hi!"] | [number, boolean, string] |
+| tst.ts:385:37:385:38 | 42 | 42 |
+| tst.ts:385:41:385:44 | true | true |
+| tst.ts:385:47:385:51 | "hi!" | "hi!" |
+| tst.ts:385:55:385:72 | [0, false, "bye!"] | [number, boolean, string] |
+| tst.ts:385:56:385:56 | 0 | 0 |
+| tst.ts:385:59:385:63 | false | false |
+| tst.ts:385:66:385:71 | "bye!" | "bye!" |
 | tstModuleCJS.cts:1:17:1:28 | tstModuleCJS | () => "a" \| "b" |
 | tstModuleCJS.cts:2:12:2:15 | Math | Math |
 | tstModuleCJS.cts:2:12:2:22 | Math.random | () => number |
@@ -606,6 +623,7 @@ getTypeDefinitionType
 | tst.ts:331:1:334:14 | type Fi ...  never; | FirstString<T> |
 | tst.ts:336:1:336:51 | type F  ... lean]>; | "a" \| "b" |
 | tst.ts:342:1:345:1 | interfa ... void;\\n} | State<T> |
+| tst.ts:381:5:381:73 | type So ...  never; | 100 |
 | type_alias.ts:1:1:1:17 | type B = boolean; | boolean |
 | type_alias.ts:5:1:5:50 | type Va ... ay<T>>; | ValueOrArray<T> |
 | type_alias.ts:9:1:15:13 | type Js ... Json[]; | Json |
@@ -881,6 +899,12 @@ getTypeExprType
 | tst.ts:347:14:347:18 | State | State<T> |
 | tst.ts:347:14:347:26 | State<number> | State<number> |
 | tst.ts:347:20:347:25 | number | number |
+| tst.ts:381:10:381:16 | SomeNum | 100 |
+| tst.ts:381:20:381:72 | "100" e ... : never | 100 |
+| tst.ts:383:37:383:37 | T | T |
+| tst.ts:383:43:383:43 | T | T |
+| tst.ts:383:49:383:49 | T | T |
+| tst.ts:383:53:383:53 | T | T |
 | tstModuleCJS.cts:1:33:1:35 | 'a' | "a" |
 | tstModuleCJS.cts:1:33:1:41 | 'a' \| 'b' | "a" \| "b" |
 | tstModuleCJS.cts:1:39:1:41 | 'b' | "b" |
@@ -1027,6 +1051,15 @@ tupleTypes
 | tst.ts:42:25:42:30 | [1, 2] | readonly [1, 2] | 1 | 2 | 2 | no-rest |
 | tst.ts:42:25:42:39 | [1, 2] as const | readonly [1, 2] | 0 | 1 | 2 | no-rest |
 | tst.ts:42:25:42:39 | [1, 2] as const | readonly [1, 2] | 1 | 2 | 2 | no-rest |
+| tst.ts:385:21:385:73 | chooseR ... bye!"]) | [number, boolean, string] | 0 | number | 3 | no-rest |
+| tst.ts:385:21:385:73 | chooseR ... bye!"]) | [number, boolean, string] | 1 | boolean | 3 | no-rest |
+| tst.ts:385:21:385:73 | chooseR ... bye!"]) | [number, boolean, string] | 2 | string | 3 | no-rest |
+| tst.ts:385:36:385:52 | [42, true, "hi!"] | [number, boolean, string] | 0 | number | 3 | no-rest |
+| tst.ts:385:36:385:52 | [42, true, "hi!"] | [number, boolean, string] | 1 | boolean | 3 | no-rest |
+| tst.ts:385:36:385:52 | [42, true, "hi!"] | [number, boolean, string] | 2 | string | 3 | no-rest |
+| tst.ts:385:55:385:72 | [0, false, "bye!"] | [number, boolean, string] | 0 | number | 3 | no-rest |
+| tst.ts:385:55:385:72 | [0, false, "bye!"] | [number, boolean, string] | 1 | boolean | 3 | no-rest |
+| tst.ts:385:55:385:72 | [0, false, "bye!"] | [number, boolean, string] | 2 | string | 3 | no-rest |
 unknownType
 | tst.ts:40:5:40:15 | unknownType | unknown |
 | tst.ts:47:8:47:8 | e | unknown |

--- a/javascript/ql/test/library-tests/TypeScript/Types/tst.ts
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tst.ts
@@ -373,3 +373,14 @@ import * as B from './tstSuffixB';
 
 console.log(B.resolvedFile()); // <- 'tstSuffixB.ios.ts'
 
+
+/////////////////
+
+module TS48 {
+    // SomeNum used to be 'number'; now it's '100'.
+    type SomeNum = "100" extends `${infer U extends number}` ? U : never;
+
+    declare function chooseRandomly<T>(x: T, y: T): T;
+
+    let [a, b, c] = chooseRandomly([42, true, "hi!"], [0, false, "bye!"]);    
+}


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-4-8

The most tricky part was [a change to the syntax tree representation](https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees).   
The `modifiers` property that we rely on in `TypeScriptASTConverter.java` might disappear at a later time.  
The fix at that point will be to use `ts.canHaveModifiers()` and `ts.getModifiers()`.   

TypeScript changed how illegal decorators are stored between 4.8.1-RC and 4.8.2 ([this PR](https://github.com/microsoft/TypeScript/pull/50343)). So I had to fix that.  

Otherwise it was an uneventful update.  
There's not much new, and what's new doesn't affect us, except that we get slightly more precise types from TypeScript.

Evaluation will appear [here](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/ts48__typescript-full__code-scanning__1/reports). 