### PR TITLE
QL: silence reported consistency errors that are fine

### DIFF
--- a/ql/ql/src/codeql_ql/ast/internal/Module.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Module.qll
@@ -388,6 +388,10 @@ module ModConsistency {
       not exists(mod.asModule().getAlias())
     ) >= 2 and
     // paramerized modules are not treated nicely, so we ignore them here.
+    not exists(FileOrModule mod |
+      mod = i.getResolvedModule() and
+      mod.asModule().hasAnnotation("signature")
+    ) and
     not i.getResolvedModule().getEnclosing*().asModule().hasParameter(_, _, _) and
     not i.getLocation()
         .getFile()

--- a/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
+++ b/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
@@ -24,9 +24,13 @@ where
     PredConsistency::noResolvePredicateExpr(node) and
     msg = "PredConsistency::noResolvePredicateExpr"
     or
-    PredConsistency::multipleResolveCall(node, _, _) and
-    msg = "PredConsistency::multipleResolveCall"
-    or
+    // Can be multiple with parameterized modules
+    /*
+     * PredConsistency::multipleResolveCall(node, _, _) and
+     *    msg = "PredConsistency::multipleResolveCall"
+     *    or
+     */
+
     PredConsistency::multipleResolvePredicateExpr(node, _, _) and
     msg = "PredConsistency::multipleResolvePredicateExpr"
     or


### PR DESCRIPTION
The consistency errors got reported here: https://github.com/github/codeql/pull/10203. 

With how we do parameterized modules we can't uniquely resolve much.   