### PR TITLE
Swift: fix double parent

### DIFF
--- a/swift/codegen/schema.yml
+++ b/swift/codegen/schema.yml
@@ -80,8 +80,8 @@ AstNode:
 
 Callable:
   _children:
-    params: ParamDecl*
     self_param: ParamDecl?
+    params: ParamDecl*
     body: BraceStmt?
 
 ConditionElement:
@@ -545,7 +545,7 @@ RebindSelfInConstructorExpr:
   _extends: Expr
   _children:
     sub_expr: Expr
-    self: VarDecl
+  self: VarDecl
 
 SequenceExpr:
   _extends: Expr

--- a/swift/ql/lib/codeql/swift/generated/Callable.qll
+++ b/swift/ql/lib/codeql/swift/generated/Callable.qll
@@ -6,6 +6,17 @@ import codeql.swift.elements.Element
 import codeql.swift.elements.decl.ParamDecl
 
 class CallableBase extends Synth::TCallable, Element {
+  ParamDecl getImmediateSelfParam() {
+    result =
+      Synth::convertParamDeclFromRaw(Synth::convertCallableToRaw(this)
+            .(Raw::Callable)
+            .getSelfParam())
+  }
+
+  final ParamDecl getSelfParam() { result = getImmediateSelfParam().resolve() }
+
+  final predicate hasSelfParam() { exists(getSelfParam()) }
+
   ParamDecl getImmediateParam(int index) {
     result =
       Synth::convertParamDeclFromRaw(Synth::convertCallableToRaw(this)
@@ -18,17 +29,6 @@ class CallableBase extends Synth::TCallable, Element {
   final ParamDecl getAParam() { result = getParam(_) }
 
   final int getNumberOfParams() { result = count(getAParam()) }
-
-  ParamDecl getImmediateSelfParam() {
-    result =
-      Synth::convertParamDeclFromRaw(Synth::convertCallableToRaw(this)
-            .(Raw::Callable)
-            .getSelfParam())
-  }
-
-  final ParamDecl getSelfParam() { result = getImmediateSelfParam().resolve() }
-
-  final predicate hasSelfParam() { exists(getSelfParam()) }
 
   BraceStmt getImmediateBody() {
     result =

--- a/swift/ql/lib/codeql/swift/generated/GetImmediateParent.qll
+++ b/swift/ql/lib/codeql/swift/generated/GetImmediateParent.qll
@@ -13,9 +13,9 @@ Element getAnImmediateChild(Element e) {
   // * none() simplifies generation, as we can append `or ...` without a special case for the first item
   none()
   or
-  result = e.(Callable).getImmediateParam(_)
-  or
   result = e.(Callable).getImmediateSelfParam()
+  or
+  result = e.(Callable).getImmediateParam(_)
   or
   result = e.(Callable).getImmediateBody()
   or
@@ -122,8 +122,6 @@ Element getAnImmediateChild(Element e) {
   result = e.(OptionalEvaluationExpr).getImmediateSubExpr()
   or
   result = e.(RebindSelfInConstructorExpr).getImmediateSubExpr()
-  or
-  result = e.(RebindSelfInConstructorExpr).getImmediateSelf()
   or
   result = e.(SelfApplyExpr).getImmediateBase()
   or

--- a/swift/ql/lib/codeql/swift/generated/Raw.qll
+++ b/swift/ql/lib/codeql/swift/generated/Raw.qll
@@ -6,9 +6,9 @@ module Raw {
   }
 
   class Callable extends @callable, Element {
-    ParamDecl getParam(int index) { callable_params(this, index, result) }
-
     ParamDecl getSelfParam() { callable_self_params(this, result) }
+
+    ParamDecl getParam(int index) { callable_params(this, index, result) }
 
     BraceStmt getBody() { callable_bodies(this, result) }
   }

--- a/swift/ql/lib/swift.dbscheme
+++ b/swift/ql/lib/swift.dbscheme
@@ -166,17 +166,17 @@ nominal_type_decls(  //dir=decl
 | @abstract_function_decl
 ;
 
+#keyset[id]
+callable_self_params(
+  int id: @callable ref,
+  int self_param: @param_decl ref
+);
+
 #keyset[id, index]
 callable_params(
   int id: @callable ref,
   int index: int ref,
   int param: @param_decl ref
-);
-
-#keyset[id]
-callable_self_params(
-  int id: @callable ref,
-  int self_param: @param_decl ref
 );
 
 #keyset[id]

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -5705,10 +5705,10 @@ cfg.swift:
 
 #  456| #keyPath(...)
 #-----|  -> var ... = ...
+#-----|  -> exit #keyPath(...) (normal)
 
 #  456| #keyPath(...)
 #-----|  -> var ... = ...
-#-----|  -> exit #keyPath(...) (normal)
 
 #  456| enter #keyPath(...)
 #-----|  -> #keyPath(...)
@@ -5747,10 +5747,10 @@ cfg.swift:
 
 #  457| #keyPath(...)
 #-----|  -> var ... = ...
+#-----|  -> exit #keyPath(...) (normal)
 
 #  457| #keyPath(...)
 #-----|  -> var ... = ...
-#-----|  -> exit #keyPath(...) (normal)
 
 #  457| enter #keyPath(...)
 #-----|  -> #keyPath(...)
@@ -5801,10 +5801,10 @@ cfg.swift:
 
 #  458| #keyPath(...)
 #-----|  -> var ... = ...
+#-----|  -> exit #keyPath(...) (normal)
 
 #  458| #keyPath(...)
 #-----|  -> var ... = ...
-#-----|  -> exit #keyPath(...) (normal)
 
 #  458| enter #keyPath(...)
 #-----|  -> #keyPath(...)
@@ -5867,10 +5867,10 @@ cfg.swift:
 
 #  459| #keyPath(...)
 #-----|  -> var ... = ...
+#-----|  -> exit #keyPath(...) (normal)
 
 #  459| #keyPath(...)
 #-----|  -> var ... = ...
-#-----|  -> exit #keyPath(...) (normal)
 
 #  459| enter #keyPath(...)
 #-----|  -> #keyPath(...)
@@ -6211,15 +6211,15 @@ cfg.swift:
 #-----|  -> apply_kpGet_mayB_x
 
 #  464| apply_kpGet_mayB_x
+
+#  464| apply_kpGet_mayB_x
+
+#  464| apply_kpGet_mayB_x
+
+#  464| apply_kpGet_mayB_x
+
+#  464| apply_kpGet_mayB_x
 #-----|  -> exit test(a:) (normal)
-
-#  464| apply_kpGet_mayB_x
-
-#  464| apply_kpGet_mayB_x
-
-#  464| apply_kpGet_mayB_x
-
-#  464| apply_kpGet_mayB_x
 
 #  464| apply_kpGet_mayB_x
 #-----| match -> a

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -5705,10 +5705,10 @@ cfg.swift:
 
 #  456| #keyPath(...)
 #-----|  -> var ... = ...
-#-----|  -> exit #keyPath(...) (normal)
 
 #  456| #keyPath(...)
 #-----|  -> var ... = ...
+#-----|  -> exit #keyPath(...) (normal)
 
 #  456| enter #keyPath(...)
 #-----|  -> #keyPath(...)
@@ -5747,10 +5747,10 @@ cfg.swift:
 
 #  457| #keyPath(...)
 #-----|  -> var ... = ...
-#-----|  -> exit #keyPath(...) (normal)
 
 #  457| #keyPath(...)
 #-----|  -> var ... = ...
+#-----|  -> exit #keyPath(...) (normal)
 
 #  457| enter #keyPath(...)
 #-----|  -> #keyPath(...)
@@ -5801,10 +5801,10 @@ cfg.swift:
 
 #  458| #keyPath(...)
 #-----|  -> var ... = ...
-#-----|  -> exit #keyPath(...) (normal)
 
 #  458| #keyPath(...)
 #-----|  -> var ... = ...
+#-----|  -> exit #keyPath(...) (normal)
 
 #  458| enter #keyPath(...)
 #-----|  -> #keyPath(...)
@@ -5867,10 +5867,10 @@ cfg.swift:
 
 #  459| #keyPath(...)
 #-----|  -> var ... = ...
-#-----|  -> exit #keyPath(...) (normal)
 
 #  459| #keyPath(...)
 #-----|  -> var ... = ...
+#-----|  -> exit #keyPath(...) (normal)
 
 #  459| enter #keyPath(...)
 #-----|  -> #keyPath(...)
@@ -6211,15 +6211,15 @@ cfg.swift:
 #-----|  -> apply_kpGet_mayB_x
 
 #  464| apply_kpGet_mayB_x
-
-#  464| apply_kpGet_mayB_x
-
-#  464| apply_kpGet_mayB_x
-
-#  464| apply_kpGet_mayB_x
-
-#  464| apply_kpGet_mayB_x
 #-----|  -> exit test(a:) (normal)
+
+#  464| apply_kpGet_mayB_x
+
+#  464| apply_kpGet_mayB_x
+
+#  464| apply_kpGet_mayB_x
+
+#  464| apply_kpGet_mayB_x
 
 #  464| apply_kpGet_mayB_x
 #-----| match -> a

--- a/swift/ql/test/library-tests/parent/no_double_parents.expected
+++ b/swift/ql/test/library-tests/parent/no_double_parents.expected
@@ -1,2 +1,0 @@
-| ConstructorDecl | RebindSelfInConstructorExpr | ParamDecl |
-| RebindSelfInConstructorExpr | ConstructorDecl | ParamDecl |

--- a/swift/ql/test/library-tests/parent/parent.expected
+++ b/swift/ql/test/library-tests/parent/parent.expected
@@ -623,6 +623,7 @@
 | expressions.swift:77:21:77:21 | init | ConstructorDecl | expressions.swift:77:21:77:21 | self | ParamDecl |
 | expressions.swift:77:21:77:21 | init | ConstructorDecl | file://:0:0:0:0 | x | ParamDecl |
 | expressions.swift:77:21:77:21 | init | ConstructorDecl | file://:0:0:0:0 | { ... } | BraceStmt |
+| expressions.swift:78:3:80:3 | init | ConstructorDecl | expressions.swift:78:3:78:3 | self | ParamDecl |
 | expressions.swift:78:3:80:3 | init | ConstructorDecl | expressions.swift:78:10:80:3 | { ... } | BraceStmt |
 | expressions.swift:78:10:80:3 | { ... } | BraceStmt | expressions.swift:79:5:79:21 | self = ... | RebindSelfInConstructorExpr |
 | expressions.swift:78:10:80:3 | { ... } | BraceStmt | expressions.swift:80:3:80:3 | return | ReturnStmt |


### PR DESCRIPTION
`RebindSelfInConstructorExpr` marking the `self` `VarDecl` as a child was causing a double parent problem.

The change in order in the `Callable` children is mainly cosmetic now, but will have more meaning after generating `PrintAst` (where we want `self` before the other params).