### PR TITLE
Kotlin: Remove another cast

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -659,7 +659,7 @@ open class KotlinUsesExtractor(
                             }
                         }.buildSimpleType()
 
-                var componentType = s.getArrayElementType(pluginContext.irBuiltIns)
+                var componentType: IrType = s.getArrayElementType(pluginContext.irBuiltIns)
                 var isPrimitiveArray = false
                 var dimensions = 0
                 var elementType: IrType = s

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -649,9 +649,9 @@ open class KotlinUsesExtractor(
 
             (s.isBoxedArray && s.arguments.isNotEmpty()) || s.isPrimitiveArray() -> {
 
-                fun replaceComponentTypeWithAny(t: IrSimpleType, dimensions: Int): IrSimpleType =
+                fun replaceComponentTypeWithAny(t: IrSimpleType, dimensions: Int): IrType =
                     if (dimensions == 0)
-                        pluginContext.irBuiltIns.anyType as IrSimpleType
+                        pluginContext.irBuiltIns.anyType
                     else
                         t.toBuilder().also { it.arguments = (it.arguments[0] as IrTypeProjection)
                             .let { oldArg ->


### PR DESCRIPTION
I think we'll end up giving a warning/error later, but that's better than having a cast throw now.