### PR TITLE
Add TypeModel hook for adding MaD type-defs from CodeQL

### DIFF
--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -1495,7 +1495,7 @@ module API {
         /** Gets the EntryPoint associated with this label. */
         API::EntryPoint getEntryPoint() { result = e }
 
-        override string toString() { result = "getASuccessor(Label::entryPoint(\"" + e + "\"))" }
+        override string toString() { result = "entryPoint(\"" + e + "\")" }
       }
 
       /** A label that gets a promised value. */

--- a/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
@@ -11,6 +11,11 @@ private import semmle.javascript.dataflow.TypeTracking
 private import semmle.javascript.internal.CachedStages
 
 /**
+ * An alias for `SourceNode`.
+ */
+class LocalSourceNode = SourceNode;
+
+/**
  * A source node for local data flow, that is, a node from which local data flow is tracked.
  *
  * This includes function invocations, parameters, object creation, and references to a property or global variable.

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -72,7 +72,7 @@ private class Unit = Specific::Unit;
 
 private module API = Specific::API;
 
-private module DataFlow = Specific::DF;
+private module DataFlow = Specific::DataFlow;
 
 private import Specific::AccessPathSyntax
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -427,15 +427,14 @@ pragma[nomagic]
 private API::Node getNodeFromType(string package, string type) {
   exists(string package2, string type2, AccessPath path2 |
     typeModel(package, type, package2, type2, path2) and
-    result = getNodeFromPath(package2, type2, path2, path2.getNumToken())
+    result = getNodeFromPath(package2, type2, path2)
   )
   or
   result = any(TypeModelUseEntry e).getNodeForType(package, type)
   or
   result = any(TypeModelDefEntry e).getNodeForType(package, type)
   or
-  isRelevantFullPath(package, type, _) and
-  result = Specific::getExtraNodeFromPath(package, type, _, 0)
+  result = Specific::getExtraNodeFromType(package, type)
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -96,7 +96,7 @@ API::Node getExtraNodeFromType(string package, string type) {
   result = API::moduleImport(package)
   or
   // Access instance of a type based on type annotations
-  result = API::Node::ofType(getAPackageAlias(package), type)
+  result = API::Internal::getANodeOfTypeRaw(getAPackageAlias(package), type)
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -27,8 +27,6 @@ class Unit = JS::Unit;
 // Re-export libraries needed by ApiGraphModels.qll
 module API = JS::API;
 
-module DF = DataFlow;
-
 import semmle.javascript.frameworks.data.internal.AccessPathSyntax as AccessPathSyntax
 import JS::DataFlow as DataFlow
 private import AccessPathSyntax

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -20,7 +20,6 @@
  */
 
 private import javascript as JS
-private import JS::DataFlow as DataFlow
 private import ApiGraphModels
 
 class Unit = JS::Unit;
@@ -31,6 +30,7 @@ module API = JS::API;
 module DF = DataFlow;
 
 import semmle.javascript.frameworks.data.internal.AccessPathSyntax as AccessPathSyntax
+import JS::DataFlow as DataFlow
 private import AccessPathSyntax
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -28,6 +28,8 @@ class Unit = JS::Unit;
 // Re-export libraries needed by ApiGraphModels.qll
 module API = JS::API;
 
+module DF = DataFlow;
+
 import semmle.javascript.frameworks.data.internal.AccessPathSyntax as AccessPathSyntax
 private import AccessPathSyntax
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -79,10 +79,6 @@ private API::Node getGlobalNode(string globalName) {
 /** Gets a JavaScript-specific interpretation of the `(package, type, path)` tuple after resolving the first `n` access path tokens. */
 bindingset[package, type, path]
 API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int n) {
-  type = "" and
-  n = 0 and
-  result = API::moduleImport(package)
-  or
   // Global variable accesses is via the 'global' package
   exists(AccessPathToken token |
     package = getAPackageAlias("global") and
@@ -92,9 +88,14 @@ API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int
     result = getGlobalNode(token.getAnArgument()) and
     n = 1
   )
+}
+
+/** Gets a JavaScript-specific interpretation of the `(package, type)` tuple. */
+API::Node getExtraNodeFromType(string package, string type) {
+  type = "" and
+  result = API::moduleImport(package)
   or
   // Access instance of a type based on type annotations
-  n = 0 and
   result = API::Node::ofType(getAPackageAlias(package), type)
 }
 

--- a/javascript/ql/test/ApiGraphs/custom-entry-point/index.js
+++ b/javascript/ql/test/ApiGraphs/custom-entry-point/index.js
@@ -1,1 +1,1 @@
-module.exports = CustomEntryPoint.foo; /* use=getASuccessor(Label::entryPoint("CustomEntryPoint")) */
+module.exports = CustomEntryPoint.foo; /* use=entryPoint("CustomEntryPoint") */

--- a/javascript/ql/test/ApiGraphs/typed/NodeOfType.expected
+++ b/javascript/ql/test/ApiGraphs/typed/NodeOfType.expected
@@ -1,4 +1,9 @@
+| body-parser |  | index.ts:4:20:4:41 | require ... arser") |
+| express |  | index.ts:3:17:3:34 | require("express") |
+| mongodb |  | index.ts:1:8:1:19 | * as mongodb |
 | mongodb | Collection | index.ts:14:3:14:17 | getCollection() |
+| mongoose |  | index.ts:17:8:17:20 | * as mongoose |
 | mongoose | Model | index.ts:22:3:22:20 | getMongooseModel() |
 | mongoose | Query | index.ts:23:3:23:20 | getMongooseQuery() |
+| puppeteer |  | index.ts:26:8:26:21 | * as puppeteer |
 | puppeteer | Browser | index.ts:30:22:30:33 | this.browser |

--- a/javascript/ql/test/library-tests/TypeScript/HasUnderlyingType/HasUnderlyingType.expected
+++ b/javascript/ql/test/library-tests/TypeScript/HasUnderlyingType/HasUnderlyingType.expected
@@ -1,4 +1,6 @@
 underlyingTypeNode
+| foo |  | file://:0:0:0:0 | use moduleImport("foo").getMember("exports") |
+| foo |  | foo.ts:1:8:1:10 | use moduleImport("foo").getMember("exports").getMember("default") |
 | foo | Bar | foo.ts:3:1:5:1 | use moduleImport("foo").getMember("exports").getMember("Bar").getInstance() |
 | foo | Bar | foo.ts:3:12:3:12 | use moduleImport("foo").getMember("exports").getMember("Bar").getInstance() |
 #select

--- a/javascript/ql/test/library-tests/frameworks/Redux/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Redux/test.expected
@@ -125,7 +125,7 @@ getAffectedStateAccessPath
 getADispatchFunctionNode
 | react-redux.jsx:65:20:65:32 | use moduleImport("react-redux").getMember("exports").getMember("useDispatch").getReturn() |
 getADispatchedValueNode
-| react-redux.jsx:27:12:30:5 | def getASuccessor(Label::entryPoint("react-redux-connect")).getParameter(1).getMember("manualAction").getReturn() |
+| react-redux.jsx:27:12:30:5 | def entryPoint("react-redux-connect").getParameter(1).getMember("manualAction").getReturn() |
 | react-redux.jsx:69:18:69:39 | def moduleImport("react-redux").getMember("exports").getMember("useDispatch").getReturn().getParameter(0) |
 | react-redux.jsx:70:18:70:38 | def moduleImport("react-redux").getMember("exports").getMember("useDispatch").getReturn().getParameter(0) |
 getAnUntypedActionInReducer

--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -454,6 +454,30 @@ module API {
   }
 
   /**
+   * An API entry point.
+   *
+   * By default, API graph nodes are only created for nodes that come from an external
+   * library or escape into an external library. The points where values are cross the boundary
+   * between codebases are called "entry points".
+   *
+   * Anything imported from an external package is considered to be an entry point, but
+   * additional entry points may be added by extending this class.
+   */
+  abstract class EntryPoint extends string {
+    bindingset[this]
+    EntryPoint() { any() }
+
+    /** Gets a data-flow node corresponding to a use-node for this entry point. */
+    DataFlow::LocalSourceNode getASource() { none() }
+
+    /** Gets a data-flow node corresponding to a def-node for this entry point. */
+    DataFlow::Node getASink() { none() }
+
+    /** Gets an API-node for this entry point. */
+    API::Node getANode() { result = root().getASuccessor(Label::entryPoint(this)) }
+  }
+
+  /**
    * Provides the actual implementation of API graphs, cached for performance.
    *
    * Ideally, we'd like nodes to correspond to (global) access paths, with edge labels
@@ -652,6 +676,12 @@ module API {
       |
         lbl = Label::memberFromRef(aw)
       )
+      or
+      exists(EntryPoint entry |
+        base = root() and
+        lbl = Label::entryPoint(entry) and
+        rhs = entry.getASink()
+      )
     }
 
     /**
@@ -734,6 +764,12 @@ module API {
           Label::member(any(string name |
               ImportStar::namePossiblyDefinedInImportStar(ref.asCfgNode(), name, s)
             ))
+      )
+      or
+      exists(EntryPoint entry |
+        base = root() and
+        lbl = Label::entryPoint(entry) and
+        ref = entry.getASource()
       )
     }
 
@@ -909,7 +945,8 @@ module API {
         MkLabelSelfParameter() or
         MkLabelReturn() or
         MkLabelSubclass() or
-        MkLabelAwait()
+        MkLabelAwait() or
+        MkLabelEntryPoint(EntryPoint ep)
 
       /** A label for a module. */
       class LabelModule extends ApiLabel, MkLabelModule {
@@ -983,6 +1020,15 @@ module API {
       class LabelAwait extends ApiLabel, MkLabelAwait {
         override string toString() { result = "getAwaited()" }
       }
+
+      /** A label for entry points. */
+      class LabelEntryPoint extends ApiLabel, MkLabelEntryPoint {
+        private EntryPoint entry;
+
+        LabelEntryPoint() { this = MkLabelEntryPoint(entry) }
+
+        override string toString() { result = "entryPoint(\"" + entry + "\")" }
+      }
     }
 
     /** Gets the edge label for the module `m`. */
@@ -1019,5 +1065,8 @@ module API {
 
     /** Gets the `await` edge label. */
     LabelAwait await() { any() }
+
+    /** Gets the label going from the root node to the nodes associated with the given entry point. */
+    LabelEntryPoint entryPoint(EntryPoint ep) { result = MkLabelEntryPoint(ep) }
   }
 }

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
@@ -72,7 +72,7 @@ private class Unit = Specific::Unit;
 
 private module API = Specific::API;
 
-private module DataFlow = Specific::DF;
+private module DataFlow = Specific::DataFlow;
 
 private import Specific::AccessPathSyntax
 

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
@@ -427,15 +427,14 @@ pragma[nomagic]
 private API::Node getNodeFromType(string package, string type) {
   exists(string package2, string type2, AccessPath path2 |
     typeModel(package, type, package2, type2, path2) and
-    result = getNodeFromPath(package2, type2, path2, path2.getNumToken())
+    result = getNodeFromPath(package2, type2, path2)
   )
   or
   result = any(TypeModelUseEntry e).getNodeForType(package, type)
   or
   result = any(TypeModelDefEntry e).getNodeForType(package, type)
   or
-  isRelevantFullPath(package, type, _) and
-  result = Specific::getExtraNodeFromPath(package, type, _, 0)
+  result = Specific::getExtraNodeFromType(package, type)
 }
 
 /**

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -20,7 +20,6 @@
  */
 
 private import python as PY
-private import semmle.python.dataflow.new.DataFlow
 private import ApiGraphModels
 import semmle.python.ApiGraphs::API as API
 
@@ -28,9 +27,7 @@ class Unit = PY::Unit;
 
 // Re-export libraries needed by ApiGraphModels.qll
 import semmle.python.frameworks.data.internal.AccessPathSyntax as AccessPathSyntax
-
-module DF = DataFlow;
-
+import semmle.python.dataflow.new.DataFlow::DataFlow as DataFlow
 private import AccessPathSyntax
 
 /**

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -40,11 +40,12 @@ predicate isPackageUsed(string package) { exists(API::moduleImport(package)) }
 
 /** Gets a Python-specific interpretation of the `(package, type, path)` tuple after resolving the first `n` access path tokens. */
 bindingset[package, type, path]
-API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int n) {
+API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int n) { none() }
+
+/** Gets a Python-specific interpretation of the `(package, type)` tuple. */
+API::Node getExtraNodeFromType(string package, string type) {
   type = "" and
-  n = 0 and
-  result = API::moduleImport(package) and
-  exists(path)
+  result = API::moduleImport(package)
 }
 
 /**

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -28,6 +28,9 @@ class Unit = PY::Unit;
 
 // Re-export libraries needed by ApiGraphModels.qll
 import semmle.python.frameworks.data.internal.AccessPathSyntax as AccessPathSyntax
+
+module DF = DataFlow;
+
 private import AccessPathSyntax
 
 /**

--- a/python/ql/test/library-tests/ApiGraphs/py3/test_entry_point.py
+++ b/python/ql/test/library-tests/ApiGraphs/py3/test_entry_point.py
@@ -1,0 +1,2 @@
+"magic_string".foo.bar #$ use=entryPoint("CustomEntryPoint").getMember("foo").getMember("bar")
+"magic_string2".foo.bar

--- a/python/ql/test/library-tests/ApiGraphs/py3/verifyApiGraphs.ql
+++ b/python/ql/test/library-tests/ApiGraphs/py3/verifyApiGraphs.ql
@@ -1,3 +1,11 @@
 // Note: This is not using standard inline-expectation tests, so will not alert if you
 // have not manually added an annotation to a line!
 import TestUtilities.VerifyApiGraphs
+
+class CustomEntryPoint extends API::EntryPoint {
+  CustomEntryPoint() { this = "CustomEntryPoint" }
+
+  override DataFlow::LocalSourceNode getASource() {
+    result.asExpr().(StrConst).getText() = "magic_string"
+  }
+}

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -838,7 +838,7 @@ module API {
 
         LabelEntryPoint() { this = MkLabelEntryPoint(name) }
 
-        override string toString() { result = name }
+        override string toString() { result = "entryPoint(\"" + name + "\")" }
 
         /** Gets the name of the entry point. */
         API::EntryPoint getName() { result = name }

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -382,11 +382,17 @@ module API {
     bindingset[this]
     EntryPoint() { any() }
 
+    /** DEPRECATED. This predicate has been renamed to `getASource`. */
+    deprecated DataFlow::LocalSourceNode getAUse() { none() }
+
+    /** DEPRECATED. This predicate has been renamed to `getASink`. */
+    deprecated DataFlow::Node getARhs() { none() }
+
     /** Gets a data-flow node corresponding to a use-node for this entry point. */
-    DataFlow::LocalSourceNode getAUse() { none() }
+    DataFlow::LocalSourceNode getASource() { none() }
 
     /** Gets a data-flow node corresponding to a def-node for this entry point. */
-    DataFlow::Node getARhs() { none() }
+    DataFlow::Node getASink() { none() }
 
     /** Gets a call corresponding to a method access node for this entry point. */
     DataFlow::CallNode getACall() { none() }
@@ -504,7 +510,7 @@ module API {
       or
       parameterStep(_, defCand(), nd)
       or
-      nd = any(EntryPoint entry).getAUse()
+      nd = any(EntryPoint entry).getASource()
       or
       nd = any(EntryPoint entry).getACall()
     }
@@ -553,7 +559,7 @@ module API {
       // If a call node is relevant as a use-node, treat its arguments as def-nodes
       argumentStep(_, useCandFwd(), rhs)
       or
-      rhs = any(EntryPoint entry).getARhs()
+      rhs = any(EntryPoint entry).getASink()
     }
 
     /** Gets a data flow node that flows to the RHS of a def-node. */
@@ -712,9 +718,9 @@ module API {
         pred = root() and
         lbl = Label::entryPoint(entry)
       |
-        succ = MkDef(entry.getARhs())
+        succ = MkDef(entry.getASink())
         or
-        succ = MkUse(entry.getAUse())
+        succ = MkUse(entry.getASource())
         or
         succ = MkMethodAccessNode(entry.getACall())
       )

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
@@ -72,7 +72,7 @@ private class Unit = Specific::Unit;
 
 private module API = Specific::API;
 
-private module DataFlow = Specific::DF;
+private module DataFlow = Specific::DataFlow;
 
 private import Specific::AccessPathSyntax
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
@@ -434,8 +434,7 @@ private API::Node getNodeFromType(string package, string type) {
   or
   result = any(TypeModelDefEntry e).getNodeForType(package, type)
   or
-  isRelevantFullPath(package, type, _) and
-  result = Specific::getExtraNodeFromPath(package, type, _, 0)
+  result = Specific::getExtraNodeFromType(package, type)
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
@@ -427,7 +427,7 @@ pragma[nomagic]
 private API::Node getNodeFromType(string package, string type) {
   exists(string package2, string type2, AccessPath path2 |
     typeModel(package, type, package2, type2, path2) and
-    result = getNodeFromPath(package2, type2, path2, path2.getNumToken())
+    result = getNodeFromPath(package2, type2, path2)
   )
   or
   result = any(TypeModelUseEntry e).getNodeForType(package, type)

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -68,8 +68,7 @@ API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int
 
 /** Gets a Ruby-specific interpretation of the `(package, type)` tuple. */
 API::Node getExtraNodeFromType(string package, string type) {
-  isRelevantFullPath(package, type, _) and
-  exists(package) and // Allow any package name, see `isPackageUsed`.
+  isRelevantFullPath(package, type, _) and // Allow any package name, see `isPackageUsed`.
   type = "" and
   result = API::root()
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -29,6 +29,7 @@ class Unit = DataFlowPrivate::Unit;
 // Re-export libraries needed by ApiGraphModels.qll
 import codeql.ruby.ApiGraphs
 import codeql.ruby.dataflow.internal.AccessPathSyntax as AccessPathSyntax
+import codeql.ruby.dataflow.internal.DataFlowPublic as DF
 private import AccessPathSyntax
 private import codeql.ruby.dataflow.internal.FlowSummaryImplSpecific as FlowSummaryImplSpecific
 private import codeql.ruby.dataflow.internal.DataFlowDispatch as DataFlowDispatch

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -56,12 +56,6 @@ predicate isPackageUsed(string package) {
 /** Gets a Ruby-specific interpretation of the `(package, type, path)` tuple after resolving the first `n` access path tokens. */
 bindingset[package, type, path]
 API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int n) {
-  isRelevantFullPath(package, type, path) and
-  exists(package) and // Allow any package name, see `isPackageUsed`.
-  type = "" and
-  n = 0 and
-  result = API::root()
-  or
   // A row of form `;any;Method[foo]` should match any method named `foo`.
   exists(package) and
   type = "any" and
@@ -70,6 +64,14 @@ API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int
     methodMatchedByName(path, entry.getName()) and
     result = entry.getANode()
   )
+}
+
+/** Gets a Ruby-specific interpretation of the `(package, type)` tuple. */
+API::Node getExtraNodeFromType(string package, string type) {
+  isRelevantFullPath(package, type, _) and
+  exists(package) and // Allow any package name, see `isPackageUsed`.
+  type = "" and
+  result = API::root()
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -20,7 +20,6 @@
  */
 
 private import ruby
-private import codeql.ruby.DataFlow
 private import codeql.ruby.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 private import ApiGraphModels
 
@@ -29,7 +28,7 @@ class Unit = DataFlowPrivate::Unit;
 // Re-export libraries needed by ApiGraphModels.qll
 import codeql.ruby.ApiGraphs
 import codeql.ruby.dataflow.internal.AccessPathSyntax as AccessPathSyntax
-import codeql.ruby.dataflow.internal.DataFlowPublic as DF
+import codeql.ruby.DataFlow::DataFlow as DataFlow
 private import AccessPathSyntax
 private import codeql.ruby.dataflow.internal.FlowSummaryImplSpecific as FlowSummaryImplSpecific
 private import codeql.ruby.dataflow.internal.DataFlowDispatch as DataFlowDispatch

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
@@ -46,7 +46,7 @@ end
 module M2
     class C3 < M1::C1 #$ use=getMember("M1").getMember("C1")
     end
-    
+
     class C4 < C2 #$ use=getMember("C2")
     end
 end
@@ -65,6 +65,6 @@ Foo.foo(a,b:c) #$ use=getMember("Foo").getMethod("foo").getReturn() def=getMembe
 
 def userDefinedFunction(x, y)
     x.noApiGraph(y)
-    x.customEntryPointCall(y) #$ call=CustomEntryPointCall use=CustomEntryPointCall.getReturn() rhs=CustomEntryPointCall.getParameter(0)
-    x.customEntryPointUse(y) #$ use=CustomEntryPointUse
+    x.customEntryPointCall(y) #$ call=entryPoint("CustomEntryPointCall") use=entryPoint("CustomEntryPointCall").getReturn() rhs=entryPoint("CustomEntryPointCall").getParameter(0)
+    x.customEntryPointUse(y) #$ use=entryPoint("CustomEntryPointUse")
 end

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/use.ql
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/use.ql
@@ -12,7 +12,7 @@ class CustomEntryPointCall extends API::EntryPoint {
 class CustomEntryPointUse extends API::EntryPoint {
   CustomEntryPointUse() { this = "CustomEntryPointUse" }
 
-  override DataFlow::LocalSourceNode getAUse() {
+  override DataFlow::LocalSourceNode getASource() {
     result.(DataFlow::CallNode).getMethodName() = "customEntryPointUse"
   }
 }

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -32,6 +32,8 @@ edges
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:114:21:114:27 | tainted |
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:117:26:117:32 | tainted |
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:117:26:117:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:119:23:119:29 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:119:23:119:29 | tainted |
 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
 | summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
@@ -109,6 +111,7 @@ edges
 | summaries.rb:104:16:104:22 | [post] tainted :  | summaries.rb:113:16:113:22 | tainted |
 | summaries.rb:104:16:104:22 | [post] tainted :  | summaries.rb:114:21:114:27 | tainted |
 | summaries.rb:104:16:104:22 | [post] tainted :  | summaries.rb:117:26:117:32 | tainted |
+| summaries.rb:104:16:104:22 | [post] tainted :  | summaries.rb:119:23:119:29 | tainted |
 | summaries.rb:104:16:104:22 | tainted :  | summaries.rb:104:16:104:22 | [post] tainted :  |
 | summaries.rb:104:16:104:22 | tainted :  | summaries.rb:104:25:104:25 | [post] y :  |
 | summaries.rb:104:16:104:22 | tainted :  | summaries.rb:104:33:104:33 | [post] z :  |
@@ -242,6 +245,8 @@ nodes
 | summaries.rb:114:21:114:27 | tainted | semmle.label | tainted |
 | summaries.rb:117:26:117:32 | tainted | semmle.label | tainted |
 | summaries.rb:117:26:117:32 | tainted | semmle.label | tainted |
+| summaries.rb:119:23:119:29 | tainted | semmle.label | tainted |
+| summaries.rb:119:23:119:29 | tainted | semmle.label | tainted |
 subpaths
 invalidSpecComponent
 #select
@@ -299,6 +304,8 @@ invalidSpecComponent
 | summaries.rb:114:21:114:27 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:114:21:114:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
 | summaries.rb:117:26:117:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:117:26:117:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
 | summaries.rb:117:26:117:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:117:26:117:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:119:23:119:29 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:119:23:119:29 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:119:23:119:29 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:119:23:119:29 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
 warning
 | CSV type row should have 5 columns but has 2: test;TooFewColumns |
 | CSV type row should have 5 columns but has 8: test;TooManyColumns;;;Member[Foo].Instance;too;many;columns |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -102,6 +102,14 @@ private class TypeFromModel extends ModelInput::TypeModelCsv {
   }
 }
 
+private class TypeFromCodeQL extends ModelInput::TypeModel {
+  override DataFlow::Node getASource(string package, string type) {
+    package = "test" and
+    type = "FooOrBar" and
+    result.asExpr().getExpr().getConstantValue().getString() = "magic_string"
+  }
+}
+
 private class InvalidTypeModel extends ModelInput::TypeModelCsv {
   override predicate row(string row) {
     row =

--- a/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
+++ b/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
@@ -115,3 +115,6 @@ Foo.sinkAnyArg(key: tainted) # $ hasValueFlow=tainted
 
 Foo.sinkAnyNamedArg(tainted)
 Foo.sinkAnyNamedArg(key: tainted) # $ hasValueFlow=tainted
+
+"magic_string".method(tainted) # $ hasValueFlow=tainted
+"magic_string2".method(tainted)


### PR DESCRIPTION
Adds the following hook in `ModelInput` as way to contribute type-definitions from CodeQL.
```ql
  /**
   * A unit class for adding additional type model rows from CodeQL models.
   */
  class TypeModel extends Unit {
    /**
     * Gets a data-flow node that is a source of the type `package;type`.
     */
    DataFlow::Node getASource(string package, string type) { none() }

    /**
     * Gets a data flow node that is a sink of the type `package;type`,
     * usually because it is an argument passed to a parameter of that type.
     */
    DataFlow::Node getASink(string package, string type) { none() }
  }
```

For example, one of the use-cases could be in https://github.com/github/codeql/pull/10090 where it would look something like this
```ql
class AttachmentInstanceType extends ModelInput::TypeModel {
  override DataFlow::LocalSourceNode getASource(string package, string type) {
    package = "activestorage" and
    type = "Attachment" and
    result instanceof AttachmentInstance
  }
}
```

Also adds `API::EntryPoint` to Python and unifies its API across the three API graph implementations (Ruby and JS had drifted apart here).

The QLDoc check failure is spurious. I've opened an internal PR that should fix it.