### PR TITLE
C#: Add `dotnet build` integration test

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/dotnet_build/Program.cs
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_build/Program.cs
@@ -1,0 +1,1 @@
+﻿Console.WriteLine(args[0]);

--- a/csharp/ql/integration-tests/all-platforms/dotnet_build/dotnet_build.csproj
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_build/dotnet_build.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/csharp/ql/integration-tests/all-platforms/dotnet_build/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_build/test.py
@@ -1,0 +1,3 @@
+from create_database_utils import *
+
+run_codeql_database_create(['dotnet build'], test_db="default-db", db=None, lang="csharp")

--- a/csharp/ql/integration-tests/all-platforms/qlpack.yml
+++ b/csharp/ql/integration-tests/all-platforms/qlpack.yml
@@ -1,0 +1,2 @@
+libraryPathDependencies:
+  - codeql-csharp


### PR DESCRIPTION
This PR adds an initial C# integration test. Follow-up PRs will add more.