### PR TITLE
Ruby: Fix bad join in `parameterMatch`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -565,6 +565,12 @@ class ArgumentPosition extends TArgumentPosition {
   }
 }
 
+pragma[nomagic]
+private predicate parameterPositionIsNotSelf(ParameterPosition ppos) { not ppos.isSelf() }
+
+pragma[nomagic]
+private predicate argumentPositionIsNotSelf(ArgumentPosition apos) { not apos.isSelf() }
+
 /** Holds if arguments at position `apos` match parameters at position `ppos`. */
 pragma[nomagic]
 predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
@@ -582,9 +588,9 @@ predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
   or
   ppos.isHashSplat() and apos.isHashSplat()
   or
-  ppos.isAny() and not apos.isSelf()
+  ppos.isAny() and argumentPositionIsNotSelf(apos)
   or
-  apos.isAny() and not ppos.isSelf()
+  apos.isAny() and parameterPositionIsNotSelf(ppos)
   or
   ppos.isAnyNamed() and apos.isKeyword(_)
   or


### PR DESCRIPTION
Thanks to the new join-order analyzer in VS Code for reporting this:
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/3667920/188622626-87ccaadf-3e38-4e5a-a82d-e48315784e7b.png">


Before
```
Evaluated relational algebra for predicate DataFlowDispatch#36b84300::parameterMatch#2#ff@281bdfu5 with tuple counts:
        23338949   ~0%    {2} r1 = JOIN DataFlowDispatch#36b84300::Cached::TParameterPosition#f WITH DataFlowDispatch#36b84300::Cached::TArgumentPosition#f CARTESIAN PRODUCT OUTPUT Lhs.0, Rhs.0

           65011   ~0%    {2} r2 = JOIN r1 WITH DataFlowDispatch#36b84300::Cached::TAnyParameterPosition#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1
           65010   ~0%    {2} r3 = r2 AND NOT DataFlowDispatch#36b84300::Cached::TSelfArgumentPosition#f(Lhs.1)

        23338949   ~0%    {2} r4 = JOIN DataFlowDispatch#36b84300::Cached::TParameterPosition#f WITH DataFlowDispatch#36b84300::Cached::TArgumentPosition#f CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0

             359   ~3%    {2} r5 = JOIN r4 WITH DataFlowDispatch#36b84300::Cached::TAnyArgumentPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0
             358   ~3%    {2} r6 = r5 AND NOT DataFlowDispatch#36b84300::Cached::TSelfParameterPosition#f(Lhs.0)

           65368   ~0%    {2} r7 = r3 UNION r6

           65011   ~0%    {2} r8 = JOIN r1 WITH DataFlowDispatch#36b84300::Cached::TSelfParameterPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0
               1   ~0%    {2} r9 = JOIN r8 WITH DataFlowDispatch#36b84300::Cached::TSelfArgumentPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0

           65011   ~0%    {2} r10 = JOIN r1 WITH DataFlowDispatch#36b84300::Cached::TBlockParameterPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0
               1   ~0%    {2} r11 = JOIN r10 WITH DataFlowDispatch#36b84300::Cached::TBlockArgumentPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0

           65011   ~3%    {2} r12 = JOIN r1 WITH DataFlowDispatch#36b84300::Cached::THashSplatParameterPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0
               1   ~0%    {2} r13 = JOIN r12 WITH DataFlowDispatch#36b84300::Cached::THashSplatArgumentPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0

               2   ~0%    {2} r14 = r11 UNION r13
               3   ~0%    {2} r15 = r9 UNION r14
           65371   ~0%    {2} r16 = r7 UNION r15

           65011   ~0%    {2} r17 = JOIN r1 WITH DataFlowDispatch#36b84300::Cached::TAnyKeywordParameterPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0
            1645   ~1%    {2} r18 = JOIN r17 WITH DataFlowDispatch#36b84300::Cached::TKeywordArgumentPosition#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.0

             359   ~0%    {2} r19 = JOIN r4 WITH DataFlowDispatch#36b84300::Cached::TAnyKeywordArgumentPosition#f ON FIRST 1 OUTPUT Lhs.1, Lhs.0
             320   ~0%    {2} r20 = JOIN r19 WITH DataFlowDispatch#36b84300::Cached::TKeywordParameterPosition#ff_1#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1

            1965   ~1%    {2} r21 = r18 UNION r20

        20803520   ~1%    {3} r22 = JOIN r1 WITH DataFlowDispatch#36b84300::Cached::TKeywordParameterPosition#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
             320   ~0%    {2} r23 = JOIN r22 WITH DataFlowDispatch#36b84300::Cached::TKeywordArgumentPosition#ff ON FIRST 2 OUTPUT Lhs.2, Lhs.1

         2145363   ~0%    {3} r24 = JOIN r1 WITH DataFlowDispatch#36b84300::Cached::TPositionalParameterPosition#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
              33   ~0%    {2} r25 = JOIN r24 WITH DataFlowDispatch#36b84300::Cached::TPositionalArgumentPosition#ff ON FIRST 2 OUTPUT Lhs.2, Lhs.1

           65011   ~0%    {3} r26 = JOIN r1 WITH DataFlowDispatch#36b84300::Cached::TPositionalParameterLowerBoundPosition#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
           63361   ~0%    {4} r27 = JOIN r26 WITH DataFlowDispatch#36b84300::Cached::TPositionalArgumentPosition#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2, Rhs.1
           63360   ~0%    {4} r28 = SELECT r27 ON In.3 >= In.2
           63360   ~0%    {2} r29 = SCAN r28 OUTPUT In.0, In.1

           63393   ~0%    {2} r30 = r25 UNION r29
           63713   ~0%    {2} r31 = r23 UNION r30
           65678   ~0%    {2} r32 = r21 UNION r31
          131049   ~0%    {2} r33 = r16 UNION r32
                          return r33
```

After
```
Evaluated relational algebra for predicate DataFlowDispatch#36b84300::parameterMatch#2#ff@698b99ci with tuple counts:
             1   ~0%    {2} r1 = JOIN DataFlowDispatch#36b84300::Cached::TSelfParameterPosition#f WITH DataFlowDispatch#36b84300::Cached::TSelfArgumentPosition#f CARTESIAN PRODUCT OUTPUT Lhs.0, Rhs.0

             1   ~0%    {2} r2 = JOIN DataFlowDispatch#36b84300::Cached::TBlockParameterPosition#f WITH DataFlowDispatch#36b84300::Cached::TBlockArgumentPosition#f CARTESIAN PRODUCT OUTPUT Lhs.0, Rhs.0

             2   ~0%    {2} r3 = r1 UNION r2

             1   ~0%    {2} r4 = JOIN DataFlowDispatch#36b84300::Cached::THashSplatParameterPosition#f WITH DataFlowDispatch#36b84300::Cached::THashSplatArgumentPosition#f CARTESIAN PRODUCT OUTPUT Lhs.0, Rhs.0

         65010   ~0%    {2} r5 = JOIN DataFlowDispatch#36b84300::Cached::TAnyParameterPosition#f WITH DataFlowDispatch#36b84300::argumentPositionIsNotSelf#1#f CARTESIAN PRODUCT OUTPUT Lhs.0, Rhs.0

           358   ~3%    {2} r6 = JOIN DataFlowDispatch#36b84300::Cached::TAnyArgumentPosition#f WITH DataFlowDispatch#36b84300::parameterPositionIsNotSelf#1#f CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0

         65368   ~0%    {2} r7 = r5 UNION r6
         65369   ~0%    {2} r8 = r4 UNION r7
         65371   ~0%    {2} r9 = r3 UNION r8

          1645   ~1%    {2} r10 = JOIN DataFlowDispatch#36b84300::Cached::TAnyKeywordParameterPosition#f WITH DataFlowDispatch#36b84300::Cached::TKeywordArgumentPosition#ff CARTESIAN PRODUCT OUTPUT Lhs.0, Rhs.1

           320   ~0%    {2} r11 = JOIN DataFlowDispatch#36b84300::Cached::TAnyKeywordArgumentPosition#f WITH DataFlowDispatch#36b84300::Cached::TKeywordParameterPosition#ff CARTESIAN PRODUCT OUTPUT Rhs.1, Lhs.0

          1965   ~1%    {2} r12 = r10 UNION r11

            33   ~0%    {2} r13 = JOIN DataFlowDispatch#36b84300::Cached::TPositionalParameterPosition#ff WITH DataFlowDispatch#36b84300::Cached::TPositionalArgumentPosition#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1

           320   ~0%    {2} r14 = JOIN DataFlowDispatch#36b84300::Cached::TKeywordParameterPosition#ff WITH DataFlowDispatch#36b84300::Cached::TKeywordArgumentPosition#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1

         63361   ~1%    {4} r15 = JOIN DataFlowDispatch#36b84300::Cached::TPositionalParameterLowerBoundPosition#ff WITH DataFlowDispatch#36b84300::Cached::TPositionalArgumentPosition#ff CARTESIAN PRODUCT OUTPUT Lhs.0, Lhs.1, Rhs.0, Rhs.1
         63360   ~1%    {4} r16 = SELECT r15 ON In.2 >= In.0
         63360   ~0%    {2} r17 = SCAN r16 OUTPUT In.1, In.3

         63680   ~0%    {2} r18 = r14 UNION r17
         63713   ~0%    {2} r19 = r13 UNION r18
         65678   ~0%    {2} r20 = r12 UNION r19
        131049   ~0%    {2} r21 = r9 UNION r20
                        return r21
```