### PR TITLE
Java: Add Implicit PendingIntents sinks for Compat classes

### DIFF
--- a/java/ql/lib/change-notes/2022-09-07-implicit-pendingintents-compat-sinks.md
+++ b/java/ql/lib/change-notes/2022-09-07-implicit-pendingintents-compat-sinks.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Added new sinks to the query `java/android/implict-pendingintents` to take into account the classes `androidx.core.app.NotificationManagerCompat` and `androidx.core.app.AlarmManagerCompat`.
+  

--- a/java/ql/lib/semmle/code/java/security/ImplicitPendingIntents.qll
+++ b/java/ql/lib/semmle/code/java/security/ImplicitPendingIntents.qll
@@ -102,6 +102,8 @@ private class PendingIntentSentSinkModels extends SinkModelCsv {
         "android.app;NotificationManager;true;notify;(String,int,Notification);;Argument[2];pending-intent-sent;manual",
         "android.app;NotificationManager;true;notifyAsPackage;(String,String,int,Notification);;Argument[3];pending-intent-sent;manual",
         "android.app;NotificationManager;true;notifyAsUser;(String,int,Notification,UserHandle);;Argument[2];pending-intent-sent;manual",
+        "androidx.core.app;NotificationManagerCompat;true;notify;(int,Notification);;Argument[1];pending-intent-sent;manual",
+        "androidx.core.app;NotificationManagerCompat;true;notify;(String,int,Notification);;Argument[2];pending-intent-sent;manual",
         "android.app;PendingIntent;false;send;(Context,int,Intent,OnFinished,Handler,String,Bundle);;Argument[2];pending-intent-sent;manual",
         "android.app;PendingIntent;false;send;(Context,int,Intent,OnFinished,Handler,String);;Argument[2];pending-intent-sent;manual",
         "android.app;PendingIntent;false;send;(Context,int,Intent,OnFinished,Handler);;Argument[2];pending-intent-sent;manual",
@@ -115,6 +117,10 @@ private class PendingIntentSentSinkModels extends SinkModelCsv {
         "android.app;AlarmManager;true;setInexactRepeating;;;Argument[3];pending-intent-sent;manual",
         "android.app;AlarmManager;true;setRepeating;;;Argument[3];pending-intent-sent;manual",
         "android.app;AlarmManager;true;setWindow;(int,long,long,PendingIntent);;Argument[3];pending-intent-sent;manual",
+        "androidx.core.app;AlarmManagerCompat;true;setAlarmClock;;;Argument[2..3];pending-intent-sent;manual",
+        "androidx.core.app;AlarmManagerCompat;true;setAndAllowWhileIdle;;;Argument[3];pending-intent-sent;manual",
+        "androidx.core.app;AlarmManagerCompat;true;setExact;;;Argument[3];pending-intent-sent;manual",
+        "androidx.core.app;AlarmManagerCompat;true;setExactAndAllowWhileIdle;;;Argument[3];pending-intent-sent;manual",
       ]
   }
 }

--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
@@ -14,6 +14,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.CancellationSignal;
 import android.os.RemoteException;
+import androidx.core.app.AlarmManagerCompat;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
 import androidx.slice.Slice;
 import androidx.slice.SliceProvider;
@@ -182,7 +184,7 @@ public class ImplicitPendingIntentsTest {
             Notification.Builder nBuilder =
                     new Notification.Builder(ctx).addAction(aBuilder.build());
             Notification notification = nBuilder.build();
-            NotificationManager nManager = new NotificationManager();
+            NotificationManager nManager = null;
             nManager.notifyAsPackage("targetPackage", "tag", 0, notification); // $hasImplicitPendingIntent
             nManager.notify(0, notification); // $hasImplicitPendingIntent
             nManager.notifyAsUser("", 0, notification, null); // $hasImplicitPendingIntent
@@ -195,7 +197,7 @@ public class ImplicitPendingIntentsTest {
             Notification.Builder nBuilder =
                     new Notification.Builder(ctx).addAction(aBuilder.build());
             Notification notification = nBuilder.build();
-            NotificationManager nManager = new NotificationManager();
+            NotificationManager nManager = null;
             nManager.notify(0, notification); // Safe
         }
         {
@@ -212,10 +214,21 @@ public class ImplicitPendingIntentsTest {
             Notification.Action action = new Notification.Action(0, "", pi2);
             Notification.Builder nBuilder = new Notification.Builder(ctx).addAction(action);
             Notification notification = nBuilder.build();
-            NotificationManager noMan = new NotificationManager();
+            NotificationManager noMan = null;
             noMan.notify(0, notification); // Safe
         }
-
+        // Compat sinks
+        {
+            Intent baseIntent = new Intent();
+            PendingIntent pi = PendingIntent.getActivity(ctx, 0, baseIntent, 0);
+            Notification.Action.Builder aBuilder = new Notification.Action.Builder(0, "", pi);
+            Notification.Builder nBuilder =
+                    new Notification.Builder(ctx).addAction(aBuilder.build());
+            Notification notification = nBuilder.build();
+            NotificationManagerCompat nManager = null;
+            nManager.notify(0, notification); // $hasImplicitPendingIntent
+            nManager.notify("", 0, notification); // $hasImplicitPendingIntent
+        }
     }
 
     public static void testPendingIntentInAnAlarm(Context ctx) {
@@ -237,6 +250,16 @@ public class ImplicitPendingIntentsTest {
             PendingIntent pi =
                     PendingIntent.getActivity(ctx, 0, baseIntent, PendingIntent.FLAG_IMMUTABLE); // Sanitizer
             aManager.set(0, 0, pi); // Safe
+        }
+        // Compat sinks
+        {
+            Intent baseIntent = new Intent();
+            PendingIntent pi = PendingIntent.getActivity(ctx, 0, baseIntent, 0);
+            AlarmManagerCompat.setAlarmClock(aManager, 0, pi, null); // $hasImplicitPendingIntent
+            AlarmManagerCompat.setAlarmClock(aManager, 0, null, pi); // $hasImplicitPendingIntent
+            AlarmManagerCompat.setAndAllowWhileIdle(aManager, 0, 0, pi); // $hasImplicitPendingIntent
+            AlarmManagerCompat.setExact(aManager, 0, 0, pi); // $hasImplicitPendingIntent
+            AlarmManagerCompat.setExactAndAllowWhileIdle(aManager, 0, 0, pi); // $hasImplicitPendingIntent
         }
     }
 

--- a/java/ql/test/stubs/google-android-9.0.0/android/app/AppComponentFactory.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/app/AppComponentFactory.java
@@ -1,0 +1,22 @@
+// Generated automatically from android.app.AppComponentFactory for testing purposes
+
+package android.app;
+
+import android.app.Activity;
+import android.app.Application;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.ContentProvider;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+
+public class AppComponentFactory
+{
+    public Activity instantiateActivity(ClassLoader p0, String p1, Intent p2){ return null; }
+    public AppComponentFactory(){}
+    public Application instantiateApplication(ClassLoader p0, String p1){ return null; }
+    public BroadcastReceiver instantiateReceiver(ClassLoader p0, String p1, Intent p2){ return null; }
+    public ClassLoader instantiateClassLoader(ClassLoader p0, ApplicationInfo p1){ return null; }
+    public ContentProvider instantiateProvider(ClassLoader p0, String p1){ return null; }
+    public Service instantiateService(ClassLoader p0, String p1, Intent p2){ return null; }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/app/AutomaticZenRule.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/app/AutomaticZenRule.java
@@ -1,0 +1,37 @@
+// Generated automatically from android.app.AutomaticZenRule for testing purposes
+
+package android.app;
+
+import android.content.ComponentName;
+import android.net.Uri;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.service.notification.ZenPolicy;
+
+public class AutomaticZenRule implements Parcelable
+{
+    protected AutomaticZenRule() {}
+    public AutomaticZenRule(Parcel p0){}
+    public AutomaticZenRule(String p0, ComponentName p1, ComponentName p2, Uri p3, ZenPolicy p4, int p5, boolean p6){}
+    public AutomaticZenRule(String p0, ComponentName p1, Uri p2, int p3, boolean p4){}
+    public ComponentName getConfigurationActivity(){ return null; }
+    public ComponentName getOwner(){ return null; }
+    public String getName(){ return null; }
+    public String toString(){ return null; }
+    public Uri getConditionId(){ return null; }
+    public ZenPolicy getZenPolicy(){ return null; }
+    public boolean equals(Object p0){ return false; }
+    public boolean isEnabled(){ return false; }
+    public int describeContents(){ return 0; }
+    public int getInterruptionFilter(){ return 0; }
+    public int hashCode(){ return 0; }
+    public long getCreationTime(){ return 0; }
+    public static Parcelable.Creator<AutomaticZenRule> CREATOR = null;
+    public void setConditionId(Uri p0){}
+    public void setConfigurationActivity(ComponentName p0){}
+    public void setEnabled(boolean p0){}
+    public void setInterruptionFilter(int p0){}
+    public void setName(String p0){}
+    public void setZenPolicy(ZenPolicy p0){}
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/service/notification/Condition.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/service/notification/Condition.java
@@ -1,0 +1,41 @@
+// Generated automatically from android.service.notification.Condition for testing purposes
+
+package android.service.notification;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class Condition implements Parcelable
+{
+    protected Condition() {}
+    public Condition copy(){ return null; }
+    public Condition(Parcel p0){}
+    public Condition(Uri p0, String p1, String p2, String p3, int p4, int p5, int p6){}
+    public Condition(Uri p0, String p1, int p2){}
+    public String toString(){ return null; }
+    public boolean equals(Object p0){ return false; }
+    public final String line1 = null;
+    public final String line2 = null;
+    public final String summary = null;
+    public final Uri id = null;
+    public final int flags = 0;
+    public final int icon = 0;
+    public final int state = 0;
+    public int describeContents(){ return 0; }
+    public int hashCode(){ return 0; }
+    public static Parcelable.Creator<Condition> CREATOR = null;
+    public static String SCHEME = null;
+    public static String relevanceToString(int p0){ return null; }
+    public static String stateToString(int p0){ return null; }
+    public static Uri.Builder newId(Context p0){ return null; }
+    public static boolean isValidId(Uri p0, String p1){ return false; }
+    public static int FLAG_RELEVANT_ALWAYS = 0;
+    public static int FLAG_RELEVANT_NOW = 0;
+    public static int STATE_ERROR = 0;
+    public static int STATE_FALSE = 0;
+    public static int STATE_TRUE = 0;
+    public static int STATE_UNKNOWN = 0;
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/service/notification/StatusBarNotification.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/service/notification/StatusBarNotification.java
@@ -1,0 +1,37 @@
+// Generated automatically from android.service.notification.StatusBarNotification for testing purposes
+
+package android.service.notification;
+
+import android.app.Notification;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.os.UserHandle;
+
+public class StatusBarNotification implements Parcelable
+{
+    protected StatusBarNotification() {}
+    public Notification getNotification(){ return null; }
+    public StatusBarNotification clone(){ return null; }
+    public StatusBarNotification(Parcel p0){}
+    public StatusBarNotification(String p0, String p1, int p2, String p3, int p4, int p5, int p6, Notification p7, UserHandle p8, long p9){}
+    public String getGroupKey(){ return null; }
+    public String getKey(){ return null; }
+    public String getOpPkg(){ return null; }
+    public String getOverrideGroupKey(){ return null; }
+    public String getPackageName(){ return null; }
+    public String getTag(){ return null; }
+    public String toString(){ return null; }
+    public UserHandle getUser(){ return null; }
+    public boolean isAppGroup(){ return false; }
+    public boolean isClearable(){ return false; }
+    public boolean isGroup(){ return false; }
+    public boolean isOngoing(){ return false; }
+    public int describeContents(){ return 0; }
+    public int getId(){ return 0; }
+    public int getUid(){ return 0; }
+    public int getUserId(){ return 0; }
+    public long getPostTime(){ return 0; }
+    public static Parcelable.Creator<StatusBarNotification> CREATOR = null;
+    public void setOverrideGroupKey(String p0){}
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/service/notification/ZenPolicy.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/service/notification/ZenPolicy.java
@@ -1,0 +1,47 @@
+// Generated automatically from android.service.notification.ZenPolicy for testing purposes
+
+package android.service.notification;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class ZenPolicy implements Parcelable
+{
+    public String toString(){ return null; }
+    public boolean equals(Object p0){ return false; }
+    public int describeContents(){ return 0; }
+    public int getPriorityCallSenders(){ return 0; }
+    public int getPriorityCategoryAlarms(){ return 0; }
+    public int getPriorityCategoryCalls(){ return 0; }
+    public int getPriorityCategoryConversations(){ return 0; }
+    public int getPriorityCategoryEvents(){ return 0; }
+    public int getPriorityCategoryMedia(){ return 0; }
+    public int getPriorityCategoryMessages(){ return 0; }
+    public int getPriorityCategoryReminders(){ return 0; }
+    public int getPriorityCategoryRepeatCallers(){ return 0; }
+    public int getPriorityCategorySystem(){ return 0; }
+    public int getPriorityConversationSenders(){ return 0; }
+    public int getPriorityMessageSenders(){ return 0; }
+    public int getVisualEffectAmbient(){ return 0; }
+    public int getVisualEffectBadge(){ return 0; }
+    public int getVisualEffectFullScreenIntent(){ return 0; }
+    public int getVisualEffectLights(){ return 0; }
+    public int getVisualEffectNotificationList(){ return 0; }
+    public int getVisualEffectPeek(){ return 0; }
+    public int getVisualEffectStatusBar(){ return 0; }
+    public int hashCode(){ return 0; }
+    public static Parcelable.Creator<ZenPolicy> CREATOR = null;
+    public static int CONVERSATION_SENDERS_ANYONE = 0;
+    public static int CONVERSATION_SENDERS_IMPORTANT = 0;
+    public static int CONVERSATION_SENDERS_NONE = 0;
+    public static int CONVERSATION_SENDERS_UNSET = 0;
+    public static int PEOPLE_TYPE_ANYONE = 0;
+    public static int PEOPLE_TYPE_CONTACTS = 0;
+    public static int PEOPLE_TYPE_NONE = 0;
+    public static int PEOPLE_TYPE_STARRED = 0;
+    public static int PEOPLE_TYPE_UNSET = 0;
+    public static int STATE_ALLOW = 0;
+    public static int STATE_DISALLOW = 0;
+    public static int STATE_UNSET = 0;
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/AlarmManagerCompat.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/AlarmManagerCompat.java
@@ -1,0 +1,15 @@
+// Generated automatically from androidx.core.app.AlarmManagerCompat for testing purposes
+
+package androidx.core.app;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+
+public class AlarmManagerCompat
+{
+    protected AlarmManagerCompat() {}
+    public static void setAlarmClock(AlarmManager p0, long p1, PendingIntent p2, PendingIntent p3){}
+    public static void setAndAllowWhileIdle(AlarmManager p0, int p1, long p2, PendingIntent p3){}
+    public static void setExact(AlarmManager p0, int p1, long p2, PendingIntent p3){}
+    public static void setExactAndAllowWhileIdle(AlarmManager p0, int p1, long p2, PendingIntent p3){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/CoreComponentFactory.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/CoreComponentFactory.java
@@ -1,0 +1,25 @@
+// Generated automatically from androidx.core.app.CoreComponentFactory for testing purposes
+
+package androidx.core.app;
+
+import android.app.Activity;
+import android.app.AppComponentFactory;
+import android.app.Application;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.ContentProvider;
+import android.content.Intent;
+
+public class CoreComponentFactory extends AppComponentFactory
+{
+    public Activity instantiateActivity(ClassLoader p0, String p1, Intent p2){ return null; }
+    public Application instantiateApplication(ClassLoader p0, String p1){ return null; }
+    public BroadcastReceiver instantiateReceiver(ClassLoader p0, String p1, Intent p2){ return null; }
+    public ContentProvider instantiateProvider(ClassLoader p0, String p1){ return null; }
+    public CoreComponentFactory(){}
+    public Service instantiateService(ClassLoader p0, String p1, Intent p2){ return null; }
+    static public interface CompatWrapped
+    {
+        Object getWrapper();
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/NotificationManagerCompat.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/NotificationManagerCompat.java
@@ -1,0 +1,43 @@
+// Generated automatically from androidx.core.app.NotificationManagerCompat for testing purposes
+
+package androidx.core.app;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationChannelGroup;
+import android.content.Context;
+import java.util.List;
+import java.util.Set;
+
+public class NotificationManagerCompat
+{
+    protected NotificationManagerCompat() {}
+    public List<NotificationChannel> getNotificationChannels(){ return null; }
+    public List<NotificationChannelGroup> getNotificationChannelGroups(){ return null; }
+    public NotificationChannel getNotificationChannel(String p0){ return null; }
+    public NotificationChannelGroup getNotificationChannelGroup(String p0){ return null; }
+    public boolean areNotificationsEnabled(){ return false; }
+    public int getImportance(){ return 0; }
+    public static NotificationManagerCompat from(Context p0){ return null; }
+    public static Set<String> getEnabledListenerPackages(Context p0){ return null; }
+    public static String ACTION_BIND_SIDE_CHANNEL = null;
+    public static String EXTRA_USE_SIDE_CHANNEL = null;
+    public static int IMPORTANCE_DEFAULT = 0;
+    public static int IMPORTANCE_HIGH = 0;
+    public static int IMPORTANCE_LOW = 0;
+    public static int IMPORTANCE_MAX = 0;
+    public static int IMPORTANCE_MIN = 0;
+    public static int IMPORTANCE_NONE = 0;
+    public static int IMPORTANCE_UNSPECIFIED = 0;
+    public void cancel(String p0, int p1){}
+    public void cancel(int p0){}
+    public void cancelAll(){}
+    public void createNotificationChannel(NotificationChannel p0){}
+    public void createNotificationChannelGroup(NotificationChannelGroup p0){}
+    public void createNotificationChannelGroups(List<NotificationChannelGroup> p0){}
+    public void createNotificationChannels(List<NotificationChannel> p0){}
+    public void deleteNotificationChannel(String p0){}
+    public void deleteNotificationChannelGroup(String p0){}
+    public void notify(String p0, int p1, Notification p2){}
+    public void notify(int p0, Notification p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/remotecallback/CallbackReceiver.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/remotecallback/CallbackReceiver.java
@@ -1,0 +1,10 @@
+// Generated automatically from androidx.remotecallback.CallbackReceiver for testing purposes
+
+package androidx.remotecallback;
+
+import android.content.Context;
+
+public interface CallbackReceiver<T>
+{
+    T createRemoteCallback(Context p0);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/slice/Clock.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/slice/Clock.java
@@ -1,0 +1,9 @@
+// Generated automatically from androidx.slice.Clock for testing purposes
+
+package androidx.slice;
+
+
+public interface Clock
+{
+    long currentTimeMillis();
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/slice/builders/impl/TemplateBuilderImpl.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/slice/builders/impl/TemplateBuilderImpl.java
@@ -1,0 +1,23 @@
+// Generated automatically from androidx.slice.builders.impl.TemplateBuilderImpl for testing purposes
+
+package androidx.slice.builders.impl;
+
+import androidx.slice.Clock;
+import androidx.slice.Slice;
+import androidx.slice.SliceSpec;
+import java.util.ArrayList;
+
+abstract public class TemplateBuilderImpl
+{
+    protected TemplateBuilderImpl() {}
+    protected ArrayList<String> parseImageMode(int p0, boolean p1){ return null; }
+    protected TemplateBuilderImpl(Slice.Builder p0, SliceSpec p1){}
+    protected TemplateBuilderImpl(Slice.Builder p0, SliceSpec p1, Clock p2){}
+    protected void setBuilder(Slice.Builder p0){}
+    public Clock getClock(){ return null; }
+    public Slice build(){ return null; }
+    public Slice.Builder createChildBuilder(){ return null; }
+    public Slice.Builder getBuilder(){ return null; }
+    public SliceSpec getSpec(){ return null; }
+    public abstract void apply(Slice.Builder p0);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/slice/compat/CompatPermissionManager.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/slice/compat/CompatPermissionManager.java
@@ -1,0 +1,16 @@
+// Generated automatically from androidx.slice.compat.CompatPermissionManager for testing purposes
+
+package androidx.slice.compat;
+
+import android.content.Context;
+import android.net.Uri;
+
+public class CompatPermissionManager
+{
+    protected CompatPermissionManager() {}
+    public CompatPermissionManager(Context p0, String p1, int p2, String[] p3){}
+    public int checkSlicePermission(Uri p0, int p1, int p2){ return 0; }
+    public static String ALL_SUFFIX = null;
+    public void grantSlicePermission(Uri p0, String p1){}
+    public void revokeSlicePermission(Uri p0, String p1){}
+}


### PR DESCRIPTION
Following #10318, this PR adds sinks related to Compat classes (`androidx.core.app.{Notification,Alarm}ManagerCompat`) to the Implicit PendingIntents query.