### PR TITLE
Java: Add new AlarmManager sinks to Use of implicit PendingIntents

### DIFF
--- a/java/ql/lib/semmle/code/java/security/ImplicitPendingIntents.qll
+++ b/java/ql/lib/semmle/code/java/security/ImplicitPendingIntents.qll
@@ -106,7 +106,15 @@ private class PendingIntentSentSinkModels extends SinkModelCsv {
         "android.app;PendingIntent;false;send;(Context,int,Intent,OnFinished,Handler,String);;Argument[2];pending-intent-sent;manual",
         "android.app;PendingIntent;false;send;(Context,int,Intent,OnFinished,Handler);;Argument[2];pending-intent-sent;manual",
         "android.app;PendingIntent;false;send;(Context,int,Intent);;Argument[2];pending-intent-sent;manual",
-        "android.app;Activity;true;setResult;(int,Intent);;Argument[1];pending-intent-sent;manual"
+        "android.app;Activity;true;setResult;(int,Intent);;Argument[1];pending-intent-sent;manual",
+        "android.app;AlarmManager;true;set;(int,long,PendingIntent);;Argument[2];pending-intent-sent;manual",
+        "android.app;AlarmManager;true;setAlarmClock;;;Argument[1];pending-intent-sent;manual",
+        "android.app;AlarmManager;true;setAndAllowWhileIdle;;;Argument[2];pending-intent-sent;manual",
+        "android.app;AlarmManager;true;setExact;(int,long,PendingIntent);;Argument[2];pending-intent-sent;manual",
+        "android.app;AlarmManager;true;setExactAndAllowWhileIdle;;;Argument[2];pending-intent-sent;manual",
+        "android.app;AlarmManager;true;setInexactRepeating;;;Argument[3];pending-intent-sent;manual",
+        "android.app;AlarmManager;true;setRepeating;;;Argument[3];pending-intent-sent;manual",
+        "android.app;AlarmManager;true;setWindow;(int,long,long,PendingIntent);;Argument[3];pending-intent-sent;manual",
       ]
   }
 }

--- a/java/ql/src/change-notes/2022-09-01-implicit-pendingintents-new-sinks.md
+++ b/java/ql/src/change-notes/2022-09-01-implicit-pendingintents-new-sinks.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added new sinks related to Android's `AlarmManager` to the query `java/android/implicit-pendingintents`.

--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
@@ -2,6 +2,7 @@ package com.example.test;
 
 import java.io.FileNotFoundException;
 import android.app.Activity;
+import android.app.AlarmManager;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -215,6 +216,28 @@ public class ImplicitPendingIntentsTest {
             noMan.notify(0, notification); // Safe
         }
 
+    }
+
+    public static void testPendingIntentInAnAlarm(Context ctx) {
+        AlarmManager aManager = (AlarmManager) ctx.getSystemService(Context.ALARM_SERVICE);
+        {
+            Intent baseIntent = new Intent();
+            PendingIntent pi = PendingIntent.getActivity(ctx, 0, baseIntent, 0);
+            aManager.set(0, 0, pi); // $hasImplicitPendingIntent
+            aManager.setAlarmClock(null, pi); // $hasImplicitPendingIntent
+            aManager.setAndAllowWhileIdle(0, 0, pi); // $hasImplicitPendingIntent
+            aManager.setExact(0, 0, pi); // $hasImplicitPendingIntent
+            aManager.setExactAndAllowWhileIdle(0, 0, pi); // $hasImplicitPendingIntent
+            aManager.setInexactRepeating(0, 0, 0, pi); // $hasImplicitPendingIntent
+            aManager.setRepeating(0, 0, 0, pi); // $hasImplicitPendingIntent
+            aManager.setWindow(0, 0, 0, pi); // $hasImplicitPendingIntent
+        }
+        {
+            Intent baseIntent = new Intent();
+            PendingIntent pi =
+                    PendingIntent.getActivity(ctx, 0, baseIntent, PendingIntent.FLAG_IMMUTABLE); // Sanitizer
+            aManager.set(0, 0, pi); // Safe
+        }
     }
 
     static class TestActivity extends Activity {

--- a/java/ql/test/stubs/google-android-9.0.0/android/app/AlarmManager.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/app/AlarmManager.java
@@ -1,0 +1,54 @@
+// Generated automatically from android.app.AlarmManager for testing purposes
+
+package android.app;
+
+import android.app.PendingIntent;
+import android.os.Handler;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class AlarmManager
+{
+    public AlarmManager.AlarmClockInfo getNextAlarmClock(){ return null; }
+    public boolean canScheduleExactAlarms(){ return false; }
+    public static String ACTION_NEXT_ALARM_CLOCK_CHANGED = null;
+    public static String ACTION_SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED = null;
+    public static int ELAPSED_REALTIME = 0;
+    public static int ELAPSED_REALTIME_WAKEUP = 0;
+    public static int RTC = 0;
+    public static int RTC_WAKEUP = 0;
+    public static long INTERVAL_DAY = 0;
+    public static long INTERVAL_FIFTEEN_MINUTES = 0;
+    public static long INTERVAL_HALF_DAY = 0;
+    public static long INTERVAL_HALF_HOUR = 0;
+    public static long INTERVAL_HOUR = 0;
+    public void cancel(AlarmManager.OnAlarmListener p0){}
+    public void cancel(PendingIntent p0){}
+    public void set(int p0, long p1, PendingIntent p2){}
+    public void set(int p0, long p1, String p2, AlarmManager.OnAlarmListener p3, Handler p4){}
+    public void setAlarmClock(AlarmManager.AlarmClockInfo p0, PendingIntent p1){}
+    public void setAndAllowWhileIdle(int p0, long p1, PendingIntent p2){}
+    public void setExact(int p0, long p1, PendingIntent p2){}
+    public void setExact(int p0, long p1, String p2, AlarmManager.OnAlarmListener p3, Handler p4){}
+    public void setExactAndAllowWhileIdle(int p0, long p1, PendingIntent p2){}
+    public void setInexactRepeating(int p0, long p1, long p2, PendingIntent p3){}
+    public void setRepeating(int p0, long p1, long p2, PendingIntent p3){}
+    public void setTime(long p0){}
+    public void setTimeZone(String p0){}
+    public void setWindow(int p0, long p1, long p2, PendingIntent p3){}
+    public void setWindow(int p0, long p1, long p2, String p3, AlarmManager.OnAlarmListener p4, Handler p5){}
+    static public class AlarmClockInfo implements Parcelable
+    {
+        protected AlarmClockInfo() {}
+        public AlarmClockInfo(long p0, PendingIntent p1){}
+        public PendingIntent getShowIntent(){ return null; }
+        public int describeContents(){ return 0; }
+        public long getTriggerTime(){ return 0; }
+        public static Parcelable.Creator<AlarmManager.AlarmClockInfo> CREATOR = null;
+        public void writeToParcel(Parcel p0, int p1){}
+    }
+    static public interface OnAlarmListener
+    {
+        void onAlarm();
+    }
+}


### PR DESCRIPTION
This PR adds new sinks related to `AlarmManager` to the query Use of implicit PendingIntents.

This adds coverage for CVE-2021-0599.