### PR TITLE
Kotlin: Remove a cast from substituteTypeAndArguments

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/utils/TypeSubstitution.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/TypeSubstitution.kt
@@ -123,14 +123,17 @@ private fun IrTypeArgument.lowerBound(context: IrPluginContext) =
 
 fun IrType.substituteTypeAndArguments(substitutionMap: Map<IrTypeParameterSymbol, IrTypeArgument>?, useContext: KotlinUsesExtractor.TypeContext, pluginContext: IrPluginContext): IrType =
     substitutionMap?.let { substMap ->
-        this.classifierOrNull?.let { typeClassifier ->
+        if (this is IrSimpleType) {
+            val typeClassifier = this.classifier
             substMap[typeClassifier]?.let {
                 when(useContext) {
                     KotlinUsesExtractor.TypeContext.RETURN -> it.upperBound(pluginContext)
                     else -> it.lowerBound(pluginContext)
                 }
-            } ?: (this as IrSimpleType).substituteTypeArguments(substMap)
-        } ?: this
+            } ?: this.substituteTypeArguments(substMap)
+        } else {
+            this
+        }
     } ?: this
 
 object RawTypeAnnotation {


### PR DESCRIPTION
It looks like it was safe, but it was hard to see why, and may become unsafe following future kotlinc changes.

`classifierOrNull` is defined as
```
val IrType.classifierOrNull: IrClassifierSymbol?
    get() = when (this) {
        is IrSimpleType -> classifier
        else -> null
    }
```
so this is behaviour-preserving.
