### PR TITLE
Support type variables in MaD typings

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -395,7 +395,7 @@ private API::Node getNodeFromPath(string package, string type, AccessPath path, 
   result =
     getNodeFromSubPath(getNodeFromPath(package, type, path, n - 1), getSubPathAt(path, n - 1))
   or
-  // Apply a receiver step
+  // Apply a type step
   typeStep(getNodeFromPath(package, type, path, n), result)
 }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -253,7 +253,7 @@ private predicate isRelevantPackage(string package) {
     sourceModel(package, _, _, _) or
     sinkModel(package, _, _, _) or
     summaryModel(package, _, _, _, _, _) or
-    typeModel(package, _, _, _, _)
+    typeModel(_, _, package, _, _)
   ) and
   (
     Specific::isPackageUsed(package)

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -436,6 +436,8 @@ private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath, int n) 
   or
   result =
     getNodeFromSubPath(getNodeFromSubPath(base, subPath, n - 1), getSubPathAt(subPath, n - 1))
+  or
+  typeStep(getNodeFromSubPath(base, subPath, n), result)
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -155,6 +155,22 @@ module ModelInput {
      */
     abstract predicate row(string row);
   }
+
+  /**
+   * A unit class for adding additional type variable model rows.
+   */
+  class TypeVariableModelCsv extends Unit {
+    /**
+     * Holds if `row` specifies a path through a type variable.
+     *
+     * A row of form,
+     * ```
+     * name;path
+     * ```
+     * means `path` can be substituted for a token `TypeVar[name]`.
+     */
+    abstract predicate row(string row);
+  }
 }
 
 private import ModelInput
@@ -181,6 +197,8 @@ private predicate sinkModel(string row) { any(SinkModelCsv s).row(inversePad(row
 private predicate summaryModel(string row) { any(SummaryModelCsv s).row(inversePad(row)) }
 
 private predicate typeModel(string row) { any(TypeModelCsv s).row(inversePad(row)) }
+
+private predicate typeVariableModel(string row) { any(TypeVariableModelCsv s).row(inversePad(row)) }
 
 /** Holds if a source model exists for the given parameters. */
 predicate sourceModel(string package, string type, string path, string kind) {
@@ -219,7 +237,7 @@ private predicate summaryModel(
   )
 }
 
-/** Holds if an type model exists for the given parameters. */
+/** Holds if a type model exists for the given parameters. */
 private predicate typeModel(
   string package1, string type1, string package2, string type2, string path
 ) {
@@ -230,6 +248,15 @@ private predicate typeModel(
     row.splitAt(";", 2) = package2 and
     row.splitAt(";", 3) = type2 and
     row.splitAt(";", 4) = path
+  )
+}
+
+/** Holds if a type variable model exists for the given parameters. */
+private predicate typeVariableModel(string name, string path) {
+  exists(string row |
+    typeVariableModel(row) and
+    row.splitAt(";", 0) = name and
+    row.splitAt(";", 1) = path
   )
 }
 
@@ -290,6 +317,8 @@ private class AccessPathRange extends AccessPath::Range {
       summaryModel(package, _, _, this, _, _) or
       summaryModel(package, _, _, _, this, _)
     )
+    or
+    typeVariableModel(_, this)
   }
 }
 
@@ -361,6 +390,60 @@ private API::Node getNodeFromPath(string package, string type, AccessPath path, 
   // Similar to the other recursive case, but where the path may have stepped through one or more call-site filters
   result =
     getSuccessorFromInvoke(getInvocationFromPath(package, type, path, n - 1), path.getToken(n - 1))
+  or
+  // Apply a subpath
+  result =
+    getNodeFromSubPath(getNodeFromPath(package, type, path, n - 1), getSubPathAt(path, n - 1))
+}
+
+/**
+ * Gets a subpath for the `TypeVar` token found at the `n`th token of `path`.
+ */
+pragma[nomagic]
+private AccessPath getSubPathAt(AccessPath path, int n) {
+  exists(string typeVarName |
+    path.getToken(n).getAnArgument("TypeVar") = typeVarName and
+    typeVariableModel(typeVarName, result)
+  )
+}
+
+/**
+ * Gets a node that is found by evaluating the first `n` tokens of `subPath` starting at `base`.
+ */
+pragma[nomagic]
+private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath, int n) {
+  exists(AccessPath path, int k |
+    base = [getNodeFromPath(_, _, path, k), getNodeFromSubPath(_, path, k)] and
+    subPath = getSubPathAt(path, k) and
+    result = base and
+    n = 0
+  )
+  or
+  result = getSuccessorFromNode(getNodeFromSubPath(base, subPath, n - 1), subPath.getToken(n - 1))
+  or
+  result =
+    getSuccessorFromInvoke(getInvocationFromSubPath(base, subPath, n - 1), subPath.getToken(n - 1))
+  or
+  result =
+    getNodeFromSubPath(getNodeFromSubPath(base, subPath, n - 1), getSubPathAt(subPath, n - 1))
+}
+
+/**
+ * Gets a call site that is found by evaluating the first `n` tokens of `subPath` starting at `base`.
+ */
+private Specific::InvokeNode getInvocationFromSubPath(API::Node base, AccessPath subPath, int n) {
+  result = Specific::getAnInvocationOf(getNodeFromSubPath(base, subPath, n))
+  or
+  result = getInvocationFromSubPath(base, subPath, n - 1) and
+  invocationMatchesCallSiteFilter(result, subPath.getToken(n - 1))
+}
+
+/**
+ * Gets a node that is found by evaluating `subPath` starting at `base`.
+ */
+pragma[nomagic]
+private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath) {
+  result = getNodeFromSubPath(base, subPath, subPath.getNumToken())
 }
 
 /** Gets the node identified by the given `(package, type, path)` tuple. */
@@ -390,7 +473,7 @@ Specific::InvokeNode getInvocationFromPath(string package, string type, AccessPa
  */
 bindingset[name]
 predicate isValidTokenNameInIdentifyingAccessPath(string name) {
-  name = ["Argument", "Parameter", "ReturnValue", "WithArity"]
+  name = ["Argument", "Parameter", "ReturnValue", "WithArity", "TypeVar"]
   or
   Specific::isExtraValidTokenNameInIdentifyingAccessPath(name)
 }
@@ -417,6 +500,9 @@ predicate isValidTokenArgumentInIdentifyingAccessPath(string name, string argume
   or
   name = "WithArity" and
   argument.regexpMatch("\\d+(\\.\\.(\\d+)?)?")
+  or
+  name = "TypeVar" and
+  exists(argument)
   or
   Specific::isExtraValidTokenArgumentInIdentifyingAccessPath(name, argument)
 }
@@ -489,6 +575,8 @@ module ModelOutput {
       any(SummaryModelCsv csv).row(row) and kind = "summary" and expectedArity = 6
       or
       any(TypeModelCsv csv).row(row) and kind = "type" and expectedArity = 5
+      or
+      any(TypeVariableModelCsv csv).row(row) and kind = "type-variable" and expectedArity = 2
     |
       actualArity = count(row.indexOf(";")) + 1 and
       actualArity != expectedArity and
@@ -499,7 +587,7 @@ module ModelOutput {
     or
     // Check names and arguments of access path tokens
     exists(AccessPath path, AccessPathToken token |
-      isRelevantFullPath(_, _, path) and
+      (isRelevantFullPath(_, _, path) or typeVariableModel(_, path)) and
       token = path.getToken(_)
     |
       not isValidTokenNameInIdentifyingAccessPath(token.getName()) and

--- a/javascript/ql/test/library-tests/frameworks/data/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/data/test.expected
@@ -58,6 +58,10 @@ taintFlow
 | test.js:207:24:207:31 | source() | test.js:207:24:207:31 | source() |
 | test.js:208:24:208:31 | source() | test.js:208:24:208:31 | source() |
 | test.js:211:34:211:41 | source() | test.js:211:34:211:41 | source() |
+| test.js:214:34:214:41 | source() | test.js:214:34:214:41 | source() |
+| test.js:223:45:223:52 | source() | test.js:223:45:223:52 | source() |
+| test.js:225:39:225:46 | source() | test.js:225:39:225:46 | source() |
+| test.js:226:50:226:57 | source() | test.js:226:50:226:57 | source() |
 isSink
 | test.js:54:18:54:25 | source() | test-sink |
 | test.js:55:22:55:29 | source() | test-sink |
@@ -119,6 +123,11 @@ isSink
 | test.js:207:24:207:31 | source() | test-sink |
 | test.js:208:24:208:31 | source() | test-sink |
 | test.js:211:34:211:41 | source() | test-sink |
+| test.js:214:34:214:41 | source() | test-sink |
+| test.js:222:52:222:52 | 0 | test-sink |
+| test.js:223:45:223:52 | source() | test-sink |
+| test.js:225:39:225:46 | source() | test-sink |
+| test.js:226:50:226:57 | source() | test-sink |
 syntaxErrors
 | Member[foo |
 | Member[foo] .Member[bar] |

--- a/javascript/ql/test/library-tests/frameworks/data/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/data/test.expected
@@ -1,4 +1,6 @@
 consistencyIssue
+| library-tests/frameworks/data/test.js:231 | expected an alert, but found none | NOT OK |  |
+| library-tests/frameworks/data/test.js:232 | expected an alert, but found none | NOT OK |  |
 taintFlow
 | paramDecorator.ts:6:54:6:54 | x | paramDecorator.ts:7:10:7:10 | x |
 | test.js:5:30:5:37 | source() | test.js:5:8:5:38 | testlib ... urce()) |
@@ -62,6 +64,8 @@ taintFlow
 | test.js:223:45:223:52 | source() | test.js:223:45:223:52 | source() |
 | test.js:225:39:225:46 | source() | test.js:225:39:225:46 | source() |
 | test.js:226:50:226:57 | source() | test.js:226:50:226:57 | source() |
+| test.js:230:59:230:66 | source() | test.js:230:59:230:66 | source() |
+| test.js:233:59:233:66 | source() | test.js:233:59:233:66 | source() |
 isSink
 | test.js:54:18:54:25 | source() | test-sink |
 | test.js:55:22:55:29 | source() | test-sink |
@@ -128,6 +132,8 @@ isSink
 | test.js:223:45:223:52 | source() | test-sink |
 | test.js:225:39:225:46 | source() | test-sink |
 | test.js:226:50:226:57 | source() | test-sink |
+| test.js:230:59:230:66 | source() | test-sink |
+| test.js:233:59:233:66 | source() | test-sink |
 syntaxErrors
 | Member[foo |
 | Member[foo] .Member[bar] |

--- a/javascript/ql/test/library-tests/frameworks/data/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/data/test.expected
@@ -1,6 +1,4 @@
 consistencyIssue
-| library-tests/frameworks/data/test.js:231 | expected an alert, but found none | NOT OK |  |
-| library-tests/frameworks/data/test.js:232 | expected an alert, but found none | NOT OK |  |
 taintFlow
 | paramDecorator.ts:6:54:6:54 | x | paramDecorator.ts:7:10:7:10 | x |
 | test.js:5:30:5:37 | source() | test.js:5:8:5:38 | testlib ... urce()) |
@@ -65,6 +63,8 @@ taintFlow
 | test.js:225:39:225:46 | source() | test.js:225:39:225:46 | source() |
 | test.js:226:50:226:57 | source() | test.js:226:50:226:57 | source() |
 | test.js:230:59:230:66 | source() | test.js:230:59:230:66 | source() |
+| test.js:231:59:231:66 | source() | test.js:231:59:231:66 | source() |
+| test.js:232:59:232:66 | source() | test.js:232:59:232:66 | source() |
 | test.js:233:59:233:66 | source() | test.js:233:59:233:66 | source() |
 isSink
 | test.js:54:18:54:25 | source() | test-sink |
@@ -133,6 +133,8 @@ isSink
 | test.js:225:39:225:46 | source() | test-sink |
 | test.js:226:50:226:57 | source() | test-sink |
 | test.js:230:59:230:66 | source() | test-sink |
+| test.js:231:59:231:66 | source() | test-sink |
+| test.js:232:59:232:66 | source() | test-sink |
 | test.js:233:59:233:66 | source() | test-sink |
 syntaxErrors
 | Member[foo |

--- a/javascript/ql/test/library-tests/frameworks/data/test.js
+++ b/javascript/ql/test/library-tests/frameworks/data/test.js
@@ -209,3 +209,21 @@ testlib.bar.memberSink(source()); // NOT OK
 testlib.memberSink(source()); // OK
 testlib.overloadedSink('safe', source()); // OK
 testlib.overloadedSink('danger', source()); // NOT OK
+
+function typeVars() {
+  testlib.typevar.a.b().c.mySink(source()); // NOT OK
+
+  testlib.typevar.mySink(source()); // OK - does not match sub path
+  testlib.typevar.a.mySink(source()); // OK - does not match sub path
+  testlib.typevar.a.b.mySink(source()); // OK - does not match sub path
+  testlib.typevar.a.b.c.mySink(source()); // OK - does not match sub path
+  testlib.typevar.a.b(1).c.mySink(source()); // OK - does not match sub path
+
+  testlib.typevar.a.b().c.a.b().c.mySink(source(), 0); // OK
+  testlib.typevar.a.b().c.a.b().c.mySink(0, source()); // NOT OK
+
+  testlib.typevar.left.x.right.mySink(source()); // NOT OK
+  testlib.typevar.left.left.x.right.right.mySink(source()); // NOT OK
+  testlib.typevar.left.x.right.right.mySink(source()); // OK - mismatched left and right
+  testlib.typevar.left.left.x.right.mySink(source()); // OK - mismatched left and right
+}

--- a/javascript/ql/test/library-tests/frameworks/data/test.js
+++ b/javascript/ql/test/library-tests/frameworks/data/test.js
@@ -226,4 +226,9 @@ function typeVars() {
   testlib.typevar.left.left.x.right.right.mySink(source()); // NOT OK
   testlib.typevar.left.x.right.right.mySink(source()); // OK - mismatched left and right
   testlib.typevar.left.left.x.right.mySink(source()); // OK - mismatched left and right
+
+  testlib.typevar.getThis().getThis().left.x.right.mySink(source()); // NOT OK
+  testlib.typevar.left.getThis().getThis().x.right.mySink(source()); // NOT OK
+  testlib.typevar.left.x.getThis().getThis().right.mySink(source()); // NOT OK
+  testlib.typevar.left.x.right.getThis().getThis().mySink(source()); // NOT OK
 }

--- a/javascript/ql/test/library-tests/frameworks/data/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/data/test.ql
@@ -14,6 +14,17 @@ class Steps extends ModelInput::SummaryModelCsv {
         "testlib;;Member[preserveAllButFirstArgument];Argument[1..];ReturnValue;taint",
         "testlib;;Member[preserveAllIfCall].Call;Argument[0..];ReturnValue;taint",
         "testlib;;Member[getSource].ReturnValue.Member[continue];Argument[this];ReturnValue;taint",
+        "testlib;~HasThisFlow;;;Member[getThis].ReturnValue;type",
+      ]
+  }
+}
+
+class TypeDefs extends ModelInput::TypeModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "testlib;~HasThisFlow;testlib;;Member[typevar]",
+        "testlib;~HasThisFlow;testlib;~HasThisFlow;Member[left,right,x]",
       ]
   }
 }

--- a/javascript/ql/test/library-tests/frameworks/data/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/data/test.ql
@@ -40,6 +40,20 @@ class Sinks extends ModelInput::SinkModelCsv {
         "testlib;;Member[ParamDecoratorSink].DecoratedParameter;test-sink",
         "testlib;;AnyMember.Member[memberSink].Argument[0];test-sink",
         "testlib;;Member[overloadedSink].WithStringArgument[0=danger].Argument[1];test-sink",
+        "testlib;;Member[typevar].TypeVar[ABC].Member[mySink].Argument[0];test-sink",
+        "testlib;;Member[typevar].TypeVar[ABC].TypeVar[ABC].Member[mySink].Argument[1];test-sink",
+        "testlib;;Member[typevar].TypeVar[LeftRight].Member[mySink].Argument[0];test-sink",
+      ]
+  }
+}
+
+class TypeVars extends ModelInput::TypeVariableModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "ABC;Member[a].Member[b].WithArity[0].ReturnValue.Member[c]", //
+        "LeftRight;Member[left].TypeVar[LeftRight].Member[right]", //
+        "LeftRight;Member[x]",
       ]
   }
 }

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
@@ -395,7 +395,7 @@ private API::Node getNodeFromPath(string package, string type, AccessPath path, 
   result =
     getNodeFromSubPath(getNodeFromPath(package, type, path, n - 1), getSubPathAt(path, n - 1))
   or
-  // Apply a receiver step
+  // Apply a type step
   typeStep(getNodeFromPath(package, type, path, n), result)
 }
 
@@ -436,6 +436,8 @@ private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath, int n) 
   or
   result =
     getNodeFromSubPath(getNodeFromSubPath(base, subPath, n - 1), getSubPathAt(subPath, n - 1))
+  or
+  typeStep(getNodeFromSubPath(base, subPath, n), result)
 }
 
 /**

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
@@ -155,6 +155,22 @@ module ModelInput {
      */
     abstract predicate row(string row);
   }
+
+  /**
+   * A unit class for adding additional type variable model rows.
+   */
+  class TypeVariableModelCsv extends Unit {
+    /**
+     * Holds if `row` specifies a path through a type variable.
+     *
+     * A row of form,
+     * ```
+     * name;path
+     * ```
+     * means `path` can be substituted for a token `TypeVar[name]`.
+     */
+    abstract predicate row(string row);
+  }
 }
 
 private import ModelInput
@@ -181,6 +197,8 @@ private predicate sinkModel(string row) { any(SinkModelCsv s).row(inversePad(row
 private predicate summaryModel(string row) { any(SummaryModelCsv s).row(inversePad(row)) }
 
 private predicate typeModel(string row) { any(TypeModelCsv s).row(inversePad(row)) }
+
+private predicate typeVariableModel(string row) { any(TypeVariableModelCsv s).row(inversePad(row)) }
 
 /** Holds if a source model exists for the given parameters. */
 predicate sourceModel(string package, string type, string path, string kind) {
@@ -219,7 +237,7 @@ private predicate summaryModel(
   )
 }
 
-/** Holds if an type model exists for the given parameters. */
+/** Holds if a type model exists for the given parameters. */
 private predicate typeModel(
   string package1, string type1, string package2, string type2, string path
 ) {
@@ -230,6 +248,15 @@ private predicate typeModel(
     row.splitAt(";", 2) = package2 and
     row.splitAt(";", 3) = type2 and
     row.splitAt(";", 4) = path
+  )
+}
+
+/** Holds if a type variable model exists for the given parameters. */
+private predicate typeVariableModel(string name, string path) {
+  exists(string row |
+    typeVariableModel(row) and
+    row.splitAt(";", 0) = name and
+    row.splitAt(";", 1) = path
   )
 }
 
@@ -253,7 +280,7 @@ private predicate isRelevantPackage(string package) {
     sourceModel(package, _, _, _) or
     sinkModel(package, _, _, _) or
     summaryModel(package, _, _, _, _, _) or
-    typeModel(package, _, _, _, _)
+    typeModel(_, _, package, _, _)
   ) and
   (
     Specific::isPackageUsed(package)
@@ -290,6 +317,8 @@ private class AccessPathRange extends AccessPath::Range {
       summaryModel(package, _, _, this, _, _) or
       summaryModel(package, _, _, _, this, _)
     )
+    or
+    typeVariableModel(_, this)
   }
 }
 
@@ -361,11 +390,89 @@ private API::Node getNodeFromPath(string package, string type, AccessPath path, 
   // Similar to the other recursive case, but where the path may have stepped through one or more call-site filters
   result =
     getSuccessorFromInvoke(getInvocationFromPath(package, type, path, n - 1), path.getToken(n - 1))
+  or
+  // Apply a subpath
+  result =
+    getNodeFromSubPath(getNodeFromPath(package, type, path, n - 1), getSubPathAt(path, n - 1))
+  or
+  // Apply a receiver step
+  typeStep(getNodeFromPath(package, type, path, n), result)
+}
+
+/**
+ * Gets a subpath for the `TypeVar` token found at the `n`th token of `path`.
+ */
+pragma[nomagic]
+private AccessPath getSubPathAt(AccessPath path, int n) {
+  exists(string typeVarName |
+    path.getToken(n).getAnArgument("TypeVar") = typeVarName and
+    typeVariableModel(typeVarName, result)
+  )
+}
+
+/**
+ * Gets a node that is found by evaluating the first `n` tokens of `subPath` starting at `base`.
+ */
+pragma[nomagic]
+private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath, int n) {
+  exists(AccessPath path, int k |
+    base = [getNodeFromPath(_, _, path, k), getNodeFromSubPath(_, path, k)] and
+    subPath = getSubPathAt(path, k) and
+    result = base and
+    n = 0
+  )
+  or
+  exists(string package, string type, AccessPath basePath |
+    typeStepModel(package, type, basePath, subPath) and
+    base = getNodeFromPath(package, type, basePath) and
+    result = base and
+    n = 0
+  )
+  or
+  result = getSuccessorFromNode(getNodeFromSubPath(base, subPath, n - 1), subPath.getToken(n - 1))
+  or
+  result =
+    getSuccessorFromInvoke(getInvocationFromSubPath(base, subPath, n - 1), subPath.getToken(n - 1))
+  or
+  result =
+    getNodeFromSubPath(getNodeFromSubPath(base, subPath, n - 1), getSubPathAt(subPath, n - 1))
+}
+
+/**
+ * Gets a call site that is found by evaluating the first `n` tokens of `subPath` starting at `base`.
+ */
+private Specific::InvokeNode getInvocationFromSubPath(API::Node base, AccessPath subPath, int n) {
+  result = Specific::getAnInvocationOf(getNodeFromSubPath(base, subPath, n))
+  or
+  result = getInvocationFromSubPath(base, subPath, n - 1) and
+  invocationMatchesCallSiteFilter(result, subPath.getToken(n - 1))
+}
+
+/**
+ * Gets a node that is found by evaluating `subPath` starting at `base`.
+ */
+pragma[nomagic]
+private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath) {
+  result = getNodeFromSubPath(base, subPath, subPath.getNumToken())
 }
 
 /** Gets the node identified by the given `(package, type, path)` tuple. */
 API::Node getNodeFromPath(string package, string type, AccessPath path) {
   result = getNodeFromPath(package, type, path, path.getNumToken())
+}
+
+pragma[nomagic]
+private predicate typeStepModel(string package, string type, AccessPath basePath, AccessPath output) {
+  summaryModel(package, type, basePath, "", output, "type")
+}
+
+pragma[nomagic]
+private predicate typeStep(API::Node pred, API::Node succ) {
+  exists(string package, string type, AccessPath basePath, AccessPath output |
+    typeStepModel(package, type, basePath, output) and
+    pred = getNodeFromPath(package, type, basePath) and
+    succ = getNodeFromSubPath(pred, output)
+  )
 }
 
 /**
@@ -390,7 +497,7 @@ Specific::InvokeNode getInvocationFromPath(string package, string type, AccessPa
  */
 bindingset[name]
 predicate isValidTokenNameInIdentifyingAccessPath(string name) {
-  name = ["Argument", "Parameter", "ReturnValue", "WithArity"]
+  name = ["Argument", "Parameter", "ReturnValue", "WithArity", "TypeVar"]
   or
   Specific::isExtraValidTokenNameInIdentifyingAccessPath(name)
 }
@@ -417,6 +524,9 @@ predicate isValidTokenArgumentInIdentifyingAccessPath(string name, string argume
   or
   name = "WithArity" and
   argument.regexpMatch("\\d+(\\.\\.(\\d+)?)?")
+  or
+  name = "TypeVar" and
+  exists(argument)
   or
   Specific::isExtraValidTokenArgumentInIdentifyingAccessPath(name, argument)
 }
@@ -489,6 +599,8 @@ module ModelOutput {
       any(SummaryModelCsv csv).row(row) and kind = "summary" and expectedArity = 6
       or
       any(TypeModelCsv csv).row(row) and kind = "type" and expectedArity = 5
+      or
+      any(TypeVariableModelCsv csv).row(row) and kind = "type-variable" and expectedArity = 2
     |
       actualArity = count(row.indexOf(";")) + 1 and
       actualArity != expectedArity and
@@ -499,7 +611,7 @@ module ModelOutput {
     or
     // Check names and arguments of access path tokens
     exists(AccessPath path, AccessPathToken token |
-      isRelevantFullPath(_, _, path) and
+      (isRelevantFullPath(_, _, path) or typeVariableModel(_, path)) and
       token = path.getToken(_)
     |
       not isValidTokenNameInIdentifyingAccessPath(token.getName()) and

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
@@ -395,7 +395,7 @@ private API::Node getNodeFromPath(string package, string type, AccessPath path, 
   result =
     getNodeFromSubPath(getNodeFromPath(package, type, path, n - 1), getSubPathAt(path, n - 1))
   or
-  // Apply a receiver step
+  // Apply a type step
   typeStep(getNodeFromPath(package, type, path, n), result)
 }
 
@@ -436,6 +436,8 @@ private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath, int n) 
   or
   result =
     getNodeFromSubPath(getNodeFromSubPath(base, subPath, n - 1), getSubPathAt(subPath, n - 1))
+  or
+  typeStep(getNodeFromSubPath(base, subPath, n), result)
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
@@ -155,6 +155,22 @@ module ModelInput {
      */
     abstract predicate row(string row);
   }
+
+  /**
+   * A unit class for adding additional type variable model rows.
+   */
+  class TypeVariableModelCsv extends Unit {
+    /**
+     * Holds if `row` specifies a path through a type variable.
+     *
+     * A row of form,
+     * ```
+     * name;path
+     * ```
+     * means `path` can be substituted for a token `TypeVar[name]`.
+     */
+    abstract predicate row(string row);
+  }
 }
 
 private import ModelInput
@@ -181,6 +197,8 @@ private predicate sinkModel(string row) { any(SinkModelCsv s).row(inversePad(row
 private predicate summaryModel(string row) { any(SummaryModelCsv s).row(inversePad(row)) }
 
 private predicate typeModel(string row) { any(TypeModelCsv s).row(inversePad(row)) }
+
+private predicate typeVariableModel(string row) { any(TypeVariableModelCsv s).row(inversePad(row)) }
 
 /** Holds if a source model exists for the given parameters. */
 predicate sourceModel(string package, string type, string path, string kind) {
@@ -219,7 +237,7 @@ private predicate summaryModel(
   )
 }
 
-/** Holds if an type model exists for the given parameters. */
+/** Holds if a type model exists for the given parameters. */
 private predicate typeModel(
   string package1, string type1, string package2, string type2, string path
 ) {
@@ -230,6 +248,15 @@ private predicate typeModel(
     row.splitAt(";", 2) = package2 and
     row.splitAt(";", 3) = type2 and
     row.splitAt(";", 4) = path
+  )
+}
+
+/** Holds if a type variable model exists for the given parameters. */
+private predicate typeVariableModel(string name, string path) {
+  exists(string row |
+    typeVariableModel(row) and
+    row.splitAt(";", 0) = name and
+    row.splitAt(";", 1) = path
   )
 }
 
@@ -253,7 +280,7 @@ private predicate isRelevantPackage(string package) {
     sourceModel(package, _, _, _) or
     sinkModel(package, _, _, _) or
     summaryModel(package, _, _, _, _, _) or
-    typeModel(package, _, _, _, _)
+    typeModel(_, _, package, _, _)
   ) and
   (
     Specific::isPackageUsed(package)
@@ -290,6 +317,8 @@ private class AccessPathRange extends AccessPath::Range {
       summaryModel(package, _, _, this, _, _) or
       summaryModel(package, _, _, _, this, _)
     )
+    or
+    typeVariableModel(_, this)
   }
 }
 
@@ -361,11 +390,89 @@ private API::Node getNodeFromPath(string package, string type, AccessPath path, 
   // Similar to the other recursive case, but where the path may have stepped through one or more call-site filters
   result =
     getSuccessorFromInvoke(getInvocationFromPath(package, type, path, n - 1), path.getToken(n - 1))
+  or
+  // Apply a subpath
+  result =
+    getNodeFromSubPath(getNodeFromPath(package, type, path, n - 1), getSubPathAt(path, n - 1))
+  or
+  // Apply a receiver step
+  typeStep(getNodeFromPath(package, type, path, n), result)
+}
+
+/**
+ * Gets a subpath for the `TypeVar` token found at the `n`th token of `path`.
+ */
+pragma[nomagic]
+private AccessPath getSubPathAt(AccessPath path, int n) {
+  exists(string typeVarName |
+    path.getToken(n).getAnArgument("TypeVar") = typeVarName and
+    typeVariableModel(typeVarName, result)
+  )
+}
+
+/**
+ * Gets a node that is found by evaluating the first `n` tokens of `subPath` starting at `base`.
+ */
+pragma[nomagic]
+private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath, int n) {
+  exists(AccessPath path, int k |
+    base = [getNodeFromPath(_, _, path, k), getNodeFromSubPath(_, path, k)] and
+    subPath = getSubPathAt(path, k) and
+    result = base and
+    n = 0
+  )
+  or
+  exists(string package, string type, AccessPath basePath |
+    typeStepModel(package, type, basePath, subPath) and
+    base = getNodeFromPath(package, type, basePath) and
+    result = base and
+    n = 0
+  )
+  or
+  result = getSuccessorFromNode(getNodeFromSubPath(base, subPath, n - 1), subPath.getToken(n - 1))
+  or
+  result =
+    getSuccessorFromInvoke(getInvocationFromSubPath(base, subPath, n - 1), subPath.getToken(n - 1))
+  or
+  result =
+    getNodeFromSubPath(getNodeFromSubPath(base, subPath, n - 1), getSubPathAt(subPath, n - 1))
+}
+
+/**
+ * Gets a call site that is found by evaluating the first `n` tokens of `subPath` starting at `base`.
+ */
+private Specific::InvokeNode getInvocationFromSubPath(API::Node base, AccessPath subPath, int n) {
+  result = Specific::getAnInvocationOf(getNodeFromSubPath(base, subPath, n))
+  or
+  result = getInvocationFromSubPath(base, subPath, n - 1) and
+  invocationMatchesCallSiteFilter(result, subPath.getToken(n - 1))
+}
+
+/**
+ * Gets a node that is found by evaluating `subPath` starting at `base`.
+ */
+pragma[nomagic]
+private API::Node getNodeFromSubPath(API::Node base, AccessPath subPath) {
+  result = getNodeFromSubPath(base, subPath, subPath.getNumToken())
 }
 
 /** Gets the node identified by the given `(package, type, path)` tuple. */
 API::Node getNodeFromPath(string package, string type, AccessPath path) {
   result = getNodeFromPath(package, type, path, path.getNumToken())
+}
+
+pragma[nomagic]
+private predicate typeStepModel(string package, string type, AccessPath basePath, AccessPath output) {
+  summaryModel(package, type, basePath, "", output, "type")
+}
+
+pragma[nomagic]
+private predicate typeStep(API::Node pred, API::Node succ) {
+  exists(string package, string type, AccessPath basePath, AccessPath output |
+    typeStepModel(package, type, basePath, output) and
+    pred = getNodeFromPath(package, type, basePath) and
+    succ = getNodeFromSubPath(pred, output)
+  )
 }
 
 /**
@@ -390,7 +497,7 @@ Specific::InvokeNode getInvocationFromPath(string package, string type, AccessPa
  */
 bindingset[name]
 predicate isValidTokenNameInIdentifyingAccessPath(string name) {
-  name = ["Argument", "Parameter", "ReturnValue", "WithArity"]
+  name = ["Argument", "Parameter", "ReturnValue", "WithArity", "TypeVar"]
   or
   Specific::isExtraValidTokenNameInIdentifyingAccessPath(name)
 }
@@ -417,6 +524,9 @@ predicate isValidTokenArgumentInIdentifyingAccessPath(string name, string argume
   or
   name = "WithArity" and
   argument.regexpMatch("\\d+(\\.\\.(\\d+)?)?")
+  or
+  name = "TypeVar" and
+  exists(argument)
   or
   Specific::isExtraValidTokenArgumentInIdentifyingAccessPath(name, argument)
 }
@@ -489,6 +599,8 @@ module ModelOutput {
       any(SummaryModelCsv csv).row(row) and kind = "summary" and expectedArity = 6
       or
       any(TypeModelCsv csv).row(row) and kind = "type" and expectedArity = 5
+      or
+      any(TypeVariableModelCsv csv).row(row) and kind = "type-variable" and expectedArity = 2
     |
       actualArity = count(row.indexOf(";")) + 1 and
       actualArity != expectedArity and
@@ -499,7 +611,7 @@ module ModelOutput {
     or
     // Check names and arguments of access path tokens
     exists(AccessPath path, AccessPathToken token |
-      isRelevantFullPath(_, _, path) and
+      (isRelevantFullPath(_, _, path) or typeVariableModel(_, path)) and
       token = path.getToken(_)
     |
       not isValidTokenNameInIdentifyingAccessPath(token.getName()) and


### PR DESCRIPTION
This adds some features related to generics, to support generating MaD typings from `.d.ts` files and similar.

### Type variables

To track types through generics, we encode all the paths leading from some type to all uses of its type variables.
For example for this type,
```ts
interface Node<T> {
  value: T | undefined;
  resolve(): Promise<T>;
  next: Node<T>;
}
```
we'd generate the following rows in a table "type variable" table of form `name;path`:
```
Node.T;Member[value]
Node.T;Member[resolve].ReturnValue.Awaited
Node.T;Member[next].TypeVar[Node.T]
```

Suppose we want to record how to obtain an instance of `ImportantObject` from `mylib`, given this declaration
```ts
export function create(): Node<ImportantObject[]>;
```
we'd generate this type-definition row:
```
mylib;ImportantObject;mylib;;Member[init].ReturnValue.TypeVar[Node.T].ArrayElement
```

The rule is that the access path token `TypeVar[name]` can be expanded to any of the paths given by a `name;path` row with a matching name. Type variables are really just non-terminals in a context-free grammar, but since they have a 1:1 relationship with type variables, I decided to name them after this use-case.

Type-variable rows are thus similar to type-definitions in that the offer a way to reuse access paths, except they can occur anywhere in an access path, whereas type definitions can only occur at the beginning. Also, type-definitions are associated with a set of API nodes, whereas type variables are just intermediate steps and not themselves associated with API nodes (you can ask for all uses of a given type, but not for all uses of a given type _variable_).

###  Why`this` types are no longer type variables

`this` types were previously encoded as an extra type variable, but this caused _a lot_ of `TypeVar` tokens to occur and became really hard to understand. To demonstrate, suppose `Node<T>` from above had a method returning `this`:
```ts
interface Node<T> {
  ...
  foo(): this;
}
```
This meant `TypeVar[Node.T]` must be expanded to take into account that any number of `foo()` calls may occur initially:
```
Node.this;
Node.this;TypeVar[Node.this].Method[foo].ReturnValue
Node.T;TypeVar[Node.this].Member[value]
Node.T;TypeVar[Node.this].Member[resolve].ReturnValue.Awaited
Node.T;TypeVar[Node.this].Member[next].TypeVar[Node.T]
```
In practice these `this` types show up in a lot of places, like every time a type extending `EventEmitter` was used.

### Type steps
Instead of the above, a `this` type gives rise to a "type step", which is a kind of step between API nodes, which we use for propagating type information. It could also be used as a value-preserving flow step, but for now we just propagate type information.

The `Foo` type above would give rise to this summary row:
```
mylib;Foo;;Member[foo].ReturnValue;type
```
meaning that whenever we see a call to `x.foo()` where the `x` might have type `Foo`, we add a type step from `x` to `x.foo()`.