### PR TITLE
put a limit on the length of the equivalent range in overly-large-range

### DIFF
--- a/java/ql/lib/semmle/code/java/security/OverlyLargeRangeQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/OverlyLargeRangeQuery.qll
@@ -238,8 +238,13 @@ module RangePrinter {
 
 /** Gets a char range that is overly large because of `reason`. */
 RegExpCharacterRange getABadRange(string reason, int priority) {
+  result instanceof OverlyWideRange and
   priority = 0 and
-  reason = "is equivalent to " + result.(OverlyWideRange).printEquivalent()
+  exists(string equiv | equiv = result.(OverlyWideRange).printEquivalent() |
+    if equiv.length() <= 50
+    then reason = "is equivalent to " + equiv
+    else reason = "is equivalent to " + equiv.substring(0, 50) + "..."
+  )
   or
   priority = 1 and
   exists(RegExpCharacterRange other |

--- a/javascript/ql/lib/semmle/javascript/security/OverlyLargeRangeQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/OverlyLargeRangeQuery.qll
@@ -238,8 +238,13 @@ module RangePrinter {
 
 /** Gets a char range that is overly large because of `reason`. */
 RegExpCharacterRange getABadRange(string reason, int priority) {
+  result instanceof OverlyWideRange and
   priority = 0 and
-  reason = "is equivalent to " + result.(OverlyWideRange).printEquivalent()
+  exists(string equiv | equiv = result.(OverlyWideRange).printEquivalent() |
+    if equiv.length() <= 50
+    then reason = "is equivalent to " + equiv
+    else reason = "is equivalent to " + equiv.substring(0, 50) + "..."
+  )
   or
   priority = 1 and
   exists(RegExpCharacterRange other |

--- a/python/ql/lib/semmle/python/security/OverlyLargeRangeQuery.qll
+++ b/python/ql/lib/semmle/python/security/OverlyLargeRangeQuery.qll
@@ -238,8 +238,13 @@ module RangePrinter {
 
 /** Gets a char range that is overly large because of `reason`. */
 RegExpCharacterRange getABadRange(string reason, int priority) {
+  result instanceof OverlyWideRange and
   priority = 0 and
-  reason = "is equivalent to " + result.(OverlyWideRange).printEquivalent()
+  exists(string equiv | equiv = result.(OverlyWideRange).printEquivalent() |
+    if equiv.length() <= 50
+    then reason = "is equivalent to " + equiv
+    else reason = "is equivalent to " + equiv.substring(0, 50) + "..."
+  )
   or
   priority = 1 and
   exists(RegExpCharacterRange other |

--- a/ruby/ql/lib/codeql/ruby/security/OverlyLargeRangeQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/OverlyLargeRangeQuery.qll
@@ -238,8 +238,13 @@ module RangePrinter {
 
 /** Gets a char range that is overly large because of `reason`. */
 RegExpCharacterRange getABadRange(string reason, int priority) {
+  result instanceof OverlyWideRange and
   priority = 0 and
-  reason = "is equivalent to " + result.(OverlyWideRange).printEquivalent()
+  exists(string equiv | equiv = result.(OverlyWideRange).printEquivalent() |
+    if equiv.length() <= 50
+    then reason = "is equivalent to " + equiv
+    else reason = "is equivalent to " + equiv.substring(0, 50) + "..."
+  )
   or
   priority = 1 and
   exists(RegExpCharacterRange other |


### PR DESCRIPTION
The overly-large-range query would produce an extremely big alert message on some regexps from `natalie-lang/natalie`.  
This fixes it.  

I capped the range at 50 chars, because that broke no tests in the existing test-suite. 