### PR TITLE
fix performance issue in the ReDoS query

### DIFF
--- a/java/ql/lib/semmle/code/java/security/regexp/ExponentialBackTracking.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/ExponentialBackTracking.qll
@@ -115,6 +115,7 @@ private newtype TStatePair =
 private int rankState(State state) {
   state =
     rank[result](State s, Location l |
+      stateInsideBacktracking(s) and
       l = s.getRepr().getLocation()
     |
       s order by l.getStartLine(), l.getStartColumn(), s.toString()

--- a/javascript/ql/lib/semmle/javascript/security/regexp/ExponentialBackTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/security/regexp/ExponentialBackTracking.qll
@@ -115,6 +115,7 @@ private newtype TStatePair =
 private int rankState(State state) {
   state =
     rank[result](State s, Location l |
+      stateInsideBacktracking(s) and
       l = s.getRepr().getLocation()
     |
       s order by l.getStartLine(), l.getStartColumn(), s.toString()

--- a/python/ql/lib/semmle/python/security/regexp/ExponentialBackTracking.qll
+++ b/python/ql/lib/semmle/python/security/regexp/ExponentialBackTracking.qll
@@ -115,6 +115,7 @@ private newtype TStatePair =
 private int rankState(State state) {
   state =
     rank[result](State s, Location l |
+      stateInsideBacktracking(s) and
       l = s.getRepr().getLocation()
     |
       s order by l.getStartLine(), l.getStartColumn(), s.toString()

--- a/ruby/ql/lib/codeql/ruby/security/regexp/ExponentialBackTracking.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/ExponentialBackTracking.qll
@@ -115,6 +115,7 @@ private newtype TStatePair =
 private int rankState(State state) {
   state =
     rank[result](State s, Location l |
+      stateInsideBacktracking(s) and
       l = s.getRepr().getLocation()
     |
       s order by l.getStartLine(), l.getStartColumn(), s.toString()


### PR DESCRIPTION
I did a followup evaluation to https://github.com/github/codeql/pull/10062, which found [a performance issue in a single project](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/redosPrefix-chakra-singlethread/reports#query-run-timings-per-source-and-query-single-threaded).   

Fixed by making the `rankState()` predicate smaller by including a simple context.  

All evaluations look good: [JavaScript](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/fixRank-js/reports), [Python](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/fixRank-py/reports), [Java](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/fixRank-java/reports), [Ruby](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/fixRank-rb/reports). 