### PR TITLE
Swift: Use TypeDecl.getABaseTypeDecl().

### DIFF
--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -89,7 +89,7 @@ class CleartextStorageConfig extends TaintTracking::Configuration {
     isSink(node) and
     exists(ClassDecl cd |
       c.getAReadContent().(DataFlow::Content::FieldContent).getField() = cd.getAMember() and
-      cd.getType().(NominalType).getABaseType*().getName() = "RealmSwiftObject"
+      cd.getABaseTypeDecl*().getName() = "RealmSwiftObject"
     )
     or
     // any default implicit reads


### PR DESCRIPTION
Very minor follow-up to https://github.com/github/codeql/pull/10061, taking advantage of https://github.com/github/codeql/pull/10254.

@MathiasVP 