### PR TITLE
Swift: add generic type parameters to AST children

### DIFF
--- a/swift/codegen/lib/ql.py
+++ b/swift/codegen/lib/ql.py
@@ -96,8 +96,7 @@ class Class:
     ipa: bool = False
 
     def __post_init__(self):
-        bases = sorted(str(b) for b in self.bases)
-        self.bases = [Base(str(b), prev) for b, prev in zip(bases, itertools.chain([""], bases))]
+        self.bases = [Base(str(b), str(prev)) for b, prev in zip(self.bases, itertools.chain([""], self.bases))]
         if self.properties:
             self.properties[0].first = True
 

--- a/swift/codegen/lib/schema.py
+++ b/swift/codegen/lib/schema.py
@@ -65,7 +65,7 @@ class IpaInfo:
 @dataclass
 class Class:
     name: str
-    bases: Set[str] = field(default_factory=set)
+    bases: List[str] = field(default_factory=set)
     derived: Set[str] = field(default_factory=set)
     properties: List[Property] = field(default_factory=list)
     dir: pathlib.Path = pathlib.Path()
@@ -150,9 +150,8 @@ def load(path):
             if not k.startswith("_"):
                 cls.properties.append(_parse_property(k, v))
             elif k == "_extends":
-                v = _auto_list(v)
-                for base in v:
-                    cls.bases.add(base)
+                cls.bases = _auto_list(v)
+                for base in cls.bases:
                     classes[base].derived.add(name)
             elif k == "_dir":
                 cls.dir = pathlib.Path(v)
@@ -165,7 +164,7 @@ def load(path):
             else:
                 raise Error(f"unknown metadata {k} for class {name}")
         if not cls.bases and cls.name != root_class_name:
-            cls.bases.add(root_class_name)
+            cls.bases = [root_class_name]
             classes[root_class_name].derived.add(name)
 
     return Schema(classes=classes, includes=set(data.get("_includes", [])))

--- a/swift/codegen/schema.yml
+++ b/swift/codegen/schema.yml
@@ -72,8 +72,8 @@ ExtensionDecl:
 
 NominalTypeDecl:
   _extends:
-    - IterableDeclContext
     - GenericTypeDecl
+    - IterableDeclContext
   type: Type
 
 AstNode:

--- a/swift/codegen/schema.yml
+++ b/swift/codegen/schema.yml
@@ -1109,7 +1109,8 @@ AbstractTypeParamDecl:
   _extends: TypeDecl
 
 GenericContext:
-  generic_type_params: GenericTypeParamDecl*
+  _children:
+    generic_type_params: GenericTypeParamDecl*
 
 GenericTypeDecl:
   _extends:

--- a/swift/codegen/test/test_cppgen.py
+++ b/swift/codegen/test/test_cppgen.py
@@ -49,7 +49,7 @@ def test_two_class_hierarchy(generate):
     base = cpp.Class(name="A")
     assert generate([
         schema.Class(name="A", derived={"B"}),
-        schema.Class(name="B", bases={"A"}),
+        schema.Class(name="B", bases=["A"]),
     ]) == [
         base,
         cpp.Class(name="B", bases=[base], final=True, trap_name="Bs"),
@@ -64,11 +64,11 @@ def test_complex_hierarchy_topologically_ordered(generate):
     e = cpp.Class(name="E", bases=[b, c, d], final=True, trap_name="Es")
     f = cpp.Class(name="F", bases=[c], final=True, trap_name="Fs")
     assert generate([
-        schema.Class(name="F", bases={"C"}),
+        schema.Class(name="F", bases=["C"]),
         schema.Class(name="B", derived={"E"}),
-        schema.Class(name="D", bases={"A"}, derived={"E"}),
-        schema.Class(name="C", bases={"A"}, derived={"E", "F"}),
-        schema.Class(name="E", bases={"B", "C", "D"}),
+        schema.Class(name="D", bases=["A"], derived={"E"}),
+        schema.Class(name="C", bases=["A"], derived={"E", "F"}),
+        schema.Class(name="E", bases=["B", "C", "D"]),
         schema.Class(name="A", derived={"C", "D"}),
     ]) == [a, b, c, d, e, f]
 
@@ -154,7 +154,7 @@ def test_classes_with_dirs(generate_grouped):
     assert generate_grouped([
         schema.Class(name="A"),
         schema.Class(name="B", dir=pathlib.Path("foo")),
-        schema.Class(name="C", bases={"CBase"}, dir=pathlib.Path("bar")),
+        schema.Class(name="C", bases=["CBase"], dir=pathlib.Path("bar")),
         schema.Class(name="CBase", derived={"C"}, dir=pathlib.Path("bar")),
         schema.Class(name="D", dir=pathlib.Path("foo/bar/baz")),
     ]) == {

--- a/swift/codegen/test/test_ql.py
+++ b/swift/codegen/test/test_ql.py
@@ -80,7 +80,7 @@ def test_property_predicate_getter():
 
 def test_class_processes_bases():
     bases = ["B", "Ab", "C", "Aa"]
-    expected = [ql.Base("Aa"), ql.Base("Ab", prev="Aa"), ql.Base("B", prev="Ab"), ql.Base("C", prev="B")]
+    expected = [ql.Base("B"), ql.Base("Ab", prev="B"), ql.Base("C", prev="Ab"), ql.Base("Aa", prev="C")]
     cls = ql.Class("Foo", bases=bases)
     assert cls.bases == expected
 

--- a/swift/codegen/test/test_qlgen.py
+++ b/swift/codegen/test/test_qlgen.py
@@ -149,9 +149,9 @@ def test_one_empty_class(generate_classes):
 
 def test_hierarchy(generate_classes):
     assert generate_classes([
-        schema.Class("D", bases={"B", "C"}),
-        schema.Class("C", bases={"A"}, derived={"D"}),
-        schema.Class("B", bases={"A"}, derived={"D"}),
+        schema.Class("D", bases=["B", "C"]),
+        schema.Class("C", bases=["A"], derived={"D"}),
+        schema.Class("B", bases=["A"], derived={"D"}),
         schema.Class("A", derived={"B", "C"}),
     ]) == {
         "A.qll": (ql.Stub(name="A", base_import=gen_import_prefix + "A"),
@@ -168,18 +168,18 @@ def test_hierarchy(generate_classes):
 
 def test_hierarchy_imports(generate_import_list):
     assert generate_import_list([
-        schema.Class("D", bases={"B", "C"}),
-        schema.Class("C", bases={"A"}, derived={"D"}),
-        schema.Class("B", bases={"A"}, derived={"D"}),
+        schema.Class("D", bases=["B", "C"]),
+        schema.Class("C", bases=["A"], derived={"D"}),
+        schema.Class("B", bases=["A"], derived={"D"}),
         schema.Class("A", derived={"B", "C"}),
     ]) == ql.ImportList([stub_import_prefix + cls for cls in "ABCD"])
 
 
 def test_hierarchy_children(generate_children_implementations):
     assert generate_children_implementations([
-        schema.Class("D", bases={"B", "C"}),
-        schema.Class("C", bases={"A"}, derived={"D"}),
-        schema.Class("B", bases={"A"}, derived={"D"}),
+        schema.Class("D", bases=["B", "C"]),
+        schema.Class("C", bases=["A"], derived={"D"}),
+        schema.Class("B", bases=["A"], derived={"D"}),
         schema.Class("A", derived={"B", "C"}),
     ]) == ql.GetParentImplementation(
         classes=[ql.Class(name="A"),
@@ -347,7 +347,7 @@ def test_class_dir(generate_classes):
     dir = pathlib.Path("another/rel/path")
     assert generate_classes([
         schema.Class("A", derived={"B"}, dir=dir),
-        schema.Class("B", bases={"A"}),
+        schema.Class("B", bases=["A"]),
     ]) == {
         f"{dir}/A.qll": (ql.Stub(name="A", base_import=gen_import_prefix + "another.rel.path.A"),
                          ql.Class(name="A", dir=dir)),
@@ -368,7 +368,7 @@ def test_class_dir_imports(generate_import_list):
     dir = pathlib.Path("another/rel/path")
     assert generate_import_list([
         schema.Class("A", derived={"B"}, dir=dir),
-        schema.Class("B", bases={"A"}),
+        schema.Class("B", bases=["A"]),
     ]) == ql.ImportList([
         stub_import_prefix + "B",
         stub_import_prefix + "another.rel.path.A",
@@ -475,7 +475,7 @@ def test_test_total_properties(opts, generate_tests):
         schema.Class("A", derived={"B"}, properties=[
             schema.SingleProperty("x", "string"),
         ]),
-        schema.Class("B", bases={"A"}, properties=[
+        schema.Class("B", bases=["A"], properties=[
             schema.PredicateProperty("y", "int"),
         ]),
     ]) == {
@@ -494,7 +494,7 @@ def test_test_partial_properties(opts, generate_tests):
         schema.Class("A", derived={"B"}, properties=[
             schema.OptionalProperty("x", "string"),
         ]),
-        schema.Class("B", bases={"A"}, properties=[
+        schema.Class("B", bases=["A"], properties=[
             schema.RepeatedProperty("y", "int"),
         ]),
     ]) == {
@@ -514,9 +514,9 @@ def test_test_properties_deduplicated(opts, generate_tests):
             schema.SingleProperty("x", "string"),
             schema.RepeatedProperty("y", "int"),
         ]),
-        schema.Class("A", bases={"Base"}, derived={"Final"}),
-        schema.Class("B", bases={"Base"}, derived={"Final"}),
-        schema.Class("Final", bases={"A", "B"}),
+        schema.Class("A", bases=["Base"], derived={"Final"}),
+        schema.Class("B", bases=["Base"], derived={"Final"}),
+        schema.Class("Final", bases=["A", "B"]),
     ]) == {
         "Final/Final.ql": ql.ClassTester(class_name="Final", properties=[
             ql.PropertyForTest(
@@ -535,7 +535,7 @@ def test_test_properties_skipped(opts, generate_tests):
             schema.SingleProperty("x", "string", pragmas=["qltest_skip", "foo"]),
             schema.RepeatedProperty("y", "int", pragmas=["bar", "qltest_skip"]),
         ]),
-        schema.Class("Derived", bases={"Base"}, properties=[
+        schema.Class("Derived", bases=["Base"], properties=[
             schema.PredicateProperty("a", pragmas=["qltest_skip"]),
             schema.OptionalProperty(
                 "b", "int", pragmas=["bar", "qltest_skip", "baz"]),
@@ -552,7 +552,7 @@ def test_test_base_class_skipped(opts, generate_tests):
             schema.SingleProperty("x", "string"),
             schema.RepeatedProperty("y", "int"),
         ]),
-        schema.Class("Derived", bases={"Base"}),
+        schema.Class("Derived", bases=["Base"]),
     ]) == {
         "Derived/Derived.ql": ql.ClassTester(class_name="Derived"),
     }
@@ -562,7 +562,7 @@ def test_test_final_class_skipped(opts, generate_tests):
     write(opts.ql_test_output / "Derived" / "test.swift")
     assert generate_tests([
         schema.Class("Base", derived={"Derived"}),
-        schema.Class("Derived", bases={"Base"}, pragmas=["qltest_skip", "foo"], properties=[
+        schema.Class("Derived", bases=["Base"], pragmas=["qltest_skip", "foo"], properties=[
             schema.SingleProperty("x", "string"),
             schema.RepeatedProperty("y", "int"),
         ]),
@@ -573,9 +573,9 @@ def test_test_class_hierarchy_collapse(opts, generate_tests):
     write(opts.ql_test_output / "Base" / "test.swift")
     assert generate_tests([
         schema.Class("Base", derived={"D1", "D2"}, pragmas=["foo", "qltest_collapse_hierarchy"]),
-        schema.Class("D1", bases={"Base"}, properties=[schema.SingleProperty("x", "string")]),
-        schema.Class("D2", bases={"Base"}, derived={"D3"}, properties=[schema.SingleProperty("y", "string")]),
-        schema.Class("D3", bases={"D2"}, properties=[schema.SingleProperty("z", "string")]),
+        schema.Class("D1", bases=["Base"], properties=[schema.SingleProperty("x", "string")]),
+        schema.Class("D2", bases=["Base"], derived={"D3"}, properties=[schema.SingleProperty("y", "string")]),
+        schema.Class("D3", bases=["D2"], properties=[schema.SingleProperty("z", "string")]),
     ]) == {
         "Base/Base.ql": ql.ClassTester(class_name="Base"),
     }
@@ -586,10 +586,10 @@ def test_test_class_hierarchy_uncollapse(opts, generate_tests):
         write(opts.ql_test_output / d / "test.swift")
     assert generate_tests([
         schema.Class("Base", derived={"D1", "D2"}, pragmas=["foo", "qltest_collapse_hierarchy"]),
-        schema.Class("D1", bases={"Base"}, properties=[schema.SingleProperty("x", "string")]),
-        schema.Class("D2", bases={"Base"}, derived={"D3", "D4"}, pragmas=["qltest_uncollapse_hierarchy", "bar"]),
-        schema.Class("D3", bases={"D2"}),
-        schema.Class("D4", bases={"D2"}),
+        schema.Class("D1", bases=["Base"], properties=[schema.SingleProperty("x", "string")]),
+        schema.Class("D2", bases=["Base"], derived={"D3", "D4"}, pragmas=["qltest_uncollapse_hierarchy", "bar"]),
+        schema.Class("D3", bases=["D2"]),
+        schema.Class("D4", bases=["D2"]),
     ]) == {
         "Base/Base.ql": ql.ClassTester(class_name="Base"),
         "D3/D3.ql": ql.ClassTester(class_name="D3"),
@@ -602,9 +602,9 @@ def test_test_class_hierarchy_uncollapse_at_final(opts, generate_tests):
         write(opts.ql_test_output / d / "test.swift")
     assert generate_tests([
         schema.Class("Base", derived={"D1", "D2"}, pragmas=["foo", "qltest_collapse_hierarchy"]),
-        schema.Class("D1", bases={"Base"}, properties=[schema.SingleProperty("x", "string")]),
-        schema.Class("D2", bases={"Base"}, derived={"D3"}),
-        schema.Class("D3", bases={"D2"}, pragmas=["qltest_uncollapse_hierarchy", "bar"]),
+        schema.Class("D1", bases=["Base"], properties=[schema.SingleProperty("x", "string")]),
+        schema.Class("D2", bases=["Base"], derived={"D3"}),
+        schema.Class("D3", bases=["D2"], pragmas=["qltest_uncollapse_hierarchy", "bar"]),
     ]) == {
         "Base/Base.ql": ql.ClassTester(class_name="Base"),
         "D3/D3.ql": ql.ClassTester(class_name="D3"),

--- a/swift/codegen/test/test_schema.py
+++ b/swift/codegen/test/test_schema.py
@@ -30,7 +30,7 @@ MyClass: {}
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'MyClass'}),
-        'MyClass': schema.Class('MyClass', bases={root_name}),
+        'MyClass': schema.Class('MyClass', bases=[root_name]),
     }
 
 
@@ -41,8 +41,8 @@ MyClass2: {}
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'MyClass1', 'MyClass2'}),
-        'MyClass1': schema.Class('MyClass1', bases={root_name}),
-        'MyClass2': schema.Class('MyClass2', bases={root_name}),
+        'MyClass1': schema.Class('MyClass1', bases=[root_name]),
+        'MyClass2': schema.Class('MyClass2', bases=[root_name]),
     }
 
 
@@ -54,8 +54,8 @@ MyClass2:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'MyClass1'}),
-        'MyClass1': schema.Class('MyClass1', bases={root_name}, derived={'MyClass2'}),
-        'MyClass2': schema.Class('MyClass2', bases={'MyClass1'}),
+        'MyClass1': schema.Class('MyClass1', bases=[root_name], derived={'MyClass2'}),
+        'MyClass2': schema.Class('MyClass2', bases=['MyClass1']),
     }
 
 
@@ -70,9 +70,9 @@ C:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A', 'B'}),
-        'A': schema.Class('A', bases={root_name}, derived={'C'}),
-        'B': schema.Class('B', bases={root_name}, derived={'C'}),
-        'C': schema.Class('C', bases={'A', 'B'}),
+        'A': schema.Class('A', bases=[root_name], derived={'C'}),
+        'B': schema.Class('B', bases=[root_name], derived={'C'}),
+        'C': schema.Class('C', bases=['A', 'B']),
     }
 
 
@@ -83,7 +83,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, dir=pathlib.Path("other/dir")),
+        'A': schema.Class('A', bases=[root_name], dir=pathlib.Path("other/dir")),
     }
 
 
@@ -103,13 +103,13 @@ A: {}
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'Afoo', 'Bbar', 'Abar', 'Bfoo', 'Ax', 'Ay', 'A'}),
-        'Afoo': schema.Class('Afoo', bases={root_name}, dir=pathlib.Path("second/dir")),
-        'Bbar': schema.Class('Bbar', bases={root_name}, dir=pathlib.Path("third/dir")),
-        'Abar': schema.Class('Abar', bases={root_name}, dir=pathlib.Path("third/dir")),
-        'Bfoo': schema.Class('Bfoo', bases={root_name}, dir=pathlib.Path("second/dir")),
-        'Ax': schema.Class('Ax', bases={root_name}, dir=pathlib.Path("first/dir")),
-        'Ay': schema.Class('Ay', bases={root_name}, dir=pathlib.Path("first/dir")),
-        'A': schema.Class('A', bases={root_name}, dir=pathlib.Path()),
+        'Afoo': schema.Class('Afoo', bases=[root_name], dir=pathlib.Path("second/dir")),
+        'Bbar': schema.Class('Bbar', bases=[root_name], dir=pathlib.Path("third/dir")),
+        'Abar': schema.Class('Abar', bases=[root_name], dir=pathlib.Path("third/dir")),
+        'Bfoo': schema.Class('Bfoo', bases=[root_name], dir=pathlib.Path("second/dir")),
+        'Ax': schema.Class('Ax', bases=[root_name], dir=pathlib.Path("first/dir")),
+        'Ay': schema.Class('Ay', bases=[root_name], dir=pathlib.Path("first/dir")),
+        'A': schema.Class('A', bases=[root_name], dir=pathlib.Path()),
     }
 
 
@@ -122,7 +122,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, dir=pathlib.Path("other/dir")),
+        'A': schema.Class('A', bases=[root_name], dir=pathlib.Path("other/dir")),
     }
 
 
@@ -147,7 +147,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, properties=[
+        'A': schema.Class('A', bases=[root_name], properties=[
             schema.SingleProperty('one', 'string'),
             schema.OptionalProperty('two', 'int'),
             schema.RepeatedProperty('three', 'bool'),
@@ -182,7 +182,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, properties=[
+        'A': schema.Class('A', bases=[root_name], properties=[
             schema.SingleProperty('a', 'string'),
             schema.RepeatedProperty('b', 'B'),
             schema.SingleProperty('c', 'C', is_child=True),
@@ -211,7 +211,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, properties=[
+        'A': schema.Class('A', bases=[root_name], properties=[
             schema.RepeatedProperty('x', 'string'),
         ]),
     }
@@ -226,7 +226,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, properties=[
+        'A': schema.Class('A', bases=[root_name], properties=[
             schema.RepeatedProperty('x', 'string', pragmas=["foo", "bar"]),
         ]),
     }
@@ -241,7 +241,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, properties=[
+        'A': schema.Class('A', bases=[root_name], properties=[
             schema.RepeatedProperty('x', 'string', pragmas=["foo"]),
         ]),
     }
@@ -274,7 +274,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, properties=[
+        'A': schema.Class('A', bases=[root_name], properties=[
             schema.RepeatedProperty('x', 'string'),
         ], pragmas=["foo", "bar"]),
     }
@@ -288,7 +288,7 @@ A:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'A'}),
-        'A': schema.Class('A', bases={root_name}, properties=[
+        'A': schema.Class('A', bases=[root_name], properties=[
             schema.RepeatedProperty('x', 'string'),
         ], pragmas=["foo"]),
     }
@@ -311,7 +311,7 @@ MyClass:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'MyClass'}),
-        'MyClass': schema.Class('MyClass', bases={root_name}, ipa=schema.IpaInfo(from_class="A")),
+        'MyClass': schema.Class('MyClass', bases=[root_name], ipa=schema.IpaInfo(from_class="A")),
     }
 
 
@@ -325,7 +325,7 @@ MyClass:
 """)
     assert ret.classes == {
         root_name: schema.Class(root_name, derived={'MyClass'}),
-        'MyClass': schema.Class('MyClass', bases={root_name}, ipa=schema.IpaInfo(on_arguments={"x": "A", "y": "int"})),
+        'MyClass': schema.Class('MyClass', bases=[root_name], ipa=schema.IpaInfo(on_arguments={"x": "A", "y": "int"})),
     }
 
 

--- a/swift/ql/lib/codeql/swift/generated/ParentChild.qll
+++ b/swift/ql/lib/codeql/swift/generated/ParentChild.qll
@@ -4650,21 +4650,21 @@ private module Impl {
   private Element getImmediateChildOfNominalTypeDecl(
     NominalTypeDecl e, int index, string partialPredicateCall
   ) {
-    exists(int b, int bIterableDeclContext, int bGenericTypeDecl, int n |
+    exists(int b, int bGenericTypeDecl, int bIterableDeclContext, int n |
       b = 0 and
-      bIterableDeclContext =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
       bGenericTypeDecl =
-        bIterableDeclContext + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
-      n = bGenericTypeDecl and
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
+      bIterableDeclContext =
+        bGenericTypeDecl + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
+      n = bIterableDeclContext and
       (
         none()
         or
-        result = getImmediateChildOfIterableDeclContext(e, index - b, partialPredicateCall)
+        result = getImmediateChildOfGenericTypeDecl(e, index - b, partialPredicateCall)
         or
         result =
-          getImmediateChildOfGenericTypeDecl(e, index - bIterableDeclContext, partialPredicateCall)
+          getImmediateChildOfIterableDeclContext(e, index - bGenericTypeDecl, partialPredicateCall)
       )
     )
   }

--- a/swift/ql/lib/codeql/swift/generated/ParentChild.qll
+++ b/swift/ql/lib/codeql/swift/generated/ParentChild.qll
@@ -45,14 +45,19 @@ private module Impl {
   private Element getImmediateChildOfGenericContext(
     GenericContext e, int index, string partialPredicateCall
   ) {
-    exists(int b, int bElement, int n |
+    exists(int b, int bElement, int n, int nGenericTypeParam |
       b = 0 and
       bElement = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfElement(e, i, _)) | i) and
       n = bElement and
+      nGenericTypeParam =
+        n + 1 + max(int i | i = -1 or exists(e.getImmediateGenericTypeParam(i)) | i) and
       (
         none()
         or
         result = getImmediateChildOfElement(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateGenericTypeParam(index - n) and
+        partialPredicateCall = "GenericTypeParam(" + (index - n).toString() + ")"
       )
     )
   }

--- a/swift/ql/lib/codeql/swift/generated/ParentChild.qll
+++ b/swift/ql/lib/codeql/swift/generated/ParentChild.qll
@@ -1095,17 +1095,18 @@ private module Impl {
   private Element getImmediateChildOfAbstractClosureExpr(
     AbstractClosureExpr e, int index, string partialPredicateCall
   ) {
-    exists(int b, int bCallable, int bExpr, int n |
+    exists(int b, int bExpr, int bCallable, int n |
       b = 0 and
-      bCallable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCallable(e, i, _)) | i) and
-      bExpr = bCallable + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      bCallable =
+        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfCallable(e, i, _)) | i) and
+      n = bCallable and
       (
         none()
         or
-        result = getImmediateChildOfCallable(e, index - b, partialPredicateCall)
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
         or
-        result = getImmediateChildOfExpr(e, index - bCallable, partialPredicateCall)
+        result = getImmediateChildOfCallable(e, index - bExpr, partialPredicateCall)
       )
     )
   }
@@ -1666,24 +1667,26 @@ private module Impl {
   private Element getImmediateChildOfExtensionDecl(
     ExtensionDecl e, int index, string partialPredicateCall
   ) {
-    exists(int b, int bDecl, int bGenericContext, int bIterableDeclContext, int n |
+    exists(int b, int bGenericContext, int bIterableDeclContext, int bDecl, int n |
       b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
       bGenericContext =
-        bDecl + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
       bIterableDeclContext =
         bGenericContext + 1 +
           max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
-      n = bIterableDeclContext and
+      bDecl =
+        bIterableDeclContext + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
       (
         none()
         or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfGenericContext(e, index - bDecl, partialPredicateCall)
+        result = getImmediateChildOfGenericContext(e, index - b, partialPredicateCall)
         or
         result =
           getImmediateChildOfIterableDeclContext(e, index - bGenericContext, partialPredicateCall)
+        or
+        result = getImmediateChildOfDecl(e, index - bIterableDeclContext, partialPredicateCall)
       )
     )
   }
@@ -2773,24 +2776,24 @@ private module Impl {
   private Element getImmediateChildOfAbstractFunctionDecl(
     AbstractFunctionDecl e, int index, string partialPredicateCall
   ) {
-    exists(int b, int bCallable, int bGenericContext, int bValueDecl, int n |
+    exists(int b, int bGenericContext, int bValueDecl, int bCallable, int n |
       b = 0 and
-      bCallable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCallable(e, i, _)) | i) and
       bGenericContext =
-        bCallable + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
       bValueDecl =
         bGenericContext + 1 +
           max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
-      n = bValueDecl and
+      bCallable =
+        bValueDecl + 1 + max(int i | i = -1 or exists(getImmediateChildOfCallable(e, i, _)) | i) and
+      n = bCallable and
       (
         none()
         or
-        result = getImmediateChildOfCallable(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfGenericContext(e, index - bCallable, partialPredicateCall)
+        result = getImmediateChildOfGenericContext(e, index - b, partialPredicateCall)
         or
         result = getImmediateChildOfValueDecl(e, index - bGenericContext, partialPredicateCall)
+        or
+        result = getImmediateChildOfCallable(e, index - bValueDecl, partialPredicateCall)
       )
     )
   }
@@ -4642,21 +4645,21 @@ private module Impl {
   private Element getImmediateChildOfNominalTypeDecl(
     NominalTypeDecl e, int index, string partialPredicateCall
   ) {
-    exists(int b, int bGenericTypeDecl, int bIterableDeclContext, int n |
+    exists(int b, int bIterableDeclContext, int bGenericTypeDecl, int n |
       b = 0 and
-      bGenericTypeDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
       bIterableDeclContext =
-        bGenericTypeDecl + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
-      n = bIterableDeclContext and
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
+      bGenericTypeDecl =
+        bIterableDeclContext + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
+      n = bGenericTypeDecl and
       (
         none()
         or
-        result = getImmediateChildOfGenericTypeDecl(e, index - b, partialPredicateCall)
+        result = getImmediateChildOfIterableDeclContext(e, index - b, partialPredicateCall)
         or
         result =
-          getImmediateChildOfIterableDeclContext(e, index - bGenericTypeDecl, partialPredicateCall)
+          getImmediateChildOfGenericTypeDecl(e, index - bIterableDeclContext, partialPredicateCall)
       )
     )
   }

--- a/swift/ql/lib/codeql/swift/generated/Raw.qll
+++ b/swift/ql/lib/codeql/swift/generated/Raw.qll
@@ -1480,7 +1480,7 @@ module Raw {
     string getStringValue() { integer_literal_exprs(this, result) }
   }
 
-  class NominalTypeDecl extends @nominal_type_decl, IterableDeclContext, GenericTypeDecl {
+  class NominalTypeDecl extends @nominal_type_decl, GenericTypeDecl, IterableDeclContext {
     Type getType() { nominal_type_decls(this, result) }
   }
 

--- a/swift/ql/lib/codeql/swift/generated/Raw.qll
+++ b/swift/ql/lib/codeql/swift/generated/Raw.qll
@@ -346,7 +346,7 @@ module Raw {
     override string toString() { result = "WeakStorageType" }
   }
 
-  class AbstractClosureExpr extends @abstract_closure_expr, Callable, Expr { }
+  class AbstractClosureExpr extends @abstract_closure_expr, Expr, Callable { }
 
   class AnyPattern extends @any_pattern, Pattern {
     override string toString() { result = "AnyPattern" }
@@ -556,7 +556,7 @@ module Raw {
     Expr getSubExpr() { expr_patterns(this, result) }
   }
 
-  class ExtensionDecl extends @extension_decl, Decl, GenericContext, IterableDeclContext {
+  class ExtensionDecl extends @extension_decl, GenericContext, IterableDeclContext, Decl {
     override string toString() { result = "ExtensionDecl" }
 
     NominalTypeDecl getExtendedTypeDecl() { extension_decls(this, result) }
@@ -926,7 +926,7 @@ module Raw {
     Expr getResult(int index) { yield_stmt_results(this, index, result) }
   }
 
-  class AbstractFunctionDecl extends @abstract_function_decl, Callable, GenericContext, ValueDecl {
+  class AbstractFunctionDecl extends @abstract_function_decl, GenericContext, ValueDecl, Callable {
     string getName() { abstract_function_decls(this, result) }
   }
 
@@ -1480,7 +1480,7 @@ module Raw {
     string getStringValue() { integer_literal_exprs(this, result) }
   }
 
-  class NominalTypeDecl extends @nominal_type_decl, GenericTypeDecl, IterableDeclContext {
+  class NominalTypeDecl extends @nominal_type_decl, IterableDeclContext, GenericTypeDecl {
     Type getType() { nominal_type_decls(this, result) }
   }
 

--- a/swift/ql/lib/codeql/swift/generated/decl/AbstractFunctionDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/AbstractFunctionDecl.qll
@@ -5,8 +5,8 @@ import codeql.swift.elements.Callable
 import codeql.swift.elements.decl.GenericContext
 import codeql.swift.elements.decl.ValueDecl
 
-class AbstractFunctionDeclBase extends Synth::TAbstractFunctionDecl, Callable, GenericContext,
-  ValueDecl {
+class AbstractFunctionDeclBase extends Synth::TAbstractFunctionDecl, GenericContext, ValueDecl,
+  Callable {
   string getName() {
     result = Synth::convertAbstractFunctionDeclToRaw(this).(Raw::AbstractFunctionDecl).getName()
   }

--- a/swift/ql/lib/codeql/swift/generated/decl/ExtensionDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ExtensionDecl.qll
@@ -6,7 +6,7 @@ import codeql.swift.elements.decl.GenericContext
 import codeql.swift.elements.decl.IterableDeclContext
 import codeql.swift.elements.decl.NominalTypeDecl
 
-class ExtensionDeclBase extends Synth::TExtensionDecl, Decl, GenericContext, IterableDeclContext {
+class ExtensionDeclBase extends Synth::TExtensionDecl, GenericContext, IterableDeclContext, Decl {
   override string getAPrimaryQlClass() { result = "ExtensionDecl" }
 
   NominalTypeDecl getImmediateExtendedTypeDecl() {

--- a/swift/ql/lib/codeql/swift/generated/decl/NominalTypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/NominalTypeDecl.qll
@@ -5,7 +5,7 @@ import codeql.swift.elements.decl.GenericTypeDecl
 import codeql.swift.elements.decl.IterableDeclContext
 import codeql.swift.elements.type.Type
 
-class NominalTypeDeclBase extends Synth::TNominalTypeDecl, IterableDeclContext, GenericTypeDecl {
+class NominalTypeDeclBase extends Synth::TNominalTypeDecl, GenericTypeDecl, IterableDeclContext {
   Type getImmediateType() {
     result =
       Synth::convertTypeFromRaw(Synth::convertNominalTypeDeclToRaw(this)

--- a/swift/ql/lib/codeql/swift/generated/decl/NominalTypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/NominalTypeDecl.qll
@@ -5,7 +5,7 @@ import codeql.swift.elements.decl.GenericTypeDecl
 import codeql.swift.elements.decl.IterableDeclContext
 import codeql.swift.elements.type.Type
 
-class NominalTypeDeclBase extends Synth::TNominalTypeDecl, GenericTypeDecl, IterableDeclContext {
+class NominalTypeDeclBase extends Synth::TNominalTypeDecl, IterableDeclContext, GenericTypeDecl {
   Type getImmediateType() {
     result =
       Synth::convertTypeFromRaw(Synth::convertNominalTypeDeclToRaw(this)

--- a/swift/ql/lib/codeql/swift/generated/expr/AbstractClosureExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/AbstractClosureExpr.qll
@@ -4,4 +4,4 @@ private import codeql.swift.generated.Raw
 import codeql.swift.elements.Callable
 import codeql.swift.elements.expr.Expr
 
-class AbstractClosureExprBase extends Synth::TAbstractClosureExpr, Callable, Expr { }
+class AbstractClosureExprBase extends Synth::TAbstractClosureExpr, Expr, Callable { }

--- a/swift/ql/test/extractor-tests/declarations/all.expected
+++ b/swift/ql/test/extractor-tests/declarations/all.expected
@@ -235,3 +235,23 @@
 | declarations.swift:139:3:141:3 | id() |
 | declarations.swift:139:8:139:8 | self |
 | declarations.swift:144:1:144:7 | { ... } |
+| declarations.swift:146:1:148:1 | GenericClass |
+| declarations.swift:146:7:146:7 | deinit() |
+| declarations.swift:146:7:146:7 | init() |
+| declarations.swift:146:7:146:7 | self |
+| declarations.swift:146:7:146:7 | self |
+| declarations.swift:146:20:146:20 | A |
+| declarations.swift:146:23:146:26 | B |
+| declarations.swift:146:31:146:34 | C |
+| declarations.swift:147:3:147:41 | genericMethod(_:_:_:) |
+| declarations.swift:147:8:147:8 | self |
+| declarations.swift:147:22:147:25 | _ |
+| declarations.swift:147:28:147:31 | _ |
+| declarations.swift:147:34:147:37 | _ |
+| declarations.swift:150:1:150:63 | genericFunc(_:_:_:) |
+| declarations.swift:150:18:150:18 | A |
+| declarations.swift:150:21:150:24 | B |
+| declarations.swift:150:29:150:32 | C |
+| declarations.swift:150:44:150:47 | _ |
+| declarations.swift:150:50:150:53 | _ |
+| declarations.swift:150:56:150:59 | _ |

--- a/swift/ql/test/extractor-tests/declarations/declarations.swift
+++ b/swift/ql/test/extractor-tests/declarations/declarations.swift
@@ -143,3 +143,8 @@ extension Int {
 
 42.id()
 
+class GenericClass<A, B: Baz, C: MyProtocol> {
+  func genericMethod(_: A, _: B, _: C) {}
+}
+
+func genericFunc<A, B: Baz, C: MyProtocol>(_: A, _: B, _: C) {}

--- a/swift/ql/test/library-tests/ast/PrintAst.expected
+++ b/swift/ql/test/library-tests/ast/PrintAst.expected
@@ -452,6 +452,31 @@ declarations.swift:
 #  144|     getElement(0): [CallExpr] call to id()
 #  144|       getFunction(): [MethodRefExpr] .id()
 #  144|         getBase(): [IntegerLiteralExpr] 42
+#  146| [ClassDecl] GenericClass
+#  146|   getGenericTypeParam(0): [GenericTypeParamDecl] A
+#  146|   getGenericTypeParam(1): [GenericTypeParamDecl] B
+#  146|   getGenericTypeParam(2): [GenericTypeParamDecl] C
+#  147|   getMember(0): [ConcreteFuncDecl] genericMethod(_:_:_:)
+#  147|     getSelfParam(): [ParamDecl] self
+#  147|     getParam(0): [ParamDecl] _
+#  147|     getParam(1): [ParamDecl] _
+#  147|     getParam(2): [ParamDecl] _
+#  147|     getBody(): [BraceStmt] { ... }
+#  146|   getMember(1): [DestructorDecl] deinit()
+#  146|     getSelfParam(): [ParamDecl] self
+#  146|     getBody(): [BraceStmt] { ... }
+#  146|   getMember(2): [ConstructorDecl] init()
+#  146|     getSelfParam(): [ParamDecl] self
+#  146|     getBody(): [BraceStmt] { ... }
+#  146|       getElement(0): [ReturnStmt] return
+#  150| [ConcreteFuncDecl] genericFunc(_:_:_:)
+#  150|   getGenericTypeParam(0): [GenericTypeParamDecl] A
+#  150|   getGenericTypeParam(1): [GenericTypeParamDecl] B
+#  150|   getGenericTypeParam(2): [GenericTypeParamDecl] C
+#  150|   getParam(0): [ParamDecl] _
+#  150|   getParam(1): [ParamDecl] _
+#  150|   getParam(2): [ParamDecl] _
+#  150|   getBody(): [BraceStmt] { ... }
 expressions.swift:
 #    1| [TopLevelCodeDecl] { ... }
 #    1|   getBody(): [BraceStmt] { ... }

--- a/swift/ql/test/library-tests/ast/declarations.swift
+++ b/swift/ql/test/library-tests/ast/declarations.swift
@@ -143,3 +143,8 @@ extension Int {
 
 42.id()
 
+class GenericClass<A, B: Baz, C: MyProtocol> {
+  func genericMethod(_: A, _: B, _: C) {}
+}
+
+func genericFunc<A, B: Baz, C: MyProtocol>(_: A, _: B, _: C) {}


### PR DESCRIPTION
This required a fix in codegen, as order of bases as written in `schema.yml` was not preserved, so the order of children coming from different bases was off in the AST printer. This implied changing the type of `bases` in `schema.Class` from `Set` to `List`, and removing sorting of `bases` in `ql.Class`.

Commit by commit review is encouraged.