### PR TITLE
Ruby: Add missing edges to the call graph for singleton methods

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -432,10 +432,12 @@ private DataFlow::LocalSourceNode trackModule(Module tp, TypeTracker t) {
     resolveConstantReadAccess(result.asExpr().getExpr()) = tp
     or
     // `self` reference to Module
-    exists(Scope scope |
-      scope = result.(SsaSelfDefinitionNode).getSelfScope() and
+    exists(Scope scope | scope = result.(SsaSelfDefinitionNode).getSelfScope() |
       tp = scope.(ModuleBase).getModule() and
       not scope instanceof Toplevel // handled in `trackInstance`
+      or
+      scope = result.(SsaSelfDefinitionNode).getSelfScope() and
+      tp = scope.(SingletonMethod).getEnclosingModule().getModule()
     )
   )
   or

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -71,6 +71,9 @@ calls.rb:
 #  155| B
 #-----| super -> S
 
+#  169| Singletons
+#-----| super -> Object
+
 hello.rb:
 #    1| EnglishWords
 

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -63,6 +63,7 @@ getTarget
 | calls.rb:167:1:167:15 | call to private_on_main | calls.rb:164:1:165:3 | private_on_main |
 | calls.rb:171:9:171:24 | call to singleton_b | calls.rb:174:5:176:7 | singleton_b |
 | calls.rb:175:9:175:24 | call to singleton_c | calls.rb:178:5:179:7 | singleton_c |
+| calls.rb:182:9:182:24 | call to singleton_a | calls.rb:170:5:172:7 | singleton_a |
 | calls.rb:186:1:186:22 | call to singleton_a | calls.rb:170:5:172:7 | singleton_a |
 | hello.rb:12:5:12:24 | call to include | calls.rb:92:5:92:20 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
@@ -114,7 +115,6 @@ unresolvedCall
 | calls.rb:135:1:135:8 | call to [] |
 | calls.rb:135:4:135:5 | - ... |
 | calls.rb:135:32:135:36 | call to abs |
-| calls.rb:182:9:182:24 | call to singleton_a |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -61,6 +61,9 @@ getTarget
 | calls.rb:162:1:162:5 | call to new | calls.rb:99:5:99:16 | new |
 | calls.rb:162:1:162:14 | call to s_method | calls.rb:145:5:147:7 | s_method |
 | calls.rb:167:1:167:15 | call to private_on_main | calls.rb:164:1:165:3 | private_on_main |
+| calls.rb:171:9:171:24 | call to singleton_b | calls.rb:174:5:176:7 | singleton_b |
+| calls.rb:175:9:175:24 | call to singleton_c | calls.rb:178:5:179:7 | singleton_c |
+| calls.rb:186:1:186:22 | call to singleton_a | calls.rb:170:5:172:7 | singleton_a |
 | hello.rb:12:5:12:24 | call to include | calls.rb:92:5:92:20 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
@@ -111,6 +114,7 @@ unresolvedCall
 | calls.rb:135:1:135:8 | call to [] |
 | calls.rb:135:4:135:5 | - ... |
 | calls.rb:135:32:135:36 | call to abs |
+| calls.rb:182:9:182:24 | call to singleton_a |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |

--- a/ruby/ql/test/library-tests/modules/calls.rb
+++ b/ruby/ql/test/library-tests/modules/calls.rb
@@ -165,3 +165,22 @@ def private_on_main
 end
 
 private_on_main
+
+class Singletons
+    def self.singleton_a
+        self.singleton_b
+    end
+    
+    def self.singleton_b
+        self.singleton_c
+    end
+    
+    def self.singleton_c
+    end
+    
+    def self.singleton_d
+        self.singleton_a
+    end
+end
+  
+Singletons.singleton_a

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -169,6 +169,16 @@ lookupMethod
 | calls.rb:155:1:158:3 | B | puts | calls.rb:87:5:87:17 | puts |
 | calls.rb:155:1:158:3 | B | s_method | calls.rb:145:5:147:7 | s_method |
 | calls.rb:155:1:158:3 | B | to_s | calls.rb:156:5:157:7 | to_s |
+| calls.rb:169:1:184:3 | Singletons | call_block | calls.rb:67:1:69:3 | call_block |
+| calls.rb:169:1:184:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:169:1:184:3 | Singletons | foo | calls.rb:71:1:75:3 | foo |
+| calls.rb:169:1:184:3 | Singletons | funny | calls.rb:119:1:121:3 | funny |
+| calls.rb:169:1:184:3 | Singletons | indirect | calls.rb:137:1:139:3 | indirect |
+| calls.rb:169:1:184:3 | Singletons | new | calls.rb:99:5:99:16 | new |
+| calls.rb:169:1:184:3 | Singletons | optional_arg | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:169:1:184:3 | Singletons | private_on_main | calls.rb:164:1:165:3 | private_on_main |
+| calls.rb:169:1:184:3 | Singletons | puts | calls.rb:87:5:87:17 | puts |
+| calls.rb:169:1:184:3 | Singletons | to_s | calls.rb:151:5:152:7 | to_s |
 | file://:0:0:0:0 | Class | include | calls.rb:92:5:92:20 | include |
 | file://:0:0:0:0 | Class | module_eval | calls.rb:91:5:91:24 | module_eval |
 | file://:0:0:0:0 | Class | new | calls.rb:99:5:99:16 | new |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -12,6 +12,7 @@ getModule
 | calls.rb:144:1:148:3 | S |
 | calls.rb:150:1:153:3 | A |
 | calls.rb:155:1:158:3 | B |
+| calls.rb:169:1:184:3 | Singletons |
 | file://:0:0:0:0 | BasicObject |
 | file://:0:0:0:0 | Class |
 | file://:0:0:0:0 | Complex |
@@ -68,7 +69,7 @@ getADeclaration
 | calls.rb:82:1:84:3 | String | calls.rb:82:1:84:3 | String |
 | calls.rb:86:1:88:3 | Kernel | calls.rb:86:1:88:3 | Kernel |
 | calls.rb:90:1:95:3 | Module | calls.rb:90:1:95:3 | Module |
-| calls.rb:97:1:100:3 | Object | calls.rb:1:1:167:16 | calls.rb |
+| calls.rb:97:1:100:3 | Object | calls.rb:1:1:186:22 | calls.rb |
 | calls.rb:97:1:100:3 | Object | calls.rb:97:1:100:3 | Object |
 | calls.rb:97:1:100:3 | Object | hello.rb:1:1:22:3 | hello.rb |
 | calls.rb:97:1:100:3 | Object | modules.rb:1:1:121:4 | modules.rb |
@@ -80,6 +81,7 @@ getADeclaration
 | calls.rb:150:1:153:3 | A | calls.rb:150:1:153:3 | A |
 | calls.rb:150:1:153:3 | A | modules_rec.rb:7:1:9:3 | A |
 | calls.rb:155:1:158:3 | B | calls.rb:155:1:158:3 | B |
+| calls.rb:169:1:184:3 | Singletons | calls.rb:169:1:184:3 | Singletons |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
@@ -133,6 +135,7 @@ getSuperClass
 | calls.rb:150:1:153:3 | A | calls.rb:144:1:148:3 | S |
 | calls.rb:150:1:153:3 | A | calls.rb:155:1:158:3 | B |
 | calls.rb:155:1:158:3 | B | calls.rb:144:1:148:3 | S |
+| calls.rb:169:1:184:3 | Singletons | calls.rb:97:1:100:3 | Object |
 | file://:0:0:0:0 | Class | calls.rb:90:1:95:3 | Module |
 | file://:0:0:0:0 | Complex | file://:0:0:0:0 | Numeric |
 | file://:0:0:0:0 | FalseClass | calls.rb:97:1:100:3 | Object |
@@ -184,6 +187,7 @@ resolveConstantReadAccess
 | calls.rb:160:1:160:1 | S | S |
 | calls.rb:161:1:161:1 | A | A |
 | calls.rb:162:1:162:1 | B | B |
+| calls.rb:186:1:186:10 | Singletons | Singletons |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
 | modules.rb:48:8:48:10 | Foo | Foo |
@@ -228,6 +232,7 @@ resolveConstantWriteAccess
 | calls.rb:144:1:148:3 | S | S |
 | calls.rb:150:1:153:3 | A | A |
 | calls.rb:155:1:158:3 | B | B |
+| calls.rb:169:1:184:3 | Singletons | Singletons |
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -67,6 +67,9 @@ calls.rb:
 #  155| B
 #-----|  -> S
 
+#  169| Singletons
+#-----|  -> Object
+
 hello.rb:
 #    1| EnglishWords
 


### PR DESCRIPTION
Call targets were missing for singleton method calls inside uncalled singleton methods:

```rb
class Singletons
    def self.singleton_a
        self.singleton_b # missing call target, when there is no call to `singleton_a`
    end

    def self.singleton_b
    end
end
```