### PR TITLE
Kotlin: Fix issues in comment extraction

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -159,42 +159,6 @@ open class KotlinFileExtractor(
         }
     }
 
-
-
-    fun getLabel(element: IrElement) : String? {
-        when (element) {
-            is IrClass -> return getClassLabel(element, listOf()).classLabel
-            is IrTypeParameter -> return getTypeParameterLabel(element)
-            is IrFunction -> return getFunctionLabel(element, null)
-            is IrValueParameter -> return getValueParameterLabel(element, null)
-            is IrProperty -> return getPropertyLabel(element)
-            is IrField -> return getFieldLabel(element)
-            is IrEnumEntry -> return getEnumEntryLabel(element)
-            is IrTypeAlias -> return getTypeAliasLabel(element)
-
-            is IrAnonymousInitializer -> {
-                val parentClass = element.parentClassOrNull
-                if (parentClass == null) {
-                    logger.errorElement("Parent of anonymous initializer is not a class", element)
-                    return null
-                }
-                // Assign the comment to the class. The content of the `init` blocks might be extracted in multiple constructors.
-                return getClassLabel(parentClass, listOf()).classLabel
-            }
-
-
-            // Fresh entities:
-            is IrBody -> return null
-            is IrExpression -> return null
-
-            // todo add others:
-            else -> {
-                logger.errorElement("Unhandled element type: ${element::class}", element)
-                return null
-            }
-        }
-    }
-
     private fun extractTypeParameter(tp: IrTypeParameter, apparentIndex: Int, javaTypeParameter: JavaTypeParameter?): Label<out DbTypevariable>? {
         with("type parameter", tp) {
             val parentId = getTypeParameterParentLabel(tp) ?: return null

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -172,6 +172,17 @@ open class KotlinFileExtractor(
             is IrEnumEntry -> return getEnumEntryLabel(element)
             is IrTypeAlias -> return getTypeAliasLabel(element)
 
+            is IrAnonymousInitializer -> {
+                val parentClass = element.parentClassOrNull
+                if (parentClass == null) {
+                    logger.errorElement("Parent of anonymous initializer is not a class", element)
+                    return null
+                }
+                // Assign the comment to the class. The content of the `init` blocks might be extracted in multiple constructors.
+                return getClassLabel(parentClass, listOf()).classLabel
+            }
+
+
             // Fresh entities:
             is IrBody -> return null
             is IrExpression -> return null

--- a/java/kotlin-extractor/src/main/kotlin/comments/CommentExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/comments/CommentExtractor.kt
@@ -140,7 +140,7 @@ class CommentExtractor(private val fileExtractor: KotlinFileExtractor, private v
                     is IrAnonymousInitializer -> {
                         val parentClass = element.parentClassOrNull
                         if (parentClass == null) {
-                            logger.errorElement("Parent of anonymous initializer is not a class", element)
+                            logger.warnElement("Parent of anonymous initializer is not a class", element)
                             return null
                         }
                         // Assign the comment to the class. The content of the `init` blocks might be extracted in multiple constructors.
@@ -153,7 +153,7 @@ class CommentExtractor(private val fileExtractor: KotlinFileExtractor, private v
 
                     // todo add others:
                     else -> {
-                        logger.errorElement("Unhandled element type: ${element::class}", element)
+                        logger.warnElement("Unhandled element type found during comment extraction: ${element::class}", element)
                         return null
                     }
                 }

--- a/java/kotlin-extractor/src/main/kotlin/comments/CommentExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/comments/CommentExtractor.kt
@@ -144,7 +144,7 @@ class CommentExtractor(private val fileExtractor: KotlinFileExtractor, private v
                             return null
                         }
                         // Assign the comment to the class. The content of the `init` blocks might be extracted in multiple constructors.
-                        return fileExtractor.getClassLabel(parentClass, listOf()).classLabel
+                        return getLabel(parentClass)
                     }
 
                     // Fresh entities:

--- a/java/kotlin-extractor/src/main/kotlin/comments/CommentExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/comments/CommentExtractor.kt
@@ -7,6 +7,9 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtVisitor
@@ -102,7 +105,7 @@ class CommentExtractor(private val fileExtractor: KotlinFileExtractor, private v
                                 label = "variable ${ownerIr.name.asString()}"
                                 tw.getExistingVariableLabelFor(ownerIr)
                             } else {
-                                label = fileExtractor.getLabel(ownerIr) ?: continue
+                                label = getLabel(ownerIr) ?: continue
                                 tw.getExistingLabelFor<DbTop>(label)
                             }
                             if (existingLabel == null) {
@@ -118,9 +121,42 @@ class CommentExtractor(private val fileExtractor: KotlinFileExtractor, private v
             private fun getKDocOwner(comment: KDoc) : PsiElement? {
                 val owner = comment.owner
                 if (owner == null) {
-                    logger.warn("Couldn't get owner of KDoc.")
+                    logger.warn("Couldn't get owner of KDoc. The comment is extracted without an owner.")
                 }
                 return owner
             }
+
+            private fun getLabel(element: IrElement) : String? {
+                when (element) {
+                    is IrClass -> return fileExtractor.getClassLabel(element, listOf()).classLabel
+                    is IrTypeParameter -> return fileExtractor.getTypeParameterLabel(element)
+                    is IrFunction -> return fileExtractor.getFunctionLabel(element, null)
+                    is IrValueParameter -> return fileExtractor.getValueParameterLabel(element, null)
+                    is IrProperty -> return fileExtractor.getPropertyLabel(element)
+                    is IrField -> return fileExtractor.getFieldLabel(element)
+                    is IrEnumEntry -> return fileExtractor.getEnumEntryLabel(element)
+                    is IrTypeAlias -> return fileExtractor.getTypeAliasLabel(element)
+
+                    is IrAnonymousInitializer -> {
+                        val parentClass = element.parentClassOrNull
+                        if (parentClass == null) {
+                            logger.errorElement("Parent of anonymous initializer is not a class", element)
+                            return null
+                        }
+                        // Assign the comment to the class. The content of the `init` blocks might be extracted in multiple constructors.
+                        return fileExtractor.getClassLabel(parentClass, listOf()).classLabel
+                    }
+
+                    // Fresh entities:
+                    is IrBody -> return null
+                    is IrExpression -> return null
+
+                    // todo add others:
+                    else -> {
+                        logger.errorElement("Unhandled element type: ${element::class}", element)
+                        return null
+                    }
+                }
         }
+    }
 }

--- a/java/ql/test/kotlin/library-tests/comments/comments.expected
+++ b/java/ql/test/kotlin/library-tests/comments/comments.expected
@@ -21,6 +21,7 @@ commentOwners
 | comments.kt:37:5:37:23 | /** This is high */ | comments.kt:38:5:38:11 | High |
 | comments.kt:42:5:44:6 | /**\n     * A variable.\n    */ | comments.kt:45:5:45:13 | int a |
 | comments.kt:48:1:50:3 | /**\n * A type alias comment\n */ | comments.kt:51:1:51:24 | MyType |
+| comments.kt:54:5:56:7 | /**\n     * An init block comment\n     */ | comments.kt:53:1:58:1 | InitBlock |
 commentSections
 | comments.kt:1:1:1:25 | /** Kdoc with no owner */ | Kdoc with no owner |
 | comments.kt:4:1:11:3 | /**\n * A group of *members*.\n *\n * This class has no useful logic; it's just a documentation example.\n *\n * @property name the name of this group.\n * @constructor Creates an empty group.\n */ | A group of *members*.\n\nThis class has no useful logic; it's just a documentation example.\n\n |

--- a/java/ql/test/kotlin/library-tests/comments/comments.expected
+++ b/java/ql/test/kotlin/library-tests/comments/comments.expected
@@ -9,6 +9,7 @@ comments
 | comments.kt:37:5:37:23 | /** This is high */ | /** This is high */ |
 | comments.kt:42:5:44:6 | /**\n     * A variable.\n    */ | /**\n     * A variable.\n    */ |
 | comments.kt:48:1:50:3 | /**\n * A type alias comment\n */ | /**\n * A type alias comment\n */ |
+| comments.kt:54:5:56:7 | /**\n     * An init block comment\n     */ | /**\n     * An init block comment\n     */ |
 commentOwners
 | comments.kt:4:1:11:3 | /**\n * A group of *members*.\n *\n * This class has no useful logic; it's just a documentation example.\n *\n * @property name the name of this group.\n * @constructor Creates an empty group.\n */ | comments.kt:12:1:31:1 | Group |
 | comments.kt:4:1:11:3 | /**\n * A group of *members*.\n *\n * This class has no useful logic; it's just a documentation example.\n *\n * @property name the name of this group.\n * @constructor Creates an empty group.\n */ | comments.kt:12:1:31:1 | Group |
@@ -31,11 +32,13 @@ commentSections
 | comments.kt:37:5:37:23 | /** This is high */ | This is high |
 | comments.kt:42:5:44:6 | /**\n     * A variable.\n    */ | A variable. |
 | comments.kt:48:1:50:3 | /**\n * A type alias comment\n */ | A type alias comment |
+| comments.kt:54:5:56:7 | /**\n     * An init block comment\n     */ | An init block comment |
 commentSectionContents
 | A group of *members*.\n\nThis class has no useful logic; it's just a documentation example.\n\n | A group of *members*.\n\nThis class has no useful logic; it's just a documentation example.\n\n |
 | A type alias comment | A type alias comment |
 | A variable. | A variable. |
 | Adds a [member] to this group.\n | Adds a [member] to this group.\n |
+| An init block comment | An init block comment |
 | Creates an empty group. | Creates an empty group. |
 | Kdoc with no owner | Kdoc with no owner |
 | Medium is in the middle | Medium is in the middle |

--- a/java/ql/test/kotlin/library-tests/comments/comments.kt
+++ b/java/ql/test/kotlin/library-tests/comments/comments.kt
@@ -49,3 +49,10 @@ fun fn1() {
  * A type alias comment
  */
 typealias MyType = Group
+
+class InitBlock {
+    /**
+     * An init block comment
+     */
+    init { }
+}


### PR DESCRIPTION
This PR (i) handles the extraction of doc comments assigned to anonymous init blocks, (ii) improves extraction messages, and (iii) improves code quality.