### PR TITLE
QL4QL: Add `--search-path` to `codeql resolve languages` calls

### DIFF
--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -108,7 +108,7 @@ jobs:
       ### Run the analysis ###
       - name: Hack codeql-action options
         run: |
-          JSON=$(jq -nc --arg pack "${PACK}" '.database."run-queries"=["--search-path", $pack] | .resolve.queries=["--search-path", $pack] | .resolve.extractor=["--search-path", $pack] | .database.init=["--search-path", $pack]')
+          JSON=$(jq -nc --arg pack "${PACK}" '.database."run-queries"=["--search-path", $pack] | .resolve.queries=["--search-path", $pack] | .resolve.extractor=["--search-path", $pack] | .resolve.languages=["--search-path", $pack] | .database.init=["--search-path", $pack]')
           echo "CODEQL_ACTION_EXTRA_OPTIONS=${JSON}" >> ${GITHUB_ENV}
         env:
           PACK: ${{ runner.temp }}/pack


### PR DESCRIPTION
See also https://github.com/github/codeql-action/pull/1234

Since the introduction of TRAP caching, the CodeQL Action now does `codeql resolve languages` to find languages that support TRAP caching. This is failing for QL4QL because we aren't passing the `--search-path` to find the custom extractor in this call. This PR adds that in.