### PR TITLE
Kotlin: Extract error expression for `enumValues<T>` calls

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -1778,13 +1778,34 @@ open class KotlinFileExtractor(
                     return
                 }
 
-                val func = ((c.getTypeArgument(0) as? IrSimpleType)?.classifier?.owner as? IrClass)?.declarations?.findSubType<IrFunction> { it.name.asString() == fnName }
-                if (func == null) {
-                    logger.errorElement("Couldn't find function $fnName on enum type", c)
+                val enumType = (c.getTypeArgument(0) as? IrSimpleType)?.classifier?.owner
+                if (enumType == null) {
+                    logger.errorElement("Couldn't find type of enum type", c)
                     return
                 }
 
-                extractMethodAccess(func, false)
+                if (enumType is IrClass) {
+                    val func = enumType.declarations.findSubType<IrFunction> { it.name.asString() == fnName }
+                    if (func == null) {
+                        logger.errorElement("Couldn't find function $fnName on enum type", c)
+                        return
+                    }
+
+                    extractMethodAccess(func, false)
+                } else if (enumType is IrTypeParameter && enumType.isReified) {
+                    // A call to `enumValues<T>()` is being extracted, where `T` is a reified type parameter of an `inline` function.
+                    // We can't generate a valid expression here, because we would need to know the type of T on the call site.
+                    val id = tw.getFreshIdLabel<DbErrorexpr>()
+                    val type = useType(c.type)
+
+                    tw.writeExprs_errorexpr(id, type.javaResult.id, parent, idx)
+                    tw.writeExprsKotlinType(id, type.kotlinResult.id)
+                    tw.writeHasLocation(id, tw.getLocation(c))
+                    tw.writeCallableEnclosingExpr(id, callable)
+                    tw.writeStatementEnclosingExpr(id, enclosingStmt)
+                } else {
+                    logger.errorElement("Unexpected enum type rep ${enumType.javaClass}", c)
+                }
             }
 
             fun binopReceiver(id: Label<out DbExpr>, receiver: IrExpression?, receiverDescription: String) {

--- a/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
@@ -2832,6 +2832,27 @@ exprs.kt:
 #  268|           0: [AssignRemExpr] ...%=...
 #  268|             0: [VarAccess] updated
 #  268|             1: [IntegerLiteral] 1
+#  272|     12: [Method] getEnumValues
+#-----|       2: (Generic Parameters)
+#  272|         0: [TypeVariable] T
+#  272|       3: [TypeAccess] T[]
+#  272|         0: [TypeAccess] T
+#  272|       5: [BlockStmt] { ... }
+#  272|         0: [ReturnStmt] return ...
+#  274|     13: [Method] callToEnumValues
+#  274|       3: [TypeAccess] Unit
+#  274|       5: [BlockStmt] { ... }
+#  275|         0: [ExprStmt] <Expr>;
+#  275|           0: [ImplicitCoercionToUnitExpr] <implicit coercion to unit>
+#  275|             0: [TypeAccess] Unit
+#  275|             1: [MethodAccess] values(...)
+#  275|               -1: [TypeAccess] Color
+#  276|         1: [ExprStmt] <Expr>;
+#  276|           0: [ImplicitCoercionToUnitExpr] <implicit coercion to unit>
+#  276|             0: [TypeAccess] Unit
+#  276|             1: [MethodAccess] getEnumValues(...)
+#  276|               -2: [TypeAccess] Color
+#  276|               -1: [TypeAccess] ExprsKt
 #  142|   2: [Class] C
 #  142|     1: [Constructor] C
 #-----|       4: (Parameters)

--- a/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
@@ -2839,6 +2839,7 @@ exprs.kt:
 #  272|         0: [TypeAccess] T
 #  272|       5: [BlockStmt] { ... }
 #  272|         0: [ReturnStmt] return ...
+#  272|           0: [ErrorExpr] <error expr>
 #  274|     13: [Method] callToEnumValues
 #  274|       3: [TypeAccess] Unit
 #  274|       5: [BlockStmt] { ... }

--- a/java/ql/test/kotlin/library-tests/exprs/exprs.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/exprs.expected
@@ -1723,6 +1723,18 @@
 | exprs.kt:268:3:268:9 | updated | exprs.kt:261:1:270:1 | inPlaceOperators | VarAccess |
 | exprs.kt:268:3:268:14 | ...%=... | exprs.kt:261:1:270:1 | inPlaceOperators | AssignRemExpr |
 | exprs.kt:268:14:268:14 | 1 | exprs.kt:261:1:270:1 | inPlaceOperators | IntegerLiteral |
+| exprs.kt:272:8:272:66 | T | file://:0:0:0:0 | <none> | TypeAccess |
+| exprs.kt:272:8:272:66 | T[] | file://:0:0:0:0 | <none> | TypeAccess |
+| exprs.kt:274:1:277:1 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
+| exprs.kt:275:5:275:23 | <implicit coercion to unit> | exprs.kt:274:1:277:1 | callToEnumValues | ImplicitCoercionToUnitExpr |
+| exprs.kt:275:5:275:23 | Color | exprs.kt:274:1:277:1 | callToEnumValues | TypeAccess |
+| exprs.kt:275:5:275:23 | Unit | exprs.kt:274:1:277:1 | callToEnumValues | TypeAccess |
+| exprs.kt:275:5:275:23 | values(...) | exprs.kt:274:1:277:1 | callToEnumValues | MethodAccess |
+| exprs.kt:276:5:276:26 | <implicit coercion to unit> | exprs.kt:274:1:277:1 | callToEnumValues | ImplicitCoercionToUnitExpr |
+| exprs.kt:276:5:276:26 | Color | exprs.kt:274:1:277:1 | callToEnumValues | TypeAccess |
+| exprs.kt:276:5:276:26 | ExprsKt | exprs.kt:274:1:277:1 | callToEnumValues | TypeAccess |
+| exprs.kt:276:5:276:26 | Unit | exprs.kt:274:1:277:1 | callToEnumValues | TypeAccess |
+| exprs.kt:276:5:276:26 | getEnumValues(...) | exprs.kt:274:1:277:1 | callToEnumValues | MethodAccess |
 | funcExprs.kt:1:1:1:46 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:1:26:1:37 | Function0<Integer> | file://:0:0:0:0 | <none> | TypeAccess |
 | funcExprs.kt:1:26:1:37 | Integer | file://:0:0:0:0 | <none> | TypeAccess |

--- a/java/ql/test/kotlin/library-tests/exprs/exprs.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/exprs.expected
@@ -1725,6 +1725,7 @@
 | exprs.kt:268:14:268:14 | 1 | exprs.kt:261:1:270:1 | inPlaceOperators | IntegerLiteral |
 | exprs.kt:272:8:272:66 | T | file://:0:0:0:0 | <none> | TypeAccess |
 | exprs.kt:272:8:272:66 | T[] | file://:0:0:0:0 | <none> | TypeAccess |
+| exprs.kt:272:52:272:66 | <error expr> | exprs.kt:272:8:272:66 | getEnumValues | ErrorExpr |
 | exprs.kt:274:1:277:1 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | exprs.kt:275:5:275:23 | <implicit coercion to unit> | exprs.kt:274:1:277:1 | callToEnumValues | ImplicitCoercionToUnitExpr |
 | exprs.kt:275:5:275:23 | Color | exprs.kt:274:1:277:1 | callToEnumValues | TypeAccess |

--- a/java/ql/test/kotlin/library-tests/exprs/exprs.kt
+++ b/java/ql/test/kotlin/library-tests/exprs/exprs.kt
@@ -268,3 +268,10 @@ fun inPlaceOperators() {
   updated %= 1
 
 }
+
+inline fun <reified T : Enum<T>> getEnumValues() = enumValues<T>()
+
+fun callToEnumValues() {
+    enumValues<Color>()
+    getEnumValues<Color>()
+}


### PR DESCRIPTION
A call to `enumValues<MyEnum>()` is translated to `MyEnum.values()` in JVM. This transformation is also implemented in the extractor. However, the special case of `enumValues<T>()` was not handled. 

`T` can be `reified T : Enum<T>` of an `inline` function. In this case, the above `T.values()` conversion is done only on the call site, where `T` is already a known enum type. The method body in byte code contains a `new Enum[0]` array creation. This PR doesn't mimic this empty array creation, instead it extracts an `ErrorExpr`.