### PR TITLE
Swift: Add encryption barriers to the two swift/cleartext-* queries

### DIFF
--- a/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
+++ b/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
@@ -154,3 +154,16 @@ class SensitiveExpr extends Expr {
    */
   predicate isProbablySafe() { label.toLowerCase().regexpMatch(regexpProbablySafe()) }
 }
+
+/**
+ * An expression that may be protected with encryption, for example an
+ * argument to a function called "encrypt".
+ */
+class EncryptedExpr extends Expr {
+  EncryptedExpr() {
+    exists(CallExpr call |
+      call.getStaticTarget().getName().regexpMatch(".*(crypt|hash|encode|protect).*") and
+      call.getAnArgument().getExpr() = this
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
+++ b/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
@@ -156,13 +156,20 @@ class SensitiveExpr extends Expr {
 }
 
 /**
+ * A function that is likely used to encrypt or hash data.
+ */
+private class EncryptionFunction extends AbstractFunctionDecl {
+  EncryptionFunction() { this.getName().regexpMatch(".*(crypt|hash|encode|protect).*") }
+}
+
+/**
  * An expression that may be protected with encryption, for example an
  * argument to a function called "encrypt".
  */
 class EncryptedExpr extends Expr {
   EncryptedExpr() {
     exists(CallExpr call |
-      call.getStaticTarget().getName().regexpMatch(".*(crypt|hash|encode|protect).*") and
+      call.getStaticTarget() instanceof EncryptionFunction and
       call.getAnArgument().getExpr() = this
     )
   }

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -82,7 +82,9 @@ class CleartextStorageConfig extends TaintTracking::Configuration {
   override predicate isSanitizerIn(DataFlow::Node node) {
     // make sources barriers so that we only report the closest instance
     isSource(node)
-    or
+  }
+
+  override predicate isSanitizer(DataFlow::Node node) {
     // encryption barrier
     node.asExpr() instanceof EncryptedExpr
   }

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -82,6 +82,9 @@ class CleartextStorageConfig extends TaintTracking::Configuration {
   override predicate isSanitizerIn(DataFlow::Node node) {
     // make sources barriers so that we only report the closest instance
     isSource(node)
+    or
+    // encryption barrier
+    node.asExpr() instanceof EncryptedExpr
   }
 
   override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {

--- a/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
@@ -75,7 +75,9 @@ class CleartextTransmissionConfig extends TaintTracking::Configuration {
   override predicate isSanitizerIn(DataFlow::Node node) {
     // make sources barriers so that we only report the closest instance
     isSource(node)
-    or
+  }
+
+  override predicate isSanitizer(DataFlow::Node node) {
     // encryption barrier
     node.asExpr() instanceof EncryptedExpr
   }

--- a/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
@@ -75,6 +75,9 @@ class CleartextTransmissionConfig extends TaintTracking::Configuration {
   override predicate isSanitizerIn(DataFlow::Node node) {
     // make sources barriers so that we only report the closest instance
     isSource(node)
+    or
+    // encryption barrier
+    node.asExpr() instanceof EncryptedExpr
   }
 }
 

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -2,24 +2,13 @@ edges
 | file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [data] :  |
 | testCoreData.swift:18:19:18:26 | value :  | testCoreData.swift:19:12:19:12 | value |
 | testCoreData.swift:31:3:31:3 | newValue :  | testCoreData.swift:32:13:32:13 | newValue |
-| testCoreData.swift:37:14:37:22 | data :  | testCoreData.swift:37:49:37:49 | data :  |
-| testCoreData.swift:38:11:38:23 | data :  | testCoreData.swift:38:1:38:33 | data[return] :  |
 | testCoreData.swift:61:25:61:25 | password :  | testCoreData.swift:18:19:18:26 | value :  |
 | testCoreData.swift:64:16:64:16 | password :  | testCoreData.swift:31:3:31:3 | newValue :  |
 | testCoreData.swift:77:24:77:24 | x :  | testCoreData.swift:78:15:78:15 | x |
 | testCoreData.swift:80:10:80:22 | call to getPassword() :  | testCoreData.swift:81:15:81:15 | y |
 | testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:95:15:95:15 | x |
-| testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:99:14:99:14 | x :  |
 | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y |
-| testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:100:13:100:14 | &... :  |
-| testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:104:15:104:15 | y |
 | testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z |
-| testCoreData.swift:99:6:99:15 | call to encrypt(_:) :  | testCoreData.swift:103:15:103:15 | x |
-| testCoreData.swift:99:14:99:14 | x :  | testCoreData.swift:37:14:37:22 | data :  |
-| testCoreData.swift:99:14:99:14 | x :  | testCoreData.swift:99:6:99:15 | call to encrypt(_:) :  |
-| testCoreData.swift:100:13:100:14 | &... :  | testCoreData.swift:38:11:38:23 | data :  |
-| testCoreData.swift:100:13:100:14 | &... :  | testCoreData.swift:100:13:100:14 | [post] &... :  |
-| testCoreData.swift:100:13:100:14 | [post] &... :  | testCoreData.swift:104:15:104:15 | y |
 | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | value :  |
 | testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:35:12:35:12 | a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
@@ -34,10 +23,6 @@ nodes
 | testCoreData.swift:19:12:19:12 | value | semmle.label | value |
 | testCoreData.swift:31:3:31:3 | newValue :  | semmle.label | newValue :  |
 | testCoreData.swift:32:13:32:13 | newValue | semmle.label | newValue |
-| testCoreData.swift:37:14:37:22 | data :  | semmle.label | data :  |
-| testCoreData.swift:37:49:37:49 | data :  | semmle.label | data :  |
-| testCoreData.swift:38:1:38:33 | data[return] :  | semmle.label | data[return] :  |
-| testCoreData.swift:38:11:38:23 | data :  | semmle.label | data :  |
 | testCoreData.swift:48:15:48:15 | password | semmle.label | password |
 | testCoreData.swift:51:24:51:24 | password | semmle.label | password |
 | testCoreData.swift:58:15:58:15 | password | semmle.label | password |
@@ -54,12 +39,6 @@ nodes
 | testCoreData.swift:95:15:95:15 | x | semmle.label | x |
 | testCoreData.swift:96:15:96:15 | y | semmle.label | y |
 | testCoreData.swift:97:15:97:15 | z | semmle.label | z |
-| testCoreData.swift:99:6:99:15 | call to encrypt(_:) :  | semmle.label | call to encrypt(_:) :  |
-| testCoreData.swift:99:14:99:14 | x :  | semmle.label | x :  |
-| testCoreData.swift:100:13:100:14 | &... :  | semmle.label | &... :  |
-| testCoreData.swift:100:13:100:14 | [post] &... :  | semmle.label | [post] &... :  |
-| testCoreData.swift:103:15:103:15 | x | semmle.label | x |
-| testCoreData.swift:104:15:104:15 | y | semmle.label | y |
 | testRealm.swift:16:6:16:6 | value :  | semmle.label | value :  |
 | testRealm.swift:34:2:34:2 | [post] a [data] :  | semmle.label | [post] a [data] :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | semmle.label | myPassword :  |
@@ -68,8 +47,6 @@ nodes
 | testRealm.swift:42:11:42:11 | myPassword :  | semmle.label | myPassword :  |
 | testRealm.swift:43:47:43:47 | c | semmle.label | c |
 subpaths
-| testCoreData.swift:99:14:99:14 | x :  | testCoreData.swift:37:14:37:22 | data :  | testCoreData.swift:37:49:37:49 | data :  | testCoreData.swift:99:6:99:15 | call to encrypt(_:) :  |
-| testCoreData.swift:100:13:100:14 | &... :  | testCoreData.swift:38:11:38:23 | data :  | testCoreData.swift:38:1:38:33 | data[return] :  | testCoreData.swift:100:13:100:14 | [post] &... :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:34:2:34:2 | [post] a [data] :  |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:42:2:42:2 | [post] c [data] :  |
 #select
@@ -84,7 +61,5 @@ subpaths
 | testCoreData.swift:95:15:95:15 | x | testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:95:15:95:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:91:10:91:10 | passwd :  | passwd |
 | testCoreData.swift:96:15:96:15 | y | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:92:10:92:10 | passwd :  | passwd |
 | testCoreData.swift:97:15:97:15 | z | testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z | This operation stores 'z' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:93:10:93:10 | passwd :  | passwd |
-| testCoreData.swift:103:15:103:15 | x | testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:103:15:103:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:91:10:91:10 | passwd :  | passwd |
-| testCoreData.swift:104:15:104:15 | y | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:104:15:104:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:92:10:92:10 | passwd :  | passwd |
 | testRealm.swift:35:12:35:12 | a | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:35:12:35:12 | a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
 | testRealm.swift:43:47:43:47 | c | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:43:47:43:47 | c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
@@ -14,11 +14,6 @@ edges
 | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | testSend.swift:49:13:49:36 | call to pad(_:) :  |
 | testSend.swift:49:27:49:27 | password :  | testSend.swift:42:16:42:24 | data :  |
 | testSend.swift:49:27:49:27 | password :  | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  |
-| testSend.swift:50:13:50:36 | call to aes_crypt(_:) :  | testSend.swift:57:27:57:27 | str6 |
-| testSend.swift:50:23:50:35 | call to pad(_:) :  | testSend.swift:42:16:42:24 | data :  |
-| testSend.swift:50:23:50:35 | call to pad(_:) :  | testSend.swift:50:13:50:36 | call to aes_crypt(_:) :  |
-| testSend.swift:50:27:50:27 | password :  | testSend.swift:41:10:41:18 | data :  |
-| testSend.swift:50:27:50:27 | password :  | testSend.swift:50:23:50:35 | call to pad(_:) :  |
 | testURL.swift:13:54:13:54 | passwd :  | testURL.swift:13:22:13:54 | ... .+(_:_:) ... |
 | testURL.swift:16:55:16:55 | credit_card_no :  | testURL.swift:16:22:16:55 | ... .+(_:_:) ... |
 nodes
@@ -36,15 +31,11 @@ nodes
 | testSend.swift:49:13:49:36 | call to pad(_:) :  | semmle.label | call to pad(_:) :  |
 | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | semmle.label | call to aes_crypt(_:) :  |
 | testSend.swift:49:27:49:27 | password :  | semmle.label | password :  |
-| testSend.swift:50:13:50:36 | call to aes_crypt(_:) :  | semmle.label | call to aes_crypt(_:) :  |
-| testSend.swift:50:23:50:35 | call to pad(_:) :  | semmle.label | call to pad(_:) :  |
-| testSend.swift:50:27:50:27 | password :  | semmle.label | password :  |
 | testSend.swift:52:27:52:27 | str1 | semmle.label | str1 |
 | testSend.swift:53:27:53:27 | str2 | semmle.label | str2 |
 | testSend.swift:54:27:54:27 | str3 | semmle.label | str3 |
 | testSend.swift:55:27:55:27 | str4 | semmle.label | str4 |
 | testSend.swift:56:27:56:27 | str5 | semmle.label | str5 |
-| testSend.swift:57:27:57:27 | str6 | semmle.label | str6 |
 | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | testURL.swift:13:54:13:54 | passwd :  | semmle.label | passwd :  |
 | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
@@ -55,8 +46,6 @@ subpaths
 | testSend.swift:48:23:48:23 | password :  | testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  | testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  |
 | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  | testSend.swift:49:13:49:36 | call to pad(_:) :  |
 | testSend.swift:49:27:49:27 | password :  | testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  |
-| testSend.swift:50:23:50:35 | call to pad(_:) :  | testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  | testSend.swift:50:13:50:36 | call to aes_crypt(_:) :  |
-| testSend.swift:50:27:50:27 | password :  | testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  | testSend.swift:50:23:50:35 | call to pad(_:) :  |
 #select
 | testSend.swift:29:19:29:19 | passwordPlain | testSend.swift:29:19:29:19 | passwordPlain | testSend.swift:29:19:29:19 | passwordPlain | This operation transmits 'passwordPlain', which may contain unencrypted sensitive data from $@ | testSend.swift:29:19:29:19 | passwordPlain | passwordPlain |
 | testSend.swift:52:27:52:27 | str1 | testSend.swift:45:13:45:13 | password :  | testSend.swift:52:27:52:27 | str1 | This operation transmits 'str1', which may contain unencrypted sensitive data from $@ | testSend.swift:45:13:45:13 | password :  | password |
@@ -64,7 +53,6 @@ subpaths
 | testSend.swift:54:27:54:27 | str3 | testSend.swift:47:17:47:17 | password :  | testSend.swift:54:27:54:27 | str3 | This operation transmits 'str3', which may contain unencrypted sensitive data from $@ | testSend.swift:47:17:47:17 | password :  | password |
 | testSend.swift:55:27:55:27 | str4 | testSend.swift:48:23:48:23 | password :  | testSend.swift:55:27:55:27 | str4 | This operation transmits 'str4', which may contain unencrypted sensitive data from $@ | testSend.swift:48:23:48:23 | password :  | password |
 | testSend.swift:56:27:56:27 | str5 | testSend.swift:49:27:49:27 | password :  | testSend.swift:56:27:56:27 | str5 | This operation transmits 'str5', which may contain unencrypted sensitive data from $@ | testSend.swift:49:27:49:27 | password :  | password |
-| testSend.swift:57:27:57:27 | str6 | testSend.swift:50:27:50:27 | password :  | testSend.swift:57:27:57:27 | str6 | This operation transmits 'str6', which may contain unencrypted sensitive data from $@ | testSend.swift:50:27:50:27 | password :  | password |
 | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | testURL.swift:13:54:13:54 | passwd :  | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@ | testURL.swift:13:54:13:54 | passwd :  | passwd |
 | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | testURL.swift:16:55:16:55 | credit_card_no :  | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@ | testURL.swift:16:55:16:55 | credit_card_no :  | credit_card_no |
 | testURL.swift:20:22:20:22 | passwd | testURL.swift:20:22:20:22 | passwd | testURL.swift:20:22:20:22 | passwd | This operation transmits 'passwd', which may contain unencrypted sensitive data from $@ | testURL.swift:20:22:20:22 | passwd | passwd |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
@@ -1,16 +1,70 @@
 edges
+| testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  |
+| testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  |
+| testSend.swift:45:13:45:13 | password :  | testSend.swift:52:27:52:27 | str1 |
+| testSend.swift:46:13:46:13 | password :  | testSend.swift:53:27:53:27 | str2 |
+| testSend.swift:47:13:47:25 | call to pad(_:) :  | testSend.swift:54:27:54:27 | str3 |
+| testSend.swift:47:17:47:17 | password :  | testSend.swift:41:10:41:18 | data :  |
+| testSend.swift:47:17:47:17 | password :  | testSend.swift:47:13:47:25 | call to pad(_:) :  |
+| testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  | testSend.swift:55:27:55:27 | str4 |
+| testSend.swift:48:23:48:23 | password :  | testSend.swift:42:16:42:24 | data :  |
+| testSend.swift:48:23:48:23 | password :  | testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  |
+| testSend.swift:49:13:49:36 | call to pad(_:) :  | testSend.swift:56:27:56:27 | str5 |
+| testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | testSend.swift:41:10:41:18 | data :  |
+| testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | testSend.swift:49:13:49:36 | call to pad(_:) :  |
+| testSend.swift:49:27:49:27 | password :  | testSend.swift:42:16:42:24 | data :  |
+| testSend.swift:49:27:49:27 | password :  | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  |
+| testSend.swift:50:13:50:36 | call to aes_crypt(_:) :  | testSend.swift:57:27:57:27 | str6 |
+| testSend.swift:50:23:50:35 | call to pad(_:) :  | testSend.swift:42:16:42:24 | data :  |
+| testSend.swift:50:23:50:35 | call to pad(_:) :  | testSend.swift:50:13:50:36 | call to aes_crypt(_:) :  |
+| testSend.swift:50:27:50:27 | password :  | testSend.swift:41:10:41:18 | data :  |
+| testSend.swift:50:27:50:27 | password :  | testSend.swift:50:23:50:35 | call to pad(_:) :  |
 | testURL.swift:13:54:13:54 | passwd :  | testURL.swift:13:22:13:54 | ... .+(_:_:) ... |
 | testURL.swift:16:55:16:55 | credit_card_no :  | testURL.swift:16:22:16:55 | ... .+(_:_:) ... |
 nodes
 | testSend.swift:29:19:29:19 | passwordPlain | semmle.label | passwordPlain |
+| testSend.swift:41:10:41:18 | data :  | semmle.label | data :  |
+| testSend.swift:41:45:41:45 | data :  | semmle.label | data :  |
+| testSend.swift:42:16:42:24 | data :  | semmle.label | data :  |
+| testSend.swift:42:51:42:51 | data :  | semmle.label | data :  |
+| testSend.swift:45:13:45:13 | password :  | semmle.label | password :  |
+| testSend.swift:46:13:46:13 | password :  | semmle.label | password :  |
+| testSend.swift:47:13:47:25 | call to pad(_:) :  | semmle.label | call to pad(_:) :  |
+| testSend.swift:47:17:47:17 | password :  | semmle.label | password :  |
+| testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  | semmle.label | call to aes_crypt(_:) :  |
+| testSend.swift:48:23:48:23 | password :  | semmle.label | password :  |
+| testSend.swift:49:13:49:36 | call to pad(_:) :  | semmle.label | call to pad(_:) :  |
+| testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | semmle.label | call to aes_crypt(_:) :  |
+| testSend.swift:49:27:49:27 | password :  | semmle.label | password :  |
+| testSend.swift:50:13:50:36 | call to aes_crypt(_:) :  | semmle.label | call to aes_crypt(_:) :  |
+| testSend.swift:50:23:50:35 | call to pad(_:) :  | semmle.label | call to pad(_:) :  |
+| testSend.swift:50:27:50:27 | password :  | semmle.label | password :  |
+| testSend.swift:52:27:52:27 | str1 | semmle.label | str1 |
+| testSend.swift:53:27:53:27 | str2 | semmle.label | str2 |
+| testSend.swift:54:27:54:27 | str3 | semmle.label | str3 |
+| testSend.swift:55:27:55:27 | str4 | semmle.label | str4 |
+| testSend.swift:56:27:56:27 | str5 | semmle.label | str5 |
+| testSend.swift:57:27:57:27 | str6 | semmle.label | str6 |
 | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | testURL.swift:13:54:13:54 | passwd :  | semmle.label | passwd :  |
 | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | testURL.swift:16:55:16:55 | credit_card_no :  | semmle.label | credit_card_no :  |
 | testURL.swift:20:22:20:22 | passwd | semmle.label | passwd |
 subpaths
+| testSend.swift:47:17:47:17 | password :  | testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  | testSend.swift:47:13:47:25 | call to pad(_:) :  |
+| testSend.swift:48:23:48:23 | password :  | testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  | testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  |
+| testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  | testSend.swift:49:13:49:36 | call to pad(_:) :  |
+| testSend.swift:49:27:49:27 | password :  | testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  |
+| testSend.swift:50:23:50:35 | call to pad(_:) :  | testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  | testSend.swift:50:13:50:36 | call to aes_crypt(_:) :  |
+| testSend.swift:50:27:50:27 | password :  | testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  | testSend.swift:50:23:50:35 | call to pad(_:) :  |
 #select
 | testSend.swift:29:19:29:19 | passwordPlain | testSend.swift:29:19:29:19 | passwordPlain | testSend.swift:29:19:29:19 | passwordPlain | This operation transmits 'passwordPlain', which may contain unencrypted sensitive data from $@ | testSend.swift:29:19:29:19 | passwordPlain | passwordPlain |
+| testSend.swift:52:27:52:27 | str1 | testSend.swift:45:13:45:13 | password :  | testSend.swift:52:27:52:27 | str1 | This operation transmits 'str1', which may contain unencrypted sensitive data from $@ | testSend.swift:45:13:45:13 | password :  | password |
+| testSend.swift:53:27:53:27 | str2 | testSend.swift:46:13:46:13 | password :  | testSend.swift:53:27:53:27 | str2 | This operation transmits 'str2', which may contain unencrypted sensitive data from $@ | testSend.swift:46:13:46:13 | password :  | password |
+| testSend.swift:54:27:54:27 | str3 | testSend.swift:47:17:47:17 | password :  | testSend.swift:54:27:54:27 | str3 | This operation transmits 'str3', which may contain unencrypted sensitive data from $@ | testSend.swift:47:17:47:17 | password :  | password |
+| testSend.swift:55:27:55:27 | str4 | testSend.swift:48:23:48:23 | password :  | testSend.swift:55:27:55:27 | str4 | This operation transmits 'str4', which may contain unencrypted sensitive data from $@ | testSend.swift:48:23:48:23 | password :  | password |
+| testSend.swift:56:27:56:27 | str5 | testSend.swift:49:27:49:27 | password :  | testSend.swift:56:27:56:27 | str5 | This operation transmits 'str5', which may contain unencrypted sensitive data from $@ | testSend.swift:49:27:49:27 | password :  | password |
+| testSend.swift:57:27:57:27 | str6 | testSend.swift:50:27:50:27 | password :  | testSend.swift:57:27:57:27 | str6 | This operation transmits 'str6', which may contain unencrypted sensitive data from $@ | testSend.swift:50:27:50:27 | password :  | password |
 | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | testURL.swift:13:54:13:54 | passwd :  | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@ | testURL.swift:13:54:13:54 | passwd :  | passwd |
 | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | testURL.swift:16:55:16:55 | credit_card_no :  | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@ | testURL.swift:16:55:16:55 | credit_card_no :  | credit_card_no |
 | testURL.swift:20:22:20:22 | passwd | testURL.swift:20:22:20:22 | passwd | testURL.swift:20:22:20:22 | passwd | This operation transmits 'passwd', which may contain unencrypted sensitive data from $@ | testURL.swift:20:22:20:22 | passwd | passwd |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
@@ -1,41 +1,23 @@
 edges
 | testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  |
-| testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  |
 | testSend.swift:45:13:45:13 | password :  | testSend.swift:52:27:52:27 | str1 |
 | testSend.swift:46:13:46:13 | password :  | testSend.swift:53:27:53:27 | str2 |
 | testSend.swift:47:13:47:25 | call to pad(_:) :  | testSend.swift:54:27:54:27 | str3 |
 | testSend.swift:47:17:47:17 | password :  | testSend.swift:41:10:41:18 | data :  |
 | testSend.swift:47:17:47:17 | password :  | testSend.swift:47:13:47:25 | call to pad(_:) :  |
-| testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  | testSend.swift:55:27:55:27 | str4 |
-| testSend.swift:48:23:48:23 | password :  | testSend.swift:42:16:42:24 | data :  |
-| testSend.swift:48:23:48:23 | password :  | testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  |
-| testSend.swift:49:13:49:36 | call to pad(_:) :  | testSend.swift:56:27:56:27 | str5 |
-| testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | testSend.swift:41:10:41:18 | data :  |
-| testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | testSend.swift:49:13:49:36 | call to pad(_:) :  |
-| testSend.swift:49:27:49:27 | password :  | testSend.swift:42:16:42:24 | data :  |
-| testSend.swift:49:27:49:27 | password :  | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  |
 | testURL.swift:13:54:13:54 | passwd :  | testURL.swift:13:22:13:54 | ... .+(_:_:) ... |
 | testURL.swift:16:55:16:55 | credit_card_no :  | testURL.swift:16:22:16:55 | ... .+(_:_:) ... |
 nodes
 | testSend.swift:29:19:29:19 | passwordPlain | semmle.label | passwordPlain |
 | testSend.swift:41:10:41:18 | data :  | semmle.label | data :  |
 | testSend.swift:41:45:41:45 | data :  | semmle.label | data :  |
-| testSend.swift:42:16:42:24 | data :  | semmle.label | data :  |
-| testSend.swift:42:51:42:51 | data :  | semmle.label | data :  |
 | testSend.swift:45:13:45:13 | password :  | semmle.label | password :  |
 | testSend.swift:46:13:46:13 | password :  | semmle.label | password :  |
 | testSend.swift:47:13:47:25 | call to pad(_:) :  | semmle.label | call to pad(_:) :  |
 | testSend.swift:47:17:47:17 | password :  | semmle.label | password :  |
-| testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  | semmle.label | call to aes_crypt(_:) :  |
-| testSend.swift:48:23:48:23 | password :  | semmle.label | password :  |
-| testSend.swift:49:13:49:36 | call to pad(_:) :  | semmle.label | call to pad(_:) :  |
-| testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | semmle.label | call to aes_crypt(_:) :  |
-| testSend.swift:49:27:49:27 | password :  | semmle.label | password :  |
 | testSend.swift:52:27:52:27 | str1 | semmle.label | str1 |
 | testSend.swift:53:27:53:27 | str2 | semmle.label | str2 |
 | testSend.swift:54:27:54:27 | str3 | semmle.label | str3 |
-| testSend.swift:55:27:55:27 | str4 | semmle.label | str4 |
-| testSend.swift:56:27:56:27 | str5 | semmle.label | str5 |
 | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | testURL.swift:13:54:13:54 | passwd :  | semmle.label | passwd :  |
 | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
@@ -43,16 +25,11 @@ nodes
 | testURL.swift:20:22:20:22 | passwd | semmle.label | passwd |
 subpaths
 | testSend.swift:47:17:47:17 | password :  | testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  | testSend.swift:47:13:47:25 | call to pad(_:) :  |
-| testSend.swift:48:23:48:23 | password :  | testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  | testSend.swift:48:13:48:31 | call to aes_crypt(_:) :  |
-| testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  | testSend.swift:41:10:41:18 | data :  | testSend.swift:41:45:41:45 | data :  | testSend.swift:49:13:49:36 | call to pad(_:) :  |
-| testSend.swift:49:27:49:27 | password :  | testSend.swift:42:16:42:24 | data :  | testSend.swift:42:51:42:51 | data :  | testSend.swift:49:17:49:35 | call to aes_crypt(_:) :  |
 #select
 | testSend.swift:29:19:29:19 | passwordPlain | testSend.swift:29:19:29:19 | passwordPlain | testSend.swift:29:19:29:19 | passwordPlain | This operation transmits 'passwordPlain', which may contain unencrypted sensitive data from $@ | testSend.swift:29:19:29:19 | passwordPlain | passwordPlain |
 | testSend.swift:52:27:52:27 | str1 | testSend.swift:45:13:45:13 | password :  | testSend.swift:52:27:52:27 | str1 | This operation transmits 'str1', which may contain unencrypted sensitive data from $@ | testSend.swift:45:13:45:13 | password :  | password |
 | testSend.swift:53:27:53:27 | str2 | testSend.swift:46:13:46:13 | password :  | testSend.swift:53:27:53:27 | str2 | This operation transmits 'str2', which may contain unencrypted sensitive data from $@ | testSend.swift:46:13:46:13 | password :  | password |
 | testSend.swift:54:27:54:27 | str3 | testSend.swift:47:17:47:17 | password :  | testSend.swift:54:27:54:27 | str3 | This operation transmits 'str3', which may contain unencrypted sensitive data from $@ | testSend.swift:47:17:47:17 | password :  | password |
-| testSend.swift:55:27:55:27 | str4 | testSend.swift:48:23:48:23 | password :  | testSend.swift:55:27:55:27 | str4 | This operation transmits 'str4', which may contain unencrypted sensitive data from $@ | testSend.swift:48:23:48:23 | password :  | password |
-| testSend.swift:56:27:56:27 | str5 | testSend.swift:49:27:49:27 | password :  | testSend.swift:56:27:56:27 | str5 | This operation transmits 'str5', which may contain unencrypted sensitive data from $@ | testSend.swift:49:27:49:27 | password :  | password |
 | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | testURL.swift:13:54:13:54 | passwd :  | testURL.swift:13:22:13:54 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@ | testURL.swift:13:54:13:54 | passwd :  | passwd |
 | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | testURL.swift:16:55:16:55 | credit_card_no :  | testURL.swift:16:22:16:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@ | testURL.swift:16:55:16:55 | credit_card_no :  | credit_card_no |
 | testURL.swift:20:22:20:22 | passwd | testURL.swift:20:22:20:22 | passwd | testURL.swift:20:22:20:22 | passwd | This operation transmits 'passwd', which may contain unencrypted sensitive data from $@ | testURL.swift:20:22:20:22 | passwd | passwd |

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -25,6 +25,12 @@
 | testSend.swift:30:19:30:19 | passwordHash | isProbablySafe, label:passwordHash, type:credential |
 | testSend.swift:33:19:33:19 | passwordPlain | label:passwordPlain, type:credential |
 | testSend.swift:34:19:34:19 | passwordHash | isProbablySafe, label:passwordHash, type:credential |
+| testSend.swift:45:13:45:13 | password | label:password, type:credential |
+| testSend.swift:46:13:46:13 | password | label:password, type:credential |
+| testSend.swift:47:17:47:17 | password | label:password, type:credential |
+| testSend.swift:48:23:48:23 | password | label:password, type:credential |
+| testSend.swift:49:27:49:27 | password | label:password, type:credential |
+| testSend.swift:50:27:50:27 | password | label:password, type:credential |
 | testURL.swift:13:54:13:54 | passwd | label:passwd, type:credential |
 | testURL.swift:14:54:14:54 | encrypted_passwd | isProbablySafe, label:encrypted_passwd, type:credential |
 | testURL.swift:16:55:16:55 | credit_card_no | label:credit_card_no, type:private information |

--- a/swift/ql/test/query-tests/Security/CWE-311/testCoreData.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testCoreData.swift
@@ -100,7 +100,7 @@ func test4(obj : NSManagedObject, passwd : String) {
 	hash(data: &y);
 	z = "";
 
-	obj.setValue(x, forKey: "myKey") // GOOD (not sensitive) [FALSE POSITIVE]
-	obj.setValue(y, forKey: "myKey") // GOOD (not sensitive) [FALSE POSITIVE]
+	obj.setValue(x, forKey: "myKey") // GOOD (not sensitive)
+	obj.setValue(y, forKey: "myKey") // GOOD (not sensitive)
 	obj.setValue(z, forKey: "myKey") // GOOD (not sensitive)
 }

--- a/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
@@ -54,5 +54,5 @@ func test2(password : String, connection : NWConnection) {
 	connection.send(content: str3, completion: .idempotent) // BAD
 	connection.send(content: str4, completion: .idempotent) // GOOD (encrypted) [FALSE POSITIVE]
 	connection.send(content: str5, completion: .idempotent) // GOOD (encrypted) [FALSE POSITIVE]
-	connection.send(content: str6, completion: .idempotent) // GOOD (encrypted) [FALSE POSITIVE]
+	connection.send(content: str6, completion: .idempotent) // GOOD (encrypted)
 }

--- a/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
@@ -37,3 +37,22 @@ func test1(passwordPlain : String, passwordHash : String) {
 	nw.send(content: data2, completion: .idempotent) // BAD [NOT DETECTED]
 	nw.send(content: data3, completion: .idempotent) // GOOD (not sensitive)
 }
+
+func pad(_ data: String) -> String { return data }
+func aes_crypt(_ data: String) -> String { return data }
+
+func test2(password : String, connection : NWConnection) {
+	let str1 = password
+	let str2 = password + " "
+	let str3 = pad(password)
+	let str4 = aes_crypt(password)
+	let str5 = pad(aes_crypt(password))
+	let str6 = aes_crypt(pad(password))
+
+	connection.send(content: str1, completion: .idempotent) // BAD
+	connection.send(content: str2, completion: .idempotent) // BAD
+	connection.send(content: str3, completion: .idempotent) // BAD
+	connection.send(content: str4, completion: .idempotent) // GOOD (encrypted) [FALSE POSITIVE]
+	connection.send(content: str5, completion: .idempotent) // GOOD (encrypted) [FALSE POSITIVE]
+	connection.send(content: str6, completion: .idempotent) // GOOD (encrypted) [FALSE POSITIVE]
+}

--- a/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
@@ -52,7 +52,7 @@ func test2(password : String, connection : NWConnection) {
 	connection.send(content: str1, completion: .idempotent) // BAD
 	connection.send(content: str2, completion: .idempotent) // BAD
 	connection.send(content: str3, completion: .idempotent) // BAD
-	connection.send(content: str4, completion: .idempotent) // GOOD (encrypted) [FALSE POSITIVE]
-	connection.send(content: str5, completion: .idempotent) // GOOD (encrypted) [FALSE POSITIVE]
+	connection.send(content: str4, completion: .idempotent) // GOOD (encrypted)
+	connection.send(content: str5, completion: .idempotent) // GOOD (encrypted)
 	connection.send(content: str6, completion: .idempotent) // GOOD (encrypted)
 }


### PR DESCRIPTION
This is a simple improvement that didn't make it into the original PR of the two `cleartext-*` queries.  Removes some false positive results.