### PR TITLE
Java: A couple of small virtual dispatch fixes

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/TypeFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/TypeFlow.qll
@@ -220,7 +220,7 @@ private predicate upcastCand(TypeFlowNode n, RefType t, RefType t1, RefType t2) 
       ret.getResult() = n.asExpr() and t2 = ret.getEnclosingCallable().getReturnType().getErasure()
     )
     or
-    exists(MethodAccess ma | viableImpl_v1(ma) = n.asMethod() and t2 = ma.getType())
+    exists(MethodAccess ma | viableImpl_v1(ma) = n.asMethod() and t2 = ma.getType().getErasure())
     or
     exists(Parameter p | privateParamArg(p, n.asExpr()) and t2 = p.getType().getErasure())
     or

--- a/java/ql/lib/semmle/code/java/dispatch/VirtualDispatch.qll
+++ b/java/ql/lib/semmle/code/java/dispatch/VirtualDispatch.qll
@@ -211,10 +211,14 @@ private module Dispatch {
     exists(Method m | t.hasMethod(m, _, _) and impl = m.getSourceDeclaration())
   }
 
+  private predicate isAbstractWithSubclass(SrcRefType t) {
+    t.isAbstract() and exists(Class c | c.getASourceSupertype() = t)
+  }
+
   private predicate hasViableSubtype(RefType t, SrcRefType sub) {
     sub.extendsOrImplements*(t) and
     not sub instanceof Interface and
-    not sub.isAbstract()
+    not isAbstractWithSubclass(sub)
   }
 }
 


### PR DESCRIPTION
The first commit allows dispatch to methods defined on abstract classes for which we don't have any subclasses. Normally, ruling out abstract classes as the type to dispatch to is fine, as the dispatch targets are inherited by one or more subclasses and thus allowing the dispatch, but for abstract classes intended to be extended outside the analysed source this isn't the case, which left a few glaring holes in our dispatch relation.

The second commit fixes a minor bug in TypeFlow (included as separate commit for visibility, as the code is immediately refactored).

The third commit refactors the code a bit, and also includes upcasts to raw types and unbound parameterised types as interesting starting points for TypeFlow, thus improving our dispatch precision a little bit.