### PR TITLE
Ruby: Exclude top-level `self` accesses from `trackModule`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -425,10 +425,6 @@ private DataFlow::LocalSourceNode trackSingletonMethod(MethodBase m, string name
   name = m.getName()
 }
 
-private SsaSelfDefinitionNode selfInModule(Module tp) {
-  tp = result.getSelfScope().(ModuleBase).getModule()
-}
-
 private DataFlow::LocalSourceNode trackModule(Module tp, TypeTracker t) {
   t.start() and
   (
@@ -436,7 +432,11 @@ private DataFlow::LocalSourceNode trackModule(Module tp, TypeTracker t) {
     resolveConstantReadAccess(result.asExpr().getExpr()) = tp
     or
     // `self` reference to Module
-    result = selfInModule(tp)
+    exists(Scope scope |
+      scope = result.(SsaSelfDefinitionNode).getSelfScope() and
+      tp = scope.(ModuleBase).getModule() and
+      not scope instanceof Toplevel // handled in `trackInstance`
+    )
   )
   or
   exists(TypeTracker t2, StepSummary summary |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -76,7 +76,6 @@ getTarget
 | modules.rb:96:3:96:14 | call to include | calls.rb:92:5:92:20 | include |
 | modules.rb:102:3:102:16 | call to prepend | calls.rb:93:5:93:20 | prepend |
 | modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:93:5:93:20 | prepend |
-| modules_rec.rb:11:1:11:9 | call to prepend | calls.rb:93:5:93:20 | prepend |
 | private.rb:2:3:3:5 | call to private | calls.rb:94:5:94:20 | private |
 | private.rb:10:3:10:19 | call to private | calls.rb:94:5:94:20 | private |
 | private.rb:12:3:12:9 | call to private | calls.rb:94:5:94:20 | private |
@@ -115,6 +114,7 @@ unresolvedCall
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |
+| modules_rec.rb:11:1:11:9 | call to prepend |
 | private.rb:23:3:24:5 | call to private_class_method |
 | private.rb:28:3:28:32 | call to private_class_method |
 | private.rb:34:1:34:14 | call to private1 |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -72,7 +72,7 @@ getADeclaration
 | calls.rb:97:1:100:3 | Object | calls.rb:97:1:100:3 | Object |
 | calls.rb:97:1:100:3 | Object | hello.rb:1:1:22:3 | hello.rb |
 | calls.rb:97:1:100:3 | Object | modules.rb:1:1:121:4 | modules.rb |
-| calls.rb:97:1:100:3 | Object | modules_rec.rb:1:1:11:10 | modules_rec.rb |
+| calls.rb:97:1:100:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
 | calls.rb:97:1:100:3 | Object | private.rb:1:1:60:3 | private.rb |
 | calls.rb:102:1:104:3 | Hash | calls.rb:102:1:104:3 | Hash |
 | calls.rb:106:1:117:3 | Array | calls.rb:106:1:117:3 | Array |

--- a/ruby/ql/test/library-tests/modules/modules_rec.rb
+++ b/ruby/ql/test/library-tests/modules/modules_rec.rb
@@ -8,4 +8,4 @@ class A < B
   prepend B
 end
 
-prepend A
+prepend A # NoMethodError


### PR DESCRIPTION
When debugging a performance problem related to the call graph, I noticed that `trackInstance` could yield multiple results for top-level `self` accesses. This PR removes multiplicity by ruling out top-level accesses in `trackModule`, which means that in
```rb
def foo
end

self.foo
```
the `self` qualifier will only get type `Object` and not `Class`.