### PR TITLE
ensure consistent casing of names

### DIFF
--- a/cpp/ql/lib/change-notes/2022-09-12-uppercase.md
+++ b/cpp/ql/lib/change-notes/2022-09-12-uppercase.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Some classes/modules with upper-case acronyms in their name have been renamed to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConsistency.qll
@@ -1,2 +1,2 @@
-private import SSAConstruction as SSA
-import SSA::SsaConsistency
+private import SSAConstruction as Ssa
+import Ssa::SsaConsistency

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -1135,7 +1135,7 @@ deprecated module SSAConsistency = SsaConsistency;
  * These predicates are all just aliases for predicates defined in the `Cached` module. This ensures
  * that all of SSA construction will be evaluated in the same stage.
  */
-module SSA {
+module Ssa {
   class MemoryLocation = Alias::MemoryLocation;
 
   predicate hasPhiInstruction = Cached::hasPhiInstructionCached/2;
@@ -1144,3 +1144,6 @@ module SSA {
 
   predicate hasUnreachedInstruction = Cached::hasUnreachedInstructionCached/1;
 }
+
+/** DEPRECATED: Alias for Ssa */
+deprecated module SSA = Ssa;

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/internal/TInstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/internal/TInstruction.qll
@@ -20,24 +20,24 @@ newtype TInstruction =
     IRConstruction::Raw::hasInstruction(tag1, tag2)
   } or
   TUnaliasedSsaPhiInstruction(
-    TRawInstruction blockStartInstr, UnaliasedSsa::SSA::MemoryLocation memoryLocation
+    TRawInstruction blockStartInstr, UnaliasedSsa::Ssa::MemoryLocation memoryLocation
   ) {
-    UnaliasedSsa::SSA::hasPhiInstruction(blockStartInstr, memoryLocation)
+    UnaliasedSsa::Ssa::hasPhiInstruction(blockStartInstr, memoryLocation)
   } or
   TUnaliasedSsaChiInstruction(TRawInstruction primaryInstruction) { none() } or
   TUnaliasedSsaUnreachedInstruction(IRFunctionBase irFunc) {
-    UnaliasedSsa::SSA::hasUnreachedInstruction(irFunc)
+    UnaliasedSsa::Ssa::hasUnreachedInstruction(irFunc)
   } or
   TAliasedSsaPhiInstruction(
-    TRawInstruction blockStartInstr, AliasedSsa::SSA::MemoryLocation memoryLocation
+    TRawInstruction blockStartInstr, AliasedSsa::Ssa::MemoryLocation memoryLocation
   ) {
-    AliasedSsa::SSA::hasPhiInstruction(blockStartInstr, memoryLocation)
+    AliasedSsa::Ssa::hasPhiInstruction(blockStartInstr, memoryLocation)
   } or
   TAliasedSsaChiInstruction(TRawInstruction primaryInstruction) {
-    AliasedSsa::SSA::hasChiInstruction(primaryInstruction)
+    AliasedSsa::Ssa::hasChiInstruction(primaryInstruction)
   } or
   TAliasedSsaUnreachedInstruction(IRFunctionBase irFunc) {
-    AliasedSsa::SSA::hasUnreachedInstruction(irFunc)
+    AliasedSsa::Ssa::hasUnreachedInstruction(irFunc)
   }
 
 /**
@@ -50,7 +50,7 @@ module UnaliasedSsaInstructions {
   class TPhiInstruction = TUnaliasedSsaPhiInstruction;
 
   TPhiInstruction phiInstruction(
-    TRawInstruction blockStartInstr, UnaliasedSsa::SSA::MemoryLocation memoryLocation
+    TRawInstruction blockStartInstr, UnaliasedSsa::Ssa::MemoryLocation memoryLocation
   ) {
     result = TUnaliasedSsaPhiInstruction(blockStartInstr, memoryLocation)
   }
@@ -83,7 +83,7 @@ module AliasedSsaInstructions {
   class TPhiInstruction = TAliasedSsaPhiInstruction or TUnaliasedSsaPhiInstruction;
 
   TPhiInstruction phiInstruction(
-    TRawInstruction blockStartInstr, AliasedSsa::SSA::MemoryLocation memoryLocation
+    TRawInstruction blockStartInstr, AliasedSsa::Ssa::MemoryLocation memoryLocation
   ) {
     result = TAliasedSsaPhiInstruction(blockStartInstr, memoryLocation)
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConsistency.qll
@@ -1,2 +1,2 @@
-private import SSAConstruction as SSA
-import SSA::SsaConsistency
+private import SSAConstruction as Ssa
+import Ssa::SsaConsistency

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -1135,7 +1135,7 @@ deprecated module SSAConsistency = SsaConsistency;
  * These predicates are all just aliases for predicates defined in the `Cached` module. This ensures
  * that all of SSA construction will be evaluated in the same stage.
  */
-module SSA {
+module Ssa {
   class MemoryLocation = Alias::MemoryLocation;
 
   predicate hasPhiInstruction = Cached::hasPhiInstructionCached/2;
@@ -1144,3 +1144,6 @@ module SSA {
 
   predicate hasUnreachedInstruction = Cached::hasUnreachedInstructionCached/1;
 }
+
+/** DEPRECATED: Alias for Ssa */
+deprecated module SSA = Ssa;

--- a/csharp/ql/lib/change-notes/2022-09-12-uppercase.md
+++ b/csharp/ql/lib/change-notes/2022-09-12-uppercase.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Some classes/modules with upper-case acronyms in their name have been renamed to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/csharp/ql/lib/semmle/code/cil/CallableReturns.qll
+++ b/csharp/ql/lib/semmle/code/cil/CallableReturns.qll
@@ -56,7 +56,7 @@ private predicate alwaysNotNullVariableUpdate(VariableUpdate vu) {
 
 /** Holds if expression `expr` always evaluates to non-null. */
 private predicate alwaysNotNullExpr(Expr expr) {
-  expr instanceof Opcodes::Newobj
+  expr instanceof Opcodes::NewObj
   or
   expr instanceof Literal and not expr instanceof NullLiteral
   or

--- a/csharp/ql/lib/semmle/code/cil/Instructions.qll
+++ b/csharp/ql/lib/semmle/code/cil/Instructions.qll
@@ -766,7 +766,7 @@ module Opcodes {
   }
 
   /** A `newobj` instruction. */
-  class Newobj extends Call, @cil_newobj {
+  class NewObj extends Call, @cil_newobj {
     override string getOpcodeName() { result = "newobj" }
 
     override int getPushCount() { result = 1 }
@@ -787,6 +787,9 @@ module Opcodes {
       )
     }
   }
+
+  /** DEPRECATED: Alias for NewObj */
+  deprecated class Newobj = NewObj;
 
   /** An `initobj` instruction. */
   class Initobj extends Instruction, @cil_initobj {
@@ -847,9 +850,12 @@ module Opcodes {
   }
 
   /** A `rethrow` instruction. */
-  class Rethrow extends Throw, @cil_rethrow {
+  class ReThrow extends Throw, @cil_rethrow {
     override string getOpcodeName() { result = "rethrow" }
   }
+
+  /** DEPRECATED: Alias for ReThrow */
+  deprecated class Rethrow = ReThrow;
 
   /** A `ldlen` instruction. */
   class Ldlen extends UnaryExpr, @cil_ldlen {

--- a/csharp/ql/src/experimental/ir/implementation/internal/AliasedSSAStub.qll
+++ b/csharp/ql/src/experimental/ir/implementation/internal/AliasedSSAStub.qll
@@ -6,7 +6,7 @@
 private import IRFunctionBase
 private import TInstruction
 
-module SSA {
+module Ssa {
   class MemoryLocation = boolean;
 
   predicate hasPhiInstruction(TRawInstruction blockStartInstr, MemoryLocation memoryLocation) {
@@ -17,3 +17,6 @@ module SSA {
 
   predicate hasUnreachedInstruction(IRFunctionBase irFunc) { none() }
 }
+
+/** DEPRECATED: Alias for Ssa */
+deprecated module SSA = Ssa;

--- a/csharp/ql/src/experimental/ir/implementation/internal/TInstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/internal/TInstruction.qll
@@ -20,24 +20,24 @@ newtype TInstruction =
     IRConstruction::Raw::hasInstruction(tag1, tag2)
   } or
   TUnaliasedSsaPhiInstruction(
-    TRawInstruction blockStartInstr, UnaliasedSsa::SSA::MemoryLocation memoryLocation
+    TRawInstruction blockStartInstr, UnaliasedSsa::Ssa::MemoryLocation memoryLocation
   ) {
-    UnaliasedSsa::SSA::hasPhiInstruction(blockStartInstr, memoryLocation)
+    UnaliasedSsa::Ssa::hasPhiInstruction(blockStartInstr, memoryLocation)
   } or
   TUnaliasedSsaChiInstruction(TRawInstruction primaryInstruction) { none() } or
   TUnaliasedSsaUnreachedInstruction(IRFunctionBase irFunc) {
-    UnaliasedSsa::SSA::hasUnreachedInstruction(irFunc)
+    UnaliasedSsa::Ssa::hasUnreachedInstruction(irFunc)
   } or
   TAliasedSsaPhiInstruction(
-    TRawInstruction blockStartInstr, AliasedSsa::SSA::MemoryLocation memoryLocation
+    TRawInstruction blockStartInstr, AliasedSsa::Ssa::MemoryLocation memoryLocation
   ) {
-    AliasedSsa::SSA::hasPhiInstruction(blockStartInstr, memoryLocation)
+    AliasedSsa::Ssa::hasPhiInstruction(blockStartInstr, memoryLocation)
   } or
   TAliasedSsaChiInstruction(TRawInstruction primaryInstruction) {
-    AliasedSsa::SSA::hasChiInstruction(primaryInstruction)
+    AliasedSsa::Ssa::hasChiInstruction(primaryInstruction)
   } or
   TAliasedSsaUnreachedInstruction(IRFunctionBase irFunc) {
-    AliasedSsa::SSA::hasUnreachedInstruction(irFunc)
+    AliasedSsa::Ssa::hasUnreachedInstruction(irFunc)
   }
 
 /**
@@ -50,7 +50,7 @@ module UnaliasedSsaInstructions {
   class TPhiInstruction = TUnaliasedSsaPhiInstruction;
 
   TPhiInstruction phiInstruction(
-    TRawInstruction blockStartInstr, UnaliasedSsa::SSA::MemoryLocation memoryLocation
+    TRawInstruction blockStartInstr, UnaliasedSsa::Ssa::MemoryLocation memoryLocation
   ) {
     result = TUnaliasedSsaPhiInstruction(blockStartInstr, memoryLocation)
   }
@@ -83,7 +83,7 @@ module AliasedSsaInstructions {
   class TPhiInstruction = TAliasedSsaPhiInstruction or TUnaliasedSsaPhiInstruction;
 
   TPhiInstruction phiInstruction(
-    TRawInstruction blockStartInstr, AliasedSsa::SSA::MemoryLocation memoryLocation
+    TRawInstruction blockStartInstr, AliasedSsa::Ssa::MemoryLocation memoryLocation
   ) {
     result = TAliasedSsaPhiInstruction(blockStartInstr, memoryLocation)
   }

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConsistency.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConsistency.qll
@@ -1,2 +1,2 @@
-private import SSAConstruction as SSA
-import SSA::SsaConsistency
+private import SSAConstruction as Ssa
+import Ssa::SsaConsistency

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -1135,7 +1135,7 @@ deprecated module SSAConsistency = SsaConsistency;
  * These predicates are all just aliases for predicates defined in the `Cached` module. This ensures
  * that all of SSA construction will be evaluated in the same stage.
  */
-module SSA {
+module Ssa {
   class MemoryLocation = Alias::MemoryLocation;
 
   predicate hasPhiInstruction = Cached::hasPhiInstructionCached/2;
@@ -1144,3 +1144,6 @@ module SSA {
 
   predicate hasUnreachedInstruction = Cached::hasUnreachedInstructionCached/1;
 }
+
+/** DEPRECATED: Alias for Ssa */
+deprecated module SSA = Ssa;

--- a/go/ql/lib/change-notes/2022-09-12-uppercase.md
+++ b/go/ql/lib/change-notes/2022-09-12-uppercase.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Some classes/modules with upper-case acronyms in their name have been renamed to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/go/ql/lib/semmle/go/concepts/HTTP.qll
+++ b/go/ql/lib/semmle/go/concepts/HTTP.qll
@@ -5,7 +5,7 @@
 import go
 
 /** Provides classes for modeling HTTP-related APIs. */
-module HTTP {
+module Http {
   /** Provides a class for modeling new HTTP response-writer APIs. */
   module ResponseWriter {
     /**
@@ -191,7 +191,7 @@ module HTTP {
 
       /** Gets a content-type associated with this body. */
       string getAContentType() {
-        exists(HTTP::HeaderWrite hw | hw = this.getResponseWriter().getAHeaderWrite() |
+        exists(Http::HeaderWrite hw | hw = this.getResponseWriter().getAHeaderWrite() |
           hw.getHeaderName() = "content-type" and
           result = hw.getHeaderValue()
         )
@@ -201,7 +201,7 @@ module HTTP {
 
       /** Gets a dataflow node for a content-type associated with this body. */
       DataFlow::Node getAContentTypeNode() {
-        exists(HTTP::HeaderWrite hw | hw = this.getResponseWriter().getAHeaderWrite() |
+        exists(Http::HeaderWrite hw | hw = this.getResponseWriter().getAHeaderWrite() |
           hw.getHeaderName() = "content-type" and
           result = hw.getValue()
         )
@@ -378,3 +378,6 @@ module HTTP {
     predicate guardedBy(DataFlow::Node check) { self.guardedBy(check) }
   }
 }
+
+/** DEPRECATED: Alias for Http */
+deprecated module HTTP = Http;

--- a/go/ql/lib/semmle/go/frameworks/Beego.qll
+++ b/go/ql/lib/semmle/go/frameworks/Beego.qll
@@ -114,7 +114,7 @@ module Beego {
     }
   }
 
-  private class BeegoOutputInstance extends HTTP::ResponseWriter::Range {
+  private class BeegoOutputInstance extends Http::ResponseWriter::Range {
     SsaWithFields v;
 
     BeegoOutputInstance() {
@@ -131,7 +131,7 @@ module Beego {
     }
   }
 
-  private class BeegoHeaderWrite extends HTTP::HeaderWrite::Range, DataFlow::MethodCallNode {
+  private class BeegoHeaderWrite extends Http::HeaderWrite::Range, DataFlow::MethodCallNode {
     string methodName;
 
     BeegoHeaderWrite() {
@@ -142,7 +142,7 @@ module Beego {
     override DataFlow::Node getName() { methodName = "Header" and result = this.getArgument(0) }
 
     override string getHeaderName() {
-      result = HTTP::HeaderWrite::Range.super.getHeaderName()
+      result = Http::HeaderWrite::Range.super.getHeaderName()
       or
       methodName = "ContentType" and result = "content-type"
     }
@@ -153,12 +153,12 @@ module Beego {
       else result = this.getArgument(1)
     }
 
-    override HTTP::ResponseWriter getResponseWriter() {
+    override Http::ResponseWriter getResponseWriter() {
       result.(BeegoOutputInstance).getAHeaderObject() = this
     }
   }
 
-  private class BeegoResponseBody extends HTTP::ResponseBody::Range {
+  private class BeegoResponseBody extends Http::ResponseBody::Range {
     DataFlow::MethodCallNode call;
     string methodName;
 
@@ -170,7 +170,7 @@ module Beego {
       methodName in ["Body", "JSON", "JSONP", "ServeFormatted", "XML", "YAML"]
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = call.getReceiver() }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = call.getReceiver() }
 
     override string getAContentType() {
       // Super-method provides content-types for `Body`, which requires us to search
@@ -192,7 +192,7 @@ module Beego {
     }
   }
 
-  private class ControllerResponseBody extends HTTP::ResponseBody::Range {
+  private class ControllerResponseBody extends Http::ResponseBody::Range {
     string name;
 
     ControllerResponseBody() {
@@ -203,7 +203,7 @@ module Beego {
       )
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
 
     override string getAContentType() {
       // Actually SetData can serve JSON, XML or YAML depending on the incoming
@@ -213,7 +213,7 @@ module Beego {
     }
   }
 
-  private class ContextResponseBody extends HTTP::ResponseBody::Range {
+  private class ContextResponseBody extends Http::ResponseBody::Range {
     string name;
 
     ContextResponseBody() {
@@ -224,7 +224,7 @@ module Beego {
       )
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
 
     // Neither method is likely to be used with well-typed data such as JSON output,
     // because there are better methods to do this. Assume the Content-Type could
@@ -314,7 +314,7 @@ module Beego {
     }
   }
 
-  private class RedirectMethods extends HTTP::Redirect::Range, DataFlow::CallNode {
+  private class RedirectMethods extends Http::Redirect::Range, DataFlow::CallNode {
     string package;
     string className;
 
@@ -333,7 +333,7 @@ module Beego {
       className = "Context" and result = this.getArgument(1)
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
   }
 
   private class UtilsTaintPropagators extends TaintTracking::FunctionModel {

--- a/go/ql/lib/semmle/go/frameworks/Echo.qll
+++ b/go/ql/lib/semmle/go/frameworks/Echo.qll
@@ -29,7 +29,7 @@ private module Echo {
   /**
    * Data from a `Context` interface method that is not generally exploitable for open-redirect attacks.
    */
-  private class EchoContextRedirectUnexploitableSource extends HTTP::Redirect::UnexploitableSource {
+  private class EchoContextRedirectUnexploitableSource extends Http::Redirect::UnexploitableSource {
     EchoContextRedirectUnexploitableSource() {
       exists(DataFlow::MethodCallNode call, string methodName |
         methodName = ["FormValue", "FormParams", "FormFile", "MultipartForm", "Cookie", "Cookies"] and
@@ -77,14 +77,14 @@ private module Echo {
   /**
    * `echo.Context` methods which set the content-type to `text/html` and write a result in one operation.
    */
-  private class EchoHtmlOutputs extends HTTP::ResponseBody::Range {
+  private class EchoHtmlOutputs extends Http::ResponseBody::Range {
     EchoHtmlOutputs() {
       exists(Method m | m.hasQualifiedName(packagePath(), "Context", ["HTML", "HTMLBlob"]) |
         this = m.getACall().getArgument(1)
       )
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
 
     override string getAContentType() { result = "text/html" }
   }
@@ -92,7 +92,7 @@ private module Echo {
   /**
    * `echo.Context` methods which take a content-type as a parameter.
    */
-  private class EchoParameterizedOutputs extends HTTP::ResponseBody::Range {
+  private class EchoParameterizedOutputs extends Http::ResponseBody::Range {
     DataFlow::CallNode callNode;
 
     EchoParameterizedOutputs() {
@@ -101,7 +101,7 @@ private module Echo {
       )
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
 
     override DataFlow::Node getAContentTypeNode() { result = callNode.getArgument(1) }
   }
@@ -109,7 +109,7 @@ private module Echo {
   /**
    * The `echo.Context.Redirect` method.
    */
-  private class EchoRedirectMethod extends HTTP::Redirect::Range, DataFlow::CallNode {
+  private class EchoRedirectMethod extends Http::Redirect::Range, DataFlow::CallNode {
     EchoRedirectMethod() {
       exists(Method m | m.hasQualifiedName(packagePath(), "Context", "Redirect") |
         this = m.getACall()
@@ -118,6 +118,6 @@ private module Echo {
 
     override DataFlow::Node getUrl() { result = this.getArgument(1) }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
   }
 }

--- a/go/ql/lib/semmle/go/frameworks/ElazarlGoproxy.qll
+++ b/go/ql/lib/semmle/go/frameworks/ElazarlGoproxy.qll
@@ -11,7 +11,7 @@ module ElazarlGoproxy {
   /** Gets the package name. */
   string packagePath() { result = package("github.com/elazarl/goproxy", "") }
 
-  private class NewResponse extends HTTP::HeaderWrite::Range, DataFlow::CallNode {
+  private class NewResponse extends Http::HeaderWrite::Range, DataFlow::CallNode {
     NewResponse() { this.getTarget().hasQualifiedName(packagePath(), "NewResponse") }
 
     override string getHeaderName() { this.definesHeader(result, _) }
@@ -28,21 +28,21 @@ module ElazarlGoproxy {
       header = "content-type" and value = this.getArgument(1).getStringValue()
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
   }
 
   /** A body argument to a `NewResponse` call. */
-  private class NewResponseBody extends HTTP::ResponseBody::Range {
+  private class NewResponseBody extends Http::ResponseBody::Range {
     NewResponse call;
 
     NewResponseBody() { this = call.getArgument(3) }
 
     override DataFlow::Node getAContentTypeNode() { result = call.getArgument(1) }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
   }
 
-  private class TextResponse extends HTTP::HeaderWrite::Range, DataFlow::CallNode {
+  private class TextResponse extends Http::HeaderWrite::Range, DataFlow::CallNode {
     TextResponse() { this.getTarget().hasQualifiedName(packagePath(), "TextResponse") }
 
     override string getHeaderName() { this.definesHeader(result, _) }
@@ -59,22 +59,22 @@ module ElazarlGoproxy {
       header = "content-type" and value = "text/plain"
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
   }
 
   /** A body argument to a `TextResponse` call. */
-  private class TextResponseBody extends HTTP::ResponseBody::Range, TextResponse {
+  private class TextResponseBody extends Http::ResponseBody::Range, TextResponse {
     TextResponse call;
 
     TextResponseBody() { this = call.getArgument(2) }
 
     override DataFlow::Node getAContentTypeNode() { result = call.getArgument(1) }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
   }
 
   /** A handler attached to a goproxy proxy type. */
-  private class ProxyHandler extends HTTP::RequestHandler::Range {
+  private class ProxyHandler extends Http::RequestHandler::Range {
     DataFlow::MethodCallNode handlerReg;
 
     ProxyHandler() {

--- a/go/ql/lib/semmle/go/frameworks/Macaron.qll
+++ b/go/ql/lib/semmle/go/frameworks/Macaron.qll
@@ -5,7 +5,7 @@
 import go
 
 private module Macaron {
-  private class Context extends HTTP::ResponseWriter::Range {
+  private class Context extends Http::ResponseWriter::Range {
     SsaWithFields v;
 
     Context() {
@@ -18,13 +18,13 @@ private module Macaron {
     override DataFlow::Node getANode() { result = v.similar().getAUse().getASuccessor*() }
   }
 
-  private class RedirectCall extends HTTP::Redirect::Range, DataFlow::MethodCallNode {
+  private class RedirectCall extends Http::Redirect::Range, DataFlow::MethodCallNode {
     RedirectCall() {
       this.getTarget().hasQualifiedName("gopkg.in/macaron.v1", "Context", "Redirect")
     }
 
     override DataFlow::Node getUrl() { result = this.getArgument(0) }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = this.getReceiver() }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = this.getReceiver() }
   }
 }

--- a/go/ql/lib/semmle/go/frameworks/Revel.qll
+++ b/go/ql/lib/semmle/go/frameworks/Revel.qll
@@ -114,7 +114,7 @@ module Revel {
    * We look particularly for html file extensions, since these are the only ones we currently have special rules
    * for (in particular, detecting XSS vulnerabilities).
    */
-  private class ControllerRenderMethods extends HTTP::ResponseBody::Range {
+  private class ControllerRenderMethods extends Http::ResponseBody::Range {
     string contentType;
 
     ControllerRenderMethods() {
@@ -149,7 +149,7 @@ module Revel {
       )
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
 
     override string getAContentType() { result = contentType }
   }
@@ -174,7 +174,7 @@ module Revel {
    * It is currently assumed that a tainted `value` in `Redirect(url, value)`, which calls `Sprintf(url, value)`
    * internally, cannot lead to an open redirect vulnerability.
    */
-  private class ControllerRedirectMethod extends HTTP::Redirect::Range, DataFlow::CallNode {
+  private class ControllerRedirectMethod extends Http::Redirect::Range, DataFlow::CallNode {
     ControllerRedirectMethod() {
       exists(Method m | m.hasQualifiedName(packagePath(), "Controller", "Redirect") |
         this = m.getACall()
@@ -183,7 +183,7 @@ module Revel {
 
     override DataFlow::Node getUrl() { result = this.getArgument(0) }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
   }
 
   /**
@@ -226,7 +226,7 @@ module Revel {
   /**
    * A write to a template argument field that is read raw inside of a template.
    */
-  private class RawTemplateArgument extends HTTP::TemplateResponseBody::Range {
+  private class RawTemplateArgument extends Http::TemplateResponseBody::Range {
     RawTemplateRead read;
 
     RawTemplateArgument() {
@@ -261,7 +261,7 @@ module Revel {
 
     override string getAContentType() { result = "text/html" }
 
-    override HTTP::ResponseWriter getResponseWriter() { none() }
+    override Http::ResponseWriter getResponseWriter() { none() }
 
     override HtmlTemplate::TemplateRead getRead() { result = read }
   }

--- a/go/ql/lib/semmle/go/frameworks/Stdlib.qll
+++ b/go/ql/lib/semmle/go/frameworks/Stdlib.qll
@@ -128,7 +128,7 @@ module IntegerParser {
 }
 
 /** Provides models of commonly used functions in the `net/url` package. */
-module URL {
+module Url {
   /** The `PathEscape` or `QueryEscape` function. */
   class Escaper extends TaintTracking::FunctionModel {
     Escaper() {
@@ -263,3 +263,6 @@ module URL {
     }
   }
 }
+
+/** DEPRECATED: Alias for Url */
+deprecated module URL = Url;

--- a/go/ql/lib/semmle/go/frameworks/stdlib/NetHttp.qll
+++ b/go/ql/lib/semmle/go/frameworks/stdlib/NetHttp.qll
@@ -35,7 +35,7 @@ module NetHttp {
   }
 
   /** The declaration of a variable which either is or has a field that implements the http.ResponseWriter type */
-  private class StdlibResponseWriter extends HTTP::ResponseWriter::Range {
+  private class StdlibResponseWriter extends Http::ResponseWriter::Range {
     SsaWithFields v;
 
     StdlibResponseWriter() {
@@ -52,7 +52,7 @@ module NetHttp {
     }
   }
 
-  private class HeaderWriteCall extends HTTP::HeaderWrite::Range, DataFlow::MethodCallNode {
+  private class HeaderWriteCall extends Http::HeaderWrite::Range, DataFlow::MethodCallNode {
     HeaderWriteCall() {
       this.getTarget().hasQualifiedName("net/http", "Header", "Add") or
       this.getTarget().hasQualifiedName("net/http", "Header", "Set")
@@ -62,7 +62,7 @@ module NetHttp {
 
     override DataFlow::Node getValue() { result = this.getArgument(1) }
 
-    override HTTP::ResponseWriter getResponseWriter() {
+    override Http::ResponseWriter getResponseWriter() {
       // find `v` in
       // ```
       // header := v.Header()
@@ -72,7 +72,7 @@ module NetHttp {
     }
   }
 
-  private class MapWrite extends HTTP::HeaderWrite::Range, DataFlow::Node {
+  private class MapWrite extends Http::HeaderWrite::Range, DataFlow::Node {
     Write write;
     DataFlow::Node index;
     DataFlow::Node rhs;
@@ -86,7 +86,7 @@ module NetHttp {
 
     override DataFlow::Node getValue() { result = rhs }
 
-    override HTTP::ResponseWriter getResponseWriter() {
+    override Http::ResponseWriter getResponseWriter() {
       // find `v` in
       // ```
       // header := v.Header()
@@ -96,7 +96,7 @@ module NetHttp {
     }
   }
 
-  private class ResponseWriteHeaderCall extends HTTP::HeaderWrite::Range, DataFlow::MethodCallNode {
+  private class ResponseWriteHeaderCall extends Http::HeaderWrite::Range, DataFlow::MethodCallNode {
     ResponseWriteHeaderCall() {
       this.getTarget().implements("net/http", "ResponseWriter", "WriteHeader")
     }
@@ -107,10 +107,10 @@ module NetHttp {
 
     override DataFlow::Node getValue() { result = this.getArgument(0) }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = this.getReceiver() }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = this.getReceiver() }
   }
 
-  private class ResponseErrorCall extends HTTP::HeaderWrite::Range, DataFlow::CallNode {
+  private class ResponseErrorCall extends Http::HeaderWrite::Range, DataFlow::CallNode {
     ResponseErrorCall() { this.getTarget().hasQualifiedName("net/http", "Error") }
 
     override string getHeaderName() { result = "status" }
@@ -119,10 +119,10 @@ module NetHttp {
 
     override DataFlow::Node getValue() { result = this.getArgument(2) }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = this.getArgument(0) }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = this.getArgument(0) }
   }
 
-  private class RequestBody extends HTTP::RequestBody::Range, DataFlow::ExprNode {
+  private class RequestBody extends Http::RequestBody::Range, DataFlow::ExprNode {
     RequestBody() {
       exists(Function newRequest |
         newRequest.hasQualifiedName("net/http", "NewRequest") and
@@ -137,7 +137,7 @@ module NetHttp {
     }
   }
 
-  private class ResponseBody extends HTTP::ResponseBody::Range, DataFlow::ArgumentNode {
+  private class ResponseBody extends Http::ResponseBody::Range, DataFlow::ArgumentNode {
     DataFlow::Node responseWriter;
 
     ResponseBody() {
@@ -156,19 +156,19 @@ module NetHttp {
       )
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = responseWriter }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = responseWriter }
   }
 
-  private class RedirectCall extends HTTP::Redirect::Range, DataFlow::CallNode {
+  private class RedirectCall extends Http::Redirect::Range, DataFlow::CallNode {
     RedirectCall() { this.getTarget().hasQualifiedName("net/http", "Redirect") }
 
     override DataFlow::Node getUrl() { result = this.getArgument(2) }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = this.getArgument(0) }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = this.getArgument(0) }
   }
 
   /** A call to a function in the `net/http` package that performs an HTTP request to a URL. */
-  private class RequestCall extends HTTP::ClientRequest::Range, DataFlow::CallNode {
+  private class RequestCall extends Http::ClientRequest::Range, DataFlow::CallNode {
     RequestCall() {
       exists(string functionName |
         (
@@ -185,7 +185,7 @@ module NetHttp {
   }
 
   /** A call to the Client.Do function in the `net/http` package. */
-  private class ClientDo extends HTTP::ClientRequest::Range, DataFlow::MethodCallNode {
+  private class ClientDo extends Http::ClientRequest::Range, DataFlow::MethodCallNode {
     ClientDo() { this.getTarget().hasQualifiedName("net/http", "Client", "Do") }
 
     override DataFlow::Node getUrl() {
@@ -212,7 +212,7 @@ module NetHttp {
   }
 
   /** A call to the `Transport.RoundTrip` function in the `net/http` package. */
-  private class TransportRoundTrip extends HTTP::ClientRequest::Range, DataFlow::MethodCallNode {
+  private class TransportRoundTrip extends Http::ClientRequest::Range, DataFlow::MethodCallNode {
     TransportRoundTrip() { this.getTarget().hasQualifiedName("net/http", "Transport", "RoundTrip") }
 
     override DataFlow::Node getUrl() {
@@ -239,7 +239,7 @@ module NetHttp {
   }
 
   /** Fields and methods of `net/http.Request` that are not generally exploitable in an open-redirect attack. */
-  private class RedirectUnexploitableRequestFields extends HTTP::Redirect::UnexploitableSource {
+  private class RedirectUnexploitableRequestFields extends Http::Redirect::UnexploitableSource {
     RedirectUnexploitableRequestFields() {
       exists(Field f, string fieldName |
         f.hasQualifiedName("net/http", "Request", fieldName) and
@@ -257,7 +257,7 @@ module NetHttp {
     }
   }
 
-  private class Handler extends HTTP::RequestHandler::Range {
+  private class Handler extends Http::RequestHandler::Range {
     DataFlow::CallNode handlerReg;
 
     Handler() {

--- a/go/ql/lib/semmle/go/security/OpenUrlRedirectCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/OpenUrlRedirectCustomizations.qll
@@ -56,7 +56,7 @@ module OpenUrlRedirect {
     UntrustedFlowAsSource() {
       // exclude some fields and methods of URLs that are generally not attacker-controllable for
       // open redirect exploits
-      not this instanceof HTTP::Redirect::UnexploitableSource
+      not this instanceof Http::Redirect::UnexploitableSource
     }
   }
 
@@ -64,7 +64,7 @@ module OpenUrlRedirect {
    * An HTTP redirect, considered as a sink for `Configuration`.
    */
   class RedirectSink extends Sink, DataFlow::Node {
-    RedirectSink() { this = any(HTTP::Redirect redir).getUrl() }
+    RedirectSink() { this = any(Http::Redirect redir).getUrl() }
   }
 
   /**
@@ -73,7 +73,7 @@ module OpenUrlRedirect {
    */
   class LocationHeaderSink extends Sink, DataFlow::Node {
     LocationHeaderSink() {
-      exists(HTTP::HeaderWrite hw | hw.getHeaderName() = "location" | this = hw.getValue())
+      exists(Http::HeaderWrite hw | hw.getHeaderName() = "location" | this = hw.getValue())
     }
   }
 

--- a/go/ql/lib/semmle/go/security/RequestForgeryCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/RequestForgeryCustomizations.qll
@@ -48,7 +48,7 @@ module RequestForgery {
    * The URL of an HTTP request, viewed as a sink for request forgery.
    */
   private class ClientRequestUrlAsSink extends Sink {
-    HTTP::ClientRequest request;
+    Http::ClientRequest request;
 
     ClientRequestUrlAsSink() { this = request.getUrl() }
 

--- a/go/ql/lib/semmle/go/security/SafeUrlFlowCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/SafeUrlFlowCustomizations.qll
@@ -27,7 +27,7 @@ module SafeUrlFlow {
   /**
    * A method on a `net/url.URL` that is considered unsafe to use.
    */
-  private class UnsafeUrlMethod extends URL::UrlGetter {
+  private class UnsafeUrlMethod extends Url::UrlGetter {
     UnsafeUrlMethod() { this.getName() = "Query" }
   }
 

--- a/go/ql/lib/semmle/go/security/Xss.qll
+++ b/go/ql/lib/semmle/go/security/Xss.qll
@@ -46,14 +46,14 @@ module SharedXss {
    * a content type that does not (case-insensitively) contain the string "html". This
    * is to prevent us from flagging plain-text or JSON responses as vulnerable.
    */
-  class HttpResponseBodySink extends Sink, HTTP::ResponseBody {
+  class HttpResponseBodySink extends Sink, Http::ResponseBody {
     HttpResponseBodySink() { not nonHtmlContentType(this) }
   }
 
   /**
    * An expression that is rendered as part of a template.
    */
-  class RawTemplateInstantiationSink extends HttpResponseBodySink, HTTP::TemplateResponseBody {
+  class RawTemplateInstantiationSink extends HttpResponseBodySink, Http::TemplateResponseBody {
     override string getSinkKind() { result = "rawtemplate" }
 
     override Locatable getAssociatedLoc() { result = this.getRead().getEnclosingTextNode() }
@@ -62,7 +62,7 @@ module SharedXss {
   /**
    * Holds if `body` may send a response with a content type other than HTML.
    */
-  private predicate nonHtmlContentType(HTTP::ResponseBody body) {
+  private predicate nonHtmlContentType(Http::ResponseBody body) {
     not htmlTypeSpecified(body) and
     (
       exists(body.getAContentType())
@@ -90,7 +90,7 @@ module SharedXss {
   /**
    * Holds if `body` specifies the response's content type to be HTML.
    */
-  private predicate htmlTypeSpecified(HTTP::ResponseBody body) {
+  private predicate htmlTypeSpecified(Http::ResponseBody body) {
     body.getAContentType().regexpMatch("(?i).*html.*")
   }
 

--- a/go/ql/src/Security/CWE-020/IncompleteHostnameRegexp.ql
+++ b/go/ql/src/Security/CWE-020/IncompleteHostnameRegexp.ql
@@ -33,7 +33,7 @@ predicate isIncompleteHostNameRegexpPattern(string pattern, string hostPart) {
 
 /** Holds if `b` sets the HTTP status code (represented by a pseudo-header named  `status`) */
 predicate writesHttpError(ReachableBasicBlock b) {
-  forex(HTTP::HeaderWrite hw |
+  forex(Http::HeaderWrite hw |
     hw.getHeaderName() = "status" and hw.asInstruction().getBasicBlock() = b
   |
     exists(string code | code.matches("4__") or code.matches("5__") |
@@ -65,7 +65,7 @@ DataFlow::Node getASafeHandler() {
 }
 
 /** Holds if `regexp` is used in a check before `handler` is called. */
-predicate regexpGuardsHandler(RegexpPattern regexp, HTTP::RequestHandler handler) {
+predicate regexpGuardsHandler(RegexpPattern regexp, Http::RequestHandler handler) {
   handler.guardedBy(DataFlow::exprNode(regexp.getAUse().asExpr().getParent*()))
 }
 
@@ -99,7 +99,7 @@ class Config extends DataFlow::Configuration {
 
   override predicate isSink(DataFlow::Node sink) {
     sink instanceof RegexpPattern and
-    forall(HTTP::RequestHandler handler | regexpGuardsHandler(sink, handler) |
+    forall(Http::RequestHandler handler | regexpGuardsHandler(sink, handler) |
       not handler = getASafeHandler()
     ) and
     not regexpGuardsError(sink)

--- a/go/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/go/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -60,7 +60,7 @@ class StackTraceExposureConfig extends TaintTracking::Configuration {
     node = any(DebugStackFunction f).getACall().getResult()
   }
 
-  override predicate isSink(DataFlow::Node node) { node instanceof HTTP::ResponseBody }
+  override predicate isSink(DataFlow::Node node) { node instanceof Http::ResponseBody }
 
   override predicate isSanitizer(DataFlow::Node node) {
     // Sanitise everything controlled by an is-debug-mode check.

--- a/go/ql/src/experimental/CWE-918/SSRF.qll
+++ b/go/ql/src/experimental/CWE-918/SSRF.qll
@@ -74,7 +74,7 @@ module ServerSideRequestForgery {
    * The URL of an HTTP request, viewed as a sink for request forgery.
    */
   private class ClientRequestUrlAsSink extends Sink {
-    HTTP::ClientRequest request;
+    Http::ClientRequest request;
 
     ClientRequestUrlAsSink() { this = request.getUrl() }
 

--- a/go/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
+++ b/go/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
@@ -41,14 +41,14 @@ string headerAllowCredentials() { result = "Access-Control-Allow-Credentials".to
 /**
  * An `Access-Control-Allow-Origin` header write.
  */
-class AllowOriginHeaderWrite extends HTTP::HeaderWrite {
+class AllowOriginHeaderWrite extends Http::HeaderWrite {
   AllowOriginHeaderWrite() { this.getHeaderName() = headerAllowOrigin() }
 }
 
 /**
  * An `Access-Control-Allow-Credentials` header write.
  */
-class AllowCredentialsHeaderWrite extends HTTP::HeaderWrite {
+class AllowCredentialsHeaderWrite extends Http::HeaderWrite {
   AllowCredentialsHeaderWrite() { this.getHeaderName() = headerAllowCredentials() }
 }
 

--- a/go/ql/src/experimental/frameworks/CleverGo.qll
+++ b/go/ql/src/experimental/frameworks/CleverGo.qll
@@ -174,7 +174,7 @@ private module CleverGo {
   /**
    * Models HTTP redirects.
    */
-  private class HttpRedirect extends HTTP::Redirect::Range, DataFlow::CallNode {
+  private class HttpRedirect extends Http::Redirect::Range, DataFlow::CallNode {
     string package;
     DataFlow::Node urlNode;
 
@@ -191,13 +191,13 @@ private module CleverGo {
 
     override DataFlow::Node getUrl() { result = urlNode }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = this.getReceiver() }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = this.getReceiver() }
   }
 
   /**
    * Models HTTP ResponseBody where the content-type is static and non-modifiable.
    */
-  private class HttpResponseBodyStaticContentType extends HTTP::ResponseBody::Range {
+  private class HttpResponseBodyStaticContentType extends Http::ResponseBody::Range {
     string contentTypeString;
     DataFlow::Node receiverNode;
 
@@ -209,7 +209,7 @@ private module CleverGo {
 
     override string getAContentType() { result = contentTypeString }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets the body; the content-type is implicitly set.
@@ -304,7 +304,7 @@ private module CleverGo {
   /**
    * Models HTTP ResponseBody where the content-type can be dynamically set by the caller.
    */
-  private class HttpResponseBodyDynamicContentType extends HTTP::ResponseBody::Range {
+  private class HttpResponseBodyDynamicContentType extends Http::ResponseBody::Range {
     DataFlow::Node contentTypeNode;
     DataFlow::Node receiverNode;
 
@@ -316,7 +316,7 @@ private module CleverGo {
 
     override DataFlow::Node getAContentTypeNode() { result = contentTypeNode }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets the body; the content-type is a parameter.
@@ -352,7 +352,7 @@ private module CleverGo {
   /**
    * Models HTTP ResponseBody where only the body is set.
    */
-  private class HttpResponseBodyNoContentType extends HTTP::ResponseBody::Range {
+  private class HttpResponseBodyNoContentType extends Http::ResponseBody::Range {
     DataFlow::Node receiverNode;
 
     HttpResponseBodyNoContentType() {
@@ -361,7 +361,7 @@ private module CleverGo {
       )
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets the body. The content-type is not defined.
@@ -394,7 +394,7 @@ private module CleverGo {
    * Models HTTP header writers.
    * The write is done with a call where you can set both the key and the value of the header.
    */
-  private class HeaderWrite extends HTTP::HeaderWrite::Range, DataFlow::CallNode {
+  private class HeaderWrite extends Http::HeaderWrite::Range, DataFlow::CallNode {
     DataFlow::Node receiverNode;
     DataFlow::Node headerNameNode;
     DataFlow::Node headerValueNode;
@@ -407,7 +407,7 @@ private module CleverGo {
 
     override DataFlow::Node getValue() { result = headerValueNode }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets a header with a key-value combination.
@@ -437,7 +437,7 @@ private module CleverGo {
   /**
    * Models an HTTP static content-type header setter.
    */
-  private class StaticContentTypeHeaderSetter extends HTTP::HeaderWrite::Range, DataFlow::CallNode {
+  private class StaticContentTypeHeaderSetter extends Http::HeaderWrite::Range, DataFlow::CallNode {
     DataFlow::Node receiverNode;
     string valueString;
 
@@ -453,7 +453,7 @@ private module CleverGo {
 
     override DataFlow::Node getValue() { none() }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets the content-type header (implicit).
@@ -494,7 +494,7 @@ private module CleverGo {
   /**
    * Models an HTTP dynamic content-type header setter.
    */
-  private class DynamicContentTypeHeaderSetter extends HTTP::HeaderWrite::Range, DataFlow::CallNode {
+  private class DynamicContentTypeHeaderSetter extends Http::HeaderWrite::Range, DataFlow::CallNode {
     DataFlow::Node receiverNode;
     DataFlow::Node valueNode;
 
@@ -508,7 +508,7 @@ private module CleverGo {
 
     override DataFlow::Node getValue() { result = valueNode }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets the content-type header via a parameter.

--- a/go/ql/src/experimental/frameworks/Fiber.qll
+++ b/go/ql/src/experimental/frameworks/Fiber.qll
@@ -129,7 +129,7 @@ private module Fiber {
   /**
    * Models HTTP redirects.
    */
-  private class Redirect extends HTTP::Redirect::Range, DataFlow::CallNode {
+  private class Redirect extends Http::Redirect::Range, DataFlow::CallNode {
     string package;
     DataFlow::Node urlNode;
 
@@ -146,14 +146,14 @@ private module Fiber {
 
     override DataFlow::Node getUrl() { result = urlNode }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = this.getReceiver() }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = this.getReceiver() }
   }
 
   /**
    * Models HTTP header writers.
    * The write is done with a call where you can set both the key and the value of the header.
    */
-  private class HeaderWrite extends HTTP::HeaderWrite::Range, DataFlow::CallNode {
+  private class HeaderWrite extends Http::HeaderWrite::Range, DataFlow::CallNode {
     DataFlow::Node receiverNode;
     DataFlow::Node headerNameNode;
     DataFlow::Node headerValueNode;
@@ -166,7 +166,7 @@ private module Fiber {
 
     override DataFlow::Node getValue() { result = headerValueNode }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets a header with a key-value combination.
@@ -201,7 +201,7 @@ private module Fiber {
   /**
    * Models HTTP ResponseBody where the content-type is static and non-modifiable.
    */
-  private class ResponseBodyStaticContentType extends HTTP::ResponseBody::Range {
+  private class ResponseBodyStaticContentType extends Http::ResponseBody::Range {
     string contentTypeString;
     DataFlow::Node receiverNode;
 
@@ -213,7 +213,7 @@ private module Fiber {
 
     override string getAContentType() { result = contentTypeString }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets the body; the content-type is implicitly set.
@@ -248,7 +248,7 @@ private module Fiber {
   /**
    * Models HTTP ResponseBody where only the body is set.
    */
-  private class ResponseBodyNoContentType extends HTTP::ResponseBody::Range {
+  private class ResponseBodyNoContentType extends Http::ResponseBody::Range {
     DataFlow::Node receiverNode;
 
     ResponseBodyNoContentType() {
@@ -257,7 +257,7 @@ private module Fiber {
       )
     }
 
-    override HTTP::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
+    override Http::ResponseWriter getResponseWriter() { result.getANode() = receiverNode }
   }
 
   // Holds for a call that sets the body. The content-type is not defined.

--- a/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.ql
@@ -11,7 +11,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     // Dynamic key-value header:
-    exists(HTTP::HeaderWrite hw |
+    exists(Http::HeaderWrite hw |
       hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
@@ -26,7 +26,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     )
     or
     // Static key, dynamic value header:
-    exists(HTTP::HeaderWrite hw |
+    exists(Http::HeaderWrite hw |
       hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
@@ -41,7 +41,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     )
     or
     // Static key, static value header:
-    exists(HTTP::HeaderWrite hw |
+    exists(Http::HeaderWrite hw |
       hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.ql
@@ -9,7 +9,7 @@ class HttpRedirectTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "redirectUrl" and
-    exists(HTTP::Redirect rd |
+    exists(Http::Redirect rd |
       rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rd.getUrl().toString() and

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.ql
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.ql
@@ -8,7 +8,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = ["contentType", "responseBody"] }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(HTTP::ResponseBody rd |
+    exists(Http::ResponseBody rd |
       rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (

--- a/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.ql
@@ -11,7 +11,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     // Dynamic key-value header:
-    exists(HTTP::HeaderWrite hw |
+    exists(Http::HeaderWrite hw |
       hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
@@ -26,7 +26,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     )
     or
     // Static key, dynamic value header:
-    exists(HTTP::HeaderWrite hw |
+    exists(Http::HeaderWrite hw |
       hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (
@@ -41,7 +41,7 @@ class HttpHeaderWriteTest extends InlineExpectationsTest {
     )
     or
     // Static key, static value header:
-    exists(HTTP::HeaderWrite hw |
+    exists(Http::HeaderWrite hw |
       hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (

--- a/go/ql/test/experimental/frameworks/Fiber/Redirect.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/Redirect.ql
@@ -9,7 +9,7 @@ class HttpRedirectTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "redirectUrl" and
-    exists(HTTP::Redirect rd |
+    exists(Http::Redirect rd |
       rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rd.getUrl().toString() and

--- a/go/ql/test/experimental/frameworks/Fiber/ResponseBody.ql
+++ b/go/ql/test/experimental/frameworks/Fiber/ResponseBody.ql
@@ -8,7 +8,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = ["contentType", "responseBody"] }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(HTTP::ResponseBody rd |
+    exists(Http::ResponseBody rd |
       rd.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       (

--- a/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.ql
@@ -8,7 +8,7 @@ class HttpHandler extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "handler" and
-    exists(HTTP::RequestHandler h, DataFlow::Node check |
+    exists(Http::RequestHandler h, DataFlow::Node check |
       element = h.toString() and value = check.toString()
     |
       h.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),

--- a/go/ql/test/library-tests/semmle/go/concepts/HTTP/Header.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/HTTP/Header.ql
@@ -1,6 +1,6 @@
 import go
 
-from HTTP::HeaderWrite headerWrite, string name, string value, string definedName, string definedVal
+from Http::HeaderWrite headerWrite, string name, string value, string definedName, string definedVal
 where
   (
     name = headerWrite.getName().toString()

--- a/go/ql/test/library-tests/semmle/go/concepts/HTTP/RequestBody.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/HTTP/RequestBody.ql
@@ -1,4 +1,4 @@
 import go
 
-from HTTP::RequestBody rb
+from Http::RequestBody rb
 select rb

--- a/go/ql/test/library-tests/semmle/go/concepts/HTTP/ResponseBody.ql
+++ b/go/ql/test/library-tests/semmle/go/concepts/HTTP/ResponseBody.ql
@@ -1,4 +1,4 @@
 import go
 
-from HTTP::ResponseBody rb
+from Http::ResponseBody rb
 select rb

--- a/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.ql
@@ -23,7 +23,7 @@ class HeaderWriteTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "headerwrite" and
-    exists(HTTP::HeaderWrite hw, string name, string val | element = hw.toString() |
+    exists(Http::HeaderWrite hw, string name, string val | element = hw.toString() |
       hw.definesHeader(name, val) and
       value = name + ":" + val and
       hw.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),

--- a/go/ql/test/library-tests/semmle/go/frameworks/Macaron/Redirect.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Macaron/Redirect.ql
@@ -1,4 +1,4 @@
 import go
 
-from HTTP::Redirect redir
+from Http::Redirect redir
 select redir, redir.getResponseWriter()

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.ql
@@ -39,7 +39,7 @@ class HttpResponseBodyTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "responsebody" and
-    exists(HTTP::ResponseBody rb |
+    exists(Http::ResponseBody rb |
       rb.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
         location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
       element = rb.toString() and

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -42,10 +42,10 @@ module SinkEndpointFilter {
       result = "modeled database access"
       or
       // Remove calls to APIs that aren't relevant to NoSQL injection
-      call.getReceiver() instanceof HTTP::RequestNode and
+      call.getReceiver() instanceof Http::RequestNode and
       result = "receiver is a HTTP request expression"
       or
-      call.getReceiver() instanceof HTTP::ResponseNode and
+      call.getReceiver() instanceof Http::ResponseNode and
       result = "receiver is a HTTP response expression"
     )
     or

--- a/javascript/ql/lib/change-notes/2022-09-12-uppercase.md
+++ b/javascript/ql/lib/change-notes/2022-09-12-uppercase.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Some classes/modules with upper-case acronyms in their name have been renamed to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -652,7 +652,7 @@ module API {
           exports(m, _, _)
           or
           exists(NodeModule nm | nm = mod |
-            exists(SSA::implicitInit([nm.getModuleVariable(), nm.getExportsVariable()]))
+            exists(Ssa::implicitInit([nm.getModuleVariable(), nm.getExportsVariable()]))
           )
         )
       } or

--- a/javascript/ql/lib/semmle/javascript/RangeAnalysis.qll
+++ b/javascript/ql/lib/semmle/javascript/RangeAnalysis.qll
@@ -103,7 +103,7 @@ module RangeAnalysis {
    * the given increment/decrement expression.
    */
   private DataFlow::Node updateExprResult(UpdateExpr expr) {
-    result = DataFlow::ssaDefinitionNode(SSA::definition(expr))
+    result = DataFlow::ssaDefinitionNode(Ssa::definition(expr))
     or
     expr.isPrefix() and
     result = expr.flow()
@@ -113,7 +113,7 @@ module RangeAnalysis {
    * Gets a data flow node holding the result of the given componund assignment.
    */
   private DataFlow::Node compoundAssignResult(CompoundAssignExpr expr) {
-    result = DataFlow::ssaDefinitionNode(SSA::definition(expr))
+    result = DataFlow::ssaDefinitionNode(Ssa::definition(expr))
     or
     result = expr.flow()
   }

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -282,7 +282,7 @@ module Routing {
      * Gets an HTTP method name which this node will accept, or nothing if the node accepts all HTTP methods, not
      * taking into account the context from ancestors or children nodes.
      */
-    HTTP::RequestMethodName getOwnHttpMethod() { none() } // Overridden in subclass
+    Http::RequestMethodName getOwnHttpMethod() { none() } // Overridden in subclass
 
     private Node getAUseSiteInRouteSetup() {
       if this.getParent() instanceof RouteSetup
@@ -383,7 +383,7 @@ module Routing {
        * Gets an HTTP request method name (in upper case) matched by this node, or nothing
        * if all HTTP request method names are accepted.
        */
-      HTTP::RequestMethodName getHttpMethod() { none() }
+      Http::RequestMethodName getHttpMethod() { none() }
     }
 
     private class ValueNodeImpl extends Node, MkValueNode {
@@ -407,7 +407,7 @@ module Routing {
 
       override string getRelativePath() { result = range.getRelativePath() }
 
-      override HTTP::RequestMethodName getOwnHttpMethod() { result = range.getHttpMethod() }
+      override Http::RequestMethodName getOwnHttpMethod() { result = range.getHttpMethod() }
     }
 
     private StepSummary routeStepSummary() {
@@ -434,7 +434,7 @@ module Routing {
         or
         StepSummary::smallstep(result, this, routeStepSummary())
         or
-        HTTP::routeHandlerStep(result, this)
+        Http::routeHandlerStep(result, this)
         or
         RouteHandlerTrackingStep::step(result, this)
         or
@@ -599,7 +599,7 @@ module Routing {
        * Gets an HTTP request method name (in upper case) matched by this node, or nothing
        * if all HTTP request method names are accepted.
        */
-      HTTP::RequestMethodName getHttpMethod() { none() }
+      Http::RequestMethodName getHttpMethod() { none() }
 
       /**
        * Holds if this route setup targets `router` and occurs at the given `cfgNode`.
@@ -635,7 +635,7 @@ module Routing {
 
       override string getRelativePath() { result = range.getRelativePath() }
 
-      override HTTP::RequestMethodName getOwnHttpMethod() { result = range.getHttpMethod() }
+      override Http::RequestMethodName getOwnHttpMethod() { result = range.getHttpMethod() }
     }
 
     /**

--- a/javascript/ql/lib/semmle/javascript/SSA.qll
+++ b/javascript/ql/lib/semmle/javascript/SSA.qll
@@ -737,7 +737,7 @@ class SsaRefinementNode extends SsaPseudoDefinition, TRefinement {
   }
 }
 
-module SSA {
+module Ssa {
   /** Gets the SSA definition corresponding to the implicit initialization of `v`. */
   SsaImplicitInit implicitInit(SsaSourceVariable v) { result.getSourceVariable() = v }
 
@@ -747,3 +747,6 @@ module SSA {
   /** Gets the SSA variable corresponding to `d`. */
   SsaVariable variable(VarDef d) { result.getDefinition() = definition(d) }
 }
+
+/** DEPRECATED: Alias for Ssa */
+deprecated module SSA = Ssa;

--- a/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
@@ -770,7 +770,7 @@ private class FlowStepThroughImport extends SharedFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ImportSpecifier specifier |
       pred = DataFlow::valueNode(specifier) and
-      succ = DataFlow::ssaDefinitionNode(SSA::definition(specifier))
+      succ = DataFlow::ssaDefinitionNode(Ssa::definition(specifier))
     )
   }
 }
@@ -1777,7 +1777,7 @@ class MidPathNode extends PathNode, MkMidNode {
       SsaImplicitDefinition
     or
     // Skip SSA definition of parameter as its location coincides with the parameter node
-    nd = DataFlow::ssaDefinitionNode(SSA::definition(any(SimpleParameter p)))
+    nd = DataFlow::ssaDefinitionNode(Ssa::definition(any(SimpleParameter p)))
     or
     // Skip to the top of big left-leaning string concatenation trees.
     nd = any(AddExpr add).flow() and

--- a/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
@@ -348,7 +348,7 @@ private class NodeModuleSourcesNodes extends SourceNode::Range {
 
   NodeModuleSourcesNodes() {
     exists(NodeModule m |
-      this = DataFlow::ssaDefinitionNode(SSA::implicitInit(v)) and
+      this = DataFlow::ssaDefinitionNode(Ssa::implicitInit(v)) and
       v = [m.getModuleVariable(), m.getExportsVariable()]
     )
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -112,7 +112,7 @@ module ClientRequest {
   /**
    * Gets the name of an HTTP request method, in all-lowercase.
    */
-  private string httpMethodName() { result = any(HTTP::RequestMethodName m).toLowerCase() }
+  private string httpMethodName() { result = any(Http::RequestMethodName m).toLowerCase() }
 
   /**
    * Gets a model of an instance of the `request` library, or one of

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -10,7 +10,7 @@ module Connect {
   /**
    * An expression that creates a new Connect server.
    */
-  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, DataFlow::CallNode {
+  class ServerDefinition extends Http::Servers::StandardServerDefinition, DataFlow::CallNode {
     ServerDefinition() {
       // `app = connect()`
       this = DataFlow::moduleImport("connect").getAnInvocation()
@@ -61,7 +61,7 @@ module Connect {
   /**
    * A call to a Connect method that sets up a route.
    */
-  class RouteSetup extends DataFlow::MethodCallNode, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends DataFlow::MethodCallNode, Http::Servers::StandardRouteSetup {
     ServerDefinition server;
 
     RouteSetup() {
@@ -125,7 +125,7 @@ module Connect {
   /**
    * An access to a user-controlled Connect request input.
    */
-  private class RequestInputAccess extends HTTP::RequestInputAccess instanceof DataFlow::MethodCallNode {
+  private class RequestInputAccess extends Http::RequestInputAccess instanceof DataFlow::MethodCallNode {
     RequestNode request;
     string kind;
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -115,7 +115,7 @@ module ConnectExpressShared {
    *
    * For example, this could be the function `function(req, res, next){...}`.
    */
-  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate {
+  class RouteHandlerCandidate extends Http::RouteHandlerCandidate {
     RouteHandlerCandidate() {
       matchesSignature(this, _) and
       not (

--- a/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
@@ -368,7 +368,7 @@ private class HttpCookieWrite extends CookieWrites::CookieWrite {
   string header;
 
   HttpCookieWrite() {
-    exists(HTTP::CookieDefinition setCookie |
+    exists(Http::CookieDefinition setCookie |
       this = setCookie.getHeaderArgument() and
       not this instanceof DataFlow::ArrayCreationNode
       or

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -70,7 +70,7 @@ module Express {
     result = "param" or
     result = "all" or
     result = "use" or
-    result = any(HTTP::RequestMethodName m).toLowerCase() or
+    result = any(Http::RequestMethodName m).toLowerCase() or
     // deprecated methods
     result = "error" or
     result = "del"
@@ -92,7 +92,7 @@ module Express {
       result = this.getArgument(0).getStringValue()
     }
 
-    override HTTP::RequestMethodName getHttpMethod() { result.toLowerCase() = this.getMethodName() }
+    override Http::RequestMethodName getHttpMethod() { result.toLowerCase() = this.getMethodName() }
   }
 
   /**
@@ -136,7 +136,7 @@ module Express {
   /**
    * A call to an Express router method that sets up a route.
    */
-  class RouteSetup extends HTTP::Servers::StandardRouteSetup, DataFlow::MethodCallNode {
+  class RouteSetup extends Http::Servers::StandardRouteSetup, DataFlow::MethodCallNode {
     RouteSetup() {
       isRouter(this.getReceiver()) and
       this.getMethodName() = routeSetupMethodName()
@@ -219,7 +219,7 @@ module Express {
       |
         result = succ.backtrack(t2, t)
         or
-        HTTP::routeHandlerStep(result, succ) and
+        Http::routeHandlerStep(result, succ) and
         t = t2
       )
     }
@@ -233,7 +233,7 @@ module Express {
      *
      * Has no result for `use`, `all`, or `param` calls.
      */
-    HTTP::RequestMethodName getRequestMethod() { result.toLowerCase() = this.getMethodName() }
+    Http::RequestMethodName getRequestMethod() { result.toLowerCase() = this.getMethodName() }
 
     /**
      * Holds if this registers a route for all request methods.
@@ -260,7 +260,7 @@ module Express {
   /**
    * A call that sets up a Passport router that includes the request object.
    */
-  private class PassportRouteSetup extends HTTP::Servers::StandardRouteSetup, DataFlow::CallNode {
+  private class PassportRouteSetup extends Http::Servers::StandardRouteSetup, DataFlow::CallNode {
     DataFlow::ModuleImportNode importNode;
     DataFlow::FunctionNode callback;
 
@@ -285,7 +285,7 @@ module Express {
   /**
    * The callback given to passport in PassportRouteSetup.
    */
-  private class PassportRouteHandler extends RouteHandler, HTTP::Servers::StandardRouteHandler,
+  private class PassportRouteHandler extends RouteHandler, Http::Servers::StandardRouteHandler,
     DataFlow::FunctionNode {
     PassportRouteHandler() { this = any(PassportRouteSetup setup).getARouteHandler() }
 
@@ -470,7 +470,7 @@ module Express {
    * but support for other kinds of route handlers can be added by implementing
    * additional subclasses of this class.
    */
-  abstract class RouteHandler extends HTTP::RouteHandler {
+  abstract class RouteHandler extends Http::RouteHandler {
     /**
      * Gets the parameter of kind `kind` of this route handler.
      *
@@ -501,7 +501,7 @@ module Express {
   /**
    * An Express route handler installed by a route setup.
    */
-  class StandardRouteHandler extends RouteHandler, HTTP::Servers::StandardRouteHandler,
+  class StandardRouteHandler extends RouteHandler, Http::Servers::StandardRouteHandler,
     DataFlow::FunctionNode {
     RouteSetup routeSetup;
 
@@ -530,7 +530,7 @@ module Express {
   }
 
   /** An Express response source. */
-  abstract class ResponseSource extends HTTP::Servers::ResponseSource { }
+  abstract class ResponseSource extends Http::Servers::ResponseSource { }
 
   /**
    * An Express response source, that is, the response parameter of a
@@ -561,7 +561,7 @@ module Express {
   }
 
   /** An Express request source. */
-  abstract class RequestSource extends HTTP::Servers::RequestSource { }
+  abstract class RequestSource extends Http::Servers::RequestSource { }
 
   /**
    * An Express request source, that is, the request parameter of a
@@ -632,7 +632,7 @@ module Express {
   }
 
   /** The input parameter to an `app.param()` route handler. */
-  private class ParamHandlerInputAccess extends HTTP::RequestInputAccess {
+  private class ParamHandlerInputAccess extends Http::RequestInputAccess {
     RouteHandler rh;
 
     ParamHandlerInputAccess() {
@@ -641,7 +641,7 @@ module Express {
       )
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = rh }
+    override Http::RouteHandler getRouteHandler() { result = rh }
 
     override string getKind() { result = "parameter" }
   }
@@ -675,7 +675,7 @@ module Express {
   /**
    * An access to a user-controlled Express request input.
    */
-  class RequestInputAccess extends HTTP::RequestInputAccess {
+  class RequestInputAccess extends Http::RequestInputAccess {
     RequestSource request;
     string kind;
 
@@ -733,7 +733,7 @@ module Express {
   /**
    * An access to a header on an Express request.
    */
-  private class RequestHeaderAccess extends HTTP::RequestHeaderAccess {
+  private class RequestHeaderAccess extends Http::RequestHeaderAccess {
     RequestSource request;
 
     RequestHeaderAccess() {
@@ -762,7 +762,7 @@ module Express {
   /**
    * HTTP headers created by Express calls
    */
-  abstract private class ExplicitHeader extends HTTP::ExplicitHeaderDefinition { }
+  abstract private class ExplicitHeader extends Http::ExplicitHeaderDefinition { }
 
   /**
    * Holds if `e` is an HTTP request object.
@@ -781,7 +781,7 @@ module Express {
     RequestBodyAccess() { any(RouteHandler h).getARequestBodyAccess() = this }
   }
 
-  abstract private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {
+  abstract private class HeaderDefinition extends Http::Servers::StandardHeaderDefinition {
     HeaderDefinition() { isResponse(this.getReceiver()) }
 
     override RouteHandler getRouteHandler() { this.getReceiver() = result.getAResponseNode() }
@@ -790,7 +790,7 @@ module Express {
   /**
    * An invocation of the `redirect` method of an HTTP response object.
    */
-  private class RedirectInvocation extends HTTP::RedirectInvocation, DataFlow::MethodCallNode {
+  private class RedirectInvocation extends Http::RedirectInvocation, DataFlow::MethodCallNode {
     ResponseSource response;
 
     RedirectInvocation() { this = response.ref().getAMethodCall("redirect") }
@@ -854,7 +854,7 @@ module Express {
   /**
    * An argument passed to the `send` or `end` method of an HTTP response object.
    */
-  private class ResponseSendArgument extends HTTP::ResponseSendArgument {
+  private class ResponseSendArgument extends Http::ResponseSendArgument {
     ResponseSource response;
 
     ResponseSendArgument() { this = response.ref().getAMethodCall("send").getArgument(0) }
@@ -865,7 +865,7 @@ module Express {
   /**
    * An invocation of the `cookie` method on an HTTP response object.
    */
-  class SetCookie extends HTTP::CookieDefinition, DataFlow::MethodCallNode {
+  class SetCookie extends Http::CookieDefinition, DataFlow::MethodCallNode {
     ResponseSource response;
 
     SetCookie() { this = response.ref().getAMethodCall("cookie") }
@@ -881,7 +881,7 @@ module Express {
    * An expression passed to the `render` method of an HTTP response object
    * as the value of a template variable.
    */
-  private class TemplateInput extends HTTP::ResponseBody {
+  private class TemplateInput extends Http::ResponseBody {
     TemplateObjectInput obj;
 
     TemplateInput() {
@@ -913,13 +913,13 @@ module Express {
   /**
    * An Express server application.
    */
-  private class Application extends HTTP::ServerDefinition {
+  private class Application extends Http::ServerDefinition {
     Application() { this = appCreation() }
 
     /**
      * Gets a route handler of the application, regardless of nesting.
      */
-    override HTTP::RouteHandler getARouteHandler() {
+    override Http::RouteHandler getARouteHandler() {
       result = this.(RouterDefinition).getASubRouter*().getARouteHandler()
     }
   }
@@ -960,7 +960,7 @@ module Express {
      *
      * Example: `fun` for `router1.use(fun)` or `router.use("/route", fun)`
      */
-    HTTP::RouteHandler getARouteHandler() {
+    Http::RouteHandler getARouteHandler() {
       result.(DataFlow::SourceNode).flowsTo(this.getARouteSetup().getAnArgument())
     }
 
@@ -1044,7 +1044,7 @@ module Express {
    * A function that flows to a route setup.
    */
   private class TrackedRouteHandlerCandidateWithSetup extends RouteHandler,
-    HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+    Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
     RouteSetup routeSetup;
 
     TrackedRouteHandlerCandidateWithSetup() { this = routeSetup.getARouteHandler() }
@@ -1063,14 +1063,14 @@ module Express {
    * `router.post(handler)` where it is unknown if `router` is an
    * Express router.
    */
-  class RouteSetupCandidate extends HTTP::RouteSetupCandidate, DataFlow::MethodCallNode {
+  class RouteSetupCandidate extends Http::RouteSetupCandidate, DataFlow::MethodCallNode {
     DataFlow::ValueNode routeHandlerArg;
 
     RouteSetupCandidate() {
       exists(string methodName |
         methodName = "all" or
         methodName = "use" or
-        methodName = any(HTTP::RequestMethodName m).toLowerCase()
+        methodName = any(Http::RequestMethodName m).toLowerCase()
       |
         this.getMethodName() = methodName and
         exists(DataFlow::ValueNode arg | arg = this.getAnArgument() |

--- a/javascript/ql/lib/semmle/javascript/frameworks/ExpressModules.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ExpressModules.qll
@@ -18,25 +18,25 @@ module ExpressLibraries {
   /**
    * A header produced by a route handler of the "x-frame-options" module.
    */
-  class XFrameOptionsRouteHandlerHeader extends HTTP::ImplicitHeaderDefinition {
+  class XFrameOptionsRouteHandlerHeader extends Http::ImplicitHeaderDefinition {
     XFrameOptionsRouteHandlerHeader() { this instanceof XFrameOptionsRouteHandler }
 
     override predicate defines(string headerName, string headerValue) {
       xFrameOptionsDefaultImplicitHeaderDefinition(headerName, headerValue)
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = this }
+    override Http::RouteHandler getRouteHandler() { result = this }
   }
 
   /**
    * A route handler from the "x-frame-options" module.
    */
-  class XFrameOptionsRouteHandler extends HTTP::RouteHandler {
+  class XFrameOptionsRouteHandler extends Http::RouteHandler {
     XFrameOptionsRouteHandler() {
       this = DataFlow::moduleImport("x-frame-options").getAnInvocation()
     }
 
-    override HTTP::HeaderDefinition getAResponseHeader(string name) {
+    override Http::HeaderDefinition getAResponseHeader(string name) {
       name = this.(XFrameOptionsRouteHandlerHeader).getAHeaderName() and
       result = this
     }
@@ -45,23 +45,23 @@ module ExpressLibraries {
   /**
    * A header produced by a route handler of the "frameguard" module.
    */
-  class FrameGuardRouteHandlerHeader extends HTTP::ImplicitHeaderDefinition {
+  class FrameGuardRouteHandlerHeader extends Http::ImplicitHeaderDefinition {
     FrameGuardRouteHandlerHeader() { this instanceof FrameGuardRouteHandler }
 
     override predicate defines(string headerName, string headerValue) {
       xFrameOptionsDefaultImplicitHeaderDefinition(headerName, headerValue)
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = this }
+    override Http::RouteHandler getRouteHandler() { result = this }
   }
 
   /**
    * A route handler from the "frameguard" module.
    */
-  class FrameGuardRouteHandler extends HTTP::RouteHandler {
+  class FrameGuardRouteHandler extends Http::RouteHandler {
     FrameGuardRouteHandler() { this = DataFlow::moduleImport("frameguard").getAnInvocation() }
 
-    override HTTP::HeaderDefinition getAResponseHeader(string name) {
+    override Http::HeaderDefinition getAResponseHeader(string name) {
       name = this.(FrameGuardRouteHandlerHeader).getAHeaderName() and
       result = this
     }
@@ -70,20 +70,20 @@ module ExpressLibraries {
   /**
    * A header produced by a route handler of the "helmet" module.
    */
-  class HelmetRouteHandlerHeader extends HTTP::ImplicitHeaderDefinition {
+  class HelmetRouteHandlerHeader extends Http::ImplicitHeaderDefinition {
     HelmetRouteHandlerHeader() { this instanceof HelmetRouteHandler }
 
     override predicate defines(string headerName, string headerValue) {
       xFrameOptionsDefaultImplicitHeaderDefinition(headerName, headerValue)
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = this }
+    override Http::RouteHandler getRouteHandler() { result = this }
   }
 
   /**
    * A route handler from the "helmet" module.
    */
-  class HelmetRouteHandler extends HTTP::RouteHandler {
+  class HelmetRouteHandler extends Http::RouteHandler {
     HelmetRouteHandler() {
       exists(DataFlow::ModuleImportNode m | "helmet" = m.getPath() |
         this = m.getAnInvocation() or
@@ -91,7 +91,7 @@ module ExpressLibraries {
       )
     }
 
-    override HTTP::HeaderDefinition getAResponseHeader(string name) {
+    override Http::HeaderDefinition getAResponseHeader(string name) {
       name = this.(HelmetRouteHandlerHeader).getAHeaderName() and
       result = this
     }
@@ -108,7 +108,7 @@ module ExpressLibraries {
     /**
      * A call that creates an `express-session` middleware instance.
      */
-    class MiddlewareInstance extends DataFlow::InvokeNode, HTTP::CookieMiddlewareInstance {
+    class MiddlewareInstance extends DataFlow::InvokeNode, Http::CookieMiddlewareInstance {
       MiddlewareInstance() { this = expressSession().getACall() }
 
       /**
@@ -135,7 +135,7 @@ module ExpressLibraries {
     /**
      * A call that creates a `cookie-parser` middleware instance.
      */
-    class MiddlewareInstance extends DataFlow::InvokeNode, HTTP::CookieMiddlewareInstance {
+    class MiddlewareInstance extends DataFlow::InvokeNode, Http::CookieMiddlewareInstance {
       MiddlewareInstance() { this = cookieParser().getACall() }
 
       /**
@@ -164,7 +164,7 @@ module ExpressLibraries {
     /**
      * A call that creates a `cookie-session` middleware instance.
      */
-    class MiddlewareInstance extends DataFlow::InvokeNode, HTTP::CookieMiddlewareInstance {
+    class MiddlewareInstance extends DataFlow::InvokeNode, Http::CookieMiddlewareInstance {
       MiddlewareInstance() { this = cookieSession().getACall() }
 
       /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -12,7 +12,7 @@ module Fastify {
   /**
    * An expression that creates a new Fastify server.
    */
-  abstract class ServerDefinition extends HTTP::Servers::StandardServerDefinition { }
+  abstract class ServerDefinition extends Http::Servers::StandardServerDefinition { }
 
   /**
    * A standard way to create a Fastify server.
@@ -76,7 +76,7 @@ module Fastify {
    * but support for other kinds of route handlers can be added by implementing
    * additional subclasses of this class.
    */
-  abstract class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::ValueNode {
+  abstract class RouteHandler extends Http::Servers::StandardRouteHandler, DataFlow::ValueNode {
     /**
      * Gets the parameter of the route handler that contains the request object.
      */
@@ -103,7 +103,7 @@ module Fastify {
    * A Fastify reply source, that is, the `reply` parameter of a
    * route handler.
    */
-  private class ReplySource extends HTTP::Servers::ResponseSource {
+  private class ReplySource extends Http::Servers::ResponseSource {
     RouteHandler rh;
 
     ReplySource() { this = rh.getReplyParameter() }
@@ -118,7 +118,7 @@ module Fastify {
    * A Fastify request source, that is, the request parameter of a
    * route handler.
    */
-  private class RequestSource extends HTTP::Servers::RequestSource {
+  private class RequestSource extends Http::Servers::RequestSource {
     RouteHandler rh;
 
     RequestSource() { this = rh.getRequestParameter() }
@@ -132,7 +132,7 @@ module Fastify {
   /**
    * A call to a Fastify method that sets up a route.
    */
-  class RouteSetup extends DataFlow::MethodCallNode, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends DataFlow::MethodCallNode, Http::Servers::StandardRouteSetup {
     ServerDefinition server;
     string methodName;
 
@@ -176,7 +176,7 @@ module Fastify {
 
     override string getRelativePath() { result = this.getArgument(0).getStringValue() }
 
-    override HTTP::RequestMethodName getHttpMethod() { result = this.getMethodName().toUpperCase() }
+    override Http::RequestMethodName getHttpMethod() { result = this.getMethodName().toUpperCase() }
   }
 
   /** Gets the name of the `n`th handler function that can be installed a route setup, in order of execution. */
@@ -194,7 +194,7 @@ module Fastify {
 
     override string getRelativePath() { result = this.getOptionArgument(0, "url").getStringValue() }
 
-    override HTTP::RequestMethodName getHttpMethod() {
+    override Http::RequestMethodName getHttpMethod() {
       result = this.getOptionArgument(0, "method").getStringValue().toUpperCase()
     }
 
@@ -226,7 +226,7 @@ module Fastify {
       result = this.pluginBody(DataFlow::TypeBackTracker::end())
     }
 
-    override HTTP::RequestMethodName getHttpMethod() {
+    override Http::RequestMethodName getHttpMethod() {
       result = this.getOptionArgument(1, "method").getStringValue().toUpperCase()
     }
 
@@ -252,7 +252,7 @@ module Fastify {
   /**
    * An access to a user-controlled Fastify request input.
    */
-  private class RequestInputAccess extends HTTP::RequestInputAccess {
+  private class RequestInputAccess extends Http::RequestInputAccess {
     RouteHandler rh;
     string kind;
 
@@ -308,7 +308,7 @@ module Fastify {
   /**
    * An access to a header on a Fastify request.
    */
-  private class RequestHeaderAccess extends HTTP::RequestHeaderAccess {
+  private class RequestHeaderAccess extends Http::RequestHeaderAccess {
     RouteHandler rh;
 
     RequestHeaderAccess() {
@@ -327,7 +327,7 @@ module Fastify {
   /**
    * An argument passed to the `send` or `end` method of an HTTP response object.
    */
-  private class ResponseSendArgument extends HTTP::ResponseSendArgument {
+  private class ResponseSendArgument extends Http::ResponseSendArgument {
     RouteHandler rh;
 
     ResponseSendArgument() {
@@ -342,7 +342,7 @@ module Fastify {
   /**
    * An invocation of the `redirect` method of an HTTP response object.
    */
-  private class RedirectInvocation extends HTTP::RedirectInvocation, DataFlow::MethodCallNode {
+  private class RedirectInvocation extends Http::RedirectInvocation, DataFlow::MethodCallNode {
     RouteHandler rh;
 
     RedirectInvocation() { this = rh.getAResponseSource().ref().getAMethodCall("redirect") }
@@ -355,7 +355,7 @@ module Fastify {
   /**
    * An invocation that sets a single header of the HTTP response.
    */
-  private class SetOneHeader extends HTTP::Servers::StandardHeaderDefinition,
+  private class SetOneHeader extends Http::Servers::StandardHeaderDefinition,
     DataFlow::MethodCallNode {
     RouteHandler rh;
 
@@ -370,7 +370,7 @@ module Fastify {
   /**
    * An invocation that sets any number of headers of the HTTP response.
    */
-  class SetMultipleHeaders extends HTTP::ExplicitHeaderDefinition, DataFlow::MethodCallNode {
+  class SetMultipleHeaders extends Http::ExplicitHeaderDefinition, DataFlow::MethodCallNode {
     RouteHandler rh;
 
     SetMultipleHeaders() {
@@ -414,7 +414,7 @@ module Fastify {
     override DataFlow::Node getTemplateParamsNode() { result = this.getArgument(1) }
   }
 
-  private class FastifyCookieMiddleware extends HTTP::CookieMiddlewareInstance {
+  private class FastifyCookieMiddleware extends Http::CookieMiddlewareInstance {
     FastifyCookieMiddleware() {
       this = DataFlow::moduleImport(["fastify-cookie", "fastify-session", "fastify-secure-session"])
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Firebase.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Firebase.qll
@@ -195,7 +195,7 @@ module Firebase {
     /**
      * A call to a Firebase method that sets up a route.
      */
-    private class RouteSetup extends HTTP::Servers::StandardRouteSetup, DataFlow::CallNode {
+    private class RouteSetup extends Http::Servers::StandardRouteSetup, DataFlow::CallNode {
       RouteSetup() { this = namespace().getAPropertyRead("https").getAMemberCall("onRequest") }
 
       override DataFlow::SourceNode getARouteHandler() {
@@ -215,7 +215,7 @@ module Firebase {
     /**
      * A function used as a route handler.
      */
-    private class RouteHandler extends Express::RouteHandler, HTTP::Servers::StandardRouteHandler,
+    private class RouteHandler extends Express::RouteHandler, Http::Servers::StandardRouteHandler,
       DataFlow::FunctionNode {
       RouteHandler() { this = any(RouteSetup setup).getARouteHandler() }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -8,7 +8,7 @@ private import semmle.javascript.dataflow.internal.StepSummary
 private import semmle.javascript.dataflow.internal.CallGraphs
 private import DataFlow::PseudoProperties as PseudoProperties
 
-module HTTP {
+module Http {
   /**
    * A function invocation that causes a redirect response to be sent.
    */
@@ -242,7 +242,7 @@ module HTTP {
     DataFlow::functionOneWayForwardingStep(pred.getALocalUse(), succ)
     or
     // a container containing route-handlers.
-    exists(HTTP::RouteHandlerCandidateContainer container | pred = container.getRouteHandler(succ))
+    exists(Http::RouteHandlerCandidateContainer container | pred = container.getRouteHandler(succ))
     or
     // (function (req, res) {}).bind(this);
     exists(DataFlow::PartialInvokeNode call |
@@ -677,7 +677,7 @@ module HTTP {
     /**
      * A collection that contains one or more route potential handlers.
      */
-    private class ContainerCollection extends HTTP::RouteHandlerCandidateContainer::Range,
+    private class ContainerCollection extends Http::RouteHandlerCandidateContainer::Range,
       DataFlow::NewNode {
       ContainerCollection() {
         this = DataFlow::globalVarRef("Map").getAnInstantiation() and // restrict to Map for now
@@ -699,3 +699,6 @@ module HTTP {
     }
   }
 }
+
+/** DEPRECATED: Alias for Http */
+deprecated module HTTP = Http;

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -9,7 +9,7 @@ module Hapi {
   /**
    * An expression that creates a new Hapi server.
    */
-  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, DataFlow::NewNode {
+  class ServerDefinition extends Http::Servers::StandardServerDefinition, DataFlow::NewNode {
     ServerDefinition() {
       // `server = new Hapi.Server()`
       this = DataFlow::moduleMember("hapi", "Server").getAnInstantiation()
@@ -19,7 +19,7 @@ module Hapi {
   /**
    * A Hapi route handler.
    */
-  class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+  class RouteHandler extends Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
     RouteHandler() { exists(RouteSetup setup | this = setup.getARouteHandler()) }
 
     /**
@@ -43,7 +43,7 @@ module Hapi {
    * A Hapi response source, that is, an access to the `response` property
    * of a request object.
    */
-  private class ResponseSource extends HTTP::Servers::ResponseSource {
+  private class ResponseSource extends Http::Servers::ResponseSource {
     RequestNode req;
 
     ResponseSource() { this.(DataFlow::PropRead).accesses(req, "response") }
@@ -58,7 +58,7 @@ module Hapi {
    * A Hapi request source, that is, the request parameter of a
    * route handler.
    */
-  private class RequestSource extends HTTP::Servers::RequestSource {
+  private class RequestSource extends Http::Servers::RequestSource {
     RouteHandler rh;
 
     RequestSource() { this = rh.getRequestParameter() }
@@ -80,7 +80,7 @@ module Hapi {
   /**
    * A Hapi response node.
    */
-  class ResponseNode extends HTTP::Servers::StandardResponseNode {
+  class ResponseNode extends Http::Servers::StandardResponseNode {
     override ResponseSource src;
   }
 
@@ -95,14 +95,14 @@ module Hapi {
   /**
    * A Hapi request node.
    */
-  class RequestNode extends HTTP::Servers::StandardRequestNode {
+  class RequestNode extends Http::Servers::StandardRequestNode {
     override RequestSource src;
   }
 
   /**
    * An access to a user-controlled Hapi request input.
    */
-  private class RequestInputAccess extends HTTP::RequestInputAccess {
+  private class RequestInputAccess extends Http::RequestInputAccess {
     RouteHandler rh;
     string kind;
 
@@ -156,7 +156,7 @@ module Hapi {
   /**
    * An access to an HTTP header on a Hapi request.
    */
-  private class RequestHeaderAccess extends HTTP::RequestHeaderAccess {
+  private class RequestHeaderAccess extends Http::RequestHeaderAccess {
     RouteHandler rh;
 
     RequestHeaderAccess() {
@@ -181,7 +181,7 @@ module Hapi {
   /**
    * An HTTP header defined in a Hapi server.
    */
-  private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {
+  private class HeaderDefinition extends Http::Servers::StandardHeaderDefinition {
     ResponseNode res;
 
     HeaderDefinition() {
@@ -195,7 +195,7 @@ module Hapi {
   /**
    * A call to a Hapi method that sets up a route.
    */
-  class RouteSetup extends DataFlow::MethodCallNode, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends DataFlow::MethodCallNode, Http::Servers::StandardRouteSetup {
     ServerDefinition server;
     DataFlow::Node handler;
 
@@ -236,7 +236,7 @@ module Hapi {
    *
    * For example, this could be the function `function(request, h){...}`.
    */
-  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate {
+  class RouteHandlerCandidate extends Http::RouteHandlerCandidate {
     RouteHandlerCandidate() {
       exists(string request, string responseToolkit |
         (request = "request" or request = "req") and
@@ -256,7 +256,7 @@ module Hapi {
    * A function that looks like a Hapi route handler and flows to a route setup.
    */
   private class TrackedRouteHandlerCandidateWithSetup extends RouteHandler,
-    HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+    Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
     TrackedRouteHandlerCandidateWithSetup() { this = any(RouteSetup s).getARouteHandler() }
   }
 
@@ -276,7 +276,7 @@ module Hapi {
   /**
    * A return from a route handler.
    */
-  private class HandlerReturn extends HTTP::ResponseSendArgument {
+  private class HandlerReturn extends Http::ResponseSendArgument {
     RouteHandler handler;
 
     HandlerReturn() { this = handler.(DataFlow::FunctionNode).getAReturn() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -9,7 +9,7 @@ module Koa {
   /**
    * An expression that creates a new Koa application.
    */
-  class AppDefinition extends HTTP::Servers::StandardServerDefinition, DataFlow::InvokeNode {
+  class AppDefinition extends Http::Servers::StandardServerDefinition, DataFlow::InvokeNode {
     AppDefinition() {
       // `app = new Koa()` / `app = Koa()`
       this = DataFlow::moduleImport("koa").getAnInvocation()
@@ -19,7 +19,7 @@ module Koa {
   /**
    * An HTTP header defined in a Koa application.
    */
-  private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {
+  private class HeaderDefinition extends Http::Servers::StandardHeaderDefinition {
     RouteHandler rh;
 
     HeaderDefinition() {
@@ -36,7 +36,7 @@ module Koa {
   /**
    * A Koa route handler.
    */
-  abstract class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::SourceNode {
+  abstract class RouteHandler extends Http::Servers::StandardRouteHandler, DataFlow::SourceNode {
     /**
      * Gets the parameter of the route handler that contains the context object.
      */
@@ -227,7 +227,7 @@ module Koa {
    * A Koa request source, that is, an access to the `request` property
    * of a context object.
    */
-  private class RequestSource extends HTTP::Servers::RequestSource instanceof DataFlow::PropRead {
+  private class RequestSource extends Http::Servers::RequestSource instanceof DataFlow::PropRead {
     ContextNode ctx;
 
     RequestSource() { super.accesses(ctx, "request") }
@@ -242,7 +242,7 @@ module Koa {
    * A Koa request source, accessed through the a request property of a
    * generator route handler (deprecated in Koa 3).
    */
-  private class GeneratorRequestSource extends HTTP::Servers::RequestSource {
+  private class GeneratorRequestSource extends Http::Servers::RequestSource {
     RouteHandler rh;
 
     GeneratorRequestSource() {
@@ -262,7 +262,7 @@ module Koa {
    * A Koa response source, that is, an access to the `response` property
    * of a context object.
    */
-  private class ResponseSource extends HTTP::Servers::ResponseSource instanceof DataFlow::PropRead {
+  private class ResponseSource extends Http::Servers::ResponseSource instanceof DataFlow::PropRead {
     ContextNode ctx;
 
     ResponseSource() { super.accesses(ctx, "response") }
@@ -311,7 +311,7 @@ module Koa {
   /**
    * An expression that may hold a Koa request object.
    */
-  class RequestNode extends HTTP::Servers::StandardRequestNode {
+  class RequestNode extends Http::Servers::StandardRequestNode {
     override RequestSource src;
   }
 
@@ -326,14 +326,14 @@ module Koa {
   /**
    * An expression that may hold a Koa response object.
    */
-  class ResponseNode extends HTTP::Servers::StandardResponseNode {
+  class ResponseNode extends Http::Servers::StandardResponseNode {
     override ResponseSource src;
   }
 
   /**
    * An access to a user-controlled Koa request input.
    */
-  private class RequestInputAccess extends HTTP::RequestInputAccess {
+  private class RequestInputAccess extends Http::RequestInputAccess {
     RouteHandler rh;
     string kind;
 
@@ -399,7 +399,7 @@ module Koa {
   /**
    * An access to an HTTP header on a Koa request.
    */
-  private class RequestHeaderAccess extends HTTP::RequestHeaderAccess {
+  private class RequestHeaderAccess extends Http::RequestHeaderAccess {
     RouteHandler rh;
 
     RequestHeaderAccess() {
@@ -435,7 +435,7 @@ module Koa {
   /**
    * A call to a Koa method that sets up a route.
    */
-  class RouteSetup extends HTTP::Servers::StandardRouteSetup, DataFlow::MethodCallNode {
+  class RouteSetup extends Http::Servers::StandardRouteSetup, DataFlow::MethodCallNode {
     AppDefinition server;
 
     RouteSetup() {
@@ -457,7 +457,7 @@ module Koa {
   /**
    * A value assigned to the body of an HTTP response object.
    */
-  private class ResponseSendArgument extends HTTP::ResponseSendArgument {
+  private class ResponseSendArgument extends Http::ResponseSendArgument {
     RouteHandler rh;
 
     ResponseSendArgument() {
@@ -470,7 +470,7 @@ module Koa {
   /**
    * An invocation of the `redirect` method of an HTTP response object.
    */
-  private class RedirectInvocation extends HTTP::RedirectInvocation instanceof DataFlow::MethodCallNode {
+  private class RedirectInvocation extends Http::RedirectInvocation instanceof DataFlow::MethodCallNode {
     RouteHandler rh;
 
     RedirectInvocation() { super.calls(rh.getAResponseOrContextNode(), "redirect") }

--- a/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
@@ -9,7 +9,7 @@ private module LiveServer {
   /**
    * An expression that imports the live-server package, seen as a server-definition.
    */
-  class ServerDefinition extends HTTP::Servers::StandardServerDefinition {
+  class ServerDefinition extends Http::Servers::StandardServerDefinition {
     ServerDefinition() { this = DataFlow::moduleImport("live-server") }
 
     API::Node getImportNode() { result.asSource() = this }
@@ -30,7 +30,7 @@ private module LiveServer {
   /**
    * The call to `require("live-server").start()`, seen as a route setup.
    */
-  class RouteSetup extends HTTP::Servers::StandardRouteSetup instanceof API::CallNode {
+  class RouteSetup extends Http::Servers::StandardRouteSetup instanceof API::CallNode {
     ServerDefinition server;
 
     RouteSetup() { this = server.getImportNode().getMember("start").getACall() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Logging.qll
@@ -349,7 +349,7 @@ private module Pino {
     or
     // `pino` is installed as the "log" property on the request object in `Express` and similar libraries.
     // in `Hapi` the property is "logger".
-    exists(HTTP::RequestNode req, API::Node reqNode |
+    exists(Http::RequestNode req, API::Node reqNode |
       reqNode.asSource() = req.getALocalSource() and
       result = reqNode.getMember(["log", "logger"])
     )

--- a/javascript/ql/lib/semmle/javascript/frameworks/Micro.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Micro.qll
@@ -42,24 +42,24 @@ private module Micro {
   /**
    * A function passed to `micro` or `micro.run`.
    */
-  class MicroRouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+  class MicroRouteHandler extends Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
     MicroRouteHandler() { this = microRouteHandler().getAFunctionValue() }
   }
 
-  class MicroRequestSource extends HTTP::Servers::RequestSource {
+  class MicroRequestSource extends Http::Servers::RequestSource {
     MicroRouteHandler h;
 
     MicroRequestSource() { this = h.getParameter(0) }
 
-    override HTTP::RouteHandler getRouteHandler() { result = h }
+    override Http::RouteHandler getRouteHandler() { result = h }
   }
 
-  class MicroResponseSource extends HTTP::Servers::ResponseSource {
+  class MicroResponseSource extends Http::Servers::ResponseSource {
     MicroRouteHandler h;
 
     MicroResponseSource() { this = h.getParameter(1) }
 
-    override HTTP::RouteHandler getRouteHandler() { result = h }
+    override Http::RouteHandler getRouteHandler() { result = h }
   }
 
   deprecated class MicroRequestExpr extends NodeJSLib::RequestExpr {
@@ -78,19 +78,19 @@ private module Micro {
     override MicroResponseSource src;
   }
 
-  private HTTP::RouteHandler getRouteHandlerFromReqRes(DataFlow::Node node) {
-    exists(HTTP::Servers::RequestSource src |
+  private Http::RouteHandler getRouteHandlerFromReqRes(DataFlow::Node node) {
+    exists(Http::Servers::RequestSource src |
       src.ref().flowsTo(node) and
       result = src.getRouteHandler()
     )
     or
-    exists(HTTP::Servers::ResponseSource src |
+    exists(Http::Servers::ResponseSource src |
       src.ref().flowsTo(node) and
       result = src.getRouteHandler()
     )
   }
 
-  class MicroBodyParserCall extends HTTP::RequestInputAccess, DataFlow::CallNode {
+  class MicroBodyParserCall extends Http::RequestInputAccess, DataFlow::CallNode {
     string name;
 
     MicroBodyParserCall() {
@@ -100,14 +100,14 @@ private module Micro {
 
     override string getKind() { result = "body" }
 
-    override HTTP::RouteHandler getRouteHandler() {
+    override Http::RouteHandler getRouteHandler() {
       result = getRouteHandlerFromReqRes(getArgument(0))
     }
 
     override predicate isUserControlledObject() { name = "json" }
   }
 
-  class MicroSendArgument extends HTTP::ResponseSendArgument {
+  class MicroSendArgument extends Http::ResponseSendArgument {
     CallNode send;
 
     MicroSendArgument() {
@@ -115,7 +115,7 @@ private module Micro {
       this = send.getLastArgument()
     }
 
-    override HTTP::RouteHandler getRouteHandler() {
+    override Http::RouteHandler getRouteHandler() {
       result = getRouteHandlerFromReqRes(send.getArgument([0, 1]))
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Nest.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Nest.qll
@@ -34,7 +34,7 @@ module NestJS {
    * }
    * ```
    */
-  private class NestJSRouteHandler extends HTTP::RouteHandler, DataFlow::FunctionNode {
+  private class NestJSRouteHandler extends Http::RouteHandler, DataFlow::FunctionNode {
     NestJSRouteHandler() {
       getAFunctionDecorator(this) =
         nestjs()
@@ -42,7 +42,7 @@ module NestJS {
             .getACall()
     }
 
-    override HTTP::HeaderDefinition getAResponseHeader(string name) { none() }
+    override Http::HeaderDefinition getAResponseHeader(string name) { none() }
 
     /**
      * Holds if this has the `@Redirect()` decorator.
@@ -257,7 +257,7 @@ module NestJS {
    * The type of remote flow depends on which decorator is applied at the parameter, so
    * we just classify it as a `RemoteFlowSource`.
    */
-  private class NestJSCustomPipeInput extends HTTP::RequestInputAccess {
+  private class NestJSCustomPipeInput extends Http::RequestInputAccess {
     CustomPipeClass pipe;
 
     NestJSCustomPipeInput() {
@@ -273,7 +273,7 @@ module NestJS {
       result = pipe.getAnAffectedParameter().getInputKind()
     }
 
-    override HTTP::RouteHandler getRouteHandler() {
+    override Http::RouteHandler getRouteHandler() {
       result = pipe.getAnAffectedParameter().getNestRouteHandler()
     }
   }
@@ -295,13 +295,13 @@ module NestJS {
    * as a source of untrusted data.
    */
   private class NestJSRequestInputAsRequestInputAccess extends NestJSRequestInput,
-    HTTP::RequestInputAccess {
+    Http::RequestInputAccess {
     NestJSRequestInputAsRequestInputAccess() {
       not this.isSanitizedByPipe() and
       not this = any(CustomPipeClass cls).getAnAffectedParameter()
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = this.getNestRouteHandler() }
+    override Http::RouteHandler getRouteHandler() { result = this.getNestRouteHandler() }
 
     override string getKind() { result = this.getInputKind() }
 
@@ -316,7 +316,7 @@ module NestJS {
   }
 
   private class NestJSHeaderAccess extends NestJSRequestInputAsRequestInputAccess,
-    HTTP::RequestHeaderAccess {
+    Http::RequestHeaderAccess {
     NestJSHeaderAccess() { decoratorName = "Headers" and decorator.getNumArgument() > 0 }
 
     override string getAHeaderName() {
@@ -344,7 +344,7 @@ module NestJS {
    * ```
    * writes `<b>Hello</b>` to the response.
    */
-  private class ReturnValueAsResponseSend extends HTTP::ResponseSendArgument {
+  private class ReturnValueAsResponseSend extends Http::ResponseSendArgument {
     NestJSRouteHandler handler;
 
     ReturnValueAsResponseSend() {
@@ -357,7 +357,7 @@ module NestJS {
       )
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = handler }
+    override Http::RouteHandler getRouteHandler() { result = handler }
   }
 
   /**
@@ -439,7 +439,7 @@ module NestJS {
     /**
      * Gets the route handler that handles this request.
      */
-    override HTTP::RouteHandler getRouteHandler() {
+    override Http::RouteHandler getRouteHandler() {
       result.(DataFlow::FunctionNode).getAParameter() = this
     }
   }
@@ -456,7 +456,7 @@ module NestJS {
     /**
      * Gets the route handler that handles this request.
      */
-    override HTTP::RouteHandler getRouteHandler() {
+    override Http::RouteHandler getRouteHandler() {
       result.(DataFlow::FunctionNode).getAParameter() = this
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Next.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Next.qll
@@ -153,14 +153,14 @@ module NextJS {
   /**
    * A Next.js function that is exected on the server for every request, seen as a routehandler.
    */
-  class NextHttpRouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+  class NextHttpRouteHandler extends Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
     NextHttpRouteHandler() { this = getServerSidePropsFunction(_) or this = getInitialProps(_) }
   }
 
   /**
    * A function that handles both a request and response from Next.js, seen as a routehandler.
    */
-  class NextReqResHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+  class NextReqResHandler extends Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
     DataFlow::ParameterNode req;
     DataFlow::ParameterNode res;
 
@@ -182,28 +182,28 @@ module NextJS {
    * A NodeJS HTTP request object in a Next.js page.
    */
   class NextHttpRequestSource extends NodeJSLib::RequestSource {
-    HTTP::RouteHandler rh;
+    Http::RouteHandler rh;
 
     NextHttpRequestSource() {
       this = rh.(NextHttpRouteHandler).getParameter(0).getAPropertyRead("req") or
       this = rh.(NextReqResHandler).getRequest()
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = rh }
+    override Http::RouteHandler getRouteHandler() { result = rh }
   }
 
   /**
    * A NodeJS HTTP response object in a Next.js page.
    */
   class NextHttpResponseSource extends NodeJSLib::ResponseSource {
-    HTTP::RouteHandler rh;
+    Http::RouteHandler rh;
 
     NextHttpResponseSource() {
       this = rh.(NextHttpRouteHandler).getParameter(0).getAPropertyRead("res") or
       this = rh.(NextReqResHandler).getResponse()
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = rh }
+    override Http::RouteHandler getRouteHandler() { result = rh }
   }
 
   /**
@@ -222,7 +222,7 @@ module NextJS {
    * and we therefore model the routehandler as an Express.js routehandler.
    */
   class NextApiRouteHandler extends DataFlow::FunctionNode, Express::RouteHandler,
-    HTTP::Servers::StandardRouteHandler {
+    Http::Servers::StandardRouteHandler {
     NextApiRouteHandler() {
       exists(Module mod | mod.getFile().getParentContainer() = apiFolder() |
         this = mod.getAnExportedValue("default").getAFunctionValue()

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -81,7 +81,7 @@ module NodeJSLib {
    * A server library that provides an (enhanced) NodesJS HTTP response
    * object should implement a library specific subclass of this class.
    */
-  abstract class ResponseNode extends HTTP::Servers::StandardResponseNode { }
+  abstract class ResponseNode extends Http::Servers::StandardResponseNode { }
 
   /**
    * DEPRECATED: Use `RequestNode` instead.
@@ -100,7 +100,7 @@ module NodeJSLib {
    * A server library that provides an (enhanced) NodesJS HTTP request
    * object should implement a library specific subclass of this class.
    */
-  abstract class RequestNode extends HTTP::Servers::StandardRequestNode { }
+  abstract class RequestNode extends Http::Servers::StandardRequestNode { }
 
   /**
    * A function used as an Node.js server route handler.
@@ -109,7 +109,7 @@ module NodeJSLib {
    * but support for other kinds of route handlers can be added by implementing
    * additional subclasses of this class.
    */
-  abstract class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+  abstract class RouteHandler extends Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
     /**
      * Gets the parameter of the route handler that contains the request object.
      */
@@ -131,7 +131,7 @@ module NodeJSLib {
   /**
    * A Node.js response source.
    */
-  abstract class ResponseSource extends HTTP::Servers::ResponseSource { }
+  abstract class ResponseSource extends Http::Servers::ResponseSource { }
 
   /**
    * A standard Node.js response source, that is, the response parameter of a
@@ -151,7 +151,7 @@ module NodeJSLib {
   /**
    * A Node.js request source.
    */
-  abstract class RequestSource extends HTTP::Servers::RequestSource { }
+  abstract class RequestSource extends Http::Servers::RequestSource { }
 
   /**
    * A standard Node.js request source, that is, the request parameter of a
@@ -201,7 +201,7 @@ module NodeJSLib {
   /**
    * An access to a user-controlled Node.js request input.
    */
-  private class RequestInputAccess extends HTTP::RequestInputAccess {
+  private class RequestInputAccess extends Http::RequestInputAccess {
     RequestNode request;
     string kind;
 
@@ -223,7 +223,7 @@ module NodeJSLib {
       )
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = request.getRouteHandler() }
+    override Http::RouteHandler getRouteHandler() { result = request.getRouteHandler() }
 
     override string getKind() { result = kind }
   }
@@ -231,7 +231,7 @@ module NodeJSLib {
   /**
    * An access to an HTTP header (other than "Cookie") on an incoming Node.js request object.
    */
-  private class RequestHeaderAccess extends HTTP::RequestHeaderAccess {
+  private class RequestHeaderAccess extends Http::RequestHeaderAccess {
     RequestNode request;
 
     RequestHeaderAccess() {
@@ -247,14 +247,14 @@ module NodeJSLib {
       result = this.(DataFlow::PropRead).getPropertyName().toLowerCase()
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = request.getRouteHandler() }
+    override Http::RouteHandler getRouteHandler() { result = request.getRouteHandler() }
 
     override string getKind() { result = "header" }
 
     RequestNode getRequest() { result = request }
   }
 
-  class RouteSetup extends DataFlow::CallNode, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends DataFlow::CallNode, Http::Servers::StandardRouteSetup {
     ServerDefinition server;
     DataFlow::Node handler;
 
@@ -282,7 +282,7 @@ module NodeJSLib {
         result = succ.backtrack(t2, t)
         or
         t = t2 and
-        HTTP::routeHandlerStep(result, succ)
+        Http::routeHandlerStep(result, succ)
       )
     }
 
@@ -300,12 +300,12 @@ module NodeJSLib {
     DataFlow::Node getRouteHandlerNode() { result = handler }
   }
 
-  abstract private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {
+  abstract private class HeaderDefinition extends Http::Servers::StandardHeaderDefinition {
     ResponseNode r;
 
     HeaderDefinition() { this.getReceiver() = r }
 
-    override HTTP::RouteHandler getRouteHandler() { result = r.getRouteHandler() }
+    override Http::RouteHandler getRouteHandler() { result = r.getRouteHandler() }
   }
 
   /**
@@ -403,8 +403,8 @@ module NodeJSLib {
    * An expression passed as the first argument to the `write` or `end` method
    * of an HTTP response.
    */
-  private class ResponseSendArgument extends HTTP::ResponseSendArgument {
-    HTTP::RouteHandler rh;
+  private class ResponseSendArgument extends Http::ResponseSendArgument {
+    Http::RouteHandler rh;
 
     ResponseSendArgument() {
       exists(DataFlow::MethodCallNode mcn, string m | m = "write" or m = "end" |
@@ -415,13 +415,13 @@ module NodeJSLib {
       )
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = rh }
+    override Http::RouteHandler getRouteHandler() { result = rh }
   }
 
   /**
    * An expression that creates a new Node.js server.
    */
-  class ServerDefinition extends HTTP::Servers::StandardServerDefinition {
+  class ServerDefinition extends Http::Servers::StandardServerDefinition {
     ServerDefinition() { isCreateServer(this) }
   }
 
@@ -820,7 +820,7 @@ module NodeJSLib {
    *
    * For example, this could be the function `function(req, res){...}`.
    */
-  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate {
+  class RouteHandlerCandidate extends Http::RouteHandlerCandidate {
     RouteHandlerCandidate() {
       exists(string request, string response |
         (request = "request" or request = "req") and
@@ -840,7 +840,7 @@ module NodeJSLib {
    * A function that flows to a route setup.
    */
   private class TrackedRouteHandlerCandidateWithSetup extends RouteHandler,
-    HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+    Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
     TrackedRouteHandlerCandidateWithSetup() { this = any(RouteSetup s).getARouteHandler() }
   }
 
@@ -871,7 +871,7 @@ module NodeJSLib {
    * For example, this could be the call `server.on("request", handler)`
    * where it is unknown if `server` is a Node.js server.
    */
-  class RouteSetupCandidate extends HTTP::RouteSetupCandidate, DataFlow::MethodCallNode {
+  class RouteSetupCandidate extends Http::RouteSetupCandidate, DataFlow::MethodCallNode {
     DataFlow::ValueNode arg;
 
     RouteSetupCandidate() {
@@ -912,7 +912,7 @@ module NodeJSLib {
       exists(string moduleName, DataFlow::SourceNode callee | this = callee.getACall() |
         (moduleName = "http" or moduleName = "https") and
         (
-          callee = DataFlow::moduleMember(moduleName, any(HTTP::RequestMethodName m).toLowerCase())
+          callee = DataFlow::moduleMember(moduleName, any(Http::RequestMethodName m).toLowerCase())
           or
           callee = DataFlow::moduleMember(moduleName, "request")
         ) and

--- a/javascript/ql/lib/semmle/javascript/frameworks/Request.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Request.qll
@@ -17,7 +17,7 @@ module Request {
           action = mod.getAnInvocation()
           or
           // specialized form: `request.get(...)`
-          action = mod.getAMemberCall(any(HTTP::RequestMethodName n).toLowerCase())
+          action = mod.getAMemberCall(any(Http::RequestMethodName n).toLowerCase())
         )
       |
         exists(DataFlow::MethodCallNode auth, int argIndex |

--- a/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
@@ -9,7 +9,7 @@ module Restify {
   /**
    * An expression that creates a new Restify server.
    */
-  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, DataFlow::CallNode {
+  class ServerDefinition extends Http::Servers::StandardServerDefinition, DataFlow::CallNode {
     ServerDefinition() {
       // `server = restify.createServer()`
       this = DataFlow::moduleMember("restify", "createServer").getACall()
@@ -19,7 +19,7 @@ module Restify {
   /**
    * A Restify route handler.
    */
-  class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::ValueNode {
+  class RouteHandler extends Http::Servers::StandardRouteHandler, DataFlow::ValueNode {
     Function function;
 
     RouteHandler() {
@@ -42,7 +42,7 @@ module Restify {
    * A Restify response source, that is, the response parameter of a
    * route handler.
    */
-  private class ResponseSource extends HTTP::Servers::ResponseSource {
+  private class ResponseSource extends Http::Servers::ResponseSource {
     RouteHandler rh;
 
     ResponseSource() { this = DataFlow::parameterNode(rh.getResponseParameter()) }
@@ -57,7 +57,7 @@ module Restify {
    * A Restify request source, that is, the request parameter of a
    * route handler.
    */
-  private class RequestSource extends HTTP::Servers::RequestSource {
+  private class RequestSource extends Http::Servers::RequestSource {
     RouteHandler rh;
 
     RequestSource() { this = DataFlow::parameterNode(rh.getRequestParameter()) }
@@ -101,7 +101,7 @@ module Restify {
   /**
    * An access to a user-controlled Restify request input.
    */
-  private class RequestInputAccess extends HTTP::RequestInputAccess {
+  private class RequestInputAccess extends Http::RequestInputAccess {
     RequestNode request;
     string kind;
 
@@ -140,7 +140,7 @@ module Restify {
   /**
    * An HTTP header defined in a Restify server.
    */
-  private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {
+  private class HeaderDefinition extends Http::Servers::StandardHeaderDefinition {
     HeaderDefinition() {
       // response.header('Cache-Control', 'no-cache')
       this.getReceiver() instanceof ResponseNode and
@@ -153,13 +153,13 @@ module Restify {
   /**
    * A call to a Restify method that sets up a route.
    */
-  class RouteSetup extends DataFlow::MethodCallNode, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends DataFlow::MethodCallNode, Http::Servers::StandardRouteSetup {
     ServerDefinition server;
 
     RouteSetup() {
       // server.get('/', fun)
       // server.head('/', fun)
-      server.ref().getAMethodCall(any(HTTP::RequestMethodName m).toLowerCase()) = this
+      server.ref().getAMethodCall(any(Http::RequestMethodName m).toLowerCase()) = this
     }
 
     override DataFlow::SourceNode getARouteHandler() { result.flowsTo(this.getArgument(1)) }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
@@ -151,7 +151,7 @@ module Templating {
 
     /** Gets the data flow node representing the initialization of the given variable in this scope. */
     DataFlow::Node getVariableInit(string name) {
-      result = DataFlow::ssaDefinitionNode(SSA::implicitInit(this.getScope().getVariable(name)))
+      result = DataFlow::ssaDefinitionNode(Ssa::implicitInit(this.getScope().getVariable(name)))
     }
 
     /** Gets a data flow node corresponding to a use of the given template variable within this top-level. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/WebSocket.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/WebSocket.qll
@@ -226,21 +226,21 @@ module ServerWebSocket {
    * A `socket.on("connection", (msg, req) => {})` call seen as a HTTP route handler.
    * `req` is a `HTTP::IncomingMessage` instance.
    */
-  class ConnectionCallAsRouteHandler extends HTTP::RouteHandler, DataFlow::CallNode {
+  class ConnectionCallAsRouteHandler extends Http::RouteHandler, DataFlow::CallNode {
     ConnectionCallAsRouteHandler() { this = getAConnectionCall(_) }
 
-    override HTTP::HeaderDefinition getAResponseHeader(string name) { none() }
+    override Http::HeaderDefinition getAResponseHeader(string name) { none() }
   }
 
   /**
    * The `req` parameter of a `socket.on("connection", (msg, req) => {})` call.
    */
-  class ServerHttpRequest extends HTTP::Servers::RequestSource {
+  class ServerHttpRequest extends Http::Servers::RequestSource {
     ConnectionCallAsRouteHandler handler;
 
     ServerHttpRequest() { this = handler.getCallback(1).getParameter(1) }
 
-    override HTTP::RouteHandler getRouteHandler() { result = handler }
+    override Http::RouteHandler getRouteHandler() { result = handler }
   }
 
   /** DEPRECATED: Alias for ServerHttpRequest */
@@ -249,7 +249,7 @@ module ServerWebSocket {
   /**
    * An access user-controlled HTTP request input in a request to a WebSocket server.
    */
-  class WebSocketRequestInput extends HTTP::RequestInputAccess {
+  class WebSocketRequestInput extends Http::RequestInputAccess {
     ServerHttpRequest request;
     string kind;
 
@@ -267,7 +267,7 @@ module ServerWebSocket {
 
     override string getKind() { result = kind }
 
-    override HTTP::RouteHandler getRouteHandler() { result = request.getRouteHandler() }
+    override Http::RouteHandler getRouteHandler() { result = request.getRouteHandler() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
+++ b/javascript/ql/lib/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
@@ -11,14 +11,14 @@ private import semmle.javascript.frameworks.ConnectExpressShared
  * Add `NodeJSLib::RouteHandlerCandidate` to the extent of `NodeJSLib::RouteHandler`.
  */
 private class PromotedNodeJSLibCandidate extends NodeJSLib::RouteHandler,
-  HTTP::Servers::StandardRouteHandler {
+  Http::Servers::StandardRouteHandler {
   PromotedNodeJSLibCandidate() { this instanceof NodeJSLib::RouteHandlerCandidate }
 }
 
 /**
  * Add `Hapi::RouteHandlerCandidate` to the extent of `Hapi::RouteHandler`.
  */
-private class PromotedHapiCandidate extends Hapi::RouteHandler, HTTP::Servers::StandardRouteHandler {
+private class PromotedHapiCandidate extends Hapi::RouteHandler, Http::Servers::StandardRouteHandler {
   PromotedHapiCandidate() { this instanceof Hapi::RouteHandlerCandidate }
 }
 
@@ -26,7 +26,7 @@ private class PromotedHapiCandidate extends Hapi::RouteHandler, HTTP::Servers::S
  * Add `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Express::RouteHandler`.
  */
 private class PromotedExpressCandidate extends Express::RouteHandler,
-  HTTP::Servers::StandardRouteHandler {
+  Http::Servers::StandardRouteHandler {
   PromotedExpressCandidate() { this instanceof ConnectExpressShared::RouteHandlerCandidate }
 
   override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
@@ -38,7 +38,7 @@ private class PromotedExpressCandidate extends Express::RouteHandler,
  * Add `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Connect::RouteHandler`.
  */
 private class PromotedConnectCandidate extends Connect::RouteHandler,
-  HTTP::Servers::StandardRouteHandler {
+  Http::Servers::StandardRouteHandler {
   PromotedConnectCandidate() { this instanceof ConnectExpressShared::RouteHandlerCandidate }
 
   override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {

--- a/javascript/ql/lib/semmle/javascript/security/SensitiveActions.qll
+++ b/javascript/ql/lib/semmle/javascript/security/SensitiveActions.qll
@@ -96,7 +96,7 @@ private predicate writesProperty(DataFlow::Node node, string name) {
   exists(VarDef v | v.getAVariable().getName() = name |
     if exists(v.getSource())
     then v.getSource() = node.asExpr()
-    else node = DataFlow::ssaDefinitionNode(SSA::definition(v))
+    else node = DataFlow::ssaDefinitionNode(Ssa::definition(v))
   )
 }
 

--- a/javascript/ql/lib/semmle/javascript/security/TaintedObject.qll
+++ b/javascript/ql/lib/semmle/javascript/security/TaintedObject.qll
@@ -75,7 +75,7 @@ module TaintedObject {
 
   /** Request input accesses as a JSON source. */
   private class RequestInputAsSource extends Source {
-    RequestInputAsSource() { this.(HTTP::RequestInputAccess).isUserControlledObject() }
+    RequestInputAsSource() { this.(Http::RequestInputAccess).isUserControlledObject() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/UselessUseOfCat.qll
+++ b/javascript/ql/lib/semmle/javascript/security/UselessUseOfCat.qll
@@ -127,7 +127,7 @@ class UselessCat extends CommandCall {
         or
         // `exec` can use 3 parameters, `readFile` can only use two, so it is OK to have a third parameter if it is unused,
         func.getNumParameter() = 3 and
-        not exists(SSA::definition(func.getParameter(2).getParameter()))
+        not exists(Ssa::definition(func.getParameter(2).getParameter()))
       )
     ) and
     // The process returned by an async call is unused.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
@@ -49,7 +49,7 @@ module CleartextStorage {
    */
   class CookieStorageSink extends Sink {
     CookieStorageSink() {
-      exists(HTTP::CookieDefinition cookieDef |
+      exists(Http::CookieDefinition cookieDef |
         this = cookieDef.getValueArgument() or
         this = cookieDef.getHeaderArgument()
       )

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CorsMisconfigurationForCredentialsCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CorsMisconfigurationForCredentialsCustomizations.qll
@@ -19,7 +19,7 @@ module CorsMisconfigurationForCredentials {
     /**
      * Gets the "Access-Control-Allow-Credentials" header definition.
      */
-    abstract HTTP::HeaderDefinition getCredentialsHeader();
+    abstract Http::HeaderDefinition getCredentialsHeader();
   }
 
   /**
@@ -41,11 +41,11 @@ module CorsMisconfigurationForCredentials {
    * HTTP header with a truthy value.
    */
   class CorsOriginHeaderWithAssociatedCredentialHeader extends Sink, DataFlow::ValueNode {
-    HTTP::ExplicitHeaderDefinition credentials;
+    Http::ExplicitHeaderDefinition credentials;
 
     CorsOriginHeaderWithAssociatedCredentialHeader() {
       exists(
-        HTTP::RouteHandler routeHandler, HTTP::ExplicitHeaderDefinition origin,
+        Http::RouteHandler routeHandler, Http::ExplicitHeaderDefinition origin,
         DataFlow::Node credentialsValue
       |
         routeHandler.getAResponseHeader(_) = origin and
@@ -58,7 +58,7 @@ module CorsMisconfigurationForCredentials {
       )
     }
 
-    override HTTP::HeaderDefinition getCredentialsHeader() { result = credentials }
+    override Http::HeaderDefinition getCredentialsHeader() { result = credentials }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DifferentKindsComparisonBypassCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DifferentKindsComparisonBypassCustomizations.qll
@@ -31,7 +31,7 @@ module DifferentKindsComparisonBypass {
    * A HTTP request input that is suspicious to compare with another HTTP request input of a different kind.
    */
   class RequestInputComparisonSource extends Source {
-    HTTP::RequestInputAccess input;
+    Http::RequestInputAccess input;
 
     RequestInputComparisonSource() { input = this }
 
@@ -42,7 +42,7 @@ module DifferentKindsComparisonBypass {
     /**
      * Gets the HTTP request input of this source.
      */
-    private HTTP::RequestInputAccess getInput() { result = input }
+    private Http::RequestInputAccess getInput() { result = input }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HostHeaderPoisoningInEmailGenerationQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HostHeaderPoisoningInEmailGenerationQuery.qll
@@ -12,7 +12,7 @@ class Configuration extends TaintTracking::Configuration {
   Configuration() { this = "TaintedHostHeader" }
 
   override predicate isSource(DataFlow::Node node) {
-    exists(HTTP::RequestHeaderAccess input | node = input |
+    exists(Http::RequestHeaderAccess input | node = input |
       input.getKind() = "header" and
       input.getAHeaderName() = "host"
     )

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessSpecific.qll
@@ -9,7 +9,7 @@ private import HttpToFileAccessCustomizations::HttpToFileAccess
  * An access to a user-controlled HTTP request input, considered as a flow source for writing user-controlled data to files
  */
 private class RequestInputAccessAsSource extends Source {
-  RequestInputAccessAsSource() { this instanceof HTTP::RequestInputAccess }
+  RequestInputAccessAsSource() { this instanceof Http::RequestInputAccess }
 }
 
 /** A response from a server, considered as a flow source for writing user-controlled data to files. */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
@@ -24,15 +24,15 @@ module ReflectedXss {
    * a content type that does not (case-insensitively) contain the string "html". This
    * is to prevent us from flagging plain-text or JSON responses as vulnerable.
    */
-  class HttpResponseSink extends Sink instanceof HTTP::ResponseSendArgument {
+  class HttpResponseSink extends Sink instanceof Http::ResponseSendArgument {
     HttpResponseSink() { not exists(getANonHtmlHeaderDefinition(this)) }
   }
 
   /**
    * Gets a HeaderDefinition that defines a non-html content-type for `send`.
    */
-  HTTP::HeaderDefinition getANonHtmlHeaderDefinition(HTTP::ResponseSendArgument send) {
-    exists(HTTP::RouteHandler h |
+  Http::HeaderDefinition getANonHtmlHeaderDefinition(Http::ResponseSendArgument send) {
+    exists(Http::RouteHandler h |
       send.getRouteHandler() = h and
       result = nonHtmlContentTypeHeader(h)
     |
@@ -44,7 +44,7 @@ module ReflectedXss {
   /**
    * Holds if `h` may send a response with a content type other than HTML.
    */
-  HTTP::HeaderDefinition nonHtmlContentTypeHeader(HTTP::RouteHandler h) {
+  Http::HeaderDefinition nonHtmlContentTypeHeader(Http::RouteHandler h) {
     result = h.getAResponseHeader("content-type") and
     not exists(string tp | result.defines("content-type", tp) | tp.regexpMatch("(?i).*html.*"))
   }
@@ -52,7 +52,7 @@ module ReflectedXss {
   /**
    * Holds if a header set in `header` is likely to affect a response sent at `sender`.
    */
-  predicate headerAffects(HTTP::HeaderDefinition header, HTTP::ResponseSendArgument sender) {
+  predicate headerAffects(Http::HeaderDefinition header, Http::ResponseSendArgument sender) {
     sender.getRouteHandler() = header.getRouteHandler() and
     (
       // `sender` is affected by a dominating `header`.
@@ -60,7 +60,7 @@ module ReflectedXss {
       or
       // There is no dominating header, and `header` is non-local.
       not isLocalHeaderDefinition(header) and
-      not exists(HTTP::HeaderDefinition dominatingHeader |
+      not exists(Http::HeaderDefinition dominatingHeader |
         dominatingHeader.getBasicBlock().(ReachableBasicBlock).dominates(sender.getBasicBlock())
       )
     )
@@ -77,10 +77,10 @@ module ReflectedXss {
    * return;
    * ```
    */
-  predicate isLocalHeaderDefinition(HTTP::HeaderDefinition header) {
+  predicate isLocalHeaderDefinition(Http::HeaderDefinition header) {
     exists(ReachableBasicBlock headerBlock | headerBlock = header.getBasicBlock() |
       1 =
-        strictcount(HTTP::ResponseSendArgument sender |
+        strictcount(Http::ResponseSendArgument sender |
           sender.getRouteHandler() = header.getRouteHandler() and
           header.getBasicBlock().(ReachableBasicBlock).dominates(sender.getBasicBlock())
         ) and
@@ -108,9 +108,9 @@ module ReflectedXss {
   /** A third-party controllable request input, considered as a flow source for reflected XSS. */
   class ThirdPartyRequestInputAccessAsSource extends Source {
     ThirdPartyRequestInputAccessAsSource() {
-      this.(HTTP::RequestInputAccess).isThirdPartyControllable()
+      this.(Http::RequestInputAccess).isThirdPartyControllable()
       or
-      this.(HTTP::RequestHeaderAccess).getAHeaderName() = "referer"
+      this.(Http::RequestHeaderAccess).getAHeaderName() = "referer"
     }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/RemotePropertyInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/RemotePropertyInjectionCustomizations.qll
@@ -59,7 +59,7 @@ module RemotePropertyInjection {
    */
   class HeaderNameSink extends Sink {
     HeaderNameSink() {
-      exists(HTTP::ExplicitHeaderDefinition hd |
+      exists(Http::ExplicitHeaderDefinition hd |
         not hd instanceof Express::SetMultipleHeaders and
         this = hd.getNameNode()
       )

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ServerSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ServerSideUrlRedirectCustomizations.qll
@@ -26,7 +26,7 @@ module ServerSideUrlRedirect {
   /** A source of third-party user input, considered as a flow source for URL redirects. */
   class ThirdPartyRequestInputAccessAsSource extends Source {
     ThirdPartyRequestInputAccessAsSource() {
-      this.(HTTP::RequestInputAccess).isThirdPartyControllable()
+      this.(Http::RequestInputAccess).isThirdPartyControllable()
     }
   }
 
@@ -34,7 +34,7 @@ module ServerSideUrlRedirect {
    * An HTTP redirect, considered as a sink for `Configuration`.
    */
   class RedirectSink extends Sink {
-    RedirectSink() { this = any(HTTP::RedirectInvocation redir).getUrlArgument() }
+    RedirectSink() { this = any(Http::RedirectInvocation redir).getUrlArgument() }
   }
 
   /**
@@ -43,7 +43,7 @@ module ServerSideUrlRedirect {
    */
   class LocationHeaderSink extends Sink {
     LocationHeaderSink() {
-      any(HTTP::ExplicitHeaderDefinition def).definesHeaderValue("location", this)
+      any(Http::ExplicitHeaderDefinition def).definesHeaderValue("location", this)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/StackTraceExposureCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/StackTraceExposureCustomizations.qll
@@ -32,5 +32,5 @@ module StackTraceExposure {
    * An expression that can become part of an HTTP response body, viewed
    * as a data flow sink for stack trace exposure vulnerabilities.
    */
-  class DefaultSink extends Sink instanceof HTTP::ResponseBody { }
+  class DefaultSink extends Sink instanceof Http::ResponseBody { }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TypeConfusionThroughParameterTamperingCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TypeConfusionThroughParameterTamperingCustomizations.qll
@@ -29,7 +29,7 @@ module TypeConfusionThroughParameterTampering {
    * Node.js-based HTTP servers turn request parameters into arrays if their names are repeated.
    */
   private class TypeTamperableRequestParameter extends Source {
-    TypeTamperableRequestParameter() { this.(HTTP::RequestInputAccess).isUserControlledObject() }
+    TypeTamperableRequestParameter() { this.(Http::RequestInputAccess).isUserControlledObject() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/regexp/PolynomialReDoSCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/regexp/PolynomialReDoSCustomizations.qll
@@ -48,8 +48,8 @@ module PolynomialReDoS {
    * A remote input to a server, seen as a source for polynomial
    * regular expression denial-of-service vulnerabilities.
    */
-  class RequestInputAccessAsSource extends Source instanceof HTTP::RequestInputAccess {
-    override string getKind() { result = HTTP::RequestInputAccess.super.getKind() }
+  class RequestInputAccessAsSource extends Source instanceof Http::RequestInputAccess {
+    override string getKind() { result = Http::RequestInputAccess.super.getKind() }
   }
 
   /**

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -35,7 +35,7 @@ predicate isRouteHandlerUsingCookies(Routing::RouteHandler handler) {
  * A router handler following after cookie parsing is assumed to depend on
  * cookies, and thus require CSRF protection.
  */
-predicate hasCookieMiddleware(Routing::Node route, HTTP::CookieMiddlewareInstance cookie) {
+predicate hasCookieMiddleware(Routing::Node route, Http::CookieMiddlewareInstance cookie) {
   route.isGuardedBy(cookie)
 }
 
@@ -112,7 +112,7 @@ private DataFlow::SourceNode nodeLeadingToCsrfWriteOrCheck(DataFlow::TypeBackTra
  * Gets a route handler that sets an CSRF related cookie.
  */
 private Routing::RouteHandler getAHandlerSettingCsrfCookie() {
-  exists(HTTP::CookieDefinition setCookie |
+  exists(Http::CookieDefinition setCookie |
     setCookie.getNameArgument().getStringValue().regexpMatch("(?i).*(csrf|xsrf).*") and
     result = Routing::getRouteHandler(setCookie.getRouteHandler())
   )
@@ -180,7 +180,7 @@ predicate hasCsrfMiddleware(Routing::RouteHandler handler) {
 
 from
   Routing::RouteSetup setup, Routing::Node setupArg, Routing::RouteHandler handler,
-  HTTP::CookieMiddlewareInstance cookie
+  Http::CookieMiddlewareInstance cookie
 where
   // Require that the handler uses cookies and has cookie middleware.
   //

--- a/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.ql
+++ b/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.ql
@@ -15,6 +15,6 @@
 import javascript
 import semmle.javascript.frameworks.HTTP
 
-from HTTP::ServerDefinition server
+from Http::ServerDefinition server
 where not exists(server.getARouteHandler().getAResponseHeader("x-frame-options"))
 select server, "This server never sets the 'X-Frame-Options' HTTP header."

--- a/javascript/ql/src/Security/CWE-598/SensitiveGetQuery.ql
+++ b/javascript/ql/src/Security/CWE-598/SensitiveGetQuery.ql
@@ -14,7 +14,7 @@
 import javascript
 
 from
-  Routing::RouteSetup setup, Routing::RouteHandler handler, HTTP::RequestInputAccess input,
+  Routing::RouteSetup setup, Routing::RouteHandler handler, Http::RequestInputAccess input,
   SensitiveNode sensitive
 where
   setup.getOwnHttpMethod() = "GET" and

--- a/javascript/ql/src/Security/CWE-730/ServerCrash.ql
+++ b/javascript/ql/src/Security/CWE-730/ServerCrash.ql
@@ -88,7 +88,7 @@ Function reachableFromAsyncCallback() {
  * The main predicate of this query: used for both result display and path computation.
  */
 predicate main(
-  HTTP::RouteHandler rh, AsyncSentinelCall async, AsyncCallback cb, LikelyExceptionThrower thrower
+  Http::RouteHandler rh, AsyncSentinelCall async, AsyncCallback cb, LikelyExceptionThrower thrower
 ) {
   async.getAsyncCallee() = cb and
   rh.getAstNode() = invokesCallbackThatThrowsUncaughtException(async, thrower)
@@ -180,7 +180,7 @@ query predicate nodes(AstNode node) {
 }
 
 from
-  HTTP::RouteHandler rh, AsyncSentinelCall async, DataFlow::Node callbackArg, AsyncCallback cb,
+  Http::RouteHandler rh, AsyncSentinelCall async, DataFlow::Node callbackArg, AsyncCallback cb,
   ExprOrStmt crasher
 where
   main(rh, async, cb, crasher) and

--- a/javascript/ql/src/experimental/poi/PoI.qll
+++ b/javascript/ql/src/experimental/poi/PoI.qll
@@ -77,7 +77,7 @@ private module StandardPoIs {
     UnpromotedRouteSetupPoI() { this = "UnpromotedRouteSetupPoI" }
 
     override predicate is(Node l0) {
-      l0 instanceof HTTP::RouteSetupCandidate and not l0 instanceof HTTP::RouteSetup
+      l0 instanceof Http::RouteSetupCandidate and not l0 instanceof Http::RouteSetup
     }
   }
 
@@ -88,7 +88,7 @@ private module StandardPoIs {
     UnpromotedRouteHandlerPoI() { this = "UnpromotedRouteHandlerPoI" }
 
     override predicate is(Node l0) {
-      l0 instanceof HTTP::RouteHandlerCandidate and not l0 instanceof HTTP::RouteHandler
+      l0 instanceof Http::RouteHandlerCandidate and not l0 instanceof Http::RouteHandler
     }
   }
 
@@ -98,7 +98,7 @@ private module StandardPoIs {
   class UnpromotedRouteHandlerWithFlowPoI extends PoI {
     UnpromotedRouteHandlerWithFlowPoI() { this = "UnpromotedRouteHandlerWithFlowPoI" }
 
-    private DataFlow::SourceNode track(HTTP::RouteHandlerCandidate cand, DataFlow::TypeTracker t) {
+    private DataFlow::SourceNode track(Http::RouteHandlerCandidate cand, DataFlow::TypeTracker t) {
       t.start() and
       result = cand
       or
@@ -106,8 +106,8 @@ private module StandardPoIs {
     }
 
     override predicate is(Node l0, Node l1, string t1) {
-      l0 instanceof HTTP::RouteHandlerCandidate and
-      not l0 instanceof HTTP::RouteHandler and
+      l0 instanceof Http::RouteHandlerCandidate and
+      not l0 instanceof Http::RouteHandler and
       l1 = track(l0, TypeTracker::end()) and
       (if l1 = l0 then t1 = "ends here" else t1 = "starts/ends here")
     }

--- a/javascript/ql/src/meta/analysis-quality/CandidateTracking.qll
+++ b/javascript/ql/src/meta/analysis-quality/CandidateTracking.qll
@@ -8,7 +8,7 @@ import javascript
  * Gets a source node to which `cand` may flow inter-procedurally, with `t` tracking
  * the state of flow.
  */
-DataFlow::SourceNode track(HTTP::RouteHandlerCandidate cand, DataFlow::TypeTracker t) {
+DataFlow::SourceNode track(Http::RouteHandlerCandidate cand, DataFlow::TypeTracker t) {
   t.start() and
   result = cand
   or

--- a/javascript/ql/src/meta/analysis-quality/RouteHandlers.ql
+++ b/javascript/ql/src/meta/analysis-quality/RouteHandlers.ql
@@ -11,6 +11,6 @@
 import javascript
 import CallGraphQuality
 
-HTTP::RouteHandler relevantRouteHandler() { not result.getFile() instanceof IgnoredFile }
+Http::RouteHandler relevantRouteHandler() { not result.getFile() instanceof IgnoredFile }
 
 select projectRoot(), count(relevantRouteHandler())

--- a/javascript/ql/src/meta/analysis-quality/UnpromotedRouteHandlerCandidate.ql
+++ b/javascript/ql/src/meta/analysis-quality/UnpromotedRouteHandlerCandidate.ql
@@ -11,10 +11,10 @@
 import javascript
 import CandidateTracking
 
-from HTTP::RouteHandlerCandidate rh
+from Http::RouteHandlerCandidate rh
 where
-  not rh instanceof HTTP::RouteHandler and
-  not exists(HTTP::RouteSetupCandidate setup |
+  not rh instanceof Http::RouteHandler and
+  not exists(Http::RouteSetupCandidate setup |
     track(rh, DataFlow::TypeTracker::end()).flowsTo(setup.getARouteHandlerArg())
   )
 select rh,

--- a/javascript/ql/src/meta/analysis-quality/UnpromotedRouteSetupCandidate.ql
+++ b/javascript/ql/src/meta/analysis-quality/UnpromotedRouteSetupCandidate.ql
@@ -11,10 +11,10 @@
 import javascript
 import CandidateTracking
 
-from HTTP::RouteSetupCandidate setup
+from Http::RouteSetupCandidate setup
 where
-  not setup instanceof HTTP::RouteSetup and
-  exists(HTTP::RouteHandlerCandidate rh |
+  not setup instanceof Http::RouteSetup and
+  exists(Http::RouteHandlerCandidate rh |
     track(rh, DataFlow::TypeTracker::end()).flowsTo(setup.getARouteHandlerArg())
   )
 select setup,

--- a/javascript/ql/test/library-tests/frameworks/Express/CookieMiddlewareInstance.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/CookieMiddlewareInstance.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_CookieMiddlewareInstance(
-  HTTP::CookieMiddlewareInstance instance, DataFlow::Node res
+  Http::CookieMiddlewareInstance instance, DataFlow::Node res
 ) {
   res = instance.getASecretKey()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderAccess.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderAccess(HTTP::RequestHeaderAccess access, string res) {
+query predicate test_HeaderAccess(Http::RequestHeaderAccess access, string res) {
   res = access.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Express::RouteHandler rh) {
+query predicate test_HeaderDefinition(Http::HeaderDefinition hd, Express::RouteHandler rh) {
   rh = hd.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition_defines.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition_defines.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+query predicate test_HeaderDefinition_defines(Http::HeaderDefinition hd, string name, string value) {
   hd.defines(name, value) and hd.getRouteHandler() instanceof Express::RouteHandler
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition_getAHeaderName.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition_getAHeaderName.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+query predicate test_HeaderDefinition_getAHeaderName(Http::HeaderDefinition hd, string res) {
   hd.getRouteHandler() instanceof Express::RouteHandler and res = hd.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition_getNameExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition_getNameExpr.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_HeaderDefinition_getNameExpr(
-  HTTP::ExplicitHeaderDefinition hd, DataFlow::Node res
+  Http::ExplicitHeaderDefinition hd, DataFlow::Node res
 ) {
   hd.getRouteHandler() instanceof Express::RouteHandler and res = hd.getNameNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RedirectInvocation.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RedirectInvocation.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RedirectInvocation(HTTP::RedirectInvocation red, Express::RouteHandler rh) {
+query predicate test_RedirectInvocation(Http::RedirectInvocation red, Express::RouteHandler rh) {
   rh = red.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RequestExpr.qll
@@ -1,6 +1,6 @@
 import javascript
 
-query predicate test_RequestExpr(Express::RequestNode e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Express::RequestNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }
 

--- a/javascript/ql/test/library-tests/frameworks/Express/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RequestInputAccess.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res0, Express::RouteHandler rh
+  Http::RequestInputAccess ria, string res0, Express::RouteHandler rh
 ) {
   ria.getRouteHandler() = rh and res0 = ria.getKind()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/ResponseBody.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/ResponseBody.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseBody(HTTP::ResponseBody rb, Express::RouteHandler rh) {
+query predicate test_ResponseBody(Http::ResponseBody rb, Express::RouteHandler rh) {
   rb.getRouteHandler() = rh
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Express::ResponseNode e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Express::ResponseNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/ResponseSendArgument.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/ResponseSendArgument.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseSendArgument(HTTP::ResponseSendArgument send, Express::RouteHandler rh) {
+query predicate test_ResponseSendArgument(Http::ResponseSendArgument send, Express::RouteHandler rh) {
   rh = send.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerContainer.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerContainer.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate getRouteHandlerContainerStep(
-  HTTP::RouteHandlerCandidateContainer container, DataFlow::SourceNode handler,
+  Http::RouteHandlerCandidateContainer container, DataFlow::SourceNode handler,
   DataFlow::SourceNode access
 ) {
   handler = container.getRouteHandler(access)

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler_getARequestExpr(Express::RouteHandler rh, HTTP::RequestNode res) {
+query predicate test_RouteHandler_getARequestExpr(Express::RouteHandler rh, Http::RequestNode res) {
   res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getAResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler_getAResponseExpr(Express::RouteHandler rh, HTTP::ResponseNode res) {
+query predicate test_RouteHandler_getAResponseExpr(Express::RouteHandler rh, Http::ResponseNode res) {
   res = rh.getAResponseNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getAResponseHeader.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getAResponseHeader.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandler_getAResponseHeader(
-  Express::RouteHandler rh, string name, HTTP::HeaderDefinition res
+  Express::RouteHandler rh, string name, Http::HeaderDefinition res
 ) {
   res = rh.getAResponseHeader(name)
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRequestMethod.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRequestMethod.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getRequestMethod(Express::RouteSetup rs, HTTP::RequestMethodName res) {
+query predicate test_RouteSetup_getRequestMethod(Express::RouteSetup rs, Http::RequestMethodName res) {
   res = rs.getRequestMethod()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getARouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getARouteHandler.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouterDefinition_getARouteHandler(
-  Express::RouterDefinition r, HTTP::RouteHandler res
+  Express::RouterDefinition r, Http::RouteHandler res
 ) {
   res = r.getARouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/SetCookie.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/SetCookie.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_SetCookie(HTTP::CookieDefinition cookiedef, Express::RouteHandler rh) {
+query predicate test_SetCookie(Http::CookieDefinition cookiedef, Express::RouteHandler rh) {
   rh = cookiedef.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/Firebase/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Firebase/tests.ql
@@ -6,8 +6,8 @@ query predicate firebaseSnapshot(DataFlow::SourceNode snap) { snap = Firebase::s
 
 query predicate firebaseVal(Firebase::FirebaseVal val) { any() }
 
-query predicate requestInputAccess(HTTP::RequestInputAccess acc) { any() }
+query predicate requestInputAccess(Http::RequestInputAccess acc) { any() }
 
-query predicate responseSendArgument(HTTP::ResponseSendArgument send) { any() }
+query predicate responseSendArgument(Http::ResponseSendArgument send) { any() }
 
-query predicate routeHandler(HTTP::RouteHandler handler) { any() }
+query predicate routeHandler(Http::RouteHandler handler) { any() }

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/AdditionalRouteHandlers.ql
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/AdditionalRouteHandlers.ql
@@ -1,5 +1,5 @@
 import javascript
 private import semmle.javascript.heuristics.AdditionalRouteHandlers
 
-from HTTP::RouteHandler rh
+from Http::RouteHandler rh
 select rh

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/tests.ql
@@ -1,9 +1,9 @@
 import javascript
 
-query predicate routeHandler(HTTP::RouteHandler rh) { any() }
+query predicate routeHandler(Http::RouteHandler rh) { any() }
 
-query predicate routeHandlerCandidate(HTTP::RouteHandlerCandidate rh) { any() }
+query predicate routeHandlerCandidate(Http::RouteHandlerCandidate rh) { any() }
 
-query predicate routeSetup(HTTP::RouteSetup rh) { any() }
+query predicate routeSetup(Http::RouteSetup rh) { any() }
 
-query predicate routeSetupCandidate(HTTP::RouteSetupCandidate rh) { any() }
+query predicate routeSetupCandidate(Http::RouteSetupCandidate rh) { any() }

--- a/javascript/ql/test/library-tests/frameworks/HTTP/RemoteRequestInput.ql
+++ b/javascript/ql/test/library-tests/frameworks/HTTP/RemoteRequestInput.ql
@@ -1,4 +1,4 @@
 import javascript
 
-from HTTP::RequestInputAccess input
+from Http::RequestInputAccess input
 select input, input.getKind()

--- a/javascript/ql/test/library-tests/frameworks/HTTP/ResponseBody.ql
+++ b/javascript/ql/test/library-tests/frameworks/HTTP/ResponseBody.ql
@@ -1,4 +1,4 @@
 import javascript
 
-from HTTP::ResponseBody rb
+from Http::ResponseBody rb
 select rb

--- a/javascript/ql/test/library-tests/frameworks/Micro/TestMicro.ql
+++ b/javascript/ql/test/library-tests/frameworks/Micro/TestMicro.ql
@@ -1,17 +1,17 @@
 import javascript
 
-query HTTP::RouteHandler routeHandler() { any() }
+query Http::RouteHandler routeHandler() { any() }
 
-query HTTP::Servers::RequestSource requestSource() { any() }
+query Http::Servers::RequestSource requestSource() { any() }
 
-query HTTP::Servers::ResponseSource responseSource() { any() }
+query Http::Servers::ResponseSource responseSource() { any() }
 
-query HTTP::RequestInputAccess requestInputAccess(string kind) { kind = result.getKind() }
+query Http::RequestInputAccess requestInputAccess(string kind) { kind = result.getKind() }
 
-query HTTP::RequestInputAccess userControlledObject() { result.isUserControlledObject() }
+query Http::RequestInputAccess userControlledObject() { result.isUserControlledObject() }
 
-query HTTP::ResponseSendArgument responseSendArgument() { any() }
+query Http::ResponseSendArgument responseSendArgument() { any() }
 
-query HTTP::ResponseSendArgument responseSendArgumentHandler(HTTP::RouteHandler h) {
+query Http::ResponseSendArgument responseSendArgumentHandler(Http::RouteHandler h) {
   h = result.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/Nest/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/Nest/test.ql
@@ -1,19 +1,19 @@
 import javascript
 private import semmle.javascript.security.dataflow.ServerSideUrlRedirectCustomizations
 
-query HTTP::RouteHandler routeHandler() { any() }
+query Http::RouteHandler routeHandler() { any() }
 
-query HTTP::Servers::RequestSource requestSource() { any() }
+query Http::Servers::RequestSource requestSource() { any() }
 
-query HTTP::Servers::ResponseSource responseSource() { any() }
+query Http::Servers::ResponseSource responseSource() { any() }
 
 query RemoteFlowSource requestInputAccess(string kind) {
-  kind = result.(HTTP::RequestInputAccess).getKind()
+  kind = result.(Http::RequestInputAccess).getKind()
   or
-  not result instanceof HTTP::RequestInputAccess and
+  not result instanceof Http::RequestInputAccess and
   kind = "RemoteFlowSource"
 }
 
-query HTTP::ResponseSendArgument responseSendArgument() { any() }
+query Http::ResponseSendArgument responseSendArgument() { any() }
 
 query ServerSideUrlRedirect::Sink redirectSink() { any() }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderAccess.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderAccess(HTTP::RequestHeaderAccess access, string res) {
+query predicate test_HeaderAccess(Http::RequestHeaderAccess access, string res) {
   res = access.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, NodeJSLib::RouteHandler rh) {
+query predicate test_HeaderDefinition(Http::HeaderDefinition hd, NodeJSLib::RouteHandler rh) {
   rh = hd.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_defines.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_defines.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+query predicate test_HeaderDefinition_defines(Http::HeaderDefinition hd, string name, string value) {
   hd.defines(name, value) and hd.getRouteHandler() instanceof NodeJSLib::RouteHandler
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_getAHeaderName.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_getAHeaderName.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+query predicate test_HeaderDefinition_getAHeaderName(Http::HeaderDefinition hd, string res) {
   hd.getRouteHandler() instanceof NodeJSLib::RouteHandler and res = hd.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_getNameExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_getNameExpr.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_HeaderDefinition_getNameExpr(
-  HTTP::ExplicitHeaderDefinition hd, DataFlow::Node res
+  Http::ExplicitHeaderDefinition hd, DataFlow::Node res
 ) {
   hd.getRouteHandler() instanceof NodeJSLib::RouteHandler and res = hd.getNameNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(NodeJSLib::RequestNode e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(NodeJSLib::RequestNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RequestInputAccess.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res, NodeJSLib::RouteHandler rh
+  Http::RequestInputAccess ria, string res, NodeJSLib::RouteHandler rh
 ) {
   ria.getRouteHandler() = rh and res = ria.getKind()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(NodeJSLib::ResponseNode e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(NodeJSLib::ResponseNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseSendArgument.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseSendArgument.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_ResponseSendArgument(
-  HTTP::ResponseSendArgument send, NodeJSLib::RouteHandler rh
+  Http::ResponseSendArgument send, NodeJSLib::RouteHandler rh
 ) {
   rh = send.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler_getARequestExpr(NodeJSLib::RouteHandler rh, HTTP::RequestNode res) {
+query predicate test_RouteHandler_getARequestExpr(NodeJSLib::RouteHandler rh, Http::RequestNode res) {
   res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getAResponseExpr.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandler_getAResponseExpr(
-  NodeJSLib::RouteHandler rh, HTTP::ResponseNode res
+  NodeJSLib::RouteHandler rh, Http::ResponseNode res
 ) {
   res = rh.getAResponseNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getAResponseHeader.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getAResponseHeader.qll
@@ -1,7 +1,7 @@
 import semmle.javascript.frameworks.Express
 
 query predicate test_RouteHandler_getAResponseHeader(
-  NodeJSLib::RouteHandler rh, string name, HTTP::HeaderDefinition res
+  NodeJSLib::RouteHandler rh, string name, Http::HeaderDefinition res
 ) {
   res = rh.getAResponseHeader(name)
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ServerDefinition_getARouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ServerDefinition_getARouteHandler.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_ServerDefinition_getARouteHandler(
-  NodeJSLib::ServerDefinition s, HTTP::RouteHandler res
+  NodeJSLib::ServerDefinition s, Http::RouteHandler res
 ) {
   res = s.getARouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/connect/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/connect/tests.ql
@@ -3,26 +3,26 @@ import javascript
 query predicate test_RouteSetup(Connect::RouteSetup rs) { any() }
 
 query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res, Connect::RouteHandler rh
+  Http::RequestInputAccess ria, string res, Connect::RouteHandler rh
 ) {
   ria.getRouteHandler() = rh and res = ria.getKind()
 }
 
 query predicate test_RouteHandler_getAResponseHeader(
-  Connect::RouteHandler rh, string name, HTTP::HeaderDefinition res
+  Connect::RouteHandler rh, string name, Http::HeaderDefinition res
 ) {
   res = rh.getAResponseHeader(name)
 }
 
-query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+query predicate test_HeaderDefinition_defines(Http::HeaderDefinition hd, string name, string value) {
   hd.defines(name, value) and hd.getRouteHandler() instanceof Connect::RouteHandler
 }
 
-query predicate test_ResponseExpr(HTTP::ResponseNode e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Http::ResponseNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }
 
-query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Connect::RouteHandler rh) {
+query predicate test_HeaderDefinition(Http::HeaderDefinition hd, Connect::RouteHandler rh) {
   rh = hd.getRouteHandler()
 }
 
@@ -30,13 +30,13 @@ query predicate test_RouteSetup_getServer(Connect::RouteSetup rs, DataFlow::Node
   res = rs.getServer()
 }
 
-query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+query predicate test_HeaderDefinition_getAHeaderName(Http::HeaderDefinition hd, string res) {
   hd.getRouteHandler() instanceof Connect::RouteHandler and res = hd.getAHeaderName()
 }
 
 query predicate test_ServerDefinition(Connect::ServerDefinition s) { any() }
 
-query predicate test_RouteHandler_getAResponseExpr(Connect::RouteHandler rh, HTTP::ResponseNode res) {
+query predicate test_RouteHandler_getAResponseExpr(Connect::RouteHandler rh, Http::ResponseNode res) {
   res = rh.getAResponseNode()
 }
 
@@ -48,7 +48,7 @@ query predicate test_RouteHandler(Connect::RouteHandler rh, DataFlow::Node res) 
   res = rh.getServer()
 }
 
-query predicate test_RequestExpr(HTTP::RequestNode e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Http::RequestNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }
 
@@ -56,6 +56,6 @@ query predicate test_Credentials(Connect::Credentials cr, string res) {
   res = cr.getCredentialsKind()
 }
 
-query predicate test_RouteHandler_getARequestExpr(Connect::RouteHandler rh, HTTP::RequestNode res) {
+query predicate test_RouteHandler_getARequestExpr(Connect::RouteHandler rh, Http::RequestNode res) {
   res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/HeaderAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/HeaderAccess.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderAccess(HTTP::RequestHeaderAccess access, string res) {
+query predicate test_HeaderAccess(Http::RequestHeaderAccess access, string res) {
   res = access.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Fastify::RouteHandler rh) {
+query predicate test_HeaderDefinition(Http::HeaderDefinition hd, Fastify::RouteHandler rh) {
   rh = hd.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition_defines.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition_defines.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+query predicate test_HeaderDefinition_defines(Http::HeaderDefinition hd, string name, string value) {
   hd.defines(name, value) and hd.getRouteHandler() instanceof Fastify::RouteHandler
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition_getAHeaderName.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition_getAHeaderName.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+query predicate test_HeaderDefinition_getAHeaderName(Http::HeaderDefinition hd, string res) {
   hd.getRouteHandler() instanceof Fastify::RouteHandler and res = hd.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/RedirectInvocation.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RedirectInvocation.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RedirectInvocation(HTTP::RedirectInvocation invk, Fastify::RouteHandler rh) {
+query predicate test_RedirectInvocation(Http::RedirectInvocation invk, Fastify::RouteHandler rh) {
   invk.getRouteHandler() = rh
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RequestInputAccess.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res, Fastify::RouteHandler rh, boolean isUserControlledObject
+  Http::RequestInputAccess ria, string res, Fastify::RouteHandler rh, boolean isUserControlledObject
 ) {
   ria.getRouteHandler() = rh and
   res = ria.getKind() and

--- a/javascript/ql/test/library-tests/frameworks/fastify/ResponseSendArgument.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/ResponseSendArgument.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseSendArgument(HTTP::ResponseSendArgument arg, Fastify::RouteHandler rh) {
+query predicate test_ResponseSendArgument(Http::ResponseSendArgument arg, Fastify::RouteHandler rh) {
   arg.getRouteHandler() = rh
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getARequestExpr(Fastify::RouteHandler rh, HTTP::RequestNode res) {
+query predicate test_RouteHandler_getARequestExpr(Fastify::RouteHandler rh, Http::RequestNode res) {
   res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getAResponseHeader.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getAResponseHeader.qll
@@ -1,7 +1,7 @@
 import semmle.javascript.frameworks.Express
 
 query predicate test_RouteHandler_getAResponseHeader(
-  Fastify::RouteHandler rh, string name, HTTP::HeaderDefinition res
+  Fastify::RouteHandler rh, string name, Http::HeaderDefinition res
 ) {
   res = rh.getAResponseHeader(name)
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/HeaderAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/HeaderAccess.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderAccess(HTTP::RequestHeaderAccess access, string res) {
+query predicate test_HeaderAccess(Http::RequestHeaderAccess access, string res) {
   res = access.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/HeaderDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/HeaderDefinition.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Hapi::RouteHandler rh) {
+query predicate test_HeaderDefinition(Http::HeaderDefinition hd, Hapi::RouteHandler rh) {
   rh = hd.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/HeaderDefinition_defines.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/HeaderDefinition_defines.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+query predicate test_HeaderDefinition_defines(Http::HeaderDefinition hd, string name, string value) {
   hd.defines(name, value) and hd.getRouteHandler() instanceof Hapi::RouteHandler
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/HeaderDefinition_getAHeaderName.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/HeaderDefinition_getAHeaderName.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+query predicate test_HeaderDefinition_getAHeaderName(Http::HeaderDefinition hd, string res) {
   hd.getRouteHandler() instanceof Hapi::RouteHandler and res = hd.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(Hapi::RequestNode e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Hapi::RequestNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RequestInputAccess.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res, Hapi::RouteHandler rh
+  Http::RequestInputAccess ria, string res, Hapi::RouteHandler rh
 ) {
   ria.getRouteHandler() = rh and res = ria.getKind()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Hapi::ResponseNode e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Hapi::ResponseNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getARequestExpr(Hapi::RouteHandler rh, HTTP::RequestNode res) {
+query predicate test_RouteHandler_getARequestExpr(Hapi::RouteHandler rh, Http::RequestNode res) {
   res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler_getAResponseHeader.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler_getAResponseHeader.qll
@@ -1,7 +1,7 @@
 import semmle.javascript.frameworks.Express
 
 query predicate test_RouteHandler_getAResponseHeader(
-  Hapi::RouteHandler rh, string name, HTTP::HeaderDefinition res
+  Hapi::RouteHandler rh, string name, Http::HeaderDefinition res
 ) {
   res = rh.getAResponseHeader(name)
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/HeaderAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/HeaderAccess.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderAccess(HTTP::RequestHeaderAccess access, string res) {
+query predicate test_HeaderAccess(Http::RequestHeaderAccess access, string res) {
   res = access.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/HeaderDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/HeaderDefinition.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Koa::RouteHandler rh) {
+query predicate test_HeaderDefinition(Http::HeaderDefinition hd, Koa::RouteHandler rh) {
   rh = hd.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/HeaderDefinition_defines.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/HeaderDefinition_defines.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+query predicate test_HeaderDefinition_defines(Http::HeaderDefinition hd, string name, string value) {
   hd.defines(name, value) and hd.getRouteHandler() instanceof Koa::RouteHandler
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/HeaderDefinition_getAHeaderName.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/HeaderDefinition_getAHeaderName.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+query predicate test_HeaderDefinition_getAHeaderName(Http::HeaderDefinition hd, string res) {
   hd.getRouteHandler() instanceof Koa::RouteHandler and res = hd.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RedirectInvocation.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RedirectInvocation.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RedirectInvocation(
-  HTTP::RedirectInvocation redirect, DataFlow::Node url, HTTP::RouteHandler rh
+  Http::RedirectInvocation redirect, DataFlow::Node url, Http::RouteHandler rh
 ) {
   redirect.getUrlArgument() = url and
   redirect.getRouteHandler() = rh

--- a/javascript/ql/test/library-tests/frameworks/koa/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(Koa::RequestNode e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Koa::RequestNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RequestInputAccess.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res, Koa::RouteHandler rh
+  Http::RequestInputAccess ria, string res, Koa::RouteHandler rh
 ) {
   ria.getRouteHandler() = rh and res = ria.getKind()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Koa::ResponseNode e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Koa::ResponseNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/ResponseSendArgument.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/ResponseSendArgument.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseSendArgument(HTTP::ResponseSendArgument send, Koa::RouteHandler rh) {
+query predicate test_ResponseSendArgument(Http::ResponseSendArgument send, Koa::RouteHandler rh) {
   rh = send.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getARequestExpr(Koa::RouteHandler rh, HTTP::RequestNode res) {
+query predicate test_RouteHandler_getARequestExpr(Koa::RouteHandler rh, Http::RequestNode res) {
   res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getAResponseExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getAResponseExpr(Koa::RouteHandler rh, HTTP::ResponseNode res) {
+query predicate test_RouteHandler_getAResponseExpr(Koa::RouteHandler rh, Http::ResponseNode res) {
   res = rh.getAResponseNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getAResponseHeader.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getAResponseHeader.qll
@@ -1,7 +1,7 @@
 import semmle.javascript.frameworks.Express
 
 query predicate test_RouteHandler_getAResponseHeader(
-  Koa::RouteHandler rh, string name, HTTP::HeaderDefinition res
+  Koa::RouteHandler rh, string name, Http::HeaderDefinition res
 ) {
   res = rh.getAResponseHeader(name)
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/HeaderDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/HeaderDefinition.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Restify::RouteHandler rh) {
+query predicate test_HeaderDefinition(Http::HeaderDefinition hd, Restify::RouteHandler rh) {
   rh = hd.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/HeaderDefinition_defines.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/HeaderDefinition_defines.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+query predicate test_HeaderDefinition_defines(Http::HeaderDefinition hd, string name, string value) {
   hd.defines(name, value) and hd.getRouteHandler() instanceof Restify::RouteHandler
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/HeaderDefinition_getAHeaderName.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/HeaderDefinition_getAHeaderName.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+query predicate test_HeaderDefinition_getAHeaderName(Http::HeaderDefinition hd, string res) {
   hd.getRouteHandler() instanceof Restify::RouteHandler and res = hd.getAHeaderName()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(Restify::RequestNode e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Restify::RequestNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RequestInputAccess.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res, Restify::RouteHandler rh
+  Http::RequestInputAccess ria, string res, Restify::RouteHandler rh
 ) {
   ria.getRouteHandler() = rh and res = ria.getKind()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Restify::ResponseNode e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Restify::ResponseNode e, Http::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getARequestExpr(Restify::RouteHandler rh, HTTP::RequestNode res) {
+query predicate test_RouteHandler_getARequestExpr(Restify::RouteHandler rh, Http::RequestNode res) {
   res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getAResponseExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getAResponseExpr(Restify::RouteHandler rh, HTTP::ResponseNode res) {
+query predicate test_RouteHandler_getAResponseExpr(Restify::RouteHandler rh, Http::ResponseNode res) {
   res = rh.getAResponseNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getAResponseHeader.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getAResponseHeader.qll
@@ -1,7 +1,7 @@
 import semmle.javascript.frameworks.Express
 
 query predicate test_RouteHandler_getAResponseHeader(
-  Restify::RouteHandler rh, string name, HTTP::HeaderDefinition res
+  Restify::RouteHandler rh, string name, Http::HeaderDefinition res
 ) {
   res = rh.getAResponseHeader(name)
 }

--- a/python/ql/lib/change-notes/2022-09-12-uppercase.md
+++ b/python/ql/lib/change-notes/2022-09-12-uppercase.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Some classes/modules with upper-case acronyms in their name have been renamed to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/python/ql/lib/semmle/python/Concepts.qll
+++ b/python/ql/lib/semmle/python/Concepts.qll
@@ -565,7 +565,7 @@ module XML {
 }
 
 /** Provides classes for modeling LDAP-related APIs. */
-module LDAP {
+module Ldap {
   /**
    * A data-flow node that executes an LDAP query.
    *
@@ -597,6 +597,9 @@ module LDAP {
     }
   }
 }
+
+/** DEPRECATED: Alias for Ldap */
+deprecated module LDAP = Ldap;
 
 /**
  * A data-flow node that escapes meta-characters, which could be used to prevent
@@ -706,7 +709,7 @@ class LdapFilterEscaping extends Escaping {
 }
 
 /** Provides classes for modeling HTTP-related APIs. */
-module HTTP {
+module Http {
   /** Gets an HTTP verb, in upper case */
   string httpVerb() { result in ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"] }
 
@@ -917,7 +920,7 @@ module HTTP {
        * Extend this class to model new APIs. If you want to refine existing API models,
        * extend `HttpResponse` instead.
        */
-      abstract class Range extends HTTP::Server::HttpResponse::Range {
+      abstract class Range extends Http::Server::HttpResponse::Range {
         /** Gets the data-flow node that specifies the location of this HTTP redirect response. */
         abstract DataFlow::Node getRedirectLocation();
       }
@@ -1050,6 +1053,9 @@ module HTTP {
   // TODO: investigate whether we should treat responses to client requests as
   // remote-flow-sources in general.
 }
+
+/** DEPRECATED: Alias for Http */
+deprecated module HTTP = Http;
 
 /**
  * Provides models for cryptographic things.

--- a/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
@@ -319,7 +319,7 @@ module AiohttpWebModel {
     }
 
     /** An attribute read on an `aiohttp.web.Request` that is a `MultiDictProxy` instance. */
-    class AiohttpRequestMultiDictProxyInstances extends MultiDict::MultiDictProxy::InstanceSource {
+    class AiohttpRequestMultiDictProxyInstances extends Multidict::MultiDictProxy::InstanceSource {
       AiohttpRequestMultiDictProxyInstances() {
         this.(DataFlow::AttrRead).getObject() = Request::instance() and
         this.(DataFlow::AttrRead).getAttributeName() in ["query", "headers"]

--- a/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
@@ -59,7 +59,7 @@ module AiohttpWebModel {
    * Extend this class to refine existing API models. If you want to model new APIs,
    * extend `AiohttpRouteSetup::Range` instead.
    */
-  class AiohttpRouteSetup extends HTTP::Server::RouteSetup::Range {
+  class AiohttpRouteSetup extends Http::Server::RouteSetup::Range {
     AiohttpRouteSetup::Range range;
 
     AiohttpRouteSetup() { this = range }
@@ -161,7 +161,7 @@ module AiohttpWebModel {
 
     AiohttpAddRouteCall() {
       exists(string funcName |
-        funcName = HTTP::httpVerbLower() and
+        funcName = Http::httpVerbLower() and
         routeArgsStart = 0
         or
         funcName = "view" and
@@ -192,7 +192,7 @@ module AiohttpWebModel {
 
     AiohttpDecoratorRouteSetup() {
       exists(string decoratorName |
-        decoratorName = HTTP::httpVerbLower() and
+        decoratorName = Http::httpVerbLower() and
         routeArgsStart = 0
         or
         decoratorName = "view" and
@@ -237,7 +237,7 @@ module AiohttpWebModel {
       // TODO: This doesn't handle attribute assignment. Should be OK, but analysis is not as complete as with
       // points-to and `.lookup`, which would handle `post = my_post_handler` inside class def
       result = this.getAMethod() and
-      result.getName() = HTTP::httpVerbLower()
+      result.getName() = Http::httpVerbLower()
     }
   }
 
@@ -252,7 +252,7 @@ module AiohttpWebModel {
   }
 
   /** A request handler defined in an `aiohttp.web` view class, that has no known route. */
-  private class AiohttpViewClassRequestHandlerWithoutKnownRoute extends HTTP::Server::RequestHandler::Range {
+  private class AiohttpViewClassRequestHandlerWithoutKnownRoute extends Http::Server::RequestHandler::Range {
     AiohttpViewClassRequestHandlerWithoutKnownRoute() {
       exists(AiohttpViewClass vc | vc.getARequestHandler() = this) and
       not exists(AiohttpRouteSetup setup | setup.getARequestHandler() = this)
@@ -319,7 +319,7 @@ module AiohttpWebModel {
     }
 
     /** An attribute read on an `aiohttp.web.Request` that is a `MultiDictProxy` instance. */
-    class AiohttpRequestMultiDictProxyInstances extends Multidict::MultiDictProxy::InstanceSource {
+    class AiohttpRequestMultiDictProxyInstances extends MultiDict::MultiDictProxy::InstanceSource {
       AiohttpRequestMultiDictProxyInstances() {
         this.(DataFlow::AttrRead).getObject() = Request::instance() and
         this.(DataFlow::AttrRead).getAttributeName() in ["query", "headers"]
@@ -493,7 +493,7 @@ module AiohttpWebModel {
    * - https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.Response
    * - https://docs.aiohttp.org/en/stable/web_quickstart.html#aiohttp-web-exceptions
    */
-  class AiohttpWebResponseInstantiation extends HTTP::Server::HttpResponse::Range,
+  class AiohttpWebResponseInstantiation extends Http::Server::HttpResponse::Range,
     Response::InstanceSource, DataFlow::CallCfgNode {
     API::Node apiNode;
 
@@ -562,7 +562,7 @@ module AiohttpWebModel {
    * See the part about redirects at https://docs.aiohttp.org/en/stable/web_quickstart.html#aiohttp-web-exceptions
    */
   class AiohttpRedirectExceptionInstantiation extends AiohttpWebResponseInstantiation,
-    HTTP::Server::HttpRedirectResponse::Range {
+    Http::Server::HttpRedirectResponse::Range {
     AiohttpRedirectExceptionInstantiation() {
       exists(string httpRedirectExceptionClassName |
         httpRedirectExceptionClassName in [
@@ -585,7 +585,7 @@ module AiohttpWebModel {
   /**
    * A call to `set_cookie` on a HTTP Response.
    */
-  class AiohttpResponseSetCookieCall extends HTTP::Server::CookieWrite::Range, DataFlow::CallCfgNode {
+  class AiohttpResponseSetCookieCall extends Http::Server::CookieWrite::Range, DataFlow::CallCfgNode {
     AiohttpResponseSetCookieCall() {
       this = aiohttpResponseInstance().getMember("set_cookie").getACall()
     }
@@ -600,7 +600,7 @@ module AiohttpWebModel {
   /**
    * A call to `del_cookie` on a HTTP Response.
    */
-  class AiohttpResponseDelCookieCall extends HTTP::Server::CookieWrite::Range, DataFlow::CallCfgNode {
+  class AiohttpResponseDelCookieCall extends Http::Server::CookieWrite::Range, DataFlow::CallCfgNode {
     AiohttpResponseDelCookieCall() {
       this = aiohttpResponseInstance().getMember("del_cookie").getACall()
     }
@@ -616,7 +616,7 @@ module AiohttpWebModel {
    * A dict-like write to an item of the `cookies` attribute on a HTTP response, such as
    * `response.cookies[name] = value`.
    */
-  class AiohttpResponseCookieSubscriptWrite extends HTTP::Server::CookieWrite::Range {
+  class AiohttpResponseCookieSubscriptWrite extends Http::Server::CookieWrite::Range {
     DataFlow::Node index;
     DataFlow::Node value;
 
@@ -661,11 +661,11 @@ private module AiohttpClientModel {
     private API::Node instance() { result = classRef().getReturn() }
 
     /** A method call on a ClientSession that sends off a request */
-    private class OutgoingRequestCall extends HTTP::Client::Request::Range, API::CallNode {
+    private class OutgoingRequestCall extends Http::Client::Request::Range, API::CallNode {
       string methodName;
 
       OutgoingRequestCall() {
-        methodName in [HTTP::httpVerbLower(), "request"] and
+        methodName in [Http::httpVerbLower(), "request"] and
         this = instance().getMember(methodName).getACall()
       }
 

--- a/python/ql/lib/semmle/python/frameworks/Django.qll
+++ b/python/ql/lib/semmle/python/frameworks/Django.qll
@@ -2066,7 +2066,8 @@ module PrivateDjango {
 
         /** Gets a reference to the `django.http.response.HttpResponse.write` function. */
         private DataFlow::TypeTrackingNode write(
-          DjangoImpl::DjangoHttp::Response::HttpResponse::InstanceSource instance, DataFlow::TypeTracker t
+          DjangoImpl::DjangoHttp::Response::HttpResponse::InstanceSource instance,
+          DataFlow::TypeTracker t
         ) {
           t.startInAttr("write") and
           instance = DjangoImpl::DjangoHttp::Response::HttpResponse::instance() and

--- a/python/ql/lib/semmle/python/frameworks/Django.qll
+++ b/python/ql/lib/semmle/python/frameworks/Django.qll
@@ -1155,11 +1155,11 @@ module PrivateDjango {
     /** Gets a reference to the `django.http` module. */
     API::Node http() { result = django().getMember("http") }
 
-    /** DEPRECATED: Alias for `Http` */
-    deprecated module http = Http;
+    /** DEPRECATED: Alias for `DjangoHttp` */
+    deprecated module http = DjangoHttp;
 
     /** Provides models for the `django.http` module */
-    module Http {
+    module DjangoHttp {
       // ---------------------------------------------------------------------------
       // django.http.request
       // ---------------------------------------------------------------------------
@@ -1251,7 +1251,7 @@ module PrivateDjango {
               // special handling of the `build_absolute_uri` method, see
               // https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.HttpRequest.build_absolute_uri
               exists(DataFlow::AttrRead attr, DataFlow::CallCfgNode call, DataFlow::Node instance |
-                instance = DjangoImpl::Http::Request::HttpRequest::instance() and
+                instance = DjangoImpl::DjangoHttp::Request::HttpRequest::instance() and
                 attr.getObject() = instance
               |
                 attr.getAttributeName() = "build_absolute_uri" and
@@ -1359,7 +1359,7 @@ module PrivateDjango {
            *
            * Use the predicate `HttpResponse::instance()` to get references to instances of `django.http.response.HttpResponse`.
            */
-          abstract class InstanceSource extends HTTP::Server::HttpResponse::Range, DataFlow::Node {
+          abstract class InstanceSource extends Http::Server::HttpResponse::Range, DataFlow::Node {
           }
 
           /** A direct instantiation of `django.http.response.HttpResponse`. */
@@ -1421,7 +1421,7 @@ module PrivateDjango {
            * Use the predicate `HttpResponseRedirect::instance()` to get references to instances of `django.http.response.HttpResponseRedirect`.
            */
           abstract class InstanceSource extends HttpResponse::InstanceSource,
-            HTTP::Server::HttpRedirectResponse::Range, DataFlow::Node { }
+            Http::Server::HttpRedirectResponse::Range, DataFlow::Node { }
 
           /** A direct instantiation of `django.http.response.HttpResponseRedirect`. */
           private class ClassInstantiation extends InstanceSource, DataFlow::CallCfgNode {
@@ -1483,7 +1483,7 @@ module PrivateDjango {
            * Use the predicate `HttpResponsePermanentRedirect::instance()` to get references to instances of `django.http.response.HttpResponsePermanentRedirect`.
            */
           abstract class InstanceSource extends HttpResponse::InstanceSource,
-            HTTP::Server::HttpRedirectResponse::Range, DataFlow::Node { }
+            Http::Server::HttpRedirectResponse::Range, DataFlow::Node { }
 
           /** A direct instantiation of `django.http.response.HttpResponsePermanentRedirect`. */
           private class ClassInstantiation extends InstanceSource, DataFlow::CallCfgNode {
@@ -2066,17 +2066,17 @@ module PrivateDjango {
 
         /** Gets a reference to the `django.http.response.HttpResponse.write` function. */
         private DataFlow::TypeTrackingNode write(
-          DjangoImpl::Http::Response::HttpResponse::InstanceSource instance, DataFlow::TypeTracker t
+          DjangoImpl::DjangoHttp::Response::HttpResponse::InstanceSource instance, DataFlow::TypeTracker t
         ) {
           t.startInAttr("write") and
-          instance = DjangoImpl::Http::Response::HttpResponse::instance() and
+          instance = DjangoImpl::DjangoHttp::Response::HttpResponse::instance() and
           result = instance
           or
           exists(DataFlow::TypeTracker t2 | result = write(instance, t2).track(t2, t))
         }
 
         /** Gets a reference to the `django.http.response.HttpResponse.write` function. */
-        DataFlow::Node write(DjangoImpl::Http::Response::HttpResponse::InstanceSource instance) {
+        DataFlow::Node write(DjangoImpl::DjangoHttp::Response::HttpResponse::InstanceSource instance) {
           write(instance, DataFlow::TypeTracker::end()).flowsTo(result)
         }
 
@@ -2085,8 +2085,8 @@ module PrivateDjango {
          *
          * See https://docs.djangoproject.com/en/3.1/ref/request-response/#django.http.HttpResponse.write
          */
-        class HttpResponseWriteCall extends HTTP::Server::HttpResponse::Range, DataFlow::CallCfgNode {
-          DjangoImpl::Http::Response::HttpResponse::InstanceSource instance;
+        class HttpResponseWriteCall extends Http::Server::HttpResponse::Range, DataFlow::CallCfgNode {
+          DjangoImpl::DjangoHttp::Response::HttpResponse::InstanceSource instance;
 
           HttpResponseWriteCall() { this.getFunction() = write(instance) }
 
@@ -2104,10 +2104,10 @@ module PrivateDjango {
         /**
          * A call to `set_cookie` on a HTTP Response.
          */
-        class DjangoResponseSetCookieCall extends HTTP::Server::CookieWrite::Range,
+        class DjangoResponseSetCookieCall extends Http::Server::CookieWrite::Range,
           DataFlow::MethodCallNode {
           DjangoResponseSetCookieCall() {
-            this.calls(DjangoImpl::Http::Response::HttpResponse::instance(), "set_cookie")
+            this.calls(DjangoImpl::DjangoHttp::Response::HttpResponse::instance(), "set_cookie")
           }
 
           override DataFlow::Node getHeaderArg() { none() }
@@ -2124,10 +2124,10 @@ module PrivateDjango {
         /**
          * A call to `delete_cookie` on a HTTP Response.
          */
-        class DjangoResponseDeleteCookieCall extends HTTP::Server::CookieWrite::Range,
+        class DjangoResponseDeleteCookieCall extends Http::Server::CookieWrite::Range,
           DataFlow::MethodCallNode {
           DjangoResponseDeleteCookieCall() {
-            this.calls(DjangoImpl::Http::Response::HttpResponse::instance(), "delete_cookie")
+            this.calls(DjangoImpl::DjangoHttp::Response::HttpResponse::instance(), "delete_cookie")
           }
 
           override DataFlow::Node getHeaderArg() { none() }
@@ -2143,7 +2143,7 @@ module PrivateDjango {
          * A dict-like write to an item of the `cookies` attribute on a HTTP response, such as
          * `response.cookies[name] = value`.
          */
-        class DjangoResponseCookieSubscriptWrite extends HTTP::Server::CookieWrite::Range {
+        class DjangoResponseCookieSubscriptWrite extends Http::Server::CookieWrite::Range {
           DataFlow::Node index;
           DataFlow::Node value;
 
@@ -2154,7 +2154,7 @@ module PrivateDjango {
               this.asCfgNode() = subscript
             |
               cookieLookup.getAttributeName() = "cookies" and
-              cookieLookup.getObject() = DjangoImpl::Http::Response::HttpResponse::instance() and
+              cookieLookup.getObject() = DjangoImpl::DjangoHttp::Response::HttpResponse::instance() and
               exists(DataFlow::Node subscriptObj |
                 subscriptObj.asCfgNode() = subscript.getObject()
               |
@@ -2315,7 +2315,7 @@ module PrivateDjango {
       // points-to and `.lookup`, which would handle `post = my_post_handler` inside class def
       result = this.getAMethod() and
       (
-        result.getName() = HTTP::httpVerbLower()
+        result.getName() = Http::httpVerbLower()
         or
         result.getName() = "get_redirect_url"
       )
@@ -2410,7 +2410,7 @@ module PrivateDjango {
   }
 
   /** A data-flow node that sets up a route on a server, using the django framework. */
-  abstract class DjangoRouteSetup extends HTTP::Server::RouteSetup::Range, DataFlow::CfgNode {
+  abstract class DjangoRouteSetup extends Http::Server::RouteSetup::Range, DataFlow::CfgNode {
     /** Gets the data-flow node that is used as the argument for the view handler. */
     abstract DataFlow::Node getViewArg();
 
@@ -2427,7 +2427,7 @@ module PrivateDjango {
   }
 
   /** A request handler defined in a django view class, that has no known route. */
-  private class DjangoViewClassHandlerWithoutKnownRoute extends HTTP::Server::RequestHandler::Range,
+  private class DjangoViewClassHandlerWithoutKnownRoute extends Http::Server::RequestHandler::Range,
     DjangoRouteHandler {
     DjangoViewClassHandlerWithoutKnownRoute() {
       exists(DjangoViewClass vc | vc.getARequestHandler() = this) and
@@ -2586,7 +2586,7 @@ module PrivateDjango {
   // HttpRequest taint modeling
   // ---------------------------------------------------------------------------
   /** A parameter that will receive the django `HttpRequest` instance when a request handler is invoked. */
-  private class DjangoRequestHandlerRequestParam extends DjangoImpl::Http::Request::HttpRequest::InstanceSource,
+  private class DjangoRequestHandlerRequestParam extends DjangoImpl::DjangoHttp::Request::HttpRequest::InstanceSource,
     RemoteFlowSource::Range, DataFlow::ParameterNode {
     DjangoRequestHandlerRequestParam() {
       this.getParameter() = any(DjangoRouteSetup setup).getARequestHandler().getRequestParam()
@@ -2603,7 +2603,7 @@ module PrivateDjango {
    *
    * See https://docs.djangoproject.com/en/3.1/topics/class-based-views/generic-display/#dynamic-filtering
    */
-  private class DjangoViewClassRequestAttributeRead extends DjangoImpl::Http::Request::HttpRequest::InstanceSource,
+  private class DjangoViewClassRequestAttributeRead extends DjangoImpl::DjangoHttp::Request::HttpRequest::InstanceSource,
     RemoteFlowSource::Range, DataFlow::Node {
     DjangoViewClassRequestAttributeRead() {
       exists(DataFlow::AttrRead read | this = read |
@@ -2678,7 +2678,7 @@ module PrivateDjango {
    *
    * See https://docs.djangoproject.com/en/3.1/topics/http/shortcuts/#redirect
    */
-  private class DjangoShortcutsRedirectCall extends HTTP::Server::HttpRedirectResponse::Range,
+  private class DjangoShortcutsRedirectCall extends Http::Server::HttpRedirectResponse::Range,
     DataFlow::CallCfgNode {
     DjangoShortcutsRedirectCall() { this = DjangoImpl::Shortcuts::redirect().getACall() }
 
@@ -2712,7 +2712,7 @@ module PrivateDjango {
    *
    * See https://docs.djangoproject.com/en/3.1/ref/class-based-views/base/#redirectview
    */
-  private class DjangoRedirectViewGetRedirectUrlReturn extends HTTP::Server::HttpRedirectResponse::Range,
+  private class DjangoRedirectViewGetRedirectUrlReturn extends Http::Server::HttpRedirectResponse::Range,
     DataFlow::CfgNode {
     DjangoRedirectViewGetRedirectUrlReturn() {
       node = any(GetRedirectUrlFunction f).getAReturnValueFlowNode()
@@ -2751,7 +2751,7 @@ module PrivateDjango {
   /**
    * A custom middleware stack
    */
-  private class DjangoSettingsMiddlewareStack extends HTTP::Server::CsrfProtectionSetting::Range {
+  private class DjangoSettingsMiddlewareStack extends Http::Server::CsrfProtectionSetting::Range {
     List list;
 
     DjangoSettingsMiddlewareStack() {
@@ -2787,7 +2787,7 @@ module PrivateDjango {
     }
   }
 
-  private class DjangoCsrfDecorator extends HTTP::Server::CsrfLocalProtectionSetting::Range {
+  private class DjangoCsrfDecorator extends Http::Server::CsrfLocalProtectionSetting::Range {
     string decoratorName;
     Function function;
 

--- a/python/ql/lib/semmle/python/frameworks/FastApi.qll
+++ b/python/ql/lib/semmle/python/frameworks/FastApi.qll
@@ -48,10 +48,10 @@ private module FastApi {
    *
    * See https://fastapi.tiangolo.com/tutorial/first-steps/#define-a-path-operation-decorator
    */
-  private class FastApiRouteSetup extends HTTP::Server::RouteSetup::Range, DataFlow::CallCfgNode {
+  private class FastApiRouteSetup extends Http::Server::RouteSetup::Range, DataFlow::CallCfgNode {
     FastApiRouteSetup() {
       exists(string routeAddingMethod |
-        routeAddingMethod = HTTP::httpVerbLower()
+        routeAddingMethod = Http::httpVerbLower()
         or
         routeAddingMethod in ["api_route", "websocket"]
       |
@@ -195,7 +195,7 @@ private module FastApi {
     abstract class InstanceSource extends DataFlow::LocalSourceNode { }
 
     /** A direct instantiation of a response class. */
-    private class ResponseInstantiation extends InstanceSource, HTTP::Server::HttpResponse::Range,
+    private class ResponseInstantiation extends InstanceSource, Http::Server::HttpResponse::Range,
       DataFlow::CallCfgNode {
       API::Node baseApiNode;
       API::Node responseClass;
@@ -223,7 +223,7 @@ private module FastApi {
      * A direct instantiation of a redirect response.
      */
     private class RedirectResponseInstantiation extends ResponseInstantiation,
-      HTTP::Server::HttpRedirectResponse::Range {
+      Http::Server::HttpRedirectResponse::Range {
       RedirectResponseInstantiation() { baseApiNode = getModeledResponseClass("RedirectResponse") }
 
       override DataFlow::Node getRedirectLocation() {
@@ -245,7 +245,7 @@ private module FastApi {
     /**
      * An implicit response from a return of FastAPI request handler.
      */
-    private class FastApiRequestHandlerReturn extends HTTP::Server::HttpResponse::Range,
+    private class FastApiRequestHandlerReturn extends Http::Server::HttpResponse::Range,
       DataFlow::CfgNode {
       FastApiRouteSetup routeSetup;
 
@@ -291,7 +291,7 @@ private module FastApi {
      * `response_class` set to a `RedirectResponse`.
      */
     private class FastApiRequestHandlerRedirectReturn extends FastApiRequestHandlerReturn,
-      HTTP::Server::HttpRedirectResponse::Range {
+      Http::Server::HttpRedirectResponse::Range {
       FastApiRequestHandlerRedirectReturn() {
         exists(API::Node responseClass |
           responseClass.getAValueReachableFromSource() = routeSetup.getResponseClassArg() and
@@ -332,7 +332,7 @@ private module FastApi {
     /**
      * A call to `set_cookie` on a FastAPI Response.
      */
-    private class SetCookieCall extends HTTP::Server::CookieWrite::Range, DataFlow::MethodCallNode {
+    private class SetCookieCall extends Http::Server::CookieWrite::Range, DataFlow::MethodCallNode {
       SetCookieCall() { this.calls(instance(), "set_cookie") }
 
       override DataFlow::Node getHeaderArg() { none() }
@@ -348,7 +348,7 @@ private module FastApi {
      * A call to `append` on a `headers` of a FastAPI Response, with the `Set-Cookie`
      * header-key.
      */
-    private class HeadersAppendCookie extends HTTP::Server::CookieWrite::Range,
+    private class HeadersAppendCookie extends Http::Server::CookieWrite::Range,
       DataFlow::MethodCallNode {
       HeadersAppendCookie() {
         exists(DataFlow::AttrRead headers, DataFlow::Node keyArg |

--- a/python/ql/lib/semmle/python/frameworks/Flask.qll
+++ b/python/ql/lib/semmle/python/frameworks/Flask.qll
@@ -116,7 +116,7 @@ module Flask {
      *
      * Use the predicate `Response::instance()` to get references to instances of `flask.Response`.
      */
-    abstract class InstanceSource extends HTTP::Server::HttpResponse::Range, DataFlow::Node { }
+    abstract class InstanceSource extends Http::Server::HttpResponse::Range, DataFlow::Node { }
 
     /** A direct instantiation of `flask.Response`. */
     private class ClassInstantiation extends InstanceSource, DataFlow::CallCfgNode {
@@ -229,7 +229,7 @@ module Flask {
       // TODO: This doesn't handle attribute assignment. Should be OK, but analysis is not as complete as with
       // points-to and `.lookup`, which would handle `post = my_post_handler` inside class def
       result = this.getAMethod() and
-      result.getName() = HTTP::httpVerbLower()
+      result.getName() = Http::httpVerbLower()
     }
   }
 
@@ -241,7 +241,7 @@ module Flask {
   }
 
   /** A route setup made by flask (sharing handling of URL patterns). */
-  abstract class FlaskRouteSetup extends HTTP::Server::RouteSetup::Range {
+  abstract class FlaskRouteSetup extends Http::Server::RouteSetup::Range {
     override Parameter getARoutedParameter() {
       // If we don't know the URL pattern, we simply mark all parameters as a routed
       // parameter. This should give us more RemoteFlowSources but could also lead to
@@ -312,7 +312,7 @@ module Flask {
   }
 
   /** A request handler defined in a django view class, that has no known route. */
-  private class FlaskViewClassHandlerWithoutKnownRoute extends HTTP::Server::RequestHandler::Range {
+  private class FlaskViewClassHandlerWithoutKnownRoute extends Http::Server::RequestHandler::Range {
     FlaskViewClassHandlerWithoutKnownRoute() {
       exists(FlaskViewClass vc | vc.getARequestHandler() = this) and
       not exists(FlaskRouteSetup setup | setup.getARequestHandler() = this)
@@ -439,7 +439,7 @@ module Flask {
   // ---------------------------------------------------------------------------
   // Implicit response from returns of flask request handlers
   // ---------------------------------------------------------------------------
-  private class FlaskRouteHandlerReturn extends HTTP::Server::HttpResponse::Range, DataFlow::CfgNode {
+  private class FlaskRouteHandlerReturn extends Http::Server::HttpResponse::Range, DataFlow::CfgNode {
     FlaskRouteHandlerReturn() {
       exists(Function routeHandler |
         routeHandler = any(FlaskRouteSetup rs).getARequestHandler() and
@@ -462,7 +462,7 @@ module Flask {
    *
    * See https://flask.palletsprojects.com/en/1.1.x/api/#flask.redirect
    */
-  private class FlaskRedirectCall extends HTTP::Server::HttpRedirectResponse::Range,
+  private class FlaskRedirectCall extends Http::Server::HttpRedirectResponse::Range,
     DataFlow::CallCfgNode {
     FlaskRedirectCall() { this = API::moduleImport("flask").getMember("redirect").getACall() }
 
@@ -490,7 +490,7 @@ module Flask {
    *
    * See https://flask.palletsprojects.com/en/2.0.x/api/#flask.Response.set_cookie
    */
-  class FlaskResponseSetCookieCall extends HTTP::Server::CookieWrite::Range,
+  class FlaskResponseSetCookieCall extends Http::Server::CookieWrite::Range,
     DataFlow::MethodCallNode {
     FlaskResponseSetCookieCall() { this.calls(Flask::Response::instance(), "set_cookie") }
 
@@ -506,7 +506,7 @@ module Flask {
    *
    * See https://flask.palletsprojects.com/en/2.0.x/api/#flask.Response.delete_cookie
    */
-  class FlaskResponseDeleteCookieCall extends HTTP::Server::CookieWrite::Range,
+  class FlaskResponseDeleteCookieCall extends Http::Server::CookieWrite::Range,
     DataFlow::MethodCallNode {
     FlaskResponseDeleteCookieCall() { this.calls(Flask::Response::instance(), "delete_cookie") }
 

--- a/python/ql/lib/semmle/python/frameworks/Httpx.qll
+++ b/python/ql/lib/semmle/python/frameworks/Httpx.qll
@@ -23,11 +23,11 @@ private module HttpxModel {
    *
    * See https://www.python-httpx.org/api/
    */
-  private class RequestCall extends HTTP::Client::Request::Range, API::CallNode {
+  private class RequestCall extends Http::Client::Request::Range, API::CallNode {
     string methodName;
 
     RequestCall() {
-      methodName in [HTTP::httpVerbLower(), "request", "stream"] and
+      methodName in [Http::httpVerbLower(), "request", "stream"] and
       this = API::moduleImport("httpx").getMember(methodName).getACall()
     }
 
@@ -64,11 +64,11 @@ private module HttpxModel {
     }
 
     /** A method call on a Client that sends off a request */
-    private class OutgoingRequestCall extends HTTP::Client::Request::Range, DataFlow::CallCfgNode {
+    private class OutgoingRequestCall extends Http::Client::Request::Range, DataFlow::CallCfgNode {
       string methodName;
 
       OutgoingRequestCall() {
-        methodName in [HTTP::httpVerbLower(), "request", "stream"] and
+        methodName in [Http::httpVerbLower(), "request", "stream"] and
         this = classRef().getReturn().getMember(methodName).getACall()
       }
 

--- a/python/ql/lib/semmle/python/frameworks/Ldap.qll
+++ b/python/ql/lib/semmle/python/frameworks/Ldap.qll
@@ -13,13 +13,13 @@ private import semmle.python.ApiGraphs
  *
  * See https://www.python-ldap.org/en/python-ldap-3.3.0/index.html
  */
-private module Ldap {
+private module PythonLdap {
   /**
    * The execution of an `ldap` query.
    *
    * See https://www.python-ldap.org/en/python-ldap-3.3.0/reference/ldap.html#functions
    */
-  private class LdapQueryExecution extends DataFlow::CallCfgNode, LDAP::LdapExecution::Range {
+  private class LdapQueryExecution extends DataFlow::CallCfgNode, Ldap::LdapExecution::Range {
     LdapQueryExecution() {
       this =
         API::moduleImport("ldap")

--- a/python/ql/lib/semmle/python/frameworks/Ldap3.qll
+++ b/python/ql/lib/semmle/python/frameworks/Ldap3.qll
@@ -15,7 +15,7 @@ private import semmle.python.ApiGraphs
  */
 private module Ldap3 {
   /** The execution of an `ldap` query. */
-  private class LdapQueryExecution extends DataFlow::CallCfgNode, LDAP::LdapExecution::Range {
+  private class LdapQueryExecution extends DataFlow::CallCfgNode, Ldap::LdapExecution::Range {
     LdapQueryExecution() {
       this =
         API::moduleImport("ldap3")

--- a/python/ql/lib/semmle/python/frameworks/Libtaxii.qll
+++ b/python/ql/lib/semmle/python/frameworks/Libtaxii.qll
@@ -22,7 +22,7 @@ private module Libtaxii {
    * A call to `libtaxii.common.parse`.
    * When the `allow_url` parameter value is set to `True`, there is an SSRF vulnerability..
    */
-  private class ParseCall extends HTTP::Client::Request::Range, DataFlow::CallCfgNode {
+  private class ParseCall extends Http::Client::Request::Range, DataFlow::CallCfgNode {
     ParseCall() {
       this = API::moduleImport("libtaxii").getMember("common").getMember("parse").getACall() and
       this.getArgByName("allow_url").getALocalSource().asExpr() = any(True t)

--- a/python/ql/lib/semmle/python/frameworks/Multidict.qll
+++ b/python/ql/lib/semmle/python/frameworks/Multidict.qll
@@ -16,7 +16,7 @@ private import semmle.python.frameworks.internal.InstanceTaintStepsHelper
  * Provides models for the `multidict` PyPI package.
  * See https://multidict.readthedocs.io/en/stable/.
  */
-module Multidict {
+module MultiDict {
   /**
    * Provides models for a `MultiDictProxy` class:
    * - `multidict.MultiDictProxy`
@@ -88,3 +88,6 @@ module Multidict {
     }
   }
 }
+
+/** DEPRECATED: Alias for MultiDict */
+deprecated module Multidict = MultiDict;

--- a/python/ql/lib/semmle/python/frameworks/Multidict.qll
+++ b/python/ql/lib/semmle/python/frameworks/Multidict.qll
@@ -16,7 +16,7 @@ private import semmle.python.frameworks.internal.InstanceTaintStepsHelper
  * Provides models for the `multidict` PyPI package.
  * See https://multidict.readthedocs.io/en/stable/.
  */
-module MultiDict {
+module Multidict {
   /**
    * Provides models for a `MultiDictProxy` class:
    * - `multidict.MultiDictProxy`
@@ -88,6 +88,3 @@ module MultiDict {
     }
   }
 }
-
-/** DEPRECATED: Alias for MultiDict */
-deprecated module Multidict = MultiDict;

--- a/python/ql/lib/semmle/python/frameworks/Pycurl.qll
+++ b/python/ql/lib/semmle/python/frameworks/Pycurl.qll
@@ -36,7 +36,7 @@ private module Pycurl {
      *
      * See http://pycurl.io/docs/latest/curlobject.html#pycurl.Curl.setopt.
      */
-    private class OutgoingRequestCall extends HTTP::Client::Request::Range, DataFlow::CallCfgNode {
+    private class OutgoingRequestCall extends Http::Client::Request::Range, DataFlow::CallCfgNode {
       OutgoingRequestCall() {
         this = instance().getMember("setopt").getACall() and
         this.getArg(0).asCfgNode().(AttrNode).getName() = "URL"

--- a/python/ql/lib/semmle/python/frameworks/Requests.qll
+++ b/python/ql/lib/semmle/python/frameworks/Requests.qll
@@ -28,11 +28,11 @@ private module Requests {
    *
    * See https://requests.readthedocs.io/en/latest/api/#requests.request
    */
-  private class OutgoingRequestCall extends HTTP::Client::Request::Range, API::CallNode {
+  private class OutgoingRequestCall extends Http::Client::Request::Range, API::CallNode {
     string methodName;
 
     OutgoingRequestCall() {
-      methodName in [HTTP::httpVerbLower(), "request"] and
+      methodName in [Http::httpVerbLower(), "request"] and
       (
         this = API::moduleImport("requests").getMember(methodName).getACall()
         or

--- a/python/ql/lib/semmle/python/frameworks/RestFramework.qll
+++ b/python/ql/lib/semmle/python/frameworks/RestFramework.qll
@@ -158,7 +158,7 @@ private module RestFramework {
    * `HTTP::Server::RequestHandler`. We only need this for the ones that doesn't have a
    * known route setup.
    */
-  class RestFrameworkFunctionBasedViewWithoutKnownRoute extends HTTP::Server::RequestHandler::Range,
+  class RestFrameworkFunctionBasedViewWithoutKnownRoute extends Http::Server::RequestHandler::Range,
     PrivateDjango::DjangoRouteHandler instanceof RestFrameworkFunctionBasedView {
     RestFrameworkFunctionBasedViewWithoutKnownRoute() {
       not exists(PrivateDjango::DjangoRouteSetup setup | setup.getARequestHandler() = this)
@@ -220,7 +220,7 @@ private module RestFramework {
      *
      * Use the predicate `Request::instance()` to get references to instances of `rest_framework.request.Request`.
      */
-    abstract class InstanceSource extends PrivateDjango::DjangoImpl::Http::Request::HttpRequest::InstanceSource {
+    abstract class InstanceSource extends PrivateDjango::DjangoImpl::DjangoHttp::Request::HttpRequest::InstanceSource {
     }
 
     /** A direct instantiation of `rest_framework.request.Request`. */
@@ -296,7 +296,7 @@ private module RestFramework {
     }
 
     /** A direct instantiation of `rest_framework.response.Response`. */
-    private class ClassInstantiation extends PrivateDjango::DjangoImpl::Http::Response::HttpResponse::InstanceSource,
+    private class ClassInstantiation extends PrivateDjango::DjangoImpl::DjangoHttp::Response::HttpResponse::InstanceSource,
       DataFlow::CallCfgNode {
       ClassInstantiation() { this = classRef().getACall() }
 
@@ -320,7 +320,7 @@ private module RestFramework {
    */
   module ApiException {
     /** A direct instantiation of `rest_framework.exceptions.ApiException` or subclass. */
-    private class ClassInstantiation extends HTTP::Server::HttpResponse::Range,
+    private class ClassInstantiation extends Http::Server::HttpResponse::Range,
       DataFlow::CallCfgNode {
       string className;
 

--- a/python/ql/lib/semmle/python/frameworks/Starlette.qll
+++ b/python/ql/lib/semmle/python/frameworks/Starlette.qll
@@ -85,7 +85,7 @@ module Starlette {
     }
 
     /** An attribute read on a `starlette.websockets.WebSocket` instance that is a `starlette.requests.URL` instance. */
-    private class UrlInstances extends URL::InstanceSource {
+    private class UrlInstances extends Url::InstanceSource {
       UrlInstances() {
         this.(DataFlow::AttrRead).getObject() = instance() and
         this.(DataFlow::AttrRead).getAttributeName() = "url"
@@ -98,7 +98,7 @@ module Starlette {
    *
    * See the URL part of https://www.starlette.io/websockets/.
    */
-  module URL {
+  module Url {
     /** Gets a reference to the `starlette.requests.URL` class. */
     private API::Node classRef() {
       result = API::moduleImport("starlette").getMember("requests").getMember("URL")
@@ -159,4 +159,7 @@ module Starlette {
       }
     }
   }
+
+  /** DEPRECATED: Alias for Url */
+  deprecated module URL = Url;
 }

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -1877,7 +1877,7 @@ private module StdlibPrivate {
   API::Node http() { result = API::moduleImport("http") }
 
   /** Provides models for the `http` module. */
-  module Http {
+  module StdHttp {
     // -------------------------------------------------------------------------
     // http.server
     // -------------------------------------------------------------------------
@@ -1944,9 +1944,9 @@ private module StdlibPrivate {
           SimpleHttpServer::SimpleHttpRequestHandler::classRef(),
           CgiHttpServer::CgiHttpRequestHandler::classRef(),
           // Python 3
-          Http::Server::BaseHttpRequestHandler::classRef(),
-          Http::Server::SimpleHttpRequestHandler::classRef(),
-          Http::Server::CgiHttpRequestHandler::classRef()
+          StdHttp::Server::BaseHttpRequestHandler::classRef(),
+          StdHttp::Server::SimpleHttpRequestHandler::classRef(),
+          StdHttp::Server::CgiHttpRequestHandler::classRef()
         ].getASubclass*()
     }
 
@@ -2026,10 +2026,10 @@ private module StdlibPrivate {
      *
      * Not essential for any functionality, but provides a consistent modeling.
      */
-    private class RequestHandlerFunc extends HTTP::Server::RequestHandler::Range {
+    private class RequestHandlerFunc extends Http::Server::RequestHandler::Range {
       RequestHandlerFunc() {
         this = any(HttpRequestHandlerClassDef cls).getAMethod() and
-        this.getName() = "do_" + HTTP::httpVerb()
+        this.getName() = "do_" + Http::httpVerb()
       }
 
       override Parameter getARoutedParameter() { none() }
@@ -2064,7 +2064,7 @@ private module StdlibPrivate {
      * See https://github.com/python/cpython/blob/b567b9d74bd9e476a3027335873bb0508d6e450f/Lib/wsgiref/handlers.py#L137
      * for how a request is processed and given to an application.
      */
-    class WsgirefSimpleServerApplication extends HTTP::Server::RequestHandler::Range {
+    class WsgirefSimpleServerApplication extends Http::Server::RequestHandler::Range {
       WsgirefSimpleServerApplication() {
         exists(DataFlow::Node appArg, DataFlow::CallCfgNode setAppCall |
           (
@@ -2166,7 +2166,7 @@ private module StdlibPrivate {
      *
      * See https://github.com/python/cpython/blob/b567b9d74bd9e476a3027335873bb0508d6e450f/Lib/wsgiref/handlers.py#L276
      */
-    class WsgirefSimpleServerApplicationWriteCall extends HTTP::Server::HttpResponse::Range,
+    class WsgirefSimpleServerApplicationWriteCall extends Http::Server::HttpResponse::Range,
       DataFlow::CallCfgNode {
       WsgirefSimpleServerApplicationWriteCall() { this.getFunction() = writeFunction() }
 
@@ -2180,7 +2180,7 @@ private module StdlibPrivate {
     /**
      * A return from a `WsgirefSimpleServerApplication`, which is included in the response body.
      */
-    class WsgirefSimpleServerApplicationReturn extends HTTP::Server::HttpResponse::Range,
+    class WsgirefSimpleServerApplicationReturn extends Http::Server::HttpResponse::Range,
       DataFlow::CfgNode {
       WsgirefSimpleServerApplicationReturn() {
         exists(WsgirefSimpleServerApplication requestHandler |
@@ -2267,7 +2267,7 @@ private module StdlibPrivate {
     }
 
     /** A method call on a HttpConnection that sends off a request */
-    private class RequestCall extends HTTP::Client::Request::Range, DataFlow::MethodCallNode {
+    private class RequestCall extends Http::Client::Request::Range, DataFlow::MethodCallNode {
       RequestCall() { this.calls(instance(_), ["request", "_send_request", "putrequest"]) }
 
       DataFlow::Node getUrlArg() { result in [this.getArg(1), this.getArgByName("url")] }

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -1877,7 +1877,7 @@ private module StdlibPrivate {
   API::Node http() { result = API::moduleImport("http") }
 
   /** Provides models for the `http` module. */
-  module StdHttp {
+  module StdlibHttp {
     // -------------------------------------------------------------------------
     // http.server
     // -------------------------------------------------------------------------

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -1944,9 +1944,9 @@ private module StdlibPrivate {
           SimpleHttpServer::SimpleHttpRequestHandler::classRef(),
           CgiHttpServer::CgiHttpRequestHandler::classRef(),
           // Python 3
-          StdHttp::Server::BaseHttpRequestHandler::classRef(),
-          StdHttp::Server::SimpleHttpRequestHandler::classRef(),
-          StdHttp::Server::CgiHttpRequestHandler::classRef()
+          StdlibHttp::Server::BaseHttpRequestHandler::classRef(),
+          StdlibHttp::Server::SimpleHttpRequestHandler::classRef(),
+          StdlibHttp::Server::CgiHttpRequestHandler::classRef()
         ].getASubclass*()
     }
 

--- a/python/ql/lib/semmle/python/frameworks/Stdlib/Urllib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib/Urllib.qll
@@ -30,7 +30,7 @@ private module Urllib {
      * See
      * - https://docs.python.org/3.9/library/urllib.request.html#urllib.request.Request
      */
-    private class RequestCall extends HTTP::Client::Request::Range, DataFlow::CallCfgNode {
+    private class RequestCall extends Http::Client::Request::Range, DataFlow::CallCfgNode {
       RequestCall() {
         this = API::moduleImport("urllib").getMember("request").getMember("Request").getACall()
       }
@@ -52,7 +52,7 @@ private module Urllib {
      * See
      * - https://docs.python.org/3.9/library/urllib.request.html#urllib.request.urlopen
      */
-    private class UrlOpenCall extends HTTP::Client::Request::Range, DataFlow::CallCfgNode {
+    private class UrlOpenCall extends Http::Client::Request::Range, DataFlow::CallCfgNode {
       UrlOpenCall() {
         this = API::moduleImport("urllib").getMember("request").getMember("urlopen").getACall()
       }

--- a/python/ql/lib/semmle/python/frameworks/Stdlib/Urllib2.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib/Urllib2.qll
@@ -20,7 +20,7 @@ private module Urllib2 {
    * See
    * - https://docs.python.org/2/library/urllib2.html#urllib2.Request
    */
-  private class RequestCall extends HTTP::Client::Request::Range, DataFlow::CallCfgNode {
+  private class RequestCall extends Http::Client::Request::Range, DataFlow::CallCfgNode {
     RequestCall() { this = API::moduleImport("urllib2").getMember("Request").getACall() }
 
     override DataFlow::Node getAUrlPart() { result in [this.getArg(0), this.getArgByName("url")] }
@@ -40,7 +40,7 @@ private module Urllib2 {
    * See
    * - https://docs.python.org/2/library/urllib2.html#urllib2.urlopen
    */
-  private class UrlOpenCall extends HTTP::Client::Request::Range, DataFlow::CallCfgNode {
+  private class UrlOpenCall extends Http::Client::Request::Range, DataFlow::CallCfgNode {
     UrlOpenCall() { this = API::moduleImport("urllib2").getMember("urlopen").getACall() }
 
     override DataFlow::Node getAUrlPart() { result in [this.getArg(0), this.getArgByName("url")] }

--- a/python/ql/lib/semmle/python/frameworks/Tornado.qll
+++ b/python/ql/lib/semmle/python/frameworks/Tornado.qll
@@ -99,7 +99,7 @@ private module Tornado {
             // TODO: This doesn't handle attribute assignment. Should be OK, but analysis is not as complete as with
             // points-to and `.lookup`, which would handle `post = my_post_handler` inside class def
             result = this.getAMethod() and
-            result.getName() = HTTP::httpVerbLower()
+            result.getName() = Http::httpVerbLower()
           }
 
           /** Gets a reference to this class. */
@@ -375,7 +375,7 @@ private module Tornado {
   }
 
   /** A tornado route setup. */
-  abstract class TornadoRouteSetup extends HTTP::Server::RouteSetup::Range {
+  abstract class TornadoRouteSetup extends Http::Server::RouteSetup::Range {
     override string getFramework() { result = "Tornado" }
   }
 
@@ -437,7 +437,7 @@ private module Tornado {
   }
 
   /** A request handler defined in a tornado RequestHandler class, that has no known route. */
-  private class TornadoRequestHandlerWithoutKnownRoute extends HTTP::Server::RequestHandler::Range {
+  private class TornadoRequestHandlerWithoutKnownRoute extends Http::Server::RequestHandler::Range {
     TornadoRequestHandlerWithoutKnownRoute() {
       exists(TornadoModule::Web::RequestHandler::RequestHandlerClass cls |
         cls.getARequestHandler() = this
@@ -464,7 +464,7 @@ private module Tornado {
    *
    * See https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.redirect
    */
-  private class TornadoRequestHandlerRedirectCall extends HTTP::Server::HttpRedirectResponse::Range,
+  private class TornadoRequestHandlerRedirectCall extends Http::Server::HttpRedirectResponse::Range,
     DataFlow::CallCfgNode {
     TornadoRequestHandlerRedirectCall() {
       this.getFunction() = TornadoModule::Web::RequestHandler::redirectMethod()
@@ -486,7 +486,7 @@ private module Tornado {
    *
    * See https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write
    */
-  private class TornadoRequestHandlerWriteCall extends HTTP::Server::HttpResponse::Range,
+  private class TornadoRequestHandlerWriteCall extends Http::Server::HttpResponse::Range,
     DataFlow::CallCfgNode {
     TornadoRequestHandlerWriteCall() {
       this.getFunction() = TornadoModule::Web::RequestHandler::writeMethod()
@@ -504,7 +504,7 @@ private module Tornado {
    *
    * See https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.set_cookie
    */
-  class TornadoRequestHandlerSetCookieCall extends HTTP::Server::CookieWrite::Range,
+  class TornadoRequestHandlerSetCookieCall extends Http::Server::CookieWrite::Range,
     DataFlow::MethodCallNode {
     TornadoRequestHandlerSetCookieCall() {
       this.calls(TornadoModule::Web::RequestHandler::instance(), "set_cookie")

--- a/python/ql/lib/semmle/python/frameworks/Twisted.qll
+++ b/python/ql/lib/semmle/python/frameworks/Twisted.qll
@@ -60,7 +60,7 @@ private module Twisted {
   }
 
   /** A method that handles incoming requests, on a `twisted.web.resource.Resource` subclass. */
-  class TwistedResourceRequestHandler extends HTTP::Server::RequestHandler::Range {
+  class TwistedResourceRequestHandler extends Http::Server::RequestHandler::Range {
     TwistedResourceRequestHandler() { this = any(TwistedResourceSubclass cls).getARequestHandler() }
 
     Parameter getRequestParameter() { result = this.getArg(getRequestParamIndex(this.getName())) }
@@ -176,7 +176,7 @@ private module Twisted {
   /**
    * Implicit response from returns of render methods.
    */
-  private class TwistedResourceRenderMethodReturn extends HTTP::Server::HttpResponse::Range,
+  private class TwistedResourceRenderMethodReturn extends Http::Server::HttpResponse::Range,
     DataFlow::CfgNode {
     TwistedResourceRenderMethodReturn() {
       this.asCfgNode() = any(TwistedResourceRenderMethod meth).getAReturnValueFlowNode()
@@ -194,7 +194,7 @@ private module Twisted {
    *
    * See https://twistedmatrix.com/documents/21.2.0/api/twisted.web.server.Request.html#write
    */
-  class TwistedRequestWriteCall extends HTTP::Server::HttpResponse::Range, DataFlow::MethodCallNode {
+  class TwistedRequestWriteCall extends Http::Server::HttpResponse::Range, DataFlow::MethodCallNode {
     TwistedRequestWriteCall() { this.calls(Request::instance(), "write") }
 
     override DataFlow::Node getBody() {
@@ -211,7 +211,7 @@ private module Twisted {
    *
    * See https://twistedmatrix.com/documents/21.2.0/api/twisted.web.http.Request.html#redirect
    */
-  class TwistedRequestRedirectCall extends HTTP::Server::HttpRedirectResponse::Range,
+  class TwistedRequestRedirectCall extends Http::Server::HttpRedirectResponse::Range,
     DataFlow::MethodCallNode {
     TwistedRequestRedirectCall() { this.calls(Request::instance(), "redirect") }
 
@@ -231,7 +231,7 @@ private module Twisted {
    *
    * See https://twistedmatrix.com/documents/21.2.0/api/twisted.web.http.Request.html#addCookie
    */
-  class TwistedRequestAddCookieCall extends HTTP::Server::CookieWrite::Range,
+  class TwistedRequestAddCookieCall extends Http::Server::CookieWrite::Range,
     DataFlow::MethodCallNode {
     TwistedRequestAddCookieCall() { this.calls(Twisted::Request::instance(), "addCookie") }
 
@@ -247,7 +247,7 @@ private module Twisted {
    *
    * See https://twistedmatrix.com/documents/21.2.0/api/twisted.web.http.Request.html#cookies
    */
-  class TwistedRequestCookiesAppendCall extends HTTP::Server::CookieWrite::Range,
+  class TwistedRequestCookiesAppendCall extends Http::Server::CookieWrite::Range,
     DataFlow::MethodCallNode {
     TwistedRequestCookiesAppendCall() {
       exists(DataFlow::AttrRead cookiesLookup |

--- a/python/ql/lib/semmle/python/frameworks/Urllib3.qll
+++ b/python/ql/lib/semmle/python/frameworks/Urllib3.qll
@@ -49,7 +49,7 @@ private module Urllib3 {
      * - https://urllib3.readthedocs.io/en/stable/reference/urllib3.request.html#urllib3.request.RequestMethods
      * - https://urllib3.readthedocs.io/en/stable/reference/urllib3.connectionpool.html#urllib3.HTTPConnectionPool.urlopen
      */
-    private class RequestCall extends HTTP::Client::Request::Range, API::CallNode {
+    private class RequestCall extends Http::Client::Request::Range, API::CallNode {
       RequestCall() {
         this =
           classRef()

--- a/python/ql/lib/semmle/python/frameworks/Yarl.qll
+++ b/python/ql/lib/semmle/python/frameworks/Yarl.qll
@@ -102,7 +102,7 @@ module Yarl {
     }
 
     /** An attribute read on a `yarl.URL` that is a `MultiDictProxy` instance. */
-    class YarlUrlMultiDictProxyInstance extends Multidict::MultiDictProxy::InstanceSource {
+    class YarlUrlMultiDictProxyInstance extends MultiDict::MultiDictProxy::InstanceSource {
       YarlUrlMultiDictProxyInstance() {
         this.(DataFlow::AttrRead).getObject() = Yarl::Url::instance() and
         this.(DataFlow::AttrRead).getAttributeName() = "query"

--- a/python/ql/lib/semmle/python/frameworks/Yarl.qll
+++ b/python/ql/lib/semmle/python/frameworks/Yarl.qll
@@ -102,7 +102,7 @@ module Yarl {
     }
 
     /** An attribute read on a `yarl.URL` that is a `MultiDictProxy` instance. */
-    class YarlUrlMultiDictProxyInstance extends MultiDict::MultiDictProxy::InstanceSource {
+    class YarlUrlMultiDictProxyInstance extends Multidict::MultiDictProxy::InstanceSource {
       YarlUrlMultiDictProxyInstance() {
         this.(DataFlow::AttrRead).getObject() = Yarl::Url::instance() and
         this.(DataFlow::AttrRead).getAttributeName() = "query"

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
@@ -56,7 +56,7 @@ module CleartextStorage {
   /** The data written to a cookie on a HTTP response, considered as a flow sink. */
   class CookieWriteAsSink extends Sink {
     CookieWriteAsSink() {
-      exists(HTTP::Server::CookieWrite write |
+      exists(Http::Server::CookieWrite write |
         this = write.getValueArg()
         or
         this = write.getHeaderArg()

--- a/python/ql/lib/semmle/python/security/dataflow/LdapInjectionCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/LdapInjectionCustomizations.qll
@@ -64,14 +64,14 @@ module LdapInjection {
    * A logging operation, considered as a flow sink.
    */
   class LdapExecutionAsDnSink extends DnSink {
-    LdapExecutionAsDnSink() { this = any(LDAP::LdapExecution ldap).getBaseDn() }
+    LdapExecutionAsDnSink() { this = any(Ldap::LdapExecution ldap).getBaseDn() }
   }
 
   /**
    * A logging operation, considered as a flow sink.
    */
   class LdapExecutionAsFilterSink extends FilterSink {
-    LdapExecutionAsFilterSink() { this = any(LDAP::LdapExecution ldap).getFilter() }
+    LdapExecutionAsFilterSink() { this = any(Ldap::LdapExecution ldap).getFilter() }
   }
 
   /**

--- a/python/ql/lib/semmle/python/security/dataflow/ReflectedXSSCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/ReflectedXSSCustomizations.qll
@@ -48,7 +48,7 @@ module ReflectedXss {
    */
   class ServerHttpResponseBodyAsSink extends Sink {
     ServerHttpResponseBodyAsSink() {
-      exists(HTTP::Server::HttpResponse response |
+      exists(Http::Server::HttpResponse response |
         response.getMimetype().toLowerCase() = "text/html" and
         this = response.getBody()
       )

--- a/python/ql/lib/semmle/python/security/dataflow/ServerSideRequestForgeryCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/ServerSideRequestForgeryCustomizations.qll
@@ -28,7 +28,7 @@ module ServerSideRequestForgery {
     /**
      * Gets the request this sink belongs to.
      */
-    abstract HTTP::Client::Request getRequest();
+    abstract Http::Client::Request getRequest();
   }
 
   /**
@@ -57,7 +57,7 @@ module ServerSideRequestForgery {
 
   /** The URL of an HTTP request, considered as a sink. */
   class HttpRequestUrlAsSink extends Sink {
-    HTTP::Client::Request req;
+    Http::Client::Request req;
 
     HttpRequestUrlAsSink() {
       req.getAUrlPart() = this and
@@ -74,7 +74,7 @@ module ServerSideRequestForgery {
       not req.getScope().getEnclosingModule().getName() in ["http.client", "httplib"]
     }
 
-    override HTTP::Client::Request getRequest() { result = req }
+    override Http::Client::Request getRequest() { result = req }
   }
 
   /**

--- a/python/ql/lib/semmle/python/security/dataflow/ServerSideRequestForgeryQuery.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/ServerSideRequestForgeryQuery.qll
@@ -42,7 +42,7 @@ class FullServerSideRequestForgeryConfiguration extends TaintTracking::Configura
 /**
  * Holds if all URL parts of `request` is fully user controlled.
  */
-predicate fullyControlledRequest(HTTP::Client::Request request) {
+predicate fullyControlledRequest(Http::Client::Request request) {
   exists(FullServerSideRequestForgeryConfiguration fullConfig |
     forall(DataFlow::Node urlPart | urlPart = request.getAUrlPart() |
       fullConfig.hasFlow(_, urlPart)

--- a/python/ql/lib/semmle/python/security/dataflow/StackTraceExposureCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/StackTraceExposureCustomizations.qll
@@ -49,6 +49,6 @@ module StackTraceExposure {
    * The body of a HTTP response that will be returned from a server, considered as a flow sink.
    */
   class ServerHttpResponseBodyAsSink extends Sink {
-    ServerHttpResponseBodyAsSink() { this = any(HTTP::Server::HttpResponse response).getBody() }
+    ServerHttpResponseBodyAsSink() { this = any(Http::Server::HttpResponse response).getBody() }
   }
 }

--- a/python/ql/lib/semmle/python/security/dataflow/UrlRedirectCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/UrlRedirectCustomizations.qll
@@ -48,7 +48,7 @@ module UrlRedirect {
    */
   class RedirectLocationAsSink extends Sink {
     RedirectLocationAsSink() {
-      this = any(HTTP::Server::HttpRedirectResponse e).getRedirectLocation()
+      this = any(Http::Server::HttpRedirectResponse e).getRedirectLocation()
     }
   }
 

--- a/python/ql/src/Security/CWE-295/RequestWithoutValidation.ql
+++ b/python/ql/src/Security/CWE-295/RequestWithoutValidation.ql
@@ -15,7 +15,7 @@ private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.Concepts
 
 from
-  HTTP::Client::Request request, DataFlow::Node disablingNode, DataFlow::Node origin, string ending
+  Http::Client::Request request, DataFlow::Node disablingNode, DataFlow::Node origin, string ending
 where
   request.disablesCertificateValidation(disablingNode, origin) and
   // Showing the origin is only useful when it's a different node than the one disabling

--- a/python/ql/src/Security/CWE-352/CSRFProtectionDisabled.ql
+++ b/python/ql/src/Security/CWE-352/CSRFProtectionDisabled.ql
@@ -14,24 +14,24 @@
 import python
 import semmle.python.Concepts
 
-predicate relevantSetting(HTTP::Server::CsrfProtectionSetting s) {
+predicate relevantSetting(Http::Server::CsrfProtectionSetting s) {
   // rule out test code as this is a common place to turn off CSRF protection.
   // We don't use normal `TestScope` to find test files, since we also want to match
   // a settings file such as `.../integration-tests/settings.py`
   not s.getLocation().getFile().getAbsolutePath().matches("%test%")
 }
 
-predicate vulnerableSetting(HTTP::Server::CsrfProtectionSetting s) {
+predicate vulnerableSetting(Http::Server::CsrfProtectionSetting s) {
   s.getVerificationSetting() = false and
-  not exists(HTTP::Server::CsrfLocalProtectionSetting p | p.csrfEnabled()) and
+  not exists(Http::Server::CsrfLocalProtectionSetting p | p.csrfEnabled()) and
   relevantSetting(s)
 }
 
-from HTTP::Server::CsrfProtectionSetting setting
+from Http::Server::CsrfProtectionSetting setting
 where
   vulnerableSetting(setting) and
   // We have seen examples of dummy projects with vulnerable settings alongside a main
   // project with a protecting settings file. We want to rule out this scenario, so we
   // require all non-test settings to be vulnerable.
-  forall(HTTP::Server::CsrfProtectionSetting s | relevantSetting(s) | vulnerableSetting(s))
+  forall(Http::Server::CsrfProtectionSetting s | relevantSetting(s) | vulnerableSetting(s))
 select setting, "Potential CSRF vulnerability due to forgery protection being disabled or weakened."

--- a/python/ql/src/Security/CWE-918/FullServerSideRequestForgery.ql
+++ b/python/ql/src/Security/CWE-918/FullServerSideRequestForgery.ql
@@ -16,7 +16,7 @@ import DataFlow::PathGraph
 
 from
   FullServerSideRequestForgeryConfiguration fullConfig, DataFlow::PathNode source,
-  DataFlow::PathNode sink, HTTP::Client::Request request
+  DataFlow::PathNode sink, Http::Client::Request request
 where
   request = sink.getNode().(Sink).getRequest() and
   fullConfig.hasFlowPath(source, sink) and

--- a/python/ql/src/Security/CWE-918/PartialServerSideRequestForgery.ql
+++ b/python/ql/src/Security/CWE-918/PartialServerSideRequestForgery.ql
@@ -16,7 +16,7 @@ import DataFlow::PathGraph
 
 from
   PartialServerSideRequestForgeryConfiguration partialConfig, DataFlow::PathNode source,
-  DataFlow::PathNode sink, HTTP::Client::Request request
+  DataFlow::PathNode sink, Http::Client::Request request
 where
   request = sink.getNode().(Sink).getRequest() and
   partialConfig.hasFlowPath(source, sink) and

--- a/python/ql/src/experimental/semmle/python/Concepts.qll
+++ b/python/ql/src/experimental/semmle/python/Concepts.qll
@@ -416,7 +416,7 @@ class CsvWriter extends DataFlow::Node {
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `Cookie::Range` instead.
  */
-class Cookie extends HTTP::Server::CookieWrite instanceof Cookie::Range {
+class Cookie extends Http::Server::CookieWrite instanceof Cookie::Range {
   /**
    * Holds if this cookie is secure.
    */
@@ -441,7 +441,7 @@ module Cookie {
    * Extend this class to model new APIs. If you want to refine existing API models,
    * extend `Cookie` instead.
    */
-  abstract class Range extends HTTP::Server::CookieWrite::Range {
+  abstract class Range extends Http::Server::CookieWrite::Range {
     /**
      * Holds if this cookie is secure.
      */

--- a/python/ql/src/experimental/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Django.qll
@@ -15,7 +15,7 @@ private module ExperimentalPrivateDjango {
   private module DjangoMod {
     API::Node http() { result = API::moduleImport("django").getMember("http") }
 
-    module Http {
+    module DjangoHttp {
       API::Node response() { result = http().getMember("response") }
 
       API::Node request() { result = http().getMember("request") }
@@ -54,7 +54,7 @@ private module ExperimentalPrivateDjango {
            *
            * Use the predicate `HttpResponse::instance()` to get references to instances of `django.http.response.HttpResponse`.
            */
-          abstract class InstanceSource extends HTTP::Server::HttpResponse::Range, DataFlow::Node {
+          abstract class InstanceSource extends Http::Server::HttpResponse::Range, DataFlow::Node {
           }
 
           /** A direct instantiation of `django.http.response.HttpResponse`. */
@@ -156,7 +156,7 @@ private module ExperimentalPrivateDjango {
            */
           class DjangoResponseSetCookieCall extends DataFlow::MethodCallNode, Cookie::Range {
             DjangoResponseSetCookieCall() {
-              this.calls(PrivateDjango::DjangoImpl::Http::Response::HttpResponse::instance(),
+              this.calls(PrivateDjango::DjangoImpl::DjangoHttp::Response::HttpResponse::instance(),
                 "set_cookie")
             }
 

--- a/python/ql/src/meta/alerts/RequestHandlers.ql
+++ b/python/ql/src/meta/alerts/RequestHandlers.ql
@@ -13,7 +13,7 @@ private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.Concepts
 private import meta.MetaMetrics
 
-from HTTP::Server::RequestHandler requestHandler, string title
+from Http::Server::RequestHandler requestHandler, string title
 where
   not requestHandler.getLocation().getFile() instanceof IgnoredFile and
   if requestHandler.isMethod()

--- a/python/ql/test/experimental/meta/ConceptsTest.qll
+++ b/python/ql/test/experimental/meta/ConceptsTest.qll
@@ -239,7 +239,7 @@ class HttpServerRouteSetupTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(location.getFile().getRelativePath()) and
-    exists(HTTP::Server::RouteSetup setup |
+    exists(Http::Server::RouteSetup setup |
       location = setup.getLocation() and
       element = setup.toString() and
       (
@@ -261,14 +261,14 @@ class HttpServerRequestHandlerTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(location.getFile().getRelativePath()) and
     (
-      exists(HTTP::Server::RequestHandler handler |
+      exists(Http::Server::RequestHandler handler |
         location = handler.getLocation() and
         element = handler.toString() and
         value = "" and
         tag = "requestHandler"
       )
       or
-      exists(HTTP::Server::RequestHandler handler, Parameter param |
+      exists(Http::Server::RequestHandler handler, Parameter param |
         param = handler.getARoutedParameter() and
         location = param.getLocation() and
         element = param.toString() and
@@ -299,21 +299,21 @@ class HttpServerHttpResponseTest extends InlineExpectationsTest {
     // we need to do this step since we expect subclasses could override getARelevantTag
     tag = getARelevantTag() and
     (
-      exists(HTTP::Server::HttpResponse response |
+      exists(Http::Server::HttpResponse response |
         location = response.getLocation() and
         element = response.toString() and
         value = "" and
         tag = "HttpResponse"
       )
       or
-      exists(HTTP::Server::HttpResponse response |
+      exists(Http::Server::HttpResponse response |
         location = response.getLocation() and
         element = response.toString() and
         value = prettyNodeForInlineTest(response.getBody()) and
         tag = "responseBody"
       )
       or
-      exists(HTTP::Server::HttpResponse response |
+      exists(Http::Server::HttpResponse response |
         location = response.getLocation() and
         element = response.toString() and
         // Ensure that an expectation value such as "mimetype=text/html; charset=utf-8" is parsed as a
@@ -338,14 +338,14 @@ class HttpServerHttpRedirectResponseTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(location.getFile().getRelativePath()) and
     (
-      exists(HTTP::Server::HttpRedirectResponse redirect |
+      exists(Http::Server::HttpRedirectResponse redirect |
         location = redirect.getLocation() and
         element = redirect.toString() and
         value = "" and
         tag = "HttpRedirectResponse"
       )
       or
-      exists(HTTP::Server::HttpRedirectResponse redirect |
+      exists(Http::Server::HttpRedirectResponse redirect |
         location = redirect.getLocation() and
         element = redirect.toString() and
         value = prettyNodeForInlineTest(redirect.getRedirectLocation()) and
@@ -364,7 +364,7 @@ class HttpServerCookieWriteTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(location.getFile().getRelativePath()) and
-    exists(HTTP::Server::CookieWrite cookieWrite |
+    exists(Http::Server::CookieWrite cookieWrite |
       location = cookieWrite.getLocation() and
       (
         element = cookieWrite.toString() and
@@ -519,7 +519,7 @@ class HttpClientRequestTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(location.getFile().getRelativePath()) and
-    exists(HTTP::Client::Request req, DataFlow::Node url |
+    exists(Http::Client::Request req, DataFlow::Node url |
       url = req.getAUrlPart() and
       location = url.getLocation() and
       element = url.toString() and
@@ -528,7 +528,7 @@ class HttpClientRequestTest extends InlineExpectationsTest {
     )
     or
     exists(location.getFile().getRelativePath()) and
-    exists(HTTP::Client::Request req |
+    exists(Http::Client::Request req |
       req.disablesCertificateValidation(_, _) and
       location = req.getLocation() and
       element = req.toString() and
@@ -545,7 +545,7 @@ class CsrfProtectionSettingTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(location.getFile().getRelativePath()) and
-    exists(HTTP::Server::CsrfProtectionSetting setting |
+    exists(Http::Server::CsrfProtectionSetting setting |
       location = setting.getLocation() and
       element = setting.toString() and
       value = setting.getVerificationSetting().toString() and
@@ -561,7 +561,7 @@ class CsrfLocalProtectionSettingTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(location.getFile().getRelativePath()) and
-    exists(HTTP::Server::CsrfLocalProtectionSetting p |
+    exists(Http::Server::CsrfLocalProtectionSetting p |
       location = p.getLocation() and
       element = p.toString() and
       value = p.getRequestHandler().getName().toString() and

--- a/ruby/ql/lib/change-notes/2022-09-12-uppercase.md
+++ b/ruby/ql/lib/change-notes/2022-09-12-uppercase.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Some classes/modules with upper-case acronyms in their name have been renamed to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -222,7 +222,7 @@ class HtmlEscaping extends Escaping {
 }
 
 /** Provides classes for modeling HTTP-related APIs. */
-module HTTP {
+module Http {
   /** Provides classes for modeling HTTP servers. */
   module Server {
     /**
@@ -465,7 +465,7 @@ module HTTP {
        * Extend this class to model new APIs. If you want to refine existing API models,
        * extend `HttpResponse` instead.
        */
-      abstract class Range extends HTTP::Server::HttpResponse::Range {
+      abstract class Range extends Http::Server::HttpResponse::Range {
         /** Gets the data-flow node that specifies the location of this HTTP redirect response. */
         abstract DataFlow::Node getRedirectLocation();
       }
@@ -549,6 +549,9 @@ module HTTP {
     }
   }
 }
+
+/** DEPRECATED: Alias for Http */
+deprecated module HTTP = Http;
 
 /**
  * A data flow node that executes an operating system command,

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -46,7 +46,7 @@ class ActionControllerControllerClass extends ClassDeclaration {
  * A public instance method defined within an `ActionController` controller class.
  * This may be the target of a route handler, if such a route is defined.
  */
-class ActionControllerActionMethod extends Method, HTTP::Server::RequestHandler::Range {
+class ActionControllerActionMethod extends Method, Http::Server::RequestHandler::Range {
   private ActionControllerControllerClass controllerClass;
 
   ActionControllerActionMethod() { this = controllerClass.getAMethod() and not this.isPrivate() }
@@ -126,7 +126,7 @@ abstract class ParamsCall extends MethodCall {
  * A `RemoteFlowSource::Range` to represent accessing the
  * ActionController parameters available via the `params` method.
  */
-class ParamsSource extends HTTP::Server::RequestInputAccess::Range {
+class ParamsSource extends Http::Server::RequestInputAccess::Range {
   ParamsSource() { this.asExpr().getExpr() instanceof ParamsCall }
 
   override string getSourceType() { result = "ActionController::Metal#params" }
@@ -143,7 +143,7 @@ abstract class CookiesCall extends MethodCall {
  * A `RemoteFlowSource::Range` to represent accessing the
  * ActionController parameters available via the `cookies` method.
  */
-class CookiesSource extends HTTP::Server::RequestInputAccess::Range {
+class CookiesSource extends Http::Server::RequestInputAccess::Range {
   CookiesSource() { this.asExpr().getExpr() instanceof CookiesCall }
 
   override string getSourceType() { result = "ActionController::Metal#cookies" }
@@ -211,7 +211,7 @@ class RedirectToCall extends ActionControllerContextCall {
 /**
  * A call to the `redirect_to` method, as an `HttpRedirectResponse`.
  */
-class ActionControllerRedirectResponse extends HTTP::Server::HttpRedirectResponse::Range {
+class ActionControllerRedirectResponse extends Http::Server::HttpRedirectResponse::Range {
   RedirectToCall redirectToCall;
 
   ActionControllerRedirectResponse() { this.asExpr().getExpr() = redirectToCall }

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionView.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionView.qll
@@ -127,7 +127,7 @@ abstract class RenderCall extends MethodCall {
  * A call to `render`, `render_to_body` or `render_to_string`, seen as an
  * `HttpResponse`.
  */
-private class RenderCallAsHttpResponse extends DataFlow::CallNode, HTTP::Server::HttpResponse::Range {
+private class RenderCallAsHttpResponse extends DataFlow::CallNode, Http::Server::HttpResponse::Range {
   RenderCallAsHttpResponse() {
     this.asExpr().getExpr() instanceof RenderCall or
     this.asExpr().getExpr() instanceof RenderToCall

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveResource.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveResource.qll
@@ -215,7 +215,7 @@ module ActiveResource {
     Collection getCollection() { result = this.getReceiver() }
   }
 
-  private class ModelClassMethodCallAsHttpRequest extends HTTP::Client::Request::Range,
+  private class ModelClassMethodCallAsHttpRequest extends Http::Client::Request::Range,
     ModelClassMethodCall {
     ModelClass cls;
 
@@ -239,7 +239,7 @@ module ActiveResource {
     override DataFlow::Node getResponseBody() { result = this }
   }
 
-  private class ModelInstanceMethodCallAsHttpRequest extends HTTP::Client::Request::Range,
+  private class ModelInstanceMethodCallAsHttpRequest extends Http::Client::Request::Range,
     ModelInstanceMethodCall {
     ModelClass cls;
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
@@ -164,7 +164,7 @@ private class GraphqlResolvableClass extends ClassDeclaration {
  * end
  * ```
  */
-class GraphqlResolveMethod extends Method, HTTP::Server::RequestHandler::Range {
+class GraphqlResolveMethod extends Method, Http::Server::RequestHandler::Range {
   private GraphqlResolvableClass resolvableClass;
 
   GraphqlResolveMethod() { this = resolvableClass.getMethod("resolve") }
@@ -208,7 +208,7 @@ class GraphqlResolveMethod extends Method, HTTP::Server::RequestHandler::Range {
  * end
  * ```
  */
-class GraphqlLoadMethod extends Method, HTTP::Server::RequestHandler::Range {
+class GraphqlLoadMethod extends Method, Http::Server::RequestHandler::Range {
   private GraphqlResolvableClass resolvableClass;
 
   GraphqlLoadMethod() {
@@ -340,7 +340,7 @@ private class GraphqlFieldArgumentDefinitionMethodCall extends GraphqlSchemaObje
  * end
  * ```
  */
-class GraphqlFieldResolutionMethod extends Method, HTTP::Server::RequestHandler::Range {
+class GraphqlFieldResolutionMethod extends Method, Http::Server::RequestHandler::Range {
   private GraphqlSchemaObjectClass schemaObjectClass;
 
   GraphqlFieldResolutionMethod() {

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
@@ -24,7 +24,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForHttpClientLibraries 
  * TODO: pipelining, streaming responses
  * https://github.com/excon/excon/blob/master/README.md
  */
-class ExconHttpRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class ExconHttpRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   API::Node requestNode;
   API::Node connectionNode;
   DataFlow::Node connectionUse;

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
@@ -23,7 +23,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForHttpClientLibraries 
  * connection.get("/").body
  * ```
  */
-class FaradayHttpRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class FaradayHttpRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   API::Node requestNode;
   API::Node connectionNode;
   DataFlow::Node connectionUse;

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/HttpClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/HttpClient.qll
@@ -15,7 +15,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForHttpClientLibraries 
  * HTTPClient.get_content("http://example.com")
  * ```
  */
-class HttpClientRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class HttpClientRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   API::Node requestNode;
   API::Node connectionNode;
   string method;

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
@@ -24,7 +24,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForHttpClientLibraries 
  * MyClass.new("http://example.com")
  * ```
  */
-class HttpartyRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class HttpartyRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   API::Node requestNode;
 
   HttpartyRequest() {

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
@@ -19,7 +19,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForHttpClientLibraries 
  * response = req.get("/")
  * ```
  */
-class NetHttpRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class NetHttpRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   private DataFlow::CallNode request;
   private DataFlow::Node responseBody;
   private API::Node requestNode;

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
@@ -19,7 +19,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForHttpClientLibraries 
  * URI.parse("http://example.com").open.read
  * ```
  */
-class OpenUriRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class OpenUriRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   API::Node requestNode;
 
   OpenUriRequest() {
@@ -61,7 +61,7 @@ class OpenUriRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
  * Kernel.open("http://example.com").read
  * ```
  */
-class OpenUriKernelOpenRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class OpenUriKernelOpenRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   OpenUriKernelOpenRequest() {
     this instanceof KernelMethodCall and
     this.getMethodName() = "open"

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
@@ -17,7 +17,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForHttpClientLibraries 
  * RestClient::Request.execute(url: "http://example.com").body
  * ```
  */
-class RestClientHttpRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class RestClientHttpRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   API::Node requestNode;
   API::Node connectionNode;
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -15,7 +15,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForHttpClientLibraries 
  * Typhoeus.get("http://example.com").body
  * ```
  */
-class TyphoeusHttpRequest extends HTTP::Client::Request::Range, DataFlow::CallNode {
+class TyphoeusHttpRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   API::Node requestNode;
 
   TyphoeusHttpRequest() {

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessSpecific.qll
@@ -12,10 +12,10 @@ private import HttpToFileAccessCustomizations::HttpToFileAccess
 /**
  * An access to a user-controlled HTTP request input, considered as a flow source for writing user-controlled data to files
  */
-private class RequestInputAccessAsSource extends Source instanceof HTTP::Server::RequestInputAccess {
+private class RequestInputAccessAsSource extends Source instanceof Http::Server::RequestInputAccess {
 }
 
 /** A response from an outgoing HTTP request, considered as a flow source for writing user-controlled data to files. */
 private class HttpResponseAsSource extends Source {
-  HttpResponseAsSource() { this = any(HTTP::Client::Request r).getResponseBody() }
+  HttpResponseAsSource() { this = any(Http::Client::Request r).getResponseBody() }
 }

--- a/ruby/ql/lib/codeql/ruby/security/InsecureDownloadCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/InsecureDownloadCustomizations.qll
@@ -135,7 +135,7 @@ module InsecureDownload {
    * In other words, if the URL is HTTP and the extension is in `unsafeExtension()`.
    */
   private class HttpResponseAsSink extends Sink {
-    private HTTP::Client::Request req;
+    private Http::Client::Request req;
 
     HttpResponseAsSink() {
       this = req.getAUrlPart() and
@@ -155,7 +155,7 @@ module InsecureDownload {
   /**
    * Gets a node for the response from `request`, type-tracked using `t`.
    */
-  DataFlow::LocalSourceNode clientRequestResponse(TypeTracker t, HTTP::Client::Request request) {
+  DataFlow::LocalSourceNode clientRequestResponse(TypeTracker t, Http::Client::Request request) {
     t.start() and
     result = request.getResponseBody()
     or
@@ -166,7 +166,7 @@ module InsecureDownload {
    * A url that is downloaded through an insecure connection, where the result ends up being saved to a sensitive location.
    */
   class FileWriteSink extends Sink {
-    HTTP::Client::Request request;
+    Http::Client::Request request;
 
     FileWriteSink() {
       // For example, in:

--- a/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryCustomizations.qll
@@ -45,7 +45,7 @@ module ServerSideRequestForgery {
 
   /** The URL of an HTTP request, considered as a sink. */
   class HttpRequestAsSink extends Sink {
-    HttpRequestAsSink() { exists(HTTP::Client::Request req | req.getAUrlPart() = this) }
+    HttpRequestAsSink() { exists(Http::Client::Request req | req.getAUrlPart() = this) }
   }
 
   /** A string interpolation with a fixed prefix, considered as a flow sanitizer. */

--- a/ruby/ql/lib/codeql/ruby/security/UrlRedirectCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UrlRedirectCustomizations.qll
@@ -57,7 +57,7 @@ module UrlRedirect {
    */
   class RedirectLocationAsSink extends Sink {
     RedirectLocationAsSink() {
-      exists(HTTP::Server::HttpRedirectResponse e, MethodBase method |
+      exists(Http::Server::HttpRedirectResponse e, MethodBase method |
         this = e.getRedirectLocation() and
         // We only want handlers for GET requests.
         // Handlers for other HTTP methods are not as vulnerable to URL

--- a/ruby/ql/src/queries/security/cwe-295/RequestWithoutValidation.ql
+++ b/ruby/ql/src/queries/security/cwe-295/RequestWithoutValidation.ql
@@ -16,7 +16,7 @@ import codeql.ruby.Concepts
 import codeql.ruby.DataFlow
 
 from
-  HTTP::Client::Request request, DataFlow::Node disablingNode, DataFlow::Node origin, string ending
+  Http::Client::Request request, DataFlow::Node disablingNode, DataFlow::Node origin, string ending
 where
   request.disablesCertificateValidation(disablingNode, origin) and
   // Showing the origin is only useful when it's a different node than the one disabling

--- a/ruby/ql/test/library-tests/frameworks/ActionView.ql
+++ b/ruby/ql/test/library-tests/frameworks/ActionView.ql
@@ -13,6 +13,6 @@ query predicate renderToCalls(RenderToCall c) { any() }
 
 query predicate linkToCalls(LinkToCall c) { any() }
 
-query predicate httpResponses(HTTP::Server::HttpResponse r, DataFlow::Node body, string mimeType) {
+query predicate httpResponses(Http::Server::HttpResponse r, DataFlow::Node body, string mimeType) {
   r.getBody() = body and r.getMimetype() = mimeType
 }

--- a/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.ql
+++ b/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.ql
@@ -2,7 +2,7 @@ import codeql.ruby.Concepts
 import codeql.ruby.DataFlow
 
 query predicate httpRequests(
-  HTTP::Client::Request r, string framework, DataFlow::Node urlPart, DataFlow::Node responseBody
+  Http::Client::Request r, string framework, DataFlow::Node urlPart, DataFlow::Node responseBody
 ) {
   r.getFramework() = framework and
   r.getAUrlPart() = urlPart and

--- a/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
@@ -42,8 +42,8 @@ class NWConnectionSend extends Transmitted {
  * An `Expr` that is used to form a `URL`. Such expressions are very likely to
  * be transmitted over a network, because that's what URLs are for.
  */
-class URL extends Transmitted {
-  URL() {
+class Url extends Transmitted {
+  Url() {
     // `string` arg in `URL.init` is a sink
     // (we assume here that the URL goes on to be used in a network operation)
     exists(ClassDecl c, AbstractFunctionDecl f, CallExpr call |


### PR DESCRIPTION
[I recently added a QL-for-QL query to detect when two names only differ in casing inside a single language](https://github.com/github/codeql/pull/10209).  

E.g. Python used both `Multidict` and `MultiDict`.  
This can cause confusion, so I'm fixing it. 

I did the following renamings: 
- `SSA` -> `Ssa`
- `LDAP` -> `Ldap`
- `HTTP` -> `Http`
- `Multidict` -> `MultiDict`
- `URL` -> `Url`
- `Newobj` -> `NewObj`
- `Rethrow` -> `ReThrow`

In Python I had to do a few renamings in order to avoid naming conflicts. 


I skipped `HTML` and `API`, so those are still used both as `HTML/Html` and `API/Api`.  