### PR TITLE
JS: Enable type extraction inside conditional types again

### DIFF
--- a/javascript/extractor/lib/typescript/src/ast_extractor.ts
+++ b/javascript/extractor/lib/typescript/src/ast_extractor.ts
@@ -168,20 +168,9 @@ export function augmentAst(ast: AugmentedSourceFile, code: string, project: Proj
         }
     }
 
-    // Number of conditional type expressions the visitor is currently inside.
-    // We disable type extraction inside such type expressions, to avoid complications
-    // with `infer` types.
-    let insideConditionalTypes = 0;
-
     visitAstNode(ast);
     function visitAstNode(node: AugmentedNode) {
-        if (node.kind === ts.SyntaxKind.ConditionalType) {
-            ++insideConditionalTypes;
-        }
         ts.forEachChild(node, visitAstNode);
-        if (node.kind === ts.SyntaxKind.ConditionalType) {
-            --insideConditionalTypes;
-        }
 
         // fill in line/column info
         if ("pos" in node) {
@@ -202,7 +191,7 @@ export function augmentAst(ast: AugmentedSourceFile, code: string, project: Proj
             }
         }
 
-        if (typeChecker != null && insideConditionalTypes === 0) {
+        if (typeChecker != null) {
             if (isTypedNode(node)) {
                 let contextualType = isContextuallyTypedNode(node)
                     ? typeChecker.getContextualType(node)

--- a/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
@@ -861,6 +861,16 @@ getTypeExprType
 | tst.ts:325:30:325:34 | Error | Error |
 | tst.ts:331:6:331:16 | FirstString | FirstString<T> |
 | tst.ts:331:18:331:18 | T | T |
+| tst.ts:332:3:332:3 | T | T |
+| tst.ts:332:13:332:50 | [infer  ... nown[]] | [S, ...unknown[]] |
+| tst.ts:332:14:332:35 | infer S ...  string | S |
+| tst.ts:332:20:332:20 | S | S |
+| tst.ts:332:30:332:35 | string | string |
+| tst.ts:332:38:332:49 | ...unknown[] | unknown |
+| tst.ts:332:41:332:47 | unknown | unknown |
+| tst.ts:332:41:332:49 | unknown[] | unknown[] |
+| tst.ts:333:9:333:9 | S | S |
+| tst.ts:334:9:334:13 | never | never |
 | tst.ts:336:6:336:6 | F | "a" \| "b" |
 | tst.ts:336:10:336:20 | FirstString | FirstString<T> |
 | tst.ts:336:10:336:50 | FirstSt ... olean]> | "a" \| "b" |


### PR DESCRIPTION
This re-enables type extraction inside conditional types, i.e. types of form `X extends Y ? A : B`, which are relevant for extracting MaD typings from `.d.ts` files.

This was originally disabled in https://github.com/github/codeql/pull/1295 to avoid divergence issues when extracting the type property graph. However, in https://github.com/github/codeql/pull/3781 we stopped extracting the type property graph entirely, so the previous mitigation should no longer be needed.

I verified that [this code](https://github.com/GoogleChromeLabs/comlink/blob/41eb437b877ce943b7e41636f7ce555b59c1d3a5/dist/comlink.d.ts#L63), which originally caused problems, still works after this change. [Evaluation](https://github.com/github/codeql-dca-main/issues/6483) also looks fine.

