### PR TITLE
Swift: Clean up the URL.init model.

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
@@ -53,7 +53,7 @@ private module Cached {
       c.getName() = "URL" and
       c.getAMember() = f and
       f.getName() = ["init(string:)", "init(string:relativeTo:)"] and
-      call.getFunction().(ApplyExpr).getStaticTarget() = f and
+      call.getStaticTarget() = f and
       nodeFrom.asExpr() = call.getAnArgument().getExpr() and
       nodeTo.asExpr() = call
     )


### PR DESCRIPTION
This tiny simplification was made possible by https://github.com/github/codeql/pull/10111 .