### PR TITLE
Java: Add summaries for NotificationCompat and its inner classes

### DIFF
--- a/java/ql/lib/change-notes/2022-09-06-notificationcompat-summaries.md
+++ b/java/ql/lib/change-notes/2022-09-06-notificationcompat-summaries.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Added new flow steps for `androidx.core.app.NotificationCompat` and its inner classes.
+  

--- a/java/ql/lib/semmle/code/java/frameworks/android/Notifications.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Notifications.qll
@@ -19,6 +19,17 @@ private class NotificationBuildersSummaryModels extends SummaryModelCsv {
         "android.app;Notification$Action$Builder;true;build;;;Argument[-1];ReturnValue;taint;manual",
         "android.app;Notification$Action$Builder;true;build;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue.SyntheticField[android.content.Intent.extras];value;manual",
         "android.app;Notification$Action$Builder;true;getExtras;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue;value;manual",
+        "androidx.core.app;NotificationCompat$Action;true;Action;(int,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Action;true;Action;(IconCompat,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Action;true;getExtras;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue;value;manual",
+        "androidx.core.app;NotificationCompat$Action$Builder;true;Builder;(int,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Action$Builder;true;Builder;(IconCompat,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Action$Builder;true;Builder;(Action);;Argument[0];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Action$Builder;true;addExtras;;;Argument[0].MapKey;Argument[-1].SyntheticField[android.content.Intent.extras].MapKey;value;manual",
+        "androidx.core.app;NotificationCompat$Action$Builder;true;addExtras;;;Argument[0].MapValue;Argument[-1].SyntheticField[android.content.Intent.extras].MapValue;value;manual",
+        "androidx.core.app;NotificationCompat$Action$Builder;true;build;;;Argument[-1];ReturnValue;taint;manual",
+        "androidx.core.app;NotificationCompat$Action$Builder;true;build;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue.SyntheticField[android.content.Intent.extras];value;manual",
+        "androidx.core.app;NotificationCompat$Action$Builder;true;getExtras;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue;value;manual",
         "android.app;Notification$Builder;true;addAction;(int,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual",
         "android.app;Notification$Builder;true;addAction;(Action);;Argument[0];Argument[-1];taint;manual",
         "android.app;Notification$Builder;true;addExtras;;;Argument[0].MapKey;Argument[-1].SyntheticField[android.content.Intent.extras].MapKey;value;manual",
@@ -32,18 +43,30 @@ private class NotificationBuildersSummaryModels extends SummaryModelCsv {
         "android.app;Notification$Builder;true;setExtras;;;Argument[0];Argument[-1].SyntheticField[android.content.Intent.extras];value;manual",
         "android.app;Notification$Builder;true;setDeleteIntent;;;Argument[0];Argument[-1];taint;manual",
         "android.app;Notification$Builder;true;setPublicVersion;;;Argument[0];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;addAction;(int,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;addAction;(Action);;Argument[0];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;addExtras;;;Argument[0].MapKey;Argument[-1].SyntheticField[android.content.Intent.extras].MapKey;value;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;addExtras;;;Argument[0].MapValue;Argument[-1].SyntheticField[android.content.Intent.extras].MapValue;value;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;build;;;Argument[-1];ReturnValue;taint;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;build;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue.Field[android.app.Notification.extras];value;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;setContentIntent;;;Argument[0];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;getExtras;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue;value;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;setExtras;;;Argument[0];Argument[-1].SyntheticField[android.content.Intent.extras];value;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;setDeleteIntent;;;Argument[0];Argument[-1];taint;manual",
+        "androidx.core.app;NotificationCompat$Builder;true;setPublicVersion;;;Argument[0];Argument[-1];taint;manual",
         "android.app;Notification$Style;true;build;;;Argument[-1];ReturnValue;taint;manual",
         "android.app;Notification$BigPictureStyle;true;BigPictureStyle;(Builder);;Argument[0];Argument[-1];taint;manual",
         "android.app;Notification$BigTextStyle;true;BigTextStyle;(Builder);;Argument[0];Argument[-1];taint;manual",
         "android.app;Notification$InboxStyle;true;InboxStyle;(Builder);;Argument[0];Argument[-1];taint;manual",
         "android.app;Notification$MediaStyle;true;MediaStyle;(Builder);;Argument[0];Argument[-1];taint;manual",
         // Fluent models
-        "android.app;Notification$Action$Builder;true;" +
+        ["android.app;Notification", "androidx.core.app;NotificationCompat"] +
+          "$Action$Builder;true;" +
           [
             "addExtras", "addRemoteInput", "extend", "setAllowGeneratedReplies",
             "setAuthenticationRequired", "setContextual", "setSemanticAction"
           ] + ";;;Argument[-1];ReturnValue;value;manual",
-        "android.app;Notification$Builder;true;" +
+        ["android.app;Notification", "androidx.core.app;NotificationCompat"] + "$Builder;true;" +
           [
             "addAction", "addExtras", "addPerson", "extend", "setActions", "setAutoCancel",
             "setBadgeIconType", "setBubbleMetadata", "setCategory", "setChannelId",
@@ -58,15 +81,16 @@ private class NotificationBuildersSummaryModels extends SummaryModelCsv {
             "setSubText", "setTicker", "setTimeoutAfter", "setUsesChronometer", "setVibrate",
             "setVisibility", "setWhen"
           ] + ";;;Argument[-1];ReturnValue;value;manual",
-        "android.app;Notification$BigPictureStyle;true;" +
+        ["android.app;Notification", "androidx.core.app;NotificationCompat"] +
+          "$BigPictureStyle;true;" +
           [
             "bigLargeIcon", "bigPicture", "setBigContentTitle", "setContentDescription",
             "setSummaryText", "showBigPictureWhenCollapsed"
           ] + ";;;Argument[-1];ReturnValue;value;manual",
-        "android.app;Notification$BigTextStyle;true;" +
-          ["bigText", "setBigContentTitle", "setSummaryText"] +
+        ["android.app;Notification", "androidx.core.app;NotificationCompat"] + "$BigTextStyle;true;"
+          + ["bigText", "setBigContentTitle", "setSummaryText"] +
           ";;;Argument[-1];ReturnValue;value;manual",
-        "android.app;Notification$InboxStyle;true;" +
+        ["android.app;Notification", "androidx.core.app;NotificationCompat"] + "$InboxStyle;true;" +
           ["addLine", "setBigContentTitle", "setSummaryText"] +
           ";;;Argument[-1];ReturnValue;value;manual",
         "android.app;Notification$MediaStyle;true;" +

--- a/java/ql/test/library-tests/frameworks/android/notification/Test.java
+++ b/java/ql/test/library-tests/frameworks/android/notification/Test.java
@@ -1,11 +1,13 @@
 package generatedtest;
 
 import android.app.Notification;
+import androidx.core.app.NotificationCompat;
 import android.app.PendingIntent;
 import android.app.Person;
 import android.app.Notification.Action;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Icon;
+import androidx.core.graphics.drawable.IconCompat;
 import android.media.AudioAttributes;
 import android.net.Uri;
 import android.os.Bundle;
@@ -103,7 +105,8 @@ public class Test {
 		}
 		{
 			// "android.app;Notification$Action$Builder;true;build;;;SyntheticField[android.content.Intent.extras]
-			// of Argument[-1];SyntheticField[android.content.Intent.extras] of ReturnValue;value;manual"
+			// of Argument[-1];SyntheticField[android.content.Intent.extras] of
+			// ReturnValue;value;manual"
 			Notification.Action out = null;
 			Notification.Action.Builder builder = null;
 			Bundle in = (Bundle) newWithMapValueDefault(source());
@@ -812,6 +815,647 @@ public class Test {
 			// "android.app;Notification$MediaStyle;true;setShowActionsInCompactView;;;Argument[-1];ReturnValue;value;manual"
 			Notification.MediaStyle in = (Notification.MediaStyle) source();
 			Notification.MediaStyle out = in.setShowActionsInCompactView(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;Builder;(Action);;Argument[0];Argument[-1];taint;manual"
+			NotificationCompat.Action.Builder out = null;
+			NotificationCompat.Action in = (NotificationCompat.Action) source();
+			out = new NotificationCompat.Action.Builder(in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;Builder;(IconCompat,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual"
+			NotificationCompat.Action.Builder out = null;
+			PendingIntent in = (PendingIntent) source();
+			out = new NotificationCompat.Action.Builder((IconCompat) null, (CharSequence) null, in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;Builder;(int,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual"
+			NotificationCompat.Action.Builder out = null;
+			PendingIntent in = (PendingIntent) source();
+			out = new NotificationCompat.Action.Builder(0, (CharSequence) null, in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;addExtras;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Action.Builder out = null;
+			NotificationCompat.Action.Builder in = (NotificationCompat.Action.Builder) source();
+			out = in.addExtras(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;addExtras;;;Argument[0].MapKey;Argument[-1].SyntheticField[android.content.Intent.extras].MapKey;value;manual"
+			NotificationCompat.Action.Builder out = null;
+			Bundle in = (Bundle) newWithMapKeyDefault(source());
+			out.addExtras(in);
+			sink(getMapKeyDefault(out.getExtras())); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;addExtras;;;Argument[0].MapValue;Argument[-1].SyntheticField[android.content.Intent.extras].MapValue;value;manual"
+			NotificationCompat.Action.Builder out = null;
+			Bundle in = (Bundle) newWithMapValueDefault(source());
+			out.addExtras(in);
+			sink(getMapValueDefault(out.getExtras())); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;addRemoteInput;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Action.Builder out = null;
+			NotificationCompat.Action.Builder in = (NotificationCompat.Action.Builder) source();
+			out = in.addRemoteInput(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;build;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue.SyntheticField[android.content.Intent.extras];value;manual"
+			NotificationCompat.Action out = null;
+			NotificationCompat.Action.Builder builder = null;
+			Bundle in = (Bundle) newWithMapValueDefault(source());
+			builder.addExtras(in);
+			out = builder.build();
+			sink(getMapValueDefault(out.getExtras())); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;build;;;Argument[-1];ReturnValue;taint;manual"
+			NotificationCompat.Action out = null;
+			NotificationCompat.Action.Builder in = (NotificationCompat.Action.Builder) source();
+			out = in.build();
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;extend;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Action.Builder out = null;
+			NotificationCompat.Action.Builder in = (NotificationCompat.Action.Builder) source();
+			out = in.extend(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;getExtras;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue;value;manual"
+			Bundle out = null;
+			NotificationCompat.Action.Builder in = (NotificationCompat.Action.Builder) source();
+			out = in.getExtras();
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;setAllowGeneratedReplies;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Action.Builder out = null;
+			NotificationCompat.Action.Builder in = (NotificationCompat.Action.Builder) source();
+			out = in.setAllowGeneratedReplies(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;setContextual;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Action.Builder out = null;
+			NotificationCompat.Action.Builder in = (NotificationCompat.Action.Builder) source();
+			out = in.setContextual(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action$Builder;true;setSemanticAction;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Action.Builder out = null;
+			NotificationCompat.Action.Builder in = (NotificationCompat.Action.Builder) source();
+			out = in.setSemanticAction(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action;true;Action;(IconCompat,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual"
+			NotificationCompat.Action out = null;
+			PendingIntent in = (PendingIntent) source();
+			out = new NotificationCompat.Action((IconCompat) null, (CharSequence) null, in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action;true;Action;(int,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual"
+			NotificationCompat.Action out = null;
+			PendingIntent in = (PendingIntent) source();
+			out = new NotificationCompat.Action(0, (CharSequence) null, in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Action;true;getExtras;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue;value;manual"
+			Bundle out = null;
+			NotificationCompat.Action in = (NotificationCompat.Action) source();
+			out = in.getExtras();
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$BigPictureStyle;true;bigLargeIcon;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.BigPictureStyle out = null;
+			NotificationCompat.BigPictureStyle in = (NotificationCompat.BigPictureStyle) source();
+			out = in.bigLargeIcon(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$BigPictureStyle;true;bigPicture;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.BigPictureStyle out = null;
+			NotificationCompat.BigPictureStyle in = (NotificationCompat.BigPictureStyle) source();
+			out = in.bigPicture(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$BigPictureStyle;true;setBigContentTitle;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.BigPictureStyle out = null;
+			NotificationCompat.BigPictureStyle in = (NotificationCompat.BigPictureStyle) source();
+			out = in.setBigContentTitle(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$BigPictureStyle;true;setSummaryText;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.BigPictureStyle out = null;
+			NotificationCompat.BigPictureStyle in = (NotificationCompat.BigPictureStyle) source();
+			out = in.setSummaryText(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$BigTextStyle;true;bigText;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.BigTextStyle out = null;
+			NotificationCompat.BigTextStyle in = (NotificationCompat.BigTextStyle) source();
+			out = in.bigText(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$BigTextStyle;true;setBigContentTitle;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.BigTextStyle out = null;
+			NotificationCompat.BigTextStyle in = (NotificationCompat.BigTextStyle) source();
+			out = in.setBigContentTitle(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$BigTextStyle;true;setSummaryText;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.BigTextStyle out = null;
+			NotificationCompat.BigTextStyle in = (NotificationCompat.BigTextStyle) source();
+			out = in.setSummaryText(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;addAction;(Action);;Argument[0];Argument[-1];taint;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Action in = (NotificationCompat.Action) source();
+			out.addAction(in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;addAction;(int,CharSequence,PendingIntent);;Argument[2];Argument[-1];taint;manual"
+			NotificationCompat.Builder out = null;
+			PendingIntent in = (PendingIntent) source();
+			out.addAction(0, null, in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;addAction;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.addAction(0, null, null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;addAction;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.addAction(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;addExtras;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.addExtras(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;addExtras;;;Argument[0].MapKey;Argument[-1].SyntheticField[android.content.Intent.extras].MapKey;value;manual"
+			NotificationCompat.Builder out = null;
+			Bundle in = (Bundle) newWithMapKeyDefault(source());
+			out.addExtras(in);
+			sink(getMapKeyDefault(out.getExtras())); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;addExtras;;;Argument[0].MapValue;Argument[-1].SyntheticField[android.content.Intent.extras].MapValue;value;manual"
+			NotificationCompat.Builder out = null;
+			Bundle in = (Bundle) newWithMapValueDefault(source());
+			out.addExtras(in);
+			sink(getMapValueDefault(out.getExtras())); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;addPerson;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.addPerson(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;build;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue.Field[android.app.Notification.extras];value;manual"
+			Notification out = null;
+			NotificationCompat.Builder builder = null;
+			Bundle in = (Bundle) newWithMapValueDefault(source());
+			builder.addExtras(in);
+			out = builder.build();
+			sink(getMapValueDefault(out.extras)); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;build;;;Argument[-1];ReturnValue;taint;manual"
+			Notification out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.build();
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;extend;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.extend(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;getExtras;;;Argument[-1].SyntheticField[android.content.Intent.extras];ReturnValue;value;manual"
+			Bundle out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.getExtras();
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setAutoCancel;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setAutoCancel(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setBadgeIconType;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setBadgeIconType(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setBubbleMetadata;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setBubbleMetadata(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setCategory;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setCategory(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setChannelId;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setChannelId(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setChronometerCountDown;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setChronometerCountDown(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setColor;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setColor(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setColorized;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setColorized(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setContent;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setContent(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setContentInfo;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setContentInfo(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setContentIntent;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setContentIntent(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setContentIntent;;;Argument[0];Argument[-1];taint;manual"
+			NotificationCompat.Builder out = null;
+			PendingIntent in = (PendingIntent) source();
+			out.setContentIntent(in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setContentText;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setContentText(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setContentTitle;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setContentTitle(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setCustomBigContentView;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setCustomBigContentView(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setCustomHeadsUpContentView;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setCustomHeadsUpContentView(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setDefaults;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setDefaults(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setDeleteIntent;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setDeleteIntent(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setDeleteIntent;;;Argument[0];Argument[-1];taint;manual"
+			NotificationCompat.Builder out = null;
+			PendingIntent in = (PendingIntent) source();
+			out.setDeleteIntent(in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setExtras;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setExtras(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setExtras;;;Argument[0];Argument[-1].SyntheticField[android.content.Intent.extras];value;manual"
+			NotificationCompat.Builder out = null;
+			Bundle in = (Bundle) source();
+			out.setExtras(in);
+			sink(out.getExtras()); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setFullScreenIntent;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setFullScreenIntent(null, false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setGroup;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setGroup(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setGroupAlertBehavior;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setGroupAlertBehavior(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setGroupSummary;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setGroupSummary(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setLargeIcon;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setLargeIcon(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setLights;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setLights(0, 0, 0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setLocalOnly;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setLocalOnly(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setNumber;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setNumber(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setOngoing;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setOngoing(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setOnlyAlertOnce;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setOnlyAlertOnce(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setPriority;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setPriority(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setProgress;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setProgress(0, 0, false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setPublicVersion;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setPublicVersion(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setPublicVersion;;;Argument[0];Argument[-1];taint;manual"
+			NotificationCompat.Builder out = null;
+			Notification in = (Notification) source();
+			out.setPublicVersion(in);
+			sink(out); // $ hasTaintFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setRemoteInputHistory;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setRemoteInputHistory(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setShortcutId;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setShortcutId(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setShowWhen;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setShowWhen(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setSmallIcon;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setSmallIcon(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setSmallIcon;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setSmallIcon(0, 0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setSortKey;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setSortKey(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setSound;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setSound(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setSound;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setSound(null, 0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setStyle;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setStyle(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setSubText;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setSubText(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setTicker;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setTicker(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setTicker;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setTicker(null, null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setTimeoutAfter;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setTimeoutAfter(0L);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setUsesChronometer;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setUsesChronometer(false);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setVibrate;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setVibrate(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setVisibility;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setVisibility(0);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$Builder;true;setWhen;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.Builder out = null;
+			NotificationCompat.Builder in = (NotificationCompat.Builder) source();
+			out = in.setWhen(0L);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$InboxStyle;true;addLine;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.InboxStyle out = null;
+			NotificationCompat.InboxStyle in = (NotificationCompat.InboxStyle) source();
+			out = in.addLine(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$InboxStyle;true;setBigContentTitle;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.InboxStyle out = null;
+			NotificationCompat.InboxStyle in = (NotificationCompat.InboxStyle) source();
+			out = in.setBigContentTitle(null);
+			sink(out); // $ hasValueFlow
+		}
+		{
+			// "androidx.core.app;NotificationCompat$InboxStyle;true;setSummaryText;;;Argument[-1];ReturnValue;value;manual"
+			NotificationCompat.InboxStyle out = null;
+			NotificationCompat.InboxStyle in = (NotificationCompat.InboxStyle) source();
+			out = in.setSummaryText(null);
 			sink(out); // $ hasValueFlow
 		}
 	}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/NotificationBuilderWithBuilderAccessor.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/NotificationBuilderWithBuilderAccessor.java
@@ -1,0 +1,10 @@
+// Generated automatically from androidx.core.app.NotificationBuilderWithBuilderAccessor for testing
+// purposes
+
+package androidx.core.app;
+
+import android.app.Notification;
+
+public interface NotificationBuilderWithBuilderAccessor {
+    Notification.Builder getBuilder();
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/NotificationCompat.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/NotificationCompat.java
@@ -1,0 +1,720 @@
+// Generated automatically from androidx.core.app.NotificationCompat for testing purposes
+
+package androidx.core.app;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Bundle;
+import android.widget.RemoteViews;
+import androidx.core.app.NotificationBuilderWithBuilderAccessor;
+import androidx.core.app.RemoteInput;
+import androidx.core.graphics.drawable.IconCompat;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NotificationCompat {
+    abstract static public class Style {
+        protected NotificationCompat.Builder mBuilder = null;
+
+        protected void restoreFromCompatExtras(Bundle p0) {}
+
+        public Bitmap createColoredBitmap(int p0, int p1) {
+            return null;
+        }
+
+        public Notification build() {
+            return null;
+        }
+
+        public RemoteViews applyStandardTemplate(boolean p0, int p1, boolean p2) {
+            return null;
+        }
+
+        public RemoteViews makeBigContentView(NotificationBuilderWithBuilderAccessor p0) {
+            return null;
+        }
+
+        public RemoteViews makeContentView(NotificationBuilderWithBuilderAccessor p0) {
+            return null;
+        }
+
+        public RemoteViews makeHeadsUpContentView(NotificationBuilderWithBuilderAccessor p0) {
+            return null;
+        }
+
+        public Style() {}
+
+        public void addCompatExtras(Bundle p0) {}
+
+        public void apply(NotificationBuilderWithBuilderAccessor p0) {}
+
+        public void buildIntoRemoteViews(RemoteViews p0, RemoteViews p1) {}
+
+        public void setBuilder(NotificationCompat.Builder p0) {}
+    }
+
+    public NotificationCompat() {}
+
+    public static Bundle getExtras(Notification p0) {
+        return null;
+    }
+
+    public static CharSequence getContentTitle(Notification p0) {
+        return null;
+    }
+
+    public static List<NotificationCompat.Action> getInvisibleActions(Notification p0) {
+        return null;
+    }
+
+    public static NotificationCompat.Action getAction(Notification p0, int p1) {
+        return null;
+    }
+
+    public static NotificationCompat.BubbleMetadata getBubbleMetadata(Notification p0) {
+        return null;
+    }
+
+    public static String CATEGORY_ALARM = null;
+    public static String CATEGORY_CALL = null;
+    public static String CATEGORY_EMAIL = null;
+    public static String CATEGORY_ERROR = null;
+    public static String CATEGORY_EVENT = null;
+    public static String CATEGORY_MESSAGE = null;
+    public static String CATEGORY_NAVIGATION = null;
+    public static String CATEGORY_PROGRESS = null;
+    public static String CATEGORY_PROMO = null;
+    public static String CATEGORY_RECOMMENDATION = null;
+    public static String CATEGORY_REMINDER = null;
+    public static String CATEGORY_SERVICE = null;
+    public static String CATEGORY_SOCIAL = null;
+    public static String CATEGORY_STATUS = null;
+    public static String CATEGORY_SYSTEM = null;
+    public static String CATEGORY_TRANSPORT = null;
+    public static String EXTRA_AUDIO_CONTENTS_URI = null;
+    public static String EXTRA_BACKGROUND_IMAGE_URI = null;
+    public static String EXTRA_BIG_TEXT = null;
+    public static String EXTRA_CHRONOMETER_COUNT_DOWN = null;
+    public static String EXTRA_COMPACT_ACTIONS = null;
+    public static String EXTRA_CONVERSATION_TITLE = null;
+    public static String EXTRA_HIDDEN_CONVERSATION_TITLE = null;
+    public static String EXTRA_INFO_TEXT = null;
+    public static String EXTRA_IS_GROUP_CONVERSATION = null;
+    public static String EXTRA_LARGE_ICON = null;
+    public static String EXTRA_LARGE_ICON_BIG = null;
+    public static String EXTRA_MEDIA_SESSION = null;
+    public static String EXTRA_MESSAGES = null;
+    public static String EXTRA_MESSAGING_STYLE_USER = null;
+    public static String EXTRA_PEOPLE = null;
+    public static String EXTRA_PICTURE = null;
+    public static String EXTRA_PROGRESS = null;
+    public static String EXTRA_PROGRESS_INDETERMINATE = null;
+    public static String EXTRA_PROGRESS_MAX = null;
+    public static String EXTRA_REMOTE_INPUT_HISTORY = null;
+    public static String EXTRA_SELF_DISPLAY_NAME = null;
+    public static String EXTRA_SHOW_CHRONOMETER = null;
+    public static String EXTRA_SHOW_WHEN = null;
+    public static String EXTRA_SMALL_ICON = null;
+    public static String EXTRA_SUB_TEXT = null;
+    public static String EXTRA_SUMMARY_TEXT = null;
+    public static String EXTRA_TEMPLATE = null;
+    public static String EXTRA_TEXT = null;
+    public static String EXTRA_TEXT_LINES = null;
+    public static String EXTRA_TITLE = null;
+    public static String EXTRA_TITLE_BIG = null;
+    public static String GROUP_KEY_SILENT = null;
+
+    public static String getCategory(Notification p0) {
+        return null;
+    }
+
+    public static String getChannelId(Notification p0) {
+        return null;
+    }
+
+    public static String getGroup(Notification p0) {
+        return null;
+    }
+
+    public static String getShortcutId(Notification p0) {
+        return null;
+    }
+
+    public static String getSortKey(Notification p0) {
+        return null;
+    }
+
+    public static boolean getAllowSystemGeneratedContextualActions(Notification p0) {
+        return false;
+    }
+
+    public static boolean getLocalOnly(Notification p0) {
+        return false;
+    }
+
+    public static boolean isGroupSummary(Notification p0) {
+        return false;
+    }
+
+    public static int BADGE_ICON_LARGE = 0;
+    public static int BADGE_ICON_NONE = 0;
+    public static int BADGE_ICON_SMALL = 0;
+    public static int COLOR_DEFAULT = 0;
+    public static int DEFAULT_ALL = 0;
+    public static int DEFAULT_LIGHTS = 0;
+    public static int DEFAULT_SOUND = 0;
+    public static int DEFAULT_VIBRATE = 0;
+    public static int FLAG_AUTO_CANCEL = 0;
+    public static int FLAG_BUBBLE = 0;
+    public static int FLAG_FOREGROUND_SERVICE = 0;
+    public static int FLAG_GROUP_SUMMARY = 0;
+    public static int FLAG_HIGH_PRIORITY = 0;
+    public static int FLAG_INSISTENT = 0;
+    public static int FLAG_LOCAL_ONLY = 0;
+    public static int FLAG_NO_CLEAR = 0;
+    public static int FLAG_ONGOING_EVENT = 0;
+    public static int FLAG_ONLY_ALERT_ONCE = 0;
+    public static int FLAG_SHOW_LIGHTS = 0;
+    public static int GROUP_ALERT_ALL = 0;
+    public static int GROUP_ALERT_CHILDREN = 0;
+    public static int GROUP_ALERT_SUMMARY = 0;
+    public static int PRIORITY_DEFAULT = 0;
+    public static int PRIORITY_HIGH = 0;
+    public static int PRIORITY_LOW = 0;
+    public static int PRIORITY_MAX = 0;
+    public static int PRIORITY_MIN = 0;
+    public static int STREAM_DEFAULT = 0;
+    public static int VISIBILITY_PRIVATE = 0;
+    public static int VISIBILITY_PUBLIC = 0;
+    public static int VISIBILITY_SECRET = 0;
+
+    public static int getActionCount(Notification p0) {
+        return 0;
+    }
+
+    public static int getBadgeIconType(Notification p0) {
+        return 0;
+    }
+
+    public static int getGroupAlertBehavior(Notification p0) {
+        return 0;
+    }
+
+    public static long getTimeoutAfter(Notification p0) {
+        return 0;
+    }
+
+    static public class Action {
+        protected Action() {}
+
+        public Action(IconCompat p0, CharSequence p1, PendingIntent p2) {}
+
+        public Action(int p0, CharSequence p1, PendingIntent p2) {}
+
+        public Bundle getExtras() {
+            return null;
+        }
+
+        public CharSequence getTitle() {
+            return null;
+        }
+
+        public CharSequence title = null;
+
+        public IconCompat getIconCompat() {
+            return null;
+        }
+
+        public PendingIntent actionIntent = null;
+
+        public PendingIntent getActionIntent() {
+            return null;
+        }
+
+        public RemoteInput[] getDataOnlyRemoteInputs() {
+            return null;
+        }
+
+        public RemoteInput[] getRemoteInputs() {
+            return null;
+        }
+
+        public boolean getAllowGeneratedReplies() {
+            return false;
+        }
+
+        public boolean getShowsUserInterface() {
+            return false;
+        }
+
+        public boolean isContextual() {
+            return false;
+        }
+
+        public int getIcon() {
+            return 0;
+        }
+
+        public int getSemanticAction() {
+            return 0;
+        }
+
+        public int icon = 0;
+        public static int SEMANTIC_ACTION_ARCHIVE = 0;
+        public static int SEMANTIC_ACTION_CALL = 0;
+        public static int SEMANTIC_ACTION_DELETE = 0;
+        public static int SEMANTIC_ACTION_MARK_AS_READ = 0;
+        public static int SEMANTIC_ACTION_MARK_AS_UNREAD = 0;
+        public static int SEMANTIC_ACTION_MUTE = 0;
+        public static int SEMANTIC_ACTION_NONE = 0;
+        public static int SEMANTIC_ACTION_REPLY = 0;
+        public static int SEMANTIC_ACTION_THUMBS_DOWN = 0;
+        public static int SEMANTIC_ACTION_THUMBS_UP = 0;
+        public static int SEMANTIC_ACTION_UNMUTE = 0;
+
+        static public class Builder {
+            protected Builder() {}
+
+            public Builder(IconCompat p0, CharSequence p1, PendingIntent p2) {}
+
+            public Builder(NotificationCompat.Action p0) {}
+
+            public Builder(int p0, CharSequence p1, PendingIntent p2) {}
+
+            public Bundle getExtras() {
+                return null;
+            }
+
+            public NotificationCompat.Action build() {
+                return null;
+            }
+
+            public NotificationCompat.Action.Builder addExtras(Bundle p0) {
+                return null;
+            }
+
+            public NotificationCompat.Action.Builder addRemoteInput(RemoteInput p0) {
+                return null;
+            }
+
+            public NotificationCompat.Action.Builder extend(NotificationCompat.Action.Extender p0) {
+                return null;
+            }
+
+            public NotificationCompat.Action.Builder setAllowGeneratedReplies(boolean p0) {
+                return null;
+            }
+
+            public NotificationCompat.Action.Builder setContextual(boolean p0) {
+                return null;
+            }
+
+            public NotificationCompat.Action.Builder setSemanticAction(int p0) {
+                return null;
+            }
+
+            public NotificationCompat.Action.Builder setShowsUserInterface(boolean p0) {
+                return null;
+            }
+        }
+        static public interface Extender {
+            NotificationCompat.Action.Builder extend(NotificationCompat.Action.Builder p0);
+        }
+    }
+    static public class BigPictureStyle extends NotificationCompat.Style {
+        public BigPictureStyle() {}
+
+        public BigPictureStyle(NotificationCompat.Builder p0) {}
+
+        public NotificationCompat.BigPictureStyle bigLargeIcon(Bitmap p0) {
+            return null;
+        }
+
+        public NotificationCompat.BigPictureStyle bigPicture(Bitmap p0) {
+            return null;
+        }
+
+        public NotificationCompat.BigPictureStyle setBigContentTitle(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.BigPictureStyle setSummaryText(CharSequence p0) {
+            return null;
+        }
+
+        public void apply(NotificationBuilderWithBuilderAccessor p0) {}
+    }
+    static public class BigTextStyle extends NotificationCompat.Style {
+        public BigTextStyle() {}
+
+        public BigTextStyle(NotificationCompat.Builder p0) {}
+
+        public NotificationCompat.BigTextStyle bigText(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.BigTextStyle setBigContentTitle(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.BigTextStyle setSummaryText(CharSequence p0) {
+            return null;
+        }
+
+        public void apply(NotificationBuilderWithBuilderAccessor p0) {}
+    }
+    static public class BubbleMetadata {
+        protected BubbleMetadata() {}
+
+        public IconCompat getIcon() {
+            return null;
+        }
+
+        public PendingIntent getDeleteIntent() {
+            return null;
+        }
+
+        public PendingIntent getIntent() {
+            return null;
+        }
+
+        public boolean getAutoExpandBubble() {
+            return false;
+        }
+
+        public boolean isNotificationSuppressed() {
+            return false;
+        }
+
+        public int getDesiredHeight() {
+            return 0;
+        }
+
+        public int getDesiredHeightResId() {
+            return 0;
+        }
+
+        public static Notification.BubbleMetadata toPlatform(NotificationCompat.BubbleMetadata p0) {
+            return null;
+        }
+
+        public static NotificationCompat.BubbleMetadata fromPlatform(
+                Notification.BubbleMetadata p0) {
+            return null;
+        }
+    }
+    static public class Builder {
+        protected Builder() {}
+
+        protected static CharSequence limitCharSequenceLength(CharSequence p0) {
+            return null;
+        }
+
+        public ArrayList<NotificationCompat.Action> mActions = null;
+        public ArrayList<String> mPeople = null;
+
+        public Builder(Context p0) {}
+
+        public Builder(Context p0, String p1) {}
+
+        public Bundle getExtras() {
+            return null;
+        }
+
+        public Context mContext = null;
+
+        public Notification build() {
+            return null;
+        }
+
+        public Notification getNotification() {
+            return null;
+        }
+
+        public NotificationCompat.BubbleMetadata getBubbleMetadata() {
+            return null;
+        }
+
+        public NotificationCompat.Builder addAction(NotificationCompat.Action p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder addAction(int p0, CharSequence p1, PendingIntent p2) {
+            return null;
+        }
+
+        public NotificationCompat.Builder addExtras(Bundle p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder addInvisibleAction(NotificationCompat.Action p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder addInvisibleAction(int p0, CharSequence p1,
+                PendingIntent p2) {
+            return null;
+        }
+
+        public NotificationCompat.Builder addPerson(String p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder extend(NotificationCompat.Extender p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setAllowSystemGeneratedContextualActions(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setAutoCancel(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setBadgeIconType(int p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setBubbleMetadata(NotificationCompat.BubbleMetadata p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setCategory(String p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setChannelId(String p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setChronometerCountDown(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setColor(int p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setColorized(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setContent(RemoteViews p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setContentInfo(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setContentIntent(PendingIntent p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setContentText(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setContentTitle(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setCustomBigContentView(RemoteViews p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setCustomContentView(RemoteViews p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setCustomHeadsUpContentView(RemoteViews p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setDefaults(int p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setDeleteIntent(PendingIntent p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setExtras(Bundle p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setFullScreenIntent(PendingIntent p0, boolean p1) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setGroup(String p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setGroupAlertBehavior(int p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setGroupSummary(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setLargeIcon(Bitmap p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setLights(int p0, int p1, int p2) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setLocalOnly(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setNotificationSilent() {
+            return null;
+        }
+
+        public NotificationCompat.Builder setNumber(int p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setOngoing(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setOnlyAlertOnce(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setPriority(int p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setProgress(int p0, int p1, boolean p2) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setPublicVersion(Notification p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setRemoteInputHistory(CharSequence[] p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setShortcutId(String p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setShowWhen(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setSmallIcon(int p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setSmallIcon(int p0, int p1) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setSortKey(String p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setSound(Uri p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setSound(Uri p0, int p1) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setStyle(NotificationCompat.Style p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setSubText(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setTicker(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setTicker(CharSequence p0, RemoteViews p1) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setTimeoutAfter(long p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setUsesChronometer(boolean p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setVibrate(long[] p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setVisibility(int p0) {
+            return null;
+        }
+
+        public NotificationCompat.Builder setWhen(long p0) {
+            return null;
+        }
+
+        public RemoteViews getBigContentView() {
+            return null;
+        }
+
+        public RemoteViews getContentView() {
+            return null;
+        }
+
+        public RemoteViews getHeadsUpContentView() {
+            return null;
+        }
+
+        public int getColor() {
+            return 0;
+        }
+
+        public int getPriority() {
+            return 0;
+        }
+
+        public long getWhenIfShowing() {
+            return 0;
+        }
+    }
+    static public class InboxStyle extends NotificationCompat.Style {
+        public InboxStyle() {}
+
+        public InboxStyle(NotificationCompat.Builder p0) {}
+
+        public NotificationCompat.InboxStyle addLine(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.InboxStyle setBigContentTitle(CharSequence p0) {
+            return null;
+        }
+
+        public NotificationCompat.InboxStyle setSummaryText(CharSequence p0) {
+            return null;
+        }
+
+        public void apply(NotificationBuilderWithBuilderAccessor p0) {}
+    }
+    static public interface Extender {
+        NotificationCompat.Builder extend(NotificationCompat.Builder p0);
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/RemoteInput.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/RemoteInput.java
@@ -1,0 +1,71 @@
+// Generated automatically from androidx.core.app.RemoteInput for testing purposes
+
+package androidx.core.app;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import java.util.Map;
+import java.util.Set;
+
+public class RemoteInput {
+    protected RemoteInput() {}
+
+    public Bundle getExtras() {
+        return null;
+    }
+
+    public CharSequence getLabel() {
+        return null;
+    }
+
+    public CharSequence[] getChoices() {
+        return null;
+    }
+
+    public Set<String> getAllowedDataTypes() {
+        return null;
+    }
+
+    public String getResultKey() {
+        return null;
+    }
+
+    public boolean getAllowFreeFormInput() {
+        return false;
+    }
+
+    public boolean isDataOnly() {
+        return false;
+    }
+
+    public int getEditChoicesBeforeSending() {
+        return 0;
+    }
+
+    public static Bundle getResultsFromIntent(Intent p0) {
+        return null;
+    }
+
+    public static Map<String, Uri> getDataResultsFromIntent(Intent p0, String p1) {
+        return null;
+    }
+
+    public static String EXTRA_RESULTS_DATA = null;
+    public static String RESULTS_CLIP_LABEL = null;
+    public static int EDIT_CHOICES_BEFORE_SENDING_AUTO = 0;
+    public static int EDIT_CHOICES_BEFORE_SENDING_DISABLED = 0;
+    public static int EDIT_CHOICES_BEFORE_SENDING_ENABLED = 0;
+    public static int SOURCE_CHOICE = 0;
+    public static int SOURCE_FREE_FORM_INPUT = 0;
+
+    public static int getResultsSource(Intent p0) {
+        return 0;
+    }
+
+    public static void addDataResultToIntent(RemoteInput p0, Intent p1, Map<String, Uri> p2) {}
+
+    public static void addResultsToIntent(RemoteInput[] p0, Intent p1, Bundle p2) {}
+
+    public static void setResultsSource(Intent p0, int p1) {}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/versionedparcelable/CustomVersionedParcelable.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/versionedparcelable/CustomVersionedParcelable.java
@@ -1,0 +1,14 @@
+// Generated automatically from androidx.versionedparcelable.CustomVersionedParcelable for testing
+// purposes
+
+package androidx.versionedparcelable;
+
+import androidx.versionedparcelable.VersionedParcelable;
+
+abstract public class CustomVersionedParcelable implements VersionedParcelable {
+    public CustomVersionedParcelable() {}
+
+    public void onPostParceling() {}
+
+    public void onPreParceling(boolean p0) {}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/versionedparcelable/VersionedParcelable.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/versionedparcelable/VersionedParcelable.java
@@ -1,0 +1,8 @@
+// Generated automatically from androidx.versionedparcelable.VersionedParcelable for testing
+// purposes
+
+package androidx.versionedparcelable;
+
+
+public interface VersionedParcelable {
+}


### PR DESCRIPTION
Adds summaries for [`NotificationCompat`](https://developer.android.com/reference/androidx/core/app/NotificationCompat) ands its inner classes [`NotificationCompat$Builder`](https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder), [`NotificationCompat$Action`](https://developer.android.com/reference/androidx/core/app/NotificationCompat.Action), and [`NotificationCompat$Action$Builder`](https://developer.android.com/reference/androidx/core/app/NotificationCompat.Action.Builder).

This adds coverage for CVE-2022-24886.

