### PR TITLE
C++: Workaround for missing `DeclarationEntry` for `DeclStmt`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -168,6 +168,11 @@ private predicate isInvalidFunction(Function func) {
     expr.getEnclosingFunction() = func and
     not exists(expr.getType())
   )
+  or
+  exists(DeclStmt declStmt |
+    declStmt.getEnclosingFunction() = func and
+    not exists(declStmt.getADeclarationEntry())
+  )
 }
 
 /**


### PR DESCRIPTION
This is a simple IR fix for [missing association between DeclarationEntry and DeclStmt in template instantiations](https://github.com/github/codeql-c-team/issues/1009). Draft while investigating the implications on DCA.
