### PR TITLE
C++: Fix join in sign analysis

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/SignAnalysisCommon.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/SignAnalysisCommon.qll
@@ -204,6 +204,7 @@ private class BinarySignExpr extends FlowSignExpr {
   }
 }
 
+pragma[nomagic]
 private predicate binaryExprOperands(SemBinaryExpr binary, SemExpr left, SemExpr right) {
   binary.getLeftOperand() = left and binary.getRightOperand() = right
 }


### PR DESCRIPTION
This predicate was clearly supposed to _not_ be inlined.

Before:
```ql
Evaluated recursive predicate SignAnalysisCommon#5ca83560::SignExpr::getSign#0#dispred#ff@a481b3wo in 81422ms on iteration 3 (delta size: null).
Evaluated relational algebra for predicate SignAnalysisCommon#5ca83560::SignExpr::getSign#0#dispred#ff@a481b3wo on iteration 3 running pipeline order_500000 with tuple counts:
       20500   ~13%    {3} r1 = JOIN SignAnalysisCommon#5ca83560::semExprSign#1#ff#prev_delta WITH project#SemanticExpr#0e61f670::SemUnaryExpr#ffff#3_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.1, Lhs.1
        8000    ~9%    {2} r2 = JOIN r1 WITH SignAnalysisCommon#5ca83560::CastSignExpr#class#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.2
                    
           0    ~0%    {3} r3 = JOIN SignAnalysisCommon#5ca83560::semSsaSign#2#fff#prev_delta WITH SignAnalysisCommon#5ca83560::UseSignExpr#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2
           0    ~0%    {2} r4 = JOIN r3 WITH SemanticSSA#71707ade::SemSsaReadPositionBlock::getAnExpr#0#dispred#ff ON FIRST 2 OUTPUT Lhs.1, Lhs.2
                    
           0    ~0%    {2} r5 = JOIN SignAnalysisCommon#5ca83560::semSsaDefSign#1#ff#prev_delta WITH SignAnalysisCommon#5ca83560::UseSignExpr#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1
           0    ~0%    {2} r6 = r5 AND NOT project#SemanticSSA#71707ade::SemSsaReadPositionBlock::getAnExpr#0#dispred#ff(Lhs.1)
           0    ~0%    {2} r7 = SCAN r6 OUTPUT In.1, In.0
                    
           0    ~0%    {2} r8 = r4 UNION r7
        8000    ~9%    {2} r9 = r2 UNION r8
                    
        10500    ~8%    {2} r10 = JOIN SignAnalysisCommon#5ca83560::semExprSign#1#ff#prev_delta WITH SignAnalysisCommon#5ca83560::SignExpr::getSign#0#dispred#ff#join_rhs#3 ON FIRST 1 OUTPUT Lhs.1, Rhs.1
        67000   ~11%    {3} r11 = JOIN r10 WITH Sign#b3b59406::Sign::applyUnaryOp#1#dispred#fff ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Rhs.2
        9000    ~0%    {2} r12 = JOIN r11 WITH project#SemanticExpr#0e61f670::SemKnownExpr#class#fff#3 ON FIRST 2 OUTPUT Lhs.0, Lhs.2
                    
        57500    ~3%    {2} r13 = SCAN SignAnalysisCommon#5ca83560::semExprSign#1#ff#prev_delta OUTPUT In.1, In.0
   1658348500   ~23%    {4} r14 = JOIN r13 WITH SignAnalysisCommon#5ca83560::SignExpr::getSign#0#dispred#ff#join_rhs#6 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Rhs.2, Rhs.3
        23000    ~7%    {3} r15 = JOIN r14 WITH project#SemanticExpr#0e61f670::SemBinaryExpr#fffff#2 ON FIRST 2 OUTPUT Lhs.0, Lhs.2, Lhs.3
        21500    ~4%    {4} r16 = JOIN r15 WITH project#SemanticExpr#0e61f670::SemBinaryExpr#fffff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0, Lhs.2
        2500  ~119%    {2} r17 = JOIN r16 WITH SignAnalysisCommon#5ca83560::semExprSign#1#ff#prev ON FIRST 2 OUTPUT Lhs.2, Lhs.3
...
```
(I stopped the evaluation midway.) 

After:

```ql
Evaluated recursive predicate SignAnalysisCommon#5ca83560::SignExpr::getSign#0#dispred#ff@aa8363wj in 26ms on iteration 3 (delta size: 20752).
Evaluated relational algebra for predicate SignAnalysisCommon#5ca83560::SignExpr::getSign#0#dispred#ff@aa8363wj on iteration 3 running pipeline order_500000 with tuple counts:
   21492   ~12%    {3} r1 = JOIN SignAnalysisCommon#5ca83560::semExprSign#1#ff#prev_delta WITH project#SemanticExpr#0e61f670::SemUnaryExpr#ffff#3_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.1, Lhs.1
    9002    ~9%    {2} r2 = JOIN r1 WITH SignAnalysisCommon#5ca83560::CastSignExpr#class#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.2
              
      0    ~0%    {3} r3 = JOIN SignAnalysisCommon#5ca83560::semSsaSign#2#fff#prev_delta WITH SignAnalysisCommon#5ca83560::UseSignExpr#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2
      0    ~0%    {2} r4 = JOIN r3 WITH SemanticSSA#71707ade::SemSsaReadPositionBlock::getAnExpr#0#dispred#ff ON FIRST 2 OUTPUT Lhs.1, Lhs.2
              
      0    ~0%    {2} r5 = JOIN SignAnalysisCommon#5ca83560::semSsaDefSign#1#ff#prev_delta WITH SignAnalysisCommon#5ca83560::UseSignExpr#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1
      0    ~0%    {2} r6 = r5 AND NOT project#SemanticSSA#71707ade::SemSsaReadPositionBlock::getAnExpr#0#dispred#ff(Lhs.1)
      0    ~0%    {2} r7 = SCAN r6 OUTPUT In.1, In.0
              
      0    ~0%    {2} r8 = r4 UNION r7
    9002    ~9%    {2} r9 = r2 UNION r8
              
   11349    ~8%    {2} r10 = JOIN SignAnalysisCommon#5ca83560::semExprSign#1#ff#prev_delta WITH SignAnalysisCommon#5ca83560::SignExpr::getSign#0#dispred#ff#join_rhs#3 ON FIRST 1 OUTPUT Lhs.1, Rhs.1
   73145   ~11%    {3} r11 = JOIN r10 WITH Sign#b3b59406::Sign::applyUnaryOp#1#dispred#fff ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Rhs.2
   10663    ~0%    {2} r12 = JOIN r11 WITH project#SemanticExpr#0e61f670::SemKnownExpr#class#fff#3 ON FIRST 2 OUTPUT Lhs.0, Lhs.2
              
    7196    ~7%    {3} r13 = JOIN SignAnalysisCommon#5ca83560::semExprSign#1#ff#prev_delta WITH SignAnalysisCommon#5ca83560::SignExpr::getSign#0#dispred#ff#join_rhs#6 ON FIRST 1 OUTPUT Rhs.2, Rhs.1, Lhs.1
    7845   ~10%    {3} r14 = JOIN r13 WITH SignAnalysisCommon#5ca83560::semExprSign#1#ff#prev ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1
    2319    ~4%    {4} r15 = JOIN r14 WITH SemanticExpr#0e61f670::SemKnownExpr::getOpcode#0#dispred#fb ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1, Lhs.0
    3451  ~101%    {2} r16 = JOIN r15 WITH Sign#b3b59406::Sign::applyBinaryOp#2#dispred#ffff ON FIRST 3 OUTPUT Lhs.3, Rhs.3
...
```