### PR TITLE
Ruby: Rework call graph implementation

### DIFF
--- a/ruby/ql/consistency-queries/DataFlowConsistency.ql
+++ b/ruby/ql/consistency-queries/DataFlowConsistency.ql
@@ -1,3 +1,4 @@
+import codeql.ruby.AST
 import codeql.ruby.DataFlow::DataFlow
 import codeql.ruby.dataflow.internal.DataFlowPrivate
 import codeql.ruby.dataflow.internal.DataFlowImplConsistency::Consistency
@@ -11,5 +12,7 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
     n instanceof SummaryNode
     or
     n instanceof SynthHashSplatArgumentNode
+    or
+    not isNonConstantExpr(n.asExpr())
   }
 }

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
@@ -137,14 +137,7 @@ private module Cached {
   }
 
   cached
-  Method lookupMethod(Module m, string name) {
-    // The syntax_suggest library redefines Kernel.require/require_relative.
-    // Somehow this causes performance issues on ruby/ruby. As a workaround
-    // we exclude 'require' and 'require_relative'.
-    // TODO: find the actual cause of the slowdown and fix things properly.
-    not name = ["require", "require_relative"] and
-    TMethod(result) = lookupMethodOrConst(m, name)
-  }
+  Method lookupMethod(Module m, string name) { TMethod(result) = lookupMethodOrConst(m, name) }
 
   cached
   Expr lookupConst(Module m, string name) {

--- a/ruby/ql/lib/codeql/ruby/controlflow/BasicBlocks.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/BasicBlocks.qll
@@ -311,13 +311,13 @@ private module Cached {
   }
 
   cached
-  predicate immediatelyControls(ConditionBlock cb, BasicBlock succ, BooleanSuccessor s) {
+  predicate immediatelyControls(ConditionBlock cb, BasicBlock succ, ConditionalSuccessor s) {
     succ = cb.getASuccessor(s) and
     forall(BasicBlock pred | pred = succ.getAPredecessor() and pred != cb | succ.dominates(pred))
   }
 
   cached
-  predicate controls(ConditionBlock cb, BasicBlock controlled, BooleanSuccessor s) {
+  predicate controls(ConditionBlock cb, BasicBlock controlled, ConditionalSuccessor s) {
     exists(BasicBlock succ | cb.immediatelyControls(succ, s) | succ.dominates(controlled))
   }
 }
@@ -406,7 +406,7 @@ class ConditionBlock extends BasicBlock {
    * successor of this block, and `succ` can only be reached from
    * the callable entry point by going via the `s` edge out of this basic block.
    */
-  predicate immediatelyControls(BasicBlock succ, BooleanSuccessor s) {
+  predicate immediatelyControls(BasicBlock succ, ConditionalSuccessor s) {
     immediatelyControls(this, succ, s)
   }
 
@@ -415,5 +415,7 @@ class ConditionBlock extends BasicBlock {
    * conditional value `s`. That is, `controlled` can only be reached from
    * the callable entry point by going via the `s` edge out of this basic block.
    */
-  predicate controls(BasicBlock controlled, BooleanSuccessor s) { controls(this, controlled, s) }
+  predicate controls(BasicBlock controlled, ConditionalSuccessor s) {
+    controls(this, controlled, s)
+  }
 }

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -433,7 +433,7 @@ module ExprNodes {
   }
 
   private class WhenClauseChildMapping extends NonExprChildMapping, WhenClause {
-    override predicate relevantChild(AstNode e) { e = this.getBody() }
+    override predicate relevantChild(AstNode e) { e = [this.getBody(), this.getAPattern()] }
   }
 
   /** A control-flow node that wraps a `WhenClause` AST expression. */
@@ -444,6 +444,9 @@ module ExprNodes {
 
     /** Gets the body of this `when`-clause. */
     final ExprCfgNode getBody() { e.hasCfgChild(e.getBody(), this, result) }
+
+    /** Gets the `i`th pattern this `when`-clause. */
+    final ExprCfgNode getPattern(int i) { e.hasCfgChild(e.getPattern(i), this, result) }
   }
 
   /** A control-flow node that wraps a `CasePattern`. */

--- a/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
@@ -44,7 +44,7 @@ class CfgNode extends TCfgNode {
   final File getFile() { result = this.getLocation().getFile() }
 
   /** Holds if this control flow node has conditional successors. */
-  final predicate isCondition() { exists(this.getASuccessor(any(BooleanSuccessor bs))) }
+  final predicate isCondition() { exists(this.getASuccessor(any(ConditionalSuccessor bs))) }
 
   /** Gets the scope of this node. */
   final CfgScope getScope() { result = getNodeCfgScope(this) }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -354,7 +354,7 @@ private module Cached {
           //   end
           // end
           // ```
-          selfInMethod(sourceNode.(SsaSelfDefinitionNode).getVariable(), _, m)
+          selfInMethod(sourceNode.(SsaSelfDefinitionNode).getVariable(), _, m.getSuperClass*())
         )
       )
       or
@@ -509,16 +509,17 @@ private DataFlow::Node trackInstance(Module tp, boolean exact, TypeTracker t) {
       // `self.new` inside a module
       selfInModule(sourceNode.(SsaSelfDefinitionNode).getVariable(), tp)
       or
-      // `self.new` inside a (singleton) method
-      selfInMethod(sourceNode.(SsaSelfDefinitionNode).getVariable(), _, tp)
+      // `self.new` inside a singleton method
+      selfInMethod(sourceNode.(SsaSelfDefinitionNode).getVariable(), any(SingletonMethod sm), tp)
     )
     or
-    // `self` reference in method or top-level (but not in module, where instance
-    // methods cannot be called; only singleton methods)
+    // `self` reference in method or top-level (but not in module or singleton method,
+    // where instance methods cannot be called; only singleton methods)
     result =
       any(SsaSelfDefinitionNode self |
         exists(MethodBase m |
           selfInMethod(self.getVariable(), m, tp) and
+          not m instanceof SingletonMethod and
           if m.getEnclosingModule() instanceof Toplevel then exact = true else exact = false
         )
         or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -2,10 +2,12 @@ private import ruby
 private import codeql.ruby.CFG
 private import DataFlowPrivate
 private import codeql.ruby.typetracking.TypeTracker
+private import codeql.ruby.typetracking.TypeTrackerSpecific as TypeTrackerSpecific
 private import codeql.ruby.ast.internal.Module
 private import FlowSummaryImpl as FlowSummaryImpl
 private import FlowSummaryImplSpecific as FlowSummaryImplSpecific
 private import codeql.ruby.dataflow.FlowSummary
+private import codeql.ruby.dataflow.SSA
 
 newtype TReturnKind =
   TNormalReturnKind() or
@@ -148,12 +150,19 @@ private class NormalCall extends DataFlowCall, TNormalCall {
 
 pragma[nomagic]
 private predicate methodCall(
+  CfgNodes::ExprNodes::CallCfgNode call, DataFlow::Node receiver, string method
+) {
+  method = call.getExpr().(MethodCall).getMethodName() and
+  receiver.asExpr() = call.getReceiver()
+}
+
+pragma[nomagic]
+private predicate flowsToMethodCall(
   CfgNodes::ExprNodes::CallCfgNode call, DataFlow::LocalSourceNode sourceNode, string method
 ) {
-  exists(DataFlow::Node nodeTo |
-    method = call.getExpr().(MethodCall).getMethodName() and
-    nodeTo.asExpr() = call.getReceiver() and
-    sourceNode.flowsTo(nodeTo)
+  exists(DataFlow::Node receiver |
+    methodCall(call, receiver, method) and
+    sourceNode.flowsTo(receiver)
   )
 }
 
@@ -177,9 +186,94 @@ private predicate superCall(CfgNodes::ExprNodes::CallCfgNode call, Module superC
 
 pragma[nomagic]
 private predicate instanceMethodCall(CfgNodes::ExprNodes::CallCfgNode call, Module tp, string method) {
-  exists(DataFlow::LocalSourceNode sourceNode |
-    methodCall(call, sourceNode, method) and
-    sourceNode = trackInstance(tp)
+  exists(DataFlow::LocalSourceNode sourceNode, Module m, boolean exact |
+    flowsToMethodCall(call, sourceNode, method) and
+    sourceNode = trackInstance(m, exact)
+  |
+    tp = m
+    or
+    // When we don't know the exact type, it could be any sub class
+    exact = false and
+    tp.getSuperClass+() = m
+  )
+}
+
+/** Holds if `self` belongs to module `m`. */
+pragma[nomagic]
+private predicate selfInModule(SelfVariable self, Module m) {
+  exists(Scope scope |
+    scope = self.getDeclaringScope() and
+    m = scope.(ModuleBase).getModule() and
+    not scope instanceof Toplevel
+  )
+}
+
+/** Holds if `self` belongs to a method inside module `m`. */
+pragma[nomagic]
+private predicate selfInMethod(SelfVariable self, Module m) {
+  exists(Scope scope, ModuleBase encl |
+    scope = self.getDeclaringScope() and
+    encl = scope.(MethodBase).getEnclosingModule() and
+    if encl instanceof SingletonClass
+    then m = encl.getEnclosingModule().getModule()
+    else m = encl.getModule()
+  )
+}
+
+/** Holds if `self` belongs to the top-level. */
+pragma[nomagic]
+private predicate selfInToplevel(SelfVariable self, Module m) {
+  self.getDeclaringScope() instanceof Toplevel and
+  m = TResolved("Object")
+}
+
+/**
+ * Holds if SSA definition `def` belongs to a variable introduced via pattern
+ * matching on type `m`. For example, in
+ *
+ * ```rb
+ * case object
+ *   in C => c then c.foo
+ * end
+ * ```
+ *
+ * the SSA definition for `c` is introduced by matching on `C`.
+ */
+predicate asModulePattern(SsaDefinitionNode def, Module m) {
+  exists(AsPattern ap |
+    m = resolveConstantReadAccess(ap.getPattern()) and
+    def.getDefinition().(Ssa::WriteDefinition).getWriteAccess() = ap.getVariableAccess()
+  )
+}
+
+/**
+ * Holds if `read1` and `read2` are adjacent reads of SSA definition `def`,
+ * and `read2` is checked to have type `m`. For example, in
+ *
+ * ```rb
+ * case object
+ *   when C then object.foo
+ * end
+ * ```
+ *
+ * the two reads of `object` are adjacent, and the second is checked to have type `C`.
+ */
+predicate hasAdjacentTypeCheckedReads(
+  Ssa::Definition def, CfgNodes::ExprCfgNode read1, CfgNodes::ExprCfgNode read2, Module m
+) {
+  exists(
+    CfgNodes::ExprCfgNode pattern, ConditionBlock cb, CfgNodes::ExprNodes::CaseExprCfgNode case
+  |
+    m = resolveConstantReadAccess(pattern.getExpr()) and
+    cb.getLastNode() = pattern and
+    cb.controls(read2.getBasicBlock(),
+      any(SuccessorTypes::MatchingSuccessor match | match.getValue() = true)) and
+    def.hasAdjacentReads(read1, read2) and
+    case.getValue() = read1
+  |
+    pattern = case.getBranch(_).(CfgNodes::ExprNodes::WhenClauseCfgNode).getPattern(_)
+    or
+    pattern = case.getBranch(_).(CfgNodes::ExprNodes::InClauseCfgNode).getPattern()
   )
 }
 
@@ -222,9 +316,47 @@ private module Cached {
           else any()
         )
         or
-        exists(DataFlow::LocalSourceNode sourceNode |
-          methodCall(call, sourceNode, method) and
-          sourceNode = trackSingletonMethod(result, method)
+        // singleton method defined on an instance, e.g.
+        // ```rb
+        // c = C.new
+        // def c.singleton; end # <- result
+        // c.singleton          # <- call
+        // ```
+        exists(DataFlow::Node sourceNode |
+          methodCall(call, sourceNode, method) or
+          flowsToMethodCall(call, sourceNode, method)
+        |
+          sourceNode = trackSingletonMethodOnInstance(result, method)
+        )
+        or
+        // singleton method defined on a module
+        exists(DataFlow::Node sourceNode, Module m |
+          flowsToMethodCall(call, sourceNode, method) and
+          singletonMethodOnModule(result, method, m)
+        |
+          // ```rb
+          // def C.singleton; end # <- result
+          // C.singleton          # <- call
+          // ```
+          sourceNode = trackModuleAccess(m)
+          or
+          // ```rb
+          // class C
+          //   def self.singleton; end # <- result
+          //   self.singleton          # <- call
+          // end
+          // ```
+          selfInModule(sourceNode.(SsaSelfDefinitionNode).getVariable(), m)
+          or
+          // ```rb
+          // class C
+          //   def self.singleton; end # <- result
+          //   def self.other
+          //     self.singleton        # <- call
+          //   end
+          // end
+          // ```
+          selfInMethod(sourceNode.(SsaSelfDefinitionNode).getVariable(), m)
         )
       )
       or
@@ -293,73 +425,156 @@ private module Cached {
 
 import Cached
 
-private DataFlow::LocalSourceNode trackInstance(Module tp, TypeTracker t) {
-  t.start() and
-  (
-    result.asExpr().getExpr() instanceof NilLiteral and tp = TResolved("NilClass")
-    or
-    result.asExpr().getExpr().(BooleanLiteral).isFalse() and tp = TResolved("FalseClass")
-    or
-    result.asExpr().getExpr().(BooleanLiteral).isTrue() and tp = TResolved("TrueClass")
-    or
-    result.asExpr().getExpr() instanceof IntegerLiteral and tp = TResolved("Integer")
-    or
-    result.asExpr().getExpr() instanceof FloatLiteral and tp = TResolved("Float")
-    or
-    result.asExpr().getExpr() instanceof RationalLiteral and tp = TResolved("Rational")
-    or
-    result.asExpr().getExpr() instanceof ComplexLiteral and tp = TResolved("Complex")
-    or
-    result.asExpr().getExpr() instanceof StringlikeLiteral and tp = TResolved("String")
-    or
-    result.asExpr() instanceof CfgNodes::ExprNodes::ArrayLiteralCfgNode and tp = TResolved("Array")
-    or
-    result.asExpr() instanceof CfgNodes::ExprNodes::HashLiteralCfgNode and tp = TResolved("Hash")
-    or
-    result.asExpr().getExpr() instanceof MethodBase and tp = TResolved("Symbol")
-    or
-    result.asParameter() instanceof BlockParameter and tp = TResolved("Proc")
-    or
-    result.asExpr().getExpr() instanceof Lambda and tp = TResolved("Proc")
-    or
-    exists(CfgNodes::ExprNodes::CallCfgNode call, DataFlow::Node nodeTo |
-      call.getExpr().(MethodCall).getMethodName() = "new" and
-      nodeTo.asExpr() = call.getReceiver() and
-      trackModule(tp).flowsTo(nodeTo) and
-      result.asExpr() = call
-    )
-    or
-    // `self` in method
-    tp = result.(SsaSelfDefinitionNode).getSelfScope().(Method).getEnclosingModule().getModule()
-    or
-    // `self` in singleton method
-    flowsToSingletonMethodObject(trackInstance(tp), result.(SsaSelfDefinitionNode).getSelfScope())
-    or
-    // `self` in top-level
-    result.(SsaSelfDefinitionNode).getSelfScope() instanceof Toplevel and
-    tp = TResolved("Object")
-    or
-    // a module or class
-    exists(Module m |
-      result = trackModule(m) and
-      if m.isClass() then tp = TResolved("Class") else tp = TResolved("Module")
-    )
-  )
+pragma[nomagic]
+private DataFlow::LocalSourceNode trackModuleAccess(Module m, TypeTracker t) {
+  t.start() and m = resolveConstantReadAccess(result.asExpr().getExpr())
   or
   exists(TypeTracker t2, StepSummary summary |
-    result = trackInstanceRec(tp, t2, summary) and t = t2.append(summary)
+    result = trackModuleAccessRec(m, t2, summary) and t = t2.append(summary)
   )
 }
 
 pragma[nomagic]
-private DataFlow::LocalSourceNode trackInstanceRec(Module tp, TypeTracker t, StepSummary summary) {
-  StepSummary::step(trackInstance(tp, t), result, summary)
+private DataFlow::LocalSourceNode trackModuleAccessRec(Module m, TypeTracker t, StepSummary summary) {
+  StepSummary::step(trackModuleAccess(m, t), result, summary)
 }
 
-private DataFlow::LocalSourceNode trackInstance(Module tp) {
-  result = trackInstance(tp, TypeTracker::end())
+pragma[nomagic]
+private DataFlow::LocalSourceNode trackModuleAccess(Module m) {
+  result = trackModuleAccess(m, TypeTracker::end())
 }
 
+pragma[nomagic]
+private DataFlow::LocalSourceNode trackInstance(Module tp, boolean exact, TypeTracker t) {
+  t.start() and
+  (
+    result.asExpr().getExpr() instanceof NilLiteral and
+    tp = TResolved("NilClass") and
+    exact = true
+    or
+    result.asExpr().getExpr().(BooleanLiteral).isFalse() and
+    tp = TResolved("FalseClass") and
+    exact = true
+    or
+    result.asExpr().getExpr().(BooleanLiteral).isTrue() and
+    tp = TResolved("TrueClass") and
+    exact = true
+    or
+    result.asExpr().getExpr() instanceof IntegerLiteral and
+    tp = TResolved("Integer") and
+    exact = true
+    or
+    result.asExpr().getExpr() instanceof FloatLiteral and
+    tp = TResolved("Float") and
+    exact = true
+    or
+    result.asExpr().getExpr() instanceof RationalLiteral and
+    tp = TResolved("Rational") and
+    exact = true
+    or
+    result.asExpr().getExpr() instanceof ComplexLiteral and
+    tp = TResolved("Complex") and
+    exact = true
+    or
+    result.asExpr().getExpr() instanceof StringlikeLiteral and
+    tp = TResolved("String") and
+    exact = true
+    or
+    result.asExpr() instanceof CfgNodes::ExprNodes::ArrayLiteralCfgNode and
+    tp = TResolved("Array") and
+    exact = true
+    or
+    result.asExpr() instanceof CfgNodes::ExprNodes::HashLiteralCfgNode and
+    tp = TResolved("Hash") and
+    exact = true
+    or
+    result.asExpr().getExpr() instanceof MethodBase and
+    tp = TResolved("Symbol") and
+    exact = true
+    or
+    result.asParameter() instanceof BlockParameter and
+    tp = TResolved("Proc") and
+    exact = true
+    or
+    result.asExpr().getExpr() instanceof Lambda and
+    tp = TResolved("Proc") and
+    exact = true
+    or
+    exists(CfgNodes::ExprNodes::CallCfgNode call, DataFlow::LocalSourceNode sourceNode |
+      flowsToMethodCall(call, sourceNode, "new") and
+      exact = true and
+      result.asExpr() = call
+    |
+      // `C.new`
+      sourceNode = trackModuleAccess(tp)
+      or
+      // `self.new` inside a module
+      selfInModule(sourceNode.(SsaSelfDefinitionNode).getVariable(), tp)
+      or
+      // `self.new` inside a (singleton) method
+      selfInMethod(sourceNode.(SsaSelfDefinitionNode).getVariable(), tp)
+    )
+    or
+    // `self` reference in method or top-level (but not in module, where instance
+    // methods cannot be called; only singleton methods)
+    result =
+      any(SsaSelfDefinitionNode self |
+        selfInMethod(self.getVariable(), tp) and
+        exact = false
+        or
+        selfInToplevel(self.getVariable(), tp) and
+        exact = true
+      )
+    or
+    exists(Module m |
+      (if m.isClass() then tp = TResolved("Class") else tp = TResolved("Module")) and
+      exact = true
+    |
+      // needed for e.g. `C.new`
+      m = resolveConstantReadAccess(result.asExpr().getExpr())
+      or
+      // needed for e.g. `self.include`
+      selfInModule(result.(SsaSelfDefinitionNode).getVariable(), m)
+      or
+      // needed for e.g. `self.puts`
+      selfInMethod(result.(SsaSelfDefinitionNode).getVariable(), m)
+    )
+    or
+    // `in C => c then c.foo`
+    asModulePattern(result, tp) and
+    exact = false
+    or
+    // `case object when C then object.foo`
+    hasAdjacentTypeCheckedReads(_, _, result.asExpr(), tp) and
+    exact = false
+  )
+  or
+  exists(TypeTracker t2, StepSummary summary |
+    result = trackInstanceRec(tp, t2, exact, summary) and t = t2.append(summary)
+  )
+}
+
+/**
+ * We exclude steps into `self` parameters and type checked variables. For those,
+ * we instead rely on the type of the enclosing module resp. the type being checked
+ * against, and apply an open-world assumption when determining possible dispatch
+ * targets.
+ */
+pragma[nomagic]
+private DataFlow::LocalSourceNode trackInstanceRec(
+  Module tp, TypeTracker t, boolean exact, StepSummary summary
+) {
+  StepSummary::step(trackInstance(tp, exact, t), result, summary) and
+  not result instanceof SelfParameterNode and
+  not hasAdjacentTypeCheckedReads(_, _, result.asExpr(), _)
+}
+
+pragma[nomagic]
+private DataFlow::LocalSourceNode trackInstance(Module tp, boolean exact) {
+  result = trackInstance(tp, exact, TypeTracker::end())
+}
+
+pragma[nomagic]
 private DataFlow::LocalSourceNode trackBlock(Block block, TypeTracker t) {
   t.start() and result.asExpr().getExpr() = block
   or
@@ -373,86 +588,202 @@ private DataFlow::LocalSourceNode trackBlockRec(Block block, TypeTracker t, Step
   StepSummary::step(trackBlock(block, t), result, summary)
 }
 
+pragma[nomagic]
 private DataFlow::LocalSourceNode trackBlock(Block block) {
   result = trackBlock(block, TypeTracker::end())
 }
 
-private predicate singletonMethod(MethodBase method, Expr object) {
-  object = method.(SingletonMethod).getObject()
-  or
-  exists(SingletonClass cls |
-    object = cls.getValue() and method instanceof Method and method = cls.getAMethod()
+/** Holds if `m` is a singleton method named `name`, defined on `object. */
+private predicate singletonMethod(MethodBase m, string name, Expr object) {
+  name = m.getName() and
+  (
+    object = m.(SingletonMethod).getObject()
+    or
+    m = any(SingletonClass cls | object = cls.getValue()).getAMethod().(Method)
   )
 }
 
 pragma[nomagic]
-private predicate flowsToSingletonMethodObject(DataFlow::LocalSourceNode nodeFrom, MethodBase method) {
+private predicate flowsToSingletonMethodObject(
+  DataFlow::LocalSourceNode nodeFrom, MethodBase m, string name
+) {
   exists(DataFlow::Node nodeTo |
     nodeFrom.flowsTo(nodeTo) and
-    singletonMethod(method, nodeTo.asExpr().getExpr())
+    singletonMethod(m, name, nodeTo.asExpr().getExpr())
   )
 }
 
+/**
+ * Holds if `method` is a singleton method named `name`, defined on module
+ * `m`:
+ *
+ * ```rb
+ * class C
+ *   def self.m1; end # included
+ *
+ *   class << self
+ *     def m2; end # included
+ *   end
+ * end
+ *
+ * def C.m3; end # included
+ *
+ * c_alias = C
+ * def c_alias.m4; end # included
+ *
+ * c = C.new
+ * def c.m5; end # not included
+ *
+ * class << c
+ *   def m6; end # not included
+ * end
+ * ```
+ */
 pragma[nomagic]
-private predicate moduleFlowsToSingletonMethodObject(Module m, MethodBase method) {
-  flowsToSingletonMethodObject(trackModule(m), method)
-}
-
-pragma[nomagic]
-private DataFlow::LocalSourceNode trackSingletonMethod0(MethodBase method, TypeTracker t) {
-  t.start() and
-  (
-    flowsToSingletonMethodObject(result, method)
-    or
-    exists(Module m | result = trackModule(m) and moduleFlowsToSingletonMethodObject(m, method))
+private predicate singletonMethodOnModule(MethodBase method, string name, Module m) {
+  exists(Expr object |
+    singletonMethod(method, name, object) and
+    selfInModule(object.(SelfVariableReadAccess).getVariable(), m)
   )
   or
-  exists(TypeTracker t2, StepSummary summary |
-    result = trackSingletonMethod0Rec(method, t2, summary) and t = t2.append(summary)
-  )
+  flowsToSingletonMethodObject(trackModuleAccess(m), method, name)
 }
 
+/**
+ * Holds if `method` is a singleton method named `name`, defined on expression
+ * `object`, where `object` is not likely to resolve to a module:
+ *
+ * ```rb
+ * class C
+ *   def self.m1; end # not included
+ *
+ *   class << self
+ *     def m2; end # not included
+ *   end
+ * end
+ *
+ * def C.m3; end # not included
+ *
+ * c_alias = C
+ * def c_alias.m4; end # included (due to negative recursion limitation)
+ *
+ * c = C.new
+ * def c.m5; end # included
+ *
+ * class << c
+ *   def m6; end # included
+ * end
+ * ```
+ */
 pragma[nomagic]
-private DataFlow::LocalSourceNode trackSingletonMethod0Rec(
-  MethodBase method, TypeTracker t, StepSummary summary
+predicate singletonMethodOnInstance(MethodBase method, string name, Expr object) {
+  singletonMethod(method, name, object) and
+  not selfInModule(object.(SelfVariableReadAccess).getVariable(), _) and
+  // cannot use `trackModuleAccess` because of negative recursion
+  not exists(resolveConstantReadAccess(object))
+}
+
+/**
+ * Same as `singletonMethodOnInstance`, but where `n` is the post-update node
+ * of the object that is the target of the singleton method `method`.
+ */
+predicate singletonMethodOnInstancePostUpdate(
+  MethodBase method, string name, DataFlow::PostUpdateNode n
 ) {
-  StepSummary::step(trackSingletonMethod0(method, t), result, summary)
+  singletonMethodOnInstance(method, name, n.getPreUpdateNode().asExpr().getExpr())
+}
+
+/**
+ * Holds if there is reverse flow from `nodeFrom` to `nodeTo` via a parameter.
+ *
+ * This is only used for tracking singleton methods, where we want to be able
+ * to handle cases like
+ *
+ * ```rb
+ * def add_singleton x
+ *   def x.foo; end
+ * end
+ *
+ * y = add_singleton C.new
+ * y.foo
+ * ```
+ *
+ * and
+ *
+ * ```rb
+ * class C
+ *   def add_singleton_to_self
+ *     def self.foo; end
+ *   end
+ * end
+ *
+ * y = C.new
+ * y.add_singleton_to_self
+ * y.foo
+ * ```
+ */
+pragma[nomagic]
+private predicate paramReturnFlow(DataFlow::PostUpdateNode nodeFrom, DataFlow::PostUpdateNode nodeTo) {
+  exists(
+    CfgNodes::ExprNodes::CallCfgNode call, DataFlow::Node arg, DataFlow::ParameterNode p,
+    Expr nodeFromPreExpr
+  |
+    TypeTrackerSpecific::callStep(call, arg, p) and
+    nodeTo.getPreUpdateNode() = arg and
+    nodeFromPreExpr = nodeFrom.getPreUpdateNode().asExpr().getExpr()
+  |
+    nodeFromPreExpr = p.getParameter().(NamedParameter).getVariable().getAnAccess()
+    or
+    nodeFromPreExpr = p.(SelfParameterNode).getSelfVariable().getAnAccess()
+  )
+}
+
+// Since post-update nodes are not (and should not be) `LocalSourceNode`s in general,
+// we need to do local flow manually
+pragma[nomagic]
+private predicate argPostUpdateFlowsTo(DataFlow::PostUpdateNode arg, DataFlow::Node n) {
+  paramReturnFlow(_, arg) and
+  n = arg
+  or
+  exists(DataFlow::Node mid |
+    argPostUpdateFlowsTo(arg, mid) and
+    localFlowStepTypeTracker(mid, n)
+  )
 }
 
 pragma[nomagic]
-private DataFlow::LocalSourceNode trackSingletonMethod(MethodBase m, string name) {
-  result = trackSingletonMethod0(m, TypeTracker::end()) and
-  name = m.getName()
-}
-
-private DataFlow::LocalSourceNode trackModule(Module tp, TypeTracker t) {
+private DataFlow::Node trackSingletonMethodOnInstance(MethodBase method, string name, TypeTracker t) {
   t.start() and
-  (
-    // ConstantReadAccess to Module
-    resolveConstantReadAccess(result.asExpr().getExpr()) = tp
-    or
-    // `self` reference to Module
-    exists(Scope scope | scope = result.(SsaSelfDefinitionNode).getSelfScope() |
-      tp = scope.(ModuleBase).getModule() and
-      not scope instanceof Toplevel // handled in `trackInstance`
-      or
-      scope = result.(SsaSelfDefinitionNode).getSelfScope() and
-      tp = scope.(SingletonMethod).getEnclosingModule().getModule()
-    )
-  )
+  singletonMethodOnInstancePostUpdate(method, name, result)
   or
   exists(TypeTracker t2, StepSummary summary |
-    result = trackModuleRec(tp, t2, summary) and t = t2.append(summary)
+    result = trackSingletonMethodOnInstanceRec(method, name, t2, summary) and
+    t = t2.append(summary) and
+    // do not step over redefinitions
+    not singletonMethodOnInstancePostUpdate(_, name, result)
   )
 }
 
 pragma[nomagic]
-private DataFlow::LocalSourceNode trackModuleRec(Module tp, TypeTracker t, StepSummary summary) {
-  StepSummary::step(trackModule(tp, t), result, summary)
+private DataFlow::Node trackSingletonMethodOnInstanceRec(
+  MethodBase method, string name, TypeTracker t, StepSummary summary
+) {
+  exists(DataFlow::Node mid | mid = trackSingletonMethodOnInstance(method, name, t) |
+    StepSummary::step(mid, result, summary)
+    or
+    // include flow out through parameters
+    paramReturnFlow(mid, result) and
+    summary.toString() = "return"
+    or
+    // include flow starting from an output argument
+    argPostUpdateFlowsTo(mid, result) and
+    summary.toString() = "level"
+  )
 }
 
-private DataFlow::LocalSourceNode trackModule(Module tp) {
-  result = trackModule(tp, TypeTracker::end())
+pragma[nomagic]
+private DataFlow::Node trackSingletonMethodOnInstance(MethodBase method, string name) {
+  result = trackSingletonMethodOnInstance(method, name, TypeTracker::end())
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -242,8 +242,7 @@ private module Cached {
       isNonConstantExpr(n) and
       (
         n instanceof Argument or
-        n = any(CfgNodes::ExprNodes::InstanceVariableAccessCfgNode v).getReceiver() or
-        singletonMethodOnInstance(_, _, n.getExpr())
+        n = any(CfgNodes::ExprNodes::InstanceVariableAccessCfgNode v).getReceiver()
       )
     } or
     TSummaryNode(
@@ -315,40 +314,7 @@ private module Cached {
       nodeTo = LocalFlow::getParameterDefNode(p)
     )
     or
-    exists(Ssa::Definition def |
-      LocalFlow::localSsaFlowStepUseUse(def, nodeFrom, nodeTo) and
-      // For nodes that are the target of a singleton method definition, such
-      // as `x` in `def x.foo; end`, we disallow use-use flow out of `x`, and
-      // instead add a type-tracker level-step from `x` to the post-update node
-      // of `x` (which does allow further use-use flow).
-      //
-      // This enables us to stregthen call resolution for singleton methods, since
-      // we can stop flow at redefinitions, which would otherwise not be possible,
-      // as type-tracking would step over such redefinitions.
-      //
-      // Example:
-      // ```rb
-      // def x.foo; end
-      // def x.foo; end
-      // x.foo # <- we want to resolve this call to the second definition only
-      // ```
-      not singletonMethodOnInstance(_, _, nodeFrom.asExpr().getExpr()) and
-      // We disallow adjacent use-use steps, where the target is type checked, and
-      // instead add a type-tracker level-step.
-      //
-      // This enables us to strengthen call resolution for instance methods, since
-      // we can use the extra type information on the target node.
-      //
-      // Example:
-      // ```rb
-      // case object
-      //   when C then object.foo # <- we want to resolve this call as if it was a call inside `C`
-      // end
-      // ```
-      //
-      // The second access to `object` is known to have type `C` (or a sub-type thereof).
-      not hasAdjacentTypeCheckedReads(def, nodeFrom.asExpr(), nodeTo.asExpr(), _)
-    )
+    LocalFlow::localSsaFlowStepUseUse(_, nodeFrom, nodeTo)
   }
 
   private predicate entrySsaDefinition(SsaDefinitionNode n) {
@@ -393,15 +359,6 @@ private module Cached {
     or
     // Needed for stores in type tracking
     TypeTrackerSpecific::basicStoreStep(_, n, _)
-    or
-    // Needed to be able to track singleton methods defined on instances
-    singletonMethodOnInstancePostUpdate(_, _, n)
-    or
-    // Needed to be able to track instance methods on variables introduced via pattern matching
-    asModulePattern(n, _)
-    or
-    // Needed to be able to (better) track instance methods on variables that are type checked
-    hasAdjacentTypeCheckedReads(_, _, n.asExpr(), _)
   }
 
   cached

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -35,16 +35,7 @@ private predicate summarizedLocalStep(Node nodeFrom, Node nodeTo) {
 }
 
 /** Holds if there is a level step from `nodeFrom` to `nodeTo`. */
-predicate levelStep(Node nodeFrom, Node nodeTo) {
-  summarizedLocalStep(nodeFrom, nodeTo)
-  or
-  // See comment in `localFlowStepTypeTracker/2`
-  nodeTo.(DataFlowPublic::PostUpdateNode).getPreUpdateNode() = nodeFrom and
-  DataFlowDispatch::singletonMethodOnInstance(_, _, nodeFrom.asExpr().getExpr())
-  or
-  // See comment in `localFlowStepTypeTracker/2`
-  DataFlowDispatch::hasAdjacentTypeCheckedReads(_, nodeFrom.asExpr(), nodeTo.asExpr(), _)
-}
+predicate levelStep(Node nodeFrom, Node nodeTo) { summarizedLocalStep(nodeFrom, nodeTo) }
 
 /**
  * Gets the name of a possible piece of content. This will usually include things like

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -55,12 +55,6 @@ edges
 | instance_variables.rb:32:16:32:25 | call to source :  | instance_variables.rb:32:1:32:4 | [post] foo3 [@field] :  |
 | instance_variables.rb:33:6:33:9 | foo3 [@field] :  | instance_variables.rb:33:6:33:15 | call to field |
 | instance_variables.rb:33:6:33:9 | foo3 [@field] :  | instance_variables.rb:33:6:33:15 | call to field |
-| instance_variables.rb:36:1:36:4 | [post] foo4 [@other] :  | instance_variables.rb:37:6:37:9 | foo4 [@other] :  |
-| instance_variables.rb:36:1:36:4 | [post] foo4 [@other] :  | instance_variables.rb:37:6:37:9 | foo4 [@other] :  |
-| instance_variables.rb:36:14:36:23 | call to source :  | instance_variables.rb:36:1:36:4 | [post] foo4 [@other] :  |
-| instance_variables.rb:36:14:36:23 | call to source :  | instance_variables.rb:36:1:36:4 | [post] foo4 [@other] :  |
-| instance_variables.rb:37:6:37:9 | foo4 [@other] :  | instance_variables.rb:37:6:37:15 | call to other |
-| instance_variables.rb:37:6:37:9 | foo4 [@other] :  | instance_variables.rb:37:6:37:15 | call to other |
 nodes
 | instance_variables.rb:2:19:2:19 | x :  | semmle.label | x :  |
 | instance_variables.rb:2:19:2:19 | x :  | semmle.label | x :  |
@@ -122,14 +116,6 @@ nodes
 | instance_variables.rb:33:6:33:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
 | instance_variables.rb:33:6:33:15 | call to field | semmle.label | call to field |
 | instance_variables.rb:33:6:33:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:36:1:36:4 | [post] foo4 [@other] :  | semmle.label | [post] foo4 [@other] :  |
-| instance_variables.rb:36:1:36:4 | [post] foo4 [@other] :  | semmle.label | [post] foo4 [@other] :  |
-| instance_variables.rb:36:14:36:23 | call to source :  | semmle.label | call to source :  |
-| instance_variables.rb:36:14:36:23 | call to source :  | semmle.label | call to source :  |
-| instance_variables.rb:37:6:37:9 | foo4 [@other] :  | semmle.label | foo4 [@other] :  |
-| instance_variables.rb:37:6:37:9 | foo4 [@other] :  | semmle.label | foo4 [@other] :  |
-| instance_variables.rb:37:6:37:15 | call to other | semmle.label | call to other |
-| instance_variables.rb:37:6:37:15 | call to other | semmle.label | call to other |
 subpaths
 | instance_variables.rb:16:15:16:24 | call to source :  | instance_variables.rb:2:19:2:19 | x :  | instance_variables.rb:3:9:3:14 | [post] self [@field] :  | instance_variables.rb:16:1:16:3 | [post] foo [@field] :  |
 | instance_variables.rb:16:15:16:24 | call to source :  | instance_variables.rb:2:19:2:19 | x :  | instance_variables.rb:3:9:3:14 | [post] self [@field] :  | instance_variables.rb:16:1:16:3 | [post] foo [@field] :  |
@@ -149,4 +135,3 @@ subpaths
 | instance_variables.rb:25:6:25:15 | call to field | instance_variables.rb:24:14:24:23 | call to source :  | instance_variables.rb:25:6:25:15 | call to field | $@ | instance_variables.rb:24:14:24:23 | call to source :  | call to source :  |
 | instance_variables.rb:29:6:29:19 | call to get_field | instance_variables.rb:28:14:28:23 | call to source :  | instance_variables.rb:29:6:29:19 | call to get_field | $@ | instance_variables.rb:28:14:28:23 | call to source :  | call to source :  |
 | instance_variables.rb:33:6:33:15 | call to field | instance_variables.rb:32:16:32:25 | call to source :  | instance_variables.rb:33:6:33:15 | call to field | $@ | instance_variables.rb:32:16:32:25 | call to source :  | call to source :  |
-| instance_variables.rb:37:6:37:15 | call to other | instance_variables.rb:36:14:36:23 | call to source :  | instance_variables.rb:37:6:37:15 | call to other | $@ | instance_variables.rb:36:14:36:23 | call to source :  | call to source :  |

--- a/ruby/ql/test/library-tests/dataflow/global/instance_variables.rb
+++ b/ruby/ql/test/library-tests/dataflow/global/instance_variables.rb
@@ -34,4 +34,4 @@ sink(foo3.field) # $ hasValueFlow=22
 
 foo4 = "hello"
 foo4.other = source(23)
-sink(foo4.other) # $ hasValueFlow=23
+sink(foo4.other) # no field flow for constants

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -31,59 +31,59 @@
 calls.rb:
 #   21| M
 
-#   35| C
+#   39| C
 #-----| include -> M
 #-----| super -> Object
 
-#   57| D
+#   61| D
 #-----| super -> C
 
-#   83| Integer
+#   87| Integer
 #-----| super -> Numeric
 
-#   88| String
+#   92| String
 #-----| super -> Object
 
-#   92| Kernel
+#   96| Kernel
 
-#   97| Module
+#  101| Module
 #-----| super -> Object
 
-#  104| Object
+#  108| Object
 #-----| super -> BasicObject
 #-----| include -> Kernel
 #-----| prepend -> A
 
-#  109| Hash
+#  113| Hash
 #-----| super -> Object
 
-#  114| Array
+#  118| Array
 #-----| super -> Object
 
-#  154| S
+#  158| S
 #-----| super -> Object
 
-#  160| A
+#  164| A
 #-----| super -> S
 #-----| super -> B
 #-----| prepend -> A::B
 
-#  165| B
+#  169| B
 #-----| super -> S
 
-#  179| Singletons
+#  183| Singletons
 #-----| super -> Object
 
-#  299| SelfNew
+#  303| SelfNew
 #-----| super -> Object
 
-#  313| C1
+#  317| C1
 #-----| super -> Object
 
-#  319| C2
+#  323| C2
 #-----| super -> C1
 
-#  325| C3
+#  329| C3
 #-----| super -> C2
 
 hello.rb:

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -31,60 +31,66 @@
 calls.rb:
 #   21| M
 
-#   39| C
+#   43| C
 #-----| include -> M
 #-----| super -> Object
 
-#   61| D
+#   65| D
 #-----| super -> C
 
-#   87| Integer
+#   91| Integer
 #-----| super -> Numeric
 
-#   92| String
+#   96| String
 #-----| super -> Object
 
-#   96| Kernel
+#  100| Kernel
 
-#  101| Module
+#  105| Module
 #-----| super -> Object
 
-#  108| Object
+#  112| Object
 #-----| super -> BasicObject
 #-----| include -> Kernel
 #-----| prepend -> A
 
-#  113| Hash
+#  117| Hash
 #-----| super -> Object
 
-#  118| Array
+#  122| Array
 #-----| super -> Object
 
-#  158| S
+#  162| S
 #-----| super -> Object
 
-#  164| A
+#  168| A
 #-----| super -> S
 #-----| super -> B
 #-----| prepend -> A::B
 
-#  169| B
+#  173| B
 #-----| super -> S
 
-#  183| Singletons
+#  187| Singletons
 #-----| super -> Object
 
-#  303| SelfNew
+#  307| SelfNew
 #-----| super -> Object
 
-#  317| C1
+#  322| C1
 #-----| super -> Object
 
-#  323| C2
+#  328| C2
 #-----| super -> C1
 
-#  329| C3
+#  334| C3
 #-----| super -> C2
+
+#  374| SingletonOverride1
+#-----| super -> Object
+
+#  399| SingletonOverride2
+#-----| super -> SingletonOverride1
 
 hello.rb:
 #    1| EnglishWords

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -29,50 +29,62 @@
 #-----| super -> Object
 
 calls.rb:
-#   15| M
+#   21| M
 
-#   29| C
+#   35| C
 #-----| include -> M
 #-----| super -> Object
 
-#   51| D
+#   57| D
 #-----| super -> C
 
-#   77| Integer
+#   83| Integer
 #-----| super -> Numeric
 
-#   82| String
+#   88| String
 #-----| super -> Object
 
-#   86| Kernel
+#   92| Kernel
 
-#   90| Module
+#   97| Module
 #-----| super -> Object
 
-#   97| Object
+#  104| Object
 #-----| super -> BasicObject
 #-----| include -> Kernel
 #-----| prepend -> A
 
-#  102| Hash
+#  109| Hash
 #-----| super -> Object
 
-#  106| Array
+#  114| Array
 #-----| super -> Object
 
-#  144| S
+#  154| S
 #-----| super -> Object
 
-#  150| A
+#  160| A
 #-----| super -> S
 #-----| super -> B
 #-----| prepend -> A::B
 
-#  155| B
+#  165| B
 #-----| super -> S
 
-#  169| Singletons
+#  179| Singletons
 #-----| super -> Object
+
+#  299| SelfNew
+#-----| super -> Object
+
+#  313| C1
+#-----| super -> Object
+
+#  319| C2
+#-----| super -> C1
+
+#  325| C3
+#-----| super -> C2
 
 hello.rb:
 #    1| EnglishWords

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -1,207 +1,208 @@
 getTarget
-| calls.rb:2:5:2:14 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:98:5:98:30 | puts |
 | calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:8:5:8:15 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:98:5:98:30 | puts |
 | calls.rb:11:1:11:8 | call to bar | calls.rb:7:1:9:3 | bar |
-| calls.rb:14:5:14:15 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:98:5:98:30 | puts |
 | calls.rb:17:1:17:8 | call to bar | calls.rb:13:1:15:3 | bar |
 | calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:19:1:19:8 | call to foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:81:1:85:3 | foo |
 | calls.rb:28:5:28:15 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
 | calls.rb:29:5:29:20 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
 | calls.rb:33:1:33:13 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
-| calls.rb:36:5:36:13 | call to include | calls.rb:99:5:99:20 | include |
-| calls.rb:44:9:44:18 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:45:9:45:23 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:52:5:52:9 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:53:1:53:5 | call to baz | calls.rb:43:5:49:7 | baz |
-| calls.rb:55:1:55:12 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:59:9:59:13 | call to super | calls.rb:43:5:49:7 | baz |
-| calls.rb:63:5:63:9 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:64:1:64:5 | call to baz | calls.rb:58:5:60:7 | baz |
-| calls.rb:66:1:66:12 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:69:5:69:16 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
-| calls.rb:70:5:70:16 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
-| calls.rb:74:5:74:11 | yield ... | calls.rb:80:16:80:29 | { ... } |
-| calls.rb:74:5:74:11 | yield ... | calls.rb:151:10:151:28 | { ... } |
-| calls.rb:78:11:78:18 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:79:5:79:10 | ...[...] | calls.rb:111:5:111:31 | [] |
-| calls.rb:80:5:80:29 | call to call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:80:22:80:27 | ...[...] | calls.rb:111:5:111:31 | [] |
-| calls.rb:105:5:105:18 | call to include | calls.rb:99:5:99:20 | include |
-| calls.rb:122:15:122:25 | call to length | calls.rb:118:3:118:17 | length |
-| calls.rb:123:9:123:24 | yield ... | calls.rb:139:23:139:62 | { ... } |
-| calls.rb:123:9:123:24 | yield ... | calls.rb:141:17:141:35 | { ... } |
-| calls.rb:123:9:123:24 | yield ... | calls.rb:143:17:143:40 | { ... } |
-| calls.rb:123:9:123:24 | yield ... | calls.rb:145:18:145:37 | { ... } |
-| calls.rb:123:18:123:24 | ...[...] | calls.rb:116:3:116:29 | [] |
-| calls.rb:130:5:130:20 | yield ... | calls.rb:133:7:133:30 | { ... } |
-| calls.rb:133:1:133:30 | call to funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:133:13:133:29 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:133:18:133:29 | call to capitalize | calls.rb:89:5:89:23 | capitalize |
-| calls.rb:135:1:135:14 | call to capitalize | calls.rb:89:5:89:23 | capitalize |
-| calls.rb:136:1:136:12 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
-| calls.rb:137:1:137:5 | call to abs | calls.rb:85:5:85:16 | abs |
-| calls.rb:139:1:139:62 | call to foreach | calls.rb:120:3:126:5 | foreach |
-| calls.rb:139:32:139:61 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:141:1:141:35 | call to foreach | calls.rb:120:3:126:5 | foreach |
-| calls.rb:141:23:141:34 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
-| calls.rb:143:1:143:40 | call to foreach | calls.rb:120:3:126:5 | foreach |
-| calls.rb:143:23:143:39 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:145:1:145:37 | call to foreach | calls.rb:120:3:126:5 | foreach |
-| calls.rb:145:27:145:36 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:148:5:148:17 | call to call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:151:1:151:28 | call to indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:151:16:151:27 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
-| calls.rb:156:9:156:17 | call to to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:156:9:156:17 | call to to_s | calls.rb:166:5:167:7 | to_s |
-| calls.rb:170:1:170:5 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:170:1:170:14 | call to s_method | calls.rb:155:5:157:7 | s_method |
-| calls.rb:171:1:171:5 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:171:1:171:14 | call to s_method | calls.rb:155:5:157:7 | s_method |
-| calls.rb:172:1:172:5 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:172:1:172:14 | call to s_method | calls.rb:155:5:157:7 | s_method |
-| calls.rb:177:1:177:15 | call to private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:181:9:181:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:182:9:182:24 | call to singleton_b | calls.rb:185:5:188:7 | singleton_b |
-| calls.rb:186:9:186:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:187:9:187:24 | call to singleton_c | calls.rb:190:5:192:7 | singleton_c |
-| calls.rb:191:9:191:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:195:9:195:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:196:9:196:24 | call to singleton_a | calls.rb:180:5:183:7 | singleton_a |
-| calls.rb:201:13:201:30 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:203:9:203:19 | call to singleton_e | calls.rb:200:9:202:11 | singleton_e |
-| calls.rb:208:13:208:30 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
-| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
-| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:256:1:258:3 | singleton_g |
-| calls.rb:217:1:217:22 | call to singleton_a | calls.rb:180:5:183:7 | singleton_a |
-| calls.rb:218:1:218:22 | call to singleton_f | calls.rb:207:9:209:11 | singleton_f |
-| calls.rb:220:6:220:19 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:222:1:222:11 | call to instance | calls.rb:199:5:204:7 | instance |
-| calls.rb:223:1:223:14 | call to singleton_e | calls.rb:200:9:202:11 | singleton_e |
-| calls.rb:226:5:226:24 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:229:1:229:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:230:1:230:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
-| calls.rb:233:5:233:24 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:236:1:236:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
-| calls.rb:237:1:237:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
-| calls.rb:241:9:241:28 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:245:1:245:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
-| calls.rb:246:1:246:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
-| calls.rb:248:6:248:19 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:252:1:252:8 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:254:1:254:16 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:257:5:257:22 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:260:1:260:22 | call to singleton_g | calls.rb:256:1:258:3 | singleton_g |
-| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
-| calls.rb:262:1:262:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
-| calls.rb:264:6:264:19 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:268:5:268:12 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:268:5:268:21 | call to instance | calls.rb:199:5:204:7 | instance |
-| calls.rb:271:9:271:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:274:5:274:20 | call to singleton_h | calls.rb:270:5:272:7 | singleton_h |
-| calls.rb:277:1:277:17 | call to create | calls.rb:267:1:275:3 | create |
-| calls.rb:278:1:278:22 | call to singleton_h | calls.rb:270:5:272:7 | singleton_h |
-| calls.rb:284:9:284:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:288:1:288:13 | call to singleton_i | calls.rb:283:5:285:7 | singleton_i |
-| calls.rb:289:1:289:22 | call to singleton_i | calls.rb:283:5:285:7 | singleton_i |
-| calls.rb:293:9:293:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:297:1:297:22 | call to singleton_j | calls.rb:292:5:294:7 | singleton_j |
-| calls.rb:301:9:301:31 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:305:9:305:11 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:305:9:305:20 | call to instance | calls.rb:300:5:302:7 | instance |
-| calls.rb:308:5:308:7 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:308:5:308:16 | call to instance | calls.rb:300:5:302:7 | instance |
-| calls.rb:311:1:311:17 | call to singleton | calls.rb:304:5:306:7 | singleton |
-| calls.rb:315:9:315:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:321:9:321:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:327:9:327:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:334:9:334:18 | call to instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:336:9:336:18 | call to instance | calls.rb:320:5:322:7 | instance |
-| calls.rb:336:9:336:18 | call to instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:338:9:338:18 | call to instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:338:9:338:18 | call to instance | calls.rb:320:5:322:7 | instance |
-| calls.rb:338:9:338:18 | call to instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:343:20:343:29 | call to instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:344:26:344:36 | call to instance | calls.rb:320:5:322:7 | instance |
-| calls.rb:344:26:344:36 | call to instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:345:26:345:36 | call to instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:345:26:345:36 | call to instance | calls.rb:320:5:322:7 | instance |
-| calls.rb:345:26:345:36 | call to instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:349:6:349:11 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:350:1:350:11 | call to instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:351:1:351:25 | call to pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:351:19:351:24 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:352:1:352:25 | call to pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:352:19:352:24 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:353:1:353:25 | call to pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:353:19:353:24 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:357:9:357:28 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:361:6:361:11 | call to new | calls.rb:106:5:106:16 | new |
-| calls.rb:362:1:362:16 | call to add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:363:1:363:11 | call to instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:363:1:363:11 | call to instance | calls.rb:356:5:358:7 | instance |
-| hello.rb:12:5:12:24 | call to include | calls.rb:99:5:99:20 | include |
+| calls.rb:36:5:36:14 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:40:5:40:13 | call to include | calls.rb:103:5:103:20 | include |
+| calls.rb:48:9:48:18 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:49:9:49:23 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:56:5:56:9 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:57:1:57:5 | call to baz | calls.rb:47:5:53:7 | baz |
+| calls.rb:59:1:59:12 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:63:9:63:13 | call to super | calls.rb:47:5:53:7 | baz |
+| calls.rb:67:5:67:9 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:68:1:68:5 | call to baz | calls.rb:62:5:64:7 | baz |
+| calls.rb:70:1:70:12 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:73:5:73:16 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
+| calls.rb:74:5:74:16 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
+| calls.rb:78:5:78:11 | yield ... | calls.rb:84:16:84:29 | { ... } |
+| calls.rb:78:5:78:11 | yield ... | calls.rb:155:10:155:28 | { ... } |
+| calls.rb:82:11:82:18 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:83:5:83:10 | ...[...] | calls.rb:115:5:115:31 | [] |
+| calls.rb:84:5:84:29 | call to call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:84:22:84:27 | ...[...] | calls.rb:115:5:115:31 | [] |
+| calls.rb:109:5:109:18 | call to include | calls.rb:103:5:103:20 | include |
+| calls.rb:126:15:126:25 | call to length | calls.rb:122:3:122:17 | length |
+| calls.rb:127:9:127:24 | yield ... | calls.rb:143:23:143:62 | { ... } |
+| calls.rb:127:9:127:24 | yield ... | calls.rb:145:17:145:35 | { ... } |
+| calls.rb:127:9:127:24 | yield ... | calls.rb:147:17:147:40 | { ... } |
+| calls.rb:127:9:127:24 | yield ... | calls.rb:149:18:149:37 | { ... } |
+| calls.rb:127:18:127:24 | ...[...] | calls.rb:120:3:120:29 | [] |
+| calls.rb:134:5:134:20 | yield ... | calls.rb:137:7:137:30 | { ... } |
+| calls.rb:137:1:137:30 | call to funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:137:13:137:29 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:137:18:137:29 | call to capitalize | calls.rb:93:5:93:23 | capitalize |
+| calls.rb:139:1:139:14 | call to capitalize | calls.rb:93:5:93:23 | capitalize |
+| calls.rb:140:1:140:12 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
+| calls.rb:141:1:141:5 | call to abs | calls.rb:89:5:89:16 | abs |
+| calls.rb:143:1:143:62 | call to foreach | calls.rb:124:3:130:5 | foreach |
+| calls.rb:143:32:143:61 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:145:1:145:35 | call to foreach | calls.rb:124:3:130:5 | foreach |
+| calls.rb:145:23:145:34 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
+| calls.rb:147:1:147:40 | call to foreach | calls.rb:124:3:130:5 | foreach |
+| calls.rb:147:23:147:39 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:149:1:149:37 | call to foreach | calls.rb:124:3:130:5 | foreach |
+| calls.rb:149:27:149:36 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:152:5:152:17 | call to call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:155:1:155:28 | call to indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:155:16:155:27 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
+| calls.rb:160:9:160:17 | call to to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:160:9:160:17 | call to to_s | calls.rb:170:5:171:7 | to_s |
+| calls.rb:174:1:174:5 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:174:1:174:14 | call to s_method | calls.rb:159:5:161:7 | s_method |
+| calls.rb:175:1:175:5 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:175:1:175:14 | call to s_method | calls.rb:159:5:161:7 | s_method |
+| calls.rb:176:1:176:5 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:176:1:176:14 | call to s_method | calls.rb:159:5:161:7 | s_method |
+| calls.rb:181:1:181:15 | call to private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:185:9:185:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:186:9:186:24 | call to singleton_b | calls.rb:189:5:192:7 | singleton_b |
+| calls.rb:190:9:190:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:191:9:191:24 | call to singleton_c | calls.rb:194:5:196:7 | singleton_c |
+| calls.rb:195:9:195:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:199:9:199:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:200:9:200:24 | call to singleton_a | calls.rb:184:5:187:7 | singleton_a |
+| calls.rb:205:13:205:30 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:207:9:207:19 | call to singleton_e | calls.rb:204:9:206:11 | singleton_e |
+| calls.rb:212:13:212:30 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:229:1:231:3 | singleton_g |
+| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:244:5:246:7 | singleton_g |
+| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:260:1:262:3 | singleton_g |
+| calls.rb:221:1:221:22 | call to singleton_a | calls.rb:184:5:187:7 | singleton_a |
+| calls.rb:222:1:222:22 | call to singleton_f | calls.rb:211:9:213:11 | singleton_f |
+| calls.rb:224:6:224:19 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:226:1:226:11 | call to instance | calls.rb:203:5:208:7 | instance |
+| calls.rb:227:1:227:14 | call to singleton_e | calls.rb:204:9:206:11 | singleton_e |
+| calls.rb:230:5:230:24 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:233:1:233:14 | call to singleton_g | calls.rb:229:1:231:3 | singleton_g |
+| calls.rb:234:1:234:19 | call to call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
+| calls.rb:237:5:237:24 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:240:1:240:14 | call to singleton_g | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:241:1:241:19 | call to call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
+| calls.rb:245:9:245:28 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:249:1:249:14 | call to singleton_g | calls.rb:244:5:246:7 | singleton_g |
+| calls.rb:250:1:250:19 | call to call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
+| calls.rb:252:6:252:19 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:256:1:256:8 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:258:1:258:16 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:261:5:261:22 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:264:1:264:22 | call to singleton_g | calls.rb:260:1:262:3 | singleton_g |
+| calls.rb:265:1:265:14 | call to singleton_g | calls.rb:244:5:246:7 | singleton_g |
+| calls.rb:266:1:266:19 | call to call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
+| calls.rb:268:6:268:19 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:272:5:272:12 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:272:5:272:21 | call to instance | calls.rb:203:5:208:7 | instance |
+| calls.rb:275:9:275:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:278:5:278:20 | call to singleton_h | calls.rb:274:5:276:7 | singleton_h |
+| calls.rb:281:1:281:17 | call to create | calls.rb:271:1:279:3 | create |
+| calls.rb:282:1:282:22 | call to singleton_h | calls.rb:274:5:276:7 | singleton_h |
+| calls.rb:288:9:288:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:292:1:292:13 | call to singleton_i | calls.rb:287:5:289:7 | singleton_i |
+| calls.rb:293:1:293:22 | call to singleton_i | calls.rb:287:5:289:7 | singleton_i |
+| calls.rb:297:9:297:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:301:1:301:22 | call to singleton_j | calls.rb:296:5:298:7 | singleton_j |
+| calls.rb:305:9:305:31 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:309:9:309:11 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:309:9:309:20 | call to instance | calls.rb:304:5:306:7 | instance |
+| calls.rb:312:5:312:7 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:312:5:312:16 | call to instance | calls.rb:304:5:306:7 | instance |
+| calls.rb:315:1:315:17 | call to singleton | calls.rb:308:5:310:7 | singleton |
+| calls.rb:319:9:319:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:325:9:325:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:331:9:331:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:338:9:338:18 | call to instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:340:9:340:18 | call to instance | calls.rb:324:5:326:7 | instance |
+| calls.rb:340:9:340:18 | call to instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:342:9:342:18 | call to instance | calls.rb:318:5:320:7 | instance |
+| calls.rb:342:9:342:18 | call to instance | calls.rb:324:5:326:7 | instance |
+| calls.rb:342:9:342:18 | call to instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:347:20:347:29 | call to instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:348:26:348:36 | call to instance | calls.rb:324:5:326:7 | instance |
+| calls.rb:348:26:348:36 | call to instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:349:26:349:36 | call to instance | calls.rb:318:5:320:7 | instance |
+| calls.rb:349:26:349:36 | call to instance | calls.rb:324:5:326:7 | instance |
+| calls.rb:349:26:349:36 | call to instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:353:6:353:11 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:354:1:354:11 | call to instance | calls.rb:318:5:320:7 | instance |
+| calls.rb:355:1:355:25 | call to pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:355:19:355:24 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:356:1:356:25 | call to pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:356:19:356:24 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:357:1:357:25 | call to pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:357:19:357:24 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:361:9:361:28 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:365:6:365:11 | call to new | calls.rb:110:5:110:16 | new |
+| calls.rb:366:1:366:16 | call to add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:367:1:367:11 | call to instance | calls.rb:318:5:320:7 | instance |
+| calls.rb:367:1:367:11 | call to instance | calls.rb:360:5:362:7 | instance |
+| hello.rb:12:5:12:24 | call to include | calls.rb:103:5:103:20 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
 | hello.rb:20:30:20:34 | call to world | hello.rb:5:5:7:7 | world |
-| modules.rb:12:5:12:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:22:3:22:19 | call to puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:33:3:33:25 | call to puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:44:3:44:19 | call to puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:55:3:55:30 | call to puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:89:3:89:16 | call to include | calls.rb:99:5:99:20 | include |
-| modules.rb:90:3:90:38 | call to module_eval | calls.rb:98:5:98:24 | module_eval |
-| modules.rb:90:24:90:36 | call to prepend | calls.rb:100:5:100:20 | prepend |
-| modules.rb:96:3:96:14 | call to include | calls.rb:99:5:99:20 | include |
-| modules.rb:102:3:102:16 | call to prepend | calls.rb:100:5:100:20 | prepend |
-| modules.rb:126:6:126:11 | call to new | calls.rb:106:5:106:16 | new |
-| modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:100:5:100:20 | prepend |
-| private.rb:2:3:3:5 | call to private | calls.rb:101:5:101:20 | private |
-| private.rb:10:3:10:19 | call to private | calls.rb:101:5:101:20 | private |
-| private.rb:12:3:12:9 | call to private | calls.rb:101:5:101:20 | private |
-| private.rb:34:1:34:5 | call to new | calls.rb:106:5:106:16 | new |
-| private.rb:35:1:35:5 | call to new | calls.rb:106:5:106:16 | new |
-| private.rb:36:1:36:5 | call to new | calls.rb:106:5:106:16 | new |
-| private.rb:37:1:37:5 | call to new | calls.rb:106:5:106:16 | new |
-| private.rb:38:1:38:5 | call to new | calls.rb:106:5:106:16 | new |
+| modules.rb:12:5:12:26 | call to puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:22:3:22:19 | call to puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:33:3:33:25 | call to puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:44:3:44:19 | call to puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:55:3:55:30 | call to puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:89:3:89:16 | call to include | calls.rb:103:5:103:20 | include |
+| modules.rb:90:3:90:38 | call to module_eval | calls.rb:102:5:102:24 | module_eval |
+| modules.rb:90:24:90:36 | call to prepend | calls.rb:104:5:104:20 | prepend |
+| modules.rb:96:3:96:14 | call to include | calls.rb:103:5:103:20 | include |
+| modules.rb:102:3:102:16 | call to prepend | calls.rb:104:5:104:20 | prepend |
+| modules.rb:126:6:126:11 | call to new | calls.rb:110:5:110:16 | new |
+| modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:104:5:104:20 | prepend |
+| private.rb:2:3:3:5 | call to private | calls.rb:105:5:105:20 | private |
+| private.rb:10:3:10:19 | call to private | calls.rb:105:5:105:20 | private |
+| private.rb:12:3:12:9 | call to private | calls.rb:105:5:105:20 | private |
+| private.rb:34:1:34:5 | call to new | calls.rb:110:5:110:16 | new |
+| private.rb:35:1:35:5 | call to new | calls.rb:110:5:110:16 | new |
+| private.rb:36:1:36:5 | call to new | calls.rb:110:5:110:16 | new |
+| private.rb:37:1:37:5 | call to new | calls.rb:110:5:110:16 | new |
+| private.rb:38:1:38:5 | call to new | calls.rb:110:5:110:16 | new |
 | private.rb:38:1:38:12 | call to public | private.rb:5:3:6:5 | public |
 | private.rb:40:1:40:15 | call to private_on_main | private.rb:31:1:32:3 | private_on_main |
-| private.rb:43:3:44:5 | call to private | calls.rb:101:5:101:20 | private |
-| private.rb:51:3:51:19 | call to private | calls.rb:101:5:101:20 | private |
-| private.rb:53:3:53:9 | call to private | calls.rb:101:5:101:20 | private |
+| private.rb:43:3:44:5 | call to private | calls.rb:105:5:105:20 | private |
+| private.rb:51:3:51:19 | call to private | calls.rb:105:5:105:20 | private |
+| private.rb:53:3:53:9 | call to private | calls.rb:105:5:105:20 | private |
 unresolvedCall
 | calls.rb:25:5:25:14 | call to instance_m |
 | calls.rb:26:5:26:19 | call to instance_m |
 | calls.rb:32:1:32:12 | call to instance_m |
-| calls.rb:37:5:37:14 | call to instance_m |
-| calls.rb:38:5:38:19 | call to instance_m |
-| calls.rb:40:5:40:15 | call to singleton_m |
-| calls.rb:41:5:41:20 | call to singleton_m |
-| calls.rb:47:9:47:19 | call to singleton_m |
-| calls.rb:48:9:48:24 | call to singleton_m |
-| calls.rb:54:1:54:13 | call to singleton_m |
-| calls.rb:65:1:65:13 | call to singleton_m |
-| calls.rb:94:17:94:26 | call to old_puts |
-| calls.rb:111:15:111:27 | call to old_lookup |
-| calls.rb:116:13:116:25 | call to old_lookup |
-| calls.rb:122:11:122:25 | ... < ... |
-| calls.rb:124:11:124:12 | ... + ... |
-| calls.rb:139:1:139:13 | call to [] |
-| calls.rb:139:48:139:59 | call to capitalize |
-| calls.rb:141:1:141:7 | call to [] |
-| calls.rb:143:1:143:7 | call to [] |
-| calls.rb:143:28:143:39 | call to capitalize |
-| calls.rb:145:1:145:8 | call to [] |
-| calls.rb:145:4:145:5 | - ... |
-| calls.rb:145:32:145:36 | call to abs |
-| calls.rb:249:1:249:14 | call to singleton_e |
-| calls.rb:250:1:250:14 | call to singleton_g |
-| calls.rb:263:1:263:14 | call to singleton_g |
-| calls.rb:265:1:265:14 | call to singleton_g |
+| calls.rb:41:5:41:14 | call to instance_m |
+| calls.rb:42:5:42:19 | call to instance_m |
+| calls.rb:44:5:44:15 | call to singleton_m |
+| calls.rb:45:5:45:20 | call to singleton_m |
+| calls.rb:51:9:51:19 | call to singleton_m |
+| calls.rb:52:9:52:24 | call to singleton_m |
+| calls.rb:58:1:58:13 | call to singleton_m |
+| calls.rb:69:1:69:13 | call to singleton_m |
+| calls.rb:98:17:98:26 | call to old_puts |
+| calls.rb:115:15:115:27 | call to old_lookup |
+| calls.rb:120:13:120:25 | call to old_lookup |
+| calls.rb:126:11:126:25 | ... < ... |
+| calls.rb:128:11:128:12 | ... + ... |
+| calls.rb:143:1:143:13 | call to [] |
+| calls.rb:143:48:143:59 | call to capitalize |
+| calls.rb:145:1:145:7 | call to [] |
+| calls.rb:147:1:147:7 | call to [] |
+| calls.rb:147:28:147:39 | call to capitalize |
+| calls.rb:149:1:149:8 | call to [] |
+| calls.rb:149:4:149:5 | - ... |
+| calls.rb:149:32:149:36 | call to abs |
+| calls.rb:253:1:253:14 | call to singleton_e |
+| calls.rb:254:1:254:14 | call to singleton_g |
+| calls.rb:267:1:267:14 | call to singleton_g |
+| calls.rb:269:1:269:14 | call to singleton_g |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |
@@ -214,15 +215,16 @@ unresolvedCall
 | private.rb:37:1:37:14 | call to private4 |
 privateMethod
 | calls.rb:1:1:3:3 | foo |
-| calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:73:1:75:3 | call_block |
-| calls.rb:77:1:81:3 | foo |
-| calls.rb:129:1:131:3 | funny |
-| calls.rb:147:1:149:3 | indirect |
-| calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:267:1:275:3 | create |
-| calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:77:1:79:3 | call_block |
+| calls.rb:81:1:85:3 | foo |
+| calls.rb:133:1:135:3 | funny |
+| calls.rb:151:1:153:3 | indirect |
+| calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:271:1:279:3 | create |
+| calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:359:1:363:3 | add_singleton |
 | private.rb:2:11:3:5 | private1 |
 | private.rb:8:3:9:5 | private2 |
 | private.rb:14:3:15:5 | private3 |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -11,7 +11,6 @@ getTarget
 | calls.rb:28:5:28:15 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
 | calls.rb:29:5:29:20 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
 | calls.rb:33:1:33:13 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
-| calls.rb:36:5:36:14 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
 | calls.rb:40:5:40:13 | call to include | calls.rb:103:5:103:20 | include |
 | calls.rb:48:9:48:18 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
 | calls.rb:49:9:49:23 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
@@ -178,6 +177,7 @@ unresolvedCall
 | calls.rb:25:5:25:14 | call to instance_m |
 | calls.rb:26:5:26:19 | call to instance_m |
 | calls.rb:32:1:32:12 | call to instance_m |
+| calls.rb:36:5:36:14 | call to instance_m |
 | calls.rb:41:5:41:14 | call to instance_m |
 | calls.rb:42:5:42:19 | call to instance_m |
 | calls.rb:44:5:44:15 | call to singleton_m |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -1,121 +1,217 @@
 getTarget
-| calls.rb:2:5:2:14 | call to puts | calls.rb:87:5:87:17 | puts |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:94:5:94:30 | puts |
 | calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:8:5:8:14 | call to puts | calls.rb:87:5:87:17 | puts |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:94:5:94:30 | puts |
 | calls.rb:11:1:11:8 | call to bar | calls.rb:7:1:9:3 | bar |
-| calls.rb:13:1:13:8 | call to foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:13:1:13:8 | call to foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:22:5:22:15 | call to singleton_m | calls.rb:17:5:17:29 | singleton_m |
-| calls.rb:23:5:23:20 | call to singleton_m | calls.rb:17:5:17:29 | singleton_m |
-| calls.rb:27:1:27:13 | call to singleton_m | calls.rb:17:5:17:29 | singleton_m |
-| calls.rb:30:5:30:13 | call to include | calls.rb:92:5:92:20 | include |
-| calls.rb:38:9:38:18 | call to instance_m | calls.rb:16:5:16:23 | instance_m |
-| calls.rb:39:9:39:23 | call to instance_m | calls.rb:16:5:16:23 | instance_m |
-| calls.rb:46:5:46:9 | call to new | calls.rb:99:5:99:16 | new |
-| calls.rb:47:1:47:5 | call to baz | calls.rb:37:5:43:7 | baz |
-| calls.rb:49:1:49:12 | call to instance_m | calls.rb:16:5:16:23 | instance_m |
-| calls.rb:53:9:53:13 | call to super | calls.rb:37:5:43:7 | baz |
-| calls.rb:57:5:57:9 | call to new | calls.rb:99:5:99:16 | new |
-| calls.rb:58:1:58:5 | call to baz | calls.rb:52:5:54:7 | baz |
-| calls.rb:60:1:60:12 | call to instance_m | calls.rb:16:5:16:23 | instance_m |
-| calls.rb:63:5:63:16 | call to bit_length | calls.rb:78:5:78:23 | bit_length |
-| calls.rb:64:5:64:16 | call to bit_length | calls.rb:78:5:78:23 | bit_length |
-| calls.rb:68:5:68:11 | yield ... | calls.rb:74:16:74:29 | { ... } |
-| calls.rb:68:5:68:11 | yield ... | calls.rb:141:10:141:28 | { ... } |
-| calls.rb:72:11:72:18 | call to new | calls.rb:99:5:99:16 | new |
-| calls.rb:73:5:73:10 | ...[...] | calls.rb:103:5:103:15 | [] |
-| calls.rb:74:5:74:29 | call to call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:74:22:74:27 | ...[...] | calls.rb:103:5:103:15 | [] |
-| calls.rb:98:5:98:18 | call to include | calls.rb:92:5:92:20 | include |
-| calls.rb:112:15:112:25 | call to length | calls.rb:108:3:108:17 | length |
-| calls.rb:113:9:113:24 | yield ... | calls.rb:129:23:129:62 | { ... } |
-| calls.rb:113:9:113:24 | yield ... | calls.rb:131:17:131:35 | { ... } |
-| calls.rb:113:9:113:24 | yield ... | calls.rb:133:17:133:40 | { ... } |
-| calls.rb:113:9:113:24 | yield ... | calls.rb:135:18:135:37 | { ... } |
-| calls.rb:113:18:113:24 | ...[...] | calls.rb:107:3:107:13 | [] |
-| calls.rb:120:5:120:20 | yield ... | calls.rb:123:7:123:30 | { ... } |
-| calls.rb:123:1:123:30 | call to funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:123:13:123:29 | call to puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:123:18:123:29 | call to capitalize | calls.rb:83:5:83:23 | capitalize |
-| calls.rb:125:1:125:14 | call to capitalize | calls.rb:83:5:83:23 | capitalize |
-| calls.rb:126:1:126:12 | call to bit_length | calls.rb:78:5:78:23 | bit_length |
-| calls.rb:127:1:127:5 | call to abs | calls.rb:79:5:79:16 | abs |
-| calls.rb:129:1:129:62 | call to foreach | calls.rb:110:3:116:5 | foreach |
-| calls.rb:129:32:129:61 | call to puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:131:1:131:35 | call to foreach | calls.rb:110:3:116:5 | foreach |
-| calls.rb:131:23:131:34 | call to bit_length | calls.rb:78:5:78:23 | bit_length |
-| calls.rb:133:1:133:40 | call to foreach | calls.rb:110:3:116:5 | foreach |
-| calls.rb:133:23:133:39 | call to puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:135:1:135:37 | call to foreach | calls.rb:110:3:116:5 | foreach |
-| calls.rb:135:27:135:36 | call to puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:138:5:138:17 | call to call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:141:1:141:28 | call to indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:141:16:141:27 | call to bit_length | calls.rb:78:5:78:23 | bit_length |
-| calls.rb:146:9:146:17 | call to to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:146:9:146:17 | call to to_s | calls.rb:156:5:157:7 | to_s |
-| calls.rb:160:1:160:5 | call to new | calls.rb:99:5:99:16 | new |
-| calls.rb:160:1:160:14 | call to s_method | calls.rb:145:5:147:7 | s_method |
-| calls.rb:161:1:161:5 | call to new | calls.rb:99:5:99:16 | new |
-| calls.rb:161:1:161:14 | call to s_method | calls.rb:145:5:147:7 | s_method |
-| calls.rb:162:1:162:5 | call to new | calls.rb:99:5:99:16 | new |
-| calls.rb:162:1:162:14 | call to s_method | calls.rb:145:5:147:7 | s_method |
-| calls.rb:167:1:167:15 | call to private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:171:9:171:24 | call to singleton_b | calls.rb:174:5:176:7 | singleton_b |
-| calls.rb:175:9:175:24 | call to singleton_c | calls.rb:178:5:179:7 | singleton_c |
-| calls.rb:182:9:182:24 | call to singleton_a | calls.rb:170:5:172:7 | singleton_a |
-| calls.rb:186:1:186:22 | call to singleton_a | calls.rb:170:5:172:7 | singleton_a |
-| hello.rb:12:5:12:24 | call to include | calls.rb:92:5:92:20 | include |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:13:1:15:3 | bar |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:7:1:9:3 | bar |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:13:1:15:3 | bar |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:28:5:28:15 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
+| calls.rb:29:5:29:20 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
+| calls.rb:33:1:33:13 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
+| calls.rb:36:5:36:13 | call to include | calls.rb:99:5:99:20 | include |
+| calls.rb:44:9:44:18 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:45:9:45:23 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:52:5:52:9 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:53:1:53:5 | call to baz | calls.rb:43:5:49:7 | baz |
+| calls.rb:55:1:55:12 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:59:9:59:13 | call to super | calls.rb:43:5:49:7 | baz |
+| calls.rb:63:5:63:9 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:64:1:64:5 | call to baz | calls.rb:58:5:60:7 | baz |
+| calls.rb:66:1:66:12 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:69:5:69:16 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
+| calls.rb:70:5:70:16 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
+| calls.rb:74:5:74:11 | yield ... | calls.rb:80:16:80:29 | { ... } |
+| calls.rb:74:5:74:11 | yield ... | calls.rb:151:10:151:28 | { ... } |
+| calls.rb:78:11:78:18 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:79:5:79:10 | ...[...] | calls.rb:111:5:111:31 | [] |
+| calls.rb:80:5:80:29 | call to call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:80:22:80:27 | ...[...] | calls.rb:111:5:111:31 | [] |
+| calls.rb:105:5:105:18 | call to include | calls.rb:99:5:99:20 | include |
+| calls.rb:122:15:122:25 | call to length | calls.rb:118:3:118:17 | length |
+| calls.rb:123:9:123:24 | yield ... | calls.rb:139:23:139:62 | { ... } |
+| calls.rb:123:9:123:24 | yield ... | calls.rb:141:17:141:35 | { ... } |
+| calls.rb:123:9:123:24 | yield ... | calls.rb:143:17:143:40 | { ... } |
+| calls.rb:123:9:123:24 | yield ... | calls.rb:145:18:145:37 | { ... } |
+| calls.rb:123:18:123:24 | ...[...] | calls.rb:116:3:116:29 | [] |
+| calls.rb:130:5:130:20 | yield ... | calls.rb:133:7:133:30 | { ... } |
+| calls.rb:133:1:133:30 | call to funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:133:13:133:29 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:133:18:133:29 | call to capitalize | calls.rb:89:5:89:23 | capitalize |
+| calls.rb:135:1:135:14 | call to capitalize | calls.rb:89:5:89:23 | capitalize |
+| calls.rb:136:1:136:12 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
+| calls.rb:137:1:137:5 | call to abs | calls.rb:85:5:85:16 | abs |
+| calls.rb:139:1:139:62 | call to foreach | calls.rb:120:3:126:5 | foreach |
+| calls.rb:139:32:139:61 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:141:1:141:35 | call to foreach | calls.rb:120:3:126:5 | foreach |
+| calls.rb:141:23:141:34 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
+| calls.rb:143:1:143:40 | call to foreach | calls.rb:120:3:126:5 | foreach |
+| calls.rb:143:23:143:39 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:145:1:145:37 | call to foreach | calls.rb:120:3:126:5 | foreach |
+| calls.rb:145:27:145:36 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:148:5:148:17 | call to call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:151:1:151:28 | call to indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:151:16:151:27 | call to bit_length | calls.rb:84:5:84:23 | bit_length |
+| calls.rb:156:9:156:17 | call to to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:156:9:156:17 | call to to_s | calls.rb:166:5:167:7 | to_s |
+| calls.rb:170:1:170:5 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:170:1:170:14 | call to s_method | calls.rb:155:5:157:7 | s_method |
+| calls.rb:171:1:171:5 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:171:1:171:14 | call to s_method | calls.rb:155:5:157:7 | s_method |
+| calls.rb:172:1:172:5 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:172:1:172:14 | call to s_method | calls.rb:155:5:157:7 | s_method |
+| calls.rb:177:1:177:15 | call to private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:181:9:181:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:182:9:182:24 | call to singleton_b | calls.rb:185:5:188:7 | singleton_b |
+| calls.rb:186:9:186:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:187:9:187:24 | call to singleton_c | calls.rb:190:5:192:7 | singleton_c |
+| calls.rb:191:9:191:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:195:9:195:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:196:9:196:24 | call to singleton_a | calls.rb:180:5:183:7 | singleton_a |
+| calls.rb:201:13:201:30 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:203:9:203:19 | call to singleton_e | calls.rb:200:9:202:11 | singleton_e |
+| calls.rb:208:13:208:30 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:217:1:217:22 | call to singleton_a | calls.rb:180:5:183:7 | singleton_a |
+| calls.rb:218:1:218:22 | call to singleton_f | calls.rb:207:9:209:11 | singleton_f |
+| calls.rb:220:6:220:19 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:222:1:222:11 | call to instance | calls.rb:199:5:204:7 | instance |
+| calls.rb:226:5:226:24 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:229:1:229:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:229:1:229:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:229:1:229:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:230:1:230:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
+| calls.rb:233:5:233:24 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:236:1:236:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:236:1:236:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:236:1:236:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:237:1:237:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
+| calls.rb:241:9:241:28 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:245:1:245:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:245:1:245:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:245:1:245:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:246:1:246:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
+| calls.rb:248:6:248:19 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:252:1:252:8 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:254:1:254:16 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:257:5:257:22 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:260:1:260:22 | call to singleton_g | calls.rb:256:1:258:3 | singleton_g |
+| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:262:1:262:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
+| calls.rb:264:6:264:19 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:268:5:268:12 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:268:5:268:21 | call to instance | calls.rb:199:5:204:7 | instance |
+| calls.rb:271:9:271:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:274:5:274:20 | call to singleton_h | calls.rb:270:5:272:7 | singleton_h |
+| calls.rb:277:1:277:17 | call to create | calls.rb:267:1:275:3 | create |
+| calls.rb:278:1:278:22 | call to singleton_h | calls.rb:270:5:272:7 | singleton_h |
+| calls.rb:284:9:284:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:288:1:288:13 | call to singleton_i | calls.rb:283:5:285:7 | singleton_i |
+| calls.rb:289:1:289:22 | call to singleton_i | calls.rb:283:5:285:7 | singleton_i |
+| calls.rb:293:9:293:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:297:1:297:22 | call to singleton_j | calls.rb:292:5:294:7 | singleton_j |
+| calls.rb:301:9:301:31 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:305:9:305:11 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:305:9:305:20 | call to instance | calls.rb:300:5:302:7 | instance |
+| calls.rb:308:5:308:7 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:308:5:308:16 | call to instance | calls.rb:300:5:302:7 | instance |
+| calls.rb:311:1:311:17 | call to singleton | calls.rb:304:5:306:7 | singleton |
+| calls.rb:315:9:315:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:321:9:321:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:327:9:327:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:334:9:334:18 | call to instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:334:9:334:18 | call to instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:334:9:334:18 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:336:9:336:18 | call to instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:336:9:336:18 | call to instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:336:9:336:18 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:338:9:338:18 | call to instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:338:9:338:18 | call to instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:338:9:338:18 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:343:20:343:29 | call to instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:343:20:343:29 | call to instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:343:20:343:29 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:349:6:349:11 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:350:1:350:11 | call to instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:351:1:351:25 | call to pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:351:19:351:24 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:352:1:352:25 | call to pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:352:19:352:24 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:353:1:353:25 | call to pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:353:19:353:24 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:357:9:357:28 | call to puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:361:6:361:11 | call to new | calls.rb:106:5:106:16 | new |
+| calls.rb:362:1:362:16 | call to add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:363:1:363:11 | call to instance | calls.rb:314:5:316:7 | instance |
+| hello.rb:12:5:12:24 | call to include | calls.rb:99:5:99:20 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
 | hello.rb:20:30:20:34 | call to world | hello.rb:5:5:7:7 | world |
-| modules.rb:12:5:12:26 | call to puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:22:3:22:19 | call to puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:33:3:33:25 | call to puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:44:3:44:19 | call to puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:55:3:55:30 | call to puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:89:3:89:16 | call to include | calls.rb:92:5:92:20 | include |
-| modules.rb:90:3:90:38 | call to module_eval | calls.rb:91:5:91:24 | module_eval |
-| modules.rb:90:24:90:36 | call to prepend | calls.rb:93:5:93:20 | prepend |
-| modules.rb:96:3:96:14 | call to include | calls.rb:92:5:92:20 | include |
-| modules.rb:102:3:102:16 | call to prepend | calls.rb:93:5:93:20 | prepend |
-| modules.rb:126:6:126:11 | call to new | calls.rb:99:5:99:16 | new |
-| modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:93:5:93:20 | prepend |
-| private.rb:2:3:3:5 | call to private | calls.rb:94:5:94:20 | private |
-| private.rb:10:3:10:19 | call to private | calls.rb:94:5:94:20 | private |
-| private.rb:12:3:12:9 | call to private | calls.rb:94:5:94:20 | private |
-| private.rb:34:1:34:5 | call to new | calls.rb:99:5:99:16 | new |
-| private.rb:35:1:35:5 | call to new | calls.rb:99:5:99:16 | new |
-| private.rb:36:1:36:5 | call to new | calls.rb:99:5:99:16 | new |
-| private.rb:37:1:37:5 | call to new | calls.rb:99:5:99:16 | new |
-| private.rb:38:1:38:5 | call to new | calls.rb:99:5:99:16 | new |
+| modules.rb:12:5:12:26 | call to puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:22:3:22:19 | call to puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:33:3:33:25 | call to puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:44:3:44:19 | call to puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:55:3:55:30 | call to puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:89:3:89:16 | call to include | calls.rb:99:5:99:20 | include |
+| modules.rb:90:3:90:38 | call to module_eval | calls.rb:98:5:98:24 | module_eval |
+| modules.rb:90:24:90:36 | call to prepend | calls.rb:100:5:100:20 | prepend |
+| modules.rb:96:3:96:14 | call to include | calls.rb:99:5:99:20 | include |
+| modules.rb:102:3:102:16 | call to prepend | calls.rb:100:5:100:20 | prepend |
+| modules.rb:126:6:126:11 | call to new | calls.rb:106:5:106:16 | new |
+| modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:100:5:100:20 | prepend |
+| private.rb:2:3:3:5 | call to private | calls.rb:101:5:101:20 | private |
+| private.rb:10:3:10:19 | call to private | calls.rb:101:5:101:20 | private |
+| private.rb:12:3:12:9 | call to private | calls.rb:101:5:101:20 | private |
+| private.rb:34:1:34:5 | call to new | calls.rb:106:5:106:16 | new |
+| private.rb:35:1:35:5 | call to new | calls.rb:106:5:106:16 | new |
+| private.rb:36:1:36:5 | call to new | calls.rb:106:5:106:16 | new |
+| private.rb:37:1:37:5 | call to new | calls.rb:106:5:106:16 | new |
+| private.rb:38:1:38:5 | call to new | calls.rb:106:5:106:16 | new |
 | private.rb:38:1:38:12 | call to public | private.rb:5:3:6:5 | public |
 | private.rb:40:1:40:15 | call to private_on_main | private.rb:31:1:32:3 | private_on_main |
-| private.rb:43:3:44:5 | call to private | calls.rb:94:5:94:20 | private |
-| private.rb:51:3:51:19 | call to private | calls.rb:94:5:94:20 | private |
-| private.rb:53:3:53:9 | call to private | calls.rb:94:5:94:20 | private |
+| private.rb:43:3:44:5 | call to private | calls.rb:101:5:101:20 | private |
+| private.rb:51:3:51:19 | call to private | calls.rb:101:5:101:20 | private |
+| private.rb:53:3:53:9 | call to private | calls.rb:101:5:101:20 | private |
 unresolvedCall
-| calls.rb:19:5:19:14 | call to instance_m |
-| calls.rb:20:5:20:19 | call to instance_m |
-| calls.rb:26:1:26:12 | call to instance_m |
-| calls.rb:31:5:31:14 | call to instance_m |
-| calls.rb:32:5:32:19 | call to instance_m |
-| calls.rb:34:5:34:15 | call to singleton_m |
-| calls.rb:35:5:35:20 | call to singleton_m |
-| calls.rb:41:9:41:19 | call to singleton_m |
-| calls.rb:42:9:42:24 | call to singleton_m |
-| calls.rb:48:1:48:13 | call to singleton_m |
-| calls.rb:59:1:59:13 | call to singleton_m |
-| calls.rb:112:11:112:25 | ... < ... |
-| calls.rb:114:11:114:12 | ... + ... |
-| calls.rb:129:1:129:13 | call to [] |
-| calls.rb:129:48:129:59 | call to capitalize |
-| calls.rb:131:1:131:7 | call to [] |
-| calls.rb:133:1:133:7 | call to [] |
-| calls.rb:133:28:133:39 | call to capitalize |
-| calls.rb:135:1:135:8 | call to [] |
-| calls.rb:135:4:135:5 | - ... |
-| calls.rb:135:32:135:36 | call to abs |
+| calls.rb:25:5:25:14 | call to instance_m |
+| calls.rb:26:5:26:19 | call to instance_m |
+| calls.rb:32:1:32:12 | call to instance_m |
+| calls.rb:37:5:37:14 | call to instance_m |
+| calls.rb:38:5:38:19 | call to instance_m |
+| calls.rb:40:5:40:15 | call to singleton_m |
+| calls.rb:41:5:41:20 | call to singleton_m |
+| calls.rb:47:9:47:19 | call to singleton_m |
+| calls.rb:48:9:48:24 | call to singleton_m |
+| calls.rb:54:1:54:13 | call to singleton_m |
+| calls.rb:65:1:65:13 | call to singleton_m |
+| calls.rb:94:17:94:26 | call to old_puts |
+| calls.rb:111:15:111:27 | call to old_lookup |
+| calls.rb:116:13:116:25 | call to old_lookup |
+| calls.rb:122:11:122:25 | ... < ... |
+| calls.rb:124:11:124:12 | ... + ... |
+| calls.rb:139:1:139:13 | call to [] |
+| calls.rb:139:48:139:59 | call to capitalize |
+| calls.rb:141:1:141:7 | call to [] |
+| calls.rb:143:1:143:7 | call to [] |
+| calls.rb:143:28:143:39 | call to capitalize |
+| calls.rb:145:1:145:8 | call to [] |
+| calls.rb:145:4:145:5 | - ... |
+| calls.rb:145:32:145:36 | call to abs |
+| calls.rb:223:1:223:14 | call to singleton_e |
+| calls.rb:249:1:249:14 | call to singleton_e |
+| calls.rb:250:1:250:14 | call to singleton_g |
+| calls.rb:263:1:263:14 | call to singleton_g |
+| calls.rb:265:1:265:14 | call to singleton_g |
+| calls.rb:344:26:344:36 | call to instance |
+| calls.rb:345:26:345:36 | call to instance |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |
@@ -128,12 +224,15 @@ unresolvedCall
 | private.rb:37:1:37:14 | call to private4 |
 privateMethod
 | calls.rb:1:1:3:3 | foo |
-| calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:67:1:69:3 | call_block |
-| calls.rb:71:1:75:3 | foo |
-| calls.rb:119:1:121:3 | funny |
-| calls.rb:137:1:139:3 | indirect |
-| calls.rb:164:1:165:3 | private_on_main |
+| calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:73:1:75:3 | call_block |
+| calls.rb:77:1:81:3 | foo |
+| calls.rb:129:1:131:3 | funny |
+| calls.rb:147:1:149:3 | indirect |
+| calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:267:1:275:3 | create |
+| calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:355:1:359:3 | add_singleton |
 | private.rb:2:11:3:5 | private1 |
 | private.rb:8:3:9:5 | private2 |
 | private.rb:14:3:15:5 | private3 |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -4,9 +4,7 @@ getTarget
 | calls.rb:5:1:5:3 | call to foo | calls.rb:77:1:81:3 | foo |
 | calls.rb:8:5:8:15 | call to puts | calls.rb:94:5:94:30 | puts |
 | calls.rb:11:1:11:8 | call to bar | calls.rb:7:1:9:3 | bar |
-| calls.rb:11:1:11:8 | call to bar | calls.rb:13:1:15:3 | bar |
 | calls.rb:14:5:14:15 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:17:1:17:8 | call to bar | calls.rb:7:1:9:3 | bar |
 | calls.rb:17:1:17:8 | call to bar | calls.rb:13:1:15:3 | bar |
 | calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:3:3 | foo |
 | calls.rb:19:1:19:8 | call to foo | calls.rb:77:1:81:3 | foo |
@@ -78,23 +76,19 @@ getTarget
 | calls.rb:213:9:213:24 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
 | calls.rb:213:9:213:24 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
 | calls.rb:213:9:213:24 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:256:1:258:3 | singleton_g |
 | calls.rb:217:1:217:22 | call to singleton_a | calls.rb:180:5:183:7 | singleton_a |
 | calls.rb:218:1:218:22 | call to singleton_f | calls.rb:207:9:209:11 | singleton_f |
 | calls.rb:220:6:220:19 | call to new | calls.rb:106:5:106:16 | new |
 | calls.rb:222:1:222:11 | call to instance | calls.rb:199:5:204:7 | instance |
+| calls.rb:223:1:223:14 | call to singleton_e | calls.rb:200:9:202:11 | singleton_e |
 | calls.rb:226:5:226:24 | call to puts | calls.rb:94:5:94:30 | puts |
 | calls.rb:229:1:229:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:229:1:229:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
-| calls.rb:229:1:229:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
 | calls.rb:230:1:230:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
 | calls.rb:233:5:233:24 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:236:1:236:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
 | calls.rb:236:1:236:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
-| calls.rb:236:1:236:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
 | calls.rb:237:1:237:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
 | calls.rb:241:9:241:28 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:245:1:245:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:245:1:245:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
 | calls.rb:245:1:245:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
 | calls.rb:246:1:246:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
 | calls.rb:248:6:248:19 | call to new | calls.rb:106:5:106:16 | new |
@@ -102,8 +96,6 @@ getTarget
 | calls.rb:254:1:254:16 | call to puts | calls.rb:94:5:94:30 | puts |
 | calls.rb:257:5:257:22 | call to puts | calls.rb:94:5:94:30 | puts |
 | calls.rb:260:1:260:22 | call to singleton_g | calls.rb:256:1:258:3 | singleton_g |
-| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:232:1:234:3 | singleton_g |
 | calls.rb:261:1:261:14 | call to singleton_g | calls.rb:240:5:242:7 | singleton_g |
 | calls.rb:262:1:262:19 | call to call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
 | calls.rb:264:6:264:19 | call to new | calls.rb:106:5:106:16 | new |
@@ -127,18 +119,18 @@ getTarget
 | calls.rb:315:9:315:26 | call to puts | calls.rb:94:5:94:30 | puts |
 | calls.rb:321:9:321:26 | call to puts | calls.rb:94:5:94:30 | puts |
 | calls.rb:327:9:327:26 | call to puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:334:9:334:18 | call to instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:334:9:334:18 | call to instance | calls.rb:320:5:322:7 | instance |
 | calls.rb:334:9:334:18 | call to instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:336:9:336:18 | call to instance | calls.rb:314:5:316:7 | instance |
 | calls.rb:336:9:336:18 | call to instance | calls.rb:320:5:322:7 | instance |
 | calls.rb:336:9:336:18 | call to instance | calls.rb:326:5:328:7 | instance |
 | calls.rb:338:9:338:18 | call to instance | calls.rb:314:5:316:7 | instance |
 | calls.rb:338:9:338:18 | call to instance | calls.rb:320:5:322:7 | instance |
 | calls.rb:338:9:338:18 | call to instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:343:20:343:29 | call to instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:343:20:343:29 | call to instance | calls.rb:320:5:322:7 | instance |
 | calls.rb:343:20:343:29 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:344:26:344:36 | call to instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:344:26:344:36 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:345:26:345:36 | call to instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:345:26:345:36 | call to instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:345:26:345:36 | call to instance | calls.rb:326:5:328:7 | instance |
 | calls.rb:349:6:349:11 | call to new | calls.rb:106:5:106:16 | new |
 | calls.rb:350:1:350:11 | call to instance | calls.rb:314:5:316:7 | instance |
 | calls.rb:351:1:351:25 | call to pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
@@ -151,6 +143,7 @@ getTarget
 | calls.rb:361:6:361:11 | call to new | calls.rb:106:5:106:16 | new |
 | calls.rb:362:1:362:16 | call to add_singleton | calls.rb:355:1:359:3 | add_singleton |
 | calls.rb:363:1:363:11 | call to instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:363:1:363:11 | call to instance | calls.rb:356:5:358:7 | instance |
 | hello.rb:12:5:12:24 | call to include | calls.rb:99:5:99:20 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
@@ -205,13 +198,10 @@ unresolvedCall
 | calls.rb:145:1:145:8 | call to [] |
 | calls.rb:145:4:145:5 | - ... |
 | calls.rb:145:32:145:36 | call to abs |
-| calls.rb:223:1:223:14 | call to singleton_e |
 | calls.rb:249:1:249:14 | call to singleton_e |
 | calls.rb:250:1:250:14 | call to singleton_g |
 | calls.rb:263:1:263:14 | call to singleton_g |
 | calls.rb:265:1:265:14 | call to singleton_g |
-| calls.rb:344:26:344:36 | call to instance |
-| calls.rb:345:26:345:36 | call to instance |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -9,7 +9,6 @@ getTarget
 | calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:3:3 | foo |
 | calls.rb:19:1:19:8 | call to foo | calls.rb:85:1:89:3 | foo |
 | calls.rb:23:9:23:19 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
-| calls.rb:26:9:26:18 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
 | calls.rb:32:5:32:15 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
 | calls.rb:33:5:33:20 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
 | calls.rb:37:1:37:13 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
@@ -114,7 +113,6 @@ getTarget
 | calls.rb:305:1:305:22 | call to singleton_j | calls.rb:300:5:302:7 | singleton_j |
 | calls.rb:309:9:309:31 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:310:9:310:11 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:310:9:310:20 | call to instance | calls.rb:308:5:311:7 | instance |
 | calls.rb:314:9:314:11 | call to new | calls.rb:114:5:114:16 | new |
 | calls.rb:314:9:314:20 | call to instance | calls.rb:308:5:311:7 | instance |
 | calls.rb:317:5:317:7 | call to new | calls.rb:114:5:114:16 | new |
@@ -150,8 +148,10 @@ getTarget
 | calls.rb:372:1:372:11 | call to instance | calls.rb:365:5:367:7 | instance |
 | calls.rb:377:13:377:48 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:381:13:381:22 | call to singleton1 | calls.rb:376:9:378:11 | singleton1 |
+| calls.rb:381:13:381:22 | call to singleton1 | calls.rb:401:9:403:11 | singleton1 |
 | calls.rb:386:9:386:44 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:390:9:390:18 | call to singleton2 | calls.rb:385:5:387:7 | singleton2 |
+| calls.rb:390:9:390:18 | call to singleton2 | calls.rb:406:5:408:7 | singleton2 |
 | calls.rb:393:5:393:14 | call to singleton2 | calls.rb:385:5:387:7 | singleton2 |
 | calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:380:9:382:11 | call_singleton1 |
 | calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:389:5:391:7 | call_singleton2 |
@@ -187,6 +187,7 @@ getTarget
 | private.rb:51:3:51:19 | call to private | calls.rb:109:5:109:20 | private |
 | private.rb:53:3:53:9 | call to private | calls.rb:109:5:109:20 | private |
 unresolvedCall
+| calls.rb:26:9:26:18 | call to instance_m |
 | calls.rb:29:5:29:14 | call to instance_m |
 | calls.rb:30:5:30:19 | call to instance_m |
 | calls.rb:36:1:36:12 | call to instance_m |
@@ -216,6 +217,7 @@ unresolvedCall
 | calls.rb:258:1:258:14 | call to singleton_g |
 | calls.rb:271:1:271:14 | call to singleton_g |
 | calls.rb:273:1:273:14 | call to singleton_g |
+| calls.rb:310:9:310:20 | call to instance |
 | calls.rb:411:1:411:34 | call to call_singleton1 |
 | calls.rb:412:1:412:34 | call to call_singleton2 |
 | hello.rb:20:16:20:26 | ... + ... |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -1,208 +1,223 @@
 getTarget
-| calls.rb:2:5:2:14 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:8:5:8:15 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:11:1:11:8 | call to bar | calls.rb:7:1:9:3 | bar |
-| calls.rb:14:5:14:15 | call to puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:17:1:17:8 | call to bar | calls.rb:13:1:15:3 | bar |
 | calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:19:1:19:8 | call to foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:28:5:28:15 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
-| calls.rb:29:5:29:20 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
-| calls.rb:33:1:33:13 | call to singleton_m | calls.rb:23:5:23:29 | singleton_m |
-| calls.rb:40:5:40:13 | call to include | calls.rb:103:5:103:20 | include |
-| calls.rb:48:9:48:18 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:49:9:49:23 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:56:5:56:9 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:57:1:57:5 | call to baz | calls.rb:47:5:53:7 | baz |
-| calls.rb:59:1:59:12 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:63:9:63:13 | call to super | calls.rb:47:5:53:7 | baz |
-| calls.rb:67:5:67:9 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:68:1:68:5 | call to baz | calls.rb:62:5:64:7 | baz |
-| calls.rb:70:1:70:12 | call to instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:73:5:73:16 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
-| calls.rb:74:5:74:16 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
-| calls.rb:78:5:78:11 | yield ... | calls.rb:84:16:84:29 | { ... } |
-| calls.rb:78:5:78:11 | yield ... | calls.rb:155:10:155:28 | { ... } |
-| calls.rb:82:11:82:18 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:83:5:83:10 | ...[...] | calls.rb:115:5:115:31 | [] |
-| calls.rb:84:5:84:29 | call to call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:84:22:84:27 | ...[...] | calls.rb:115:5:115:31 | [] |
-| calls.rb:109:5:109:18 | call to include | calls.rb:103:5:103:20 | include |
-| calls.rb:126:15:126:25 | call to length | calls.rb:122:3:122:17 | length |
-| calls.rb:127:9:127:24 | yield ... | calls.rb:143:23:143:62 | { ... } |
-| calls.rb:127:9:127:24 | yield ... | calls.rb:145:17:145:35 | { ... } |
-| calls.rb:127:9:127:24 | yield ... | calls.rb:147:17:147:40 | { ... } |
-| calls.rb:127:9:127:24 | yield ... | calls.rb:149:18:149:37 | { ... } |
-| calls.rb:127:18:127:24 | ...[...] | calls.rb:120:3:120:29 | [] |
-| calls.rb:134:5:134:20 | yield ... | calls.rb:137:7:137:30 | { ... } |
-| calls.rb:137:1:137:30 | call to funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:137:13:137:29 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:137:18:137:29 | call to capitalize | calls.rb:93:5:93:23 | capitalize |
-| calls.rb:139:1:139:14 | call to capitalize | calls.rb:93:5:93:23 | capitalize |
-| calls.rb:140:1:140:12 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
-| calls.rb:141:1:141:5 | call to abs | calls.rb:89:5:89:16 | abs |
-| calls.rb:143:1:143:62 | call to foreach | calls.rb:124:3:130:5 | foreach |
-| calls.rb:143:32:143:61 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:145:1:145:35 | call to foreach | calls.rb:124:3:130:5 | foreach |
-| calls.rb:145:23:145:34 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
-| calls.rb:147:1:147:40 | call to foreach | calls.rb:124:3:130:5 | foreach |
-| calls.rb:147:23:147:39 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:149:1:149:37 | call to foreach | calls.rb:124:3:130:5 | foreach |
-| calls.rb:149:27:149:36 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:152:5:152:17 | call to call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:155:1:155:28 | call to indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:155:16:155:27 | call to bit_length | calls.rb:88:5:88:23 | bit_length |
-| calls.rb:160:9:160:17 | call to to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:160:9:160:17 | call to to_s | calls.rb:170:5:171:7 | to_s |
-| calls.rb:174:1:174:5 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:174:1:174:14 | call to s_method | calls.rb:159:5:161:7 | s_method |
-| calls.rb:175:1:175:5 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:175:1:175:14 | call to s_method | calls.rb:159:5:161:7 | s_method |
-| calls.rb:176:1:176:5 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:176:1:176:14 | call to s_method | calls.rb:159:5:161:7 | s_method |
-| calls.rb:181:1:181:15 | call to private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:185:9:185:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:186:9:186:24 | call to singleton_b | calls.rb:189:5:192:7 | singleton_b |
-| calls.rb:190:9:190:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:191:9:191:24 | call to singleton_c | calls.rb:194:5:196:7 | singleton_c |
-| calls.rb:195:9:195:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:199:9:199:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:200:9:200:24 | call to singleton_a | calls.rb:184:5:187:7 | singleton_a |
-| calls.rb:205:13:205:30 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:207:9:207:19 | call to singleton_e | calls.rb:204:9:206:11 | singleton_e |
-| calls.rb:212:13:212:30 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:229:1:231:3 | singleton_g |
-| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:236:1:238:3 | singleton_g |
-| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:244:5:246:7 | singleton_g |
-| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:260:1:262:3 | singleton_g |
-| calls.rb:221:1:221:22 | call to singleton_a | calls.rb:184:5:187:7 | singleton_a |
-| calls.rb:222:1:222:22 | call to singleton_f | calls.rb:211:9:213:11 | singleton_f |
-| calls.rb:224:6:224:19 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:226:1:226:11 | call to instance | calls.rb:203:5:208:7 | instance |
-| calls.rb:227:1:227:14 | call to singleton_e | calls.rb:204:9:206:11 | singleton_e |
-| calls.rb:230:5:230:24 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:233:1:233:14 | call to singleton_g | calls.rb:229:1:231:3 | singleton_g |
-| calls.rb:234:1:234:19 | call to call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
-| calls.rb:237:5:237:24 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:240:1:240:14 | call to singleton_g | calls.rb:236:1:238:3 | singleton_g |
-| calls.rb:241:1:241:19 | call to call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
-| calls.rb:245:9:245:28 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:249:1:249:14 | call to singleton_g | calls.rb:244:5:246:7 | singleton_g |
-| calls.rb:250:1:250:19 | call to call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
-| calls.rb:252:6:252:19 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:256:1:256:8 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:258:1:258:16 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:261:5:261:22 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:264:1:264:22 | call to singleton_g | calls.rb:260:1:262:3 | singleton_g |
-| calls.rb:265:1:265:14 | call to singleton_g | calls.rb:244:5:246:7 | singleton_g |
-| calls.rb:266:1:266:19 | call to call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
-| calls.rb:268:6:268:19 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:272:5:272:12 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:272:5:272:21 | call to instance | calls.rb:203:5:208:7 | instance |
-| calls.rb:275:9:275:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:278:5:278:20 | call to singleton_h | calls.rb:274:5:276:7 | singleton_h |
-| calls.rb:281:1:281:17 | call to create | calls.rb:271:1:279:3 | create |
-| calls.rb:282:1:282:22 | call to singleton_h | calls.rb:274:5:276:7 | singleton_h |
-| calls.rb:288:9:288:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:292:1:292:13 | call to singleton_i | calls.rb:287:5:289:7 | singleton_i |
-| calls.rb:293:1:293:22 | call to singleton_i | calls.rb:287:5:289:7 | singleton_i |
-| calls.rb:297:9:297:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:301:1:301:22 | call to singleton_j | calls.rb:296:5:298:7 | singleton_j |
-| calls.rb:305:9:305:31 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:309:9:309:11 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:309:9:309:20 | call to instance | calls.rb:304:5:306:7 | instance |
-| calls.rb:312:5:312:7 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:312:5:312:16 | call to instance | calls.rb:304:5:306:7 | instance |
-| calls.rb:315:1:315:17 | call to singleton | calls.rb:308:5:310:7 | singleton |
-| calls.rb:319:9:319:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:325:9:325:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:331:9:331:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:338:9:338:18 | call to instance | calls.rb:330:5:332:7 | instance |
-| calls.rb:340:9:340:18 | call to instance | calls.rb:324:5:326:7 | instance |
-| calls.rb:340:9:340:18 | call to instance | calls.rb:330:5:332:7 | instance |
-| calls.rb:342:9:342:18 | call to instance | calls.rb:318:5:320:7 | instance |
-| calls.rb:342:9:342:18 | call to instance | calls.rb:324:5:326:7 | instance |
-| calls.rb:342:9:342:18 | call to instance | calls.rb:330:5:332:7 | instance |
-| calls.rb:347:20:347:29 | call to instance | calls.rb:330:5:332:7 | instance |
-| calls.rb:348:26:348:36 | call to instance | calls.rb:324:5:326:7 | instance |
-| calls.rb:348:26:348:36 | call to instance | calls.rb:330:5:332:7 | instance |
-| calls.rb:349:26:349:36 | call to instance | calls.rb:318:5:320:7 | instance |
-| calls.rb:349:26:349:36 | call to instance | calls.rb:324:5:326:7 | instance |
-| calls.rb:349:26:349:36 | call to instance | calls.rb:330:5:332:7 | instance |
-| calls.rb:353:6:353:11 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:354:1:354:11 | call to instance | calls.rb:318:5:320:7 | instance |
-| calls.rb:355:1:355:25 | call to pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:355:19:355:24 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:356:1:356:25 | call to pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:356:19:356:24 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:357:1:357:25 | call to pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:357:19:357:24 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:361:9:361:28 | call to puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:365:6:365:11 | call to new | calls.rb:110:5:110:16 | new |
-| calls.rb:366:1:366:16 | call to add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:367:1:367:11 | call to instance | calls.rb:318:5:320:7 | instance |
-| calls.rb:367:1:367:11 | call to instance | calls.rb:360:5:362:7 | instance |
-| hello.rb:12:5:12:24 | call to include | calls.rb:103:5:103:20 | include |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:23:9:23:19 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
+| calls.rb:26:9:26:18 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:32:5:32:15 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
+| calls.rb:33:5:33:20 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
+| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
+| calls.rb:44:5:44:13 | call to include | calls.rb:107:5:107:20 | include |
+| calls.rb:52:9:52:18 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:53:9:53:23 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:60:5:60:9 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:61:1:61:5 | call to baz | calls.rb:51:5:57:7 | baz |
+| calls.rb:63:1:63:12 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:67:9:67:13 | call to super | calls.rb:51:5:57:7 | baz |
+| calls.rb:71:5:71:9 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:72:1:72:5 | call to baz | calls.rb:66:5:68:7 | baz |
+| calls.rb:74:1:74:12 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:77:5:77:16 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:78:5:78:16 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:88:16:88:29 | { ... } |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:159:10:159:28 | { ... } |
+| calls.rb:86:11:86:18 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:87:5:87:10 | ...[...] | calls.rb:119:5:119:31 | [] |
+| calls.rb:88:5:88:29 | call to call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:88:22:88:27 | ...[...] | calls.rb:119:5:119:31 | [] |
+| calls.rb:113:5:113:18 | call to include | calls.rb:107:5:107:20 | include |
+| calls.rb:130:15:130:25 | call to length | calls.rb:126:3:126:17 | length |
+| calls.rb:131:9:131:24 | yield ... | calls.rb:147:23:147:62 | { ... } |
+| calls.rb:131:9:131:24 | yield ... | calls.rb:149:17:149:35 | { ... } |
+| calls.rb:131:9:131:24 | yield ... | calls.rb:151:17:151:40 | { ... } |
+| calls.rb:131:9:131:24 | yield ... | calls.rb:153:18:153:37 | { ... } |
+| calls.rb:131:18:131:24 | ...[...] | calls.rb:124:3:124:29 | [] |
+| calls.rb:138:5:138:20 | yield ... | calls.rb:141:7:141:30 | { ... } |
+| calls.rb:141:1:141:30 | call to funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:141:13:141:29 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:141:18:141:29 | call to capitalize | calls.rb:97:5:97:23 | capitalize |
+| calls.rb:143:1:143:14 | call to capitalize | calls.rb:97:5:97:23 | capitalize |
+| calls.rb:144:1:144:12 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:145:1:145:5 | call to abs | calls.rb:93:5:93:16 | abs |
+| calls.rb:147:1:147:62 | call to foreach | calls.rb:128:3:134:5 | foreach |
+| calls.rb:147:32:147:61 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:149:1:149:35 | call to foreach | calls.rb:128:3:134:5 | foreach |
+| calls.rb:149:23:149:34 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:151:1:151:40 | call to foreach | calls.rb:128:3:134:5 | foreach |
+| calls.rb:151:23:151:39 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:153:1:153:37 | call to foreach | calls.rb:128:3:134:5 | foreach |
+| calls.rb:153:27:153:36 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:156:5:156:17 | call to call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:159:1:159:28 | call to indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:159:16:159:27 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:164:9:164:17 | call to to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:164:9:164:17 | call to to_s | calls.rb:174:5:175:7 | to_s |
+| calls.rb:178:1:178:5 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:178:1:178:14 | call to s_method | calls.rb:163:5:165:7 | s_method |
+| calls.rb:179:1:179:5 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:179:1:179:14 | call to s_method | calls.rb:163:5:165:7 | s_method |
+| calls.rb:180:1:180:5 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:180:1:180:14 | call to s_method | calls.rb:163:5:165:7 | s_method |
+| calls.rb:185:1:185:15 | call to private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:189:9:189:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:190:9:190:24 | call to singleton_b | calls.rb:193:5:196:7 | singleton_b |
+| calls.rb:194:9:194:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:195:9:195:24 | call to singleton_c | calls.rb:198:5:200:7 | singleton_c |
+| calls.rb:199:9:199:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:203:9:203:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:204:9:204:24 | call to singleton_a | calls.rb:188:5:191:7 | singleton_a |
+| calls.rb:209:13:209:30 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:211:9:211:19 | call to singleton_e | calls.rb:208:9:210:11 | singleton_e |
+| calls.rb:216:13:216:30 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:233:1:235:3 | singleton_g |
+| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:240:1:242:3 | singleton_g |
+| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:248:5:250:7 | singleton_g |
+| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:264:1:266:3 | singleton_g |
+| calls.rb:225:1:225:22 | call to singleton_a | calls.rb:188:5:191:7 | singleton_a |
+| calls.rb:226:1:226:22 | call to singleton_f | calls.rb:215:9:217:11 | singleton_f |
+| calls.rb:228:6:228:19 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:230:1:230:11 | call to instance | calls.rb:207:5:212:7 | instance |
+| calls.rb:231:1:231:14 | call to singleton_e | calls.rb:208:9:210:11 | singleton_e |
+| calls.rb:234:5:234:24 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:237:1:237:14 | call to singleton_g | calls.rb:233:1:235:3 | singleton_g |
+| calls.rb:238:1:238:19 | call to call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
+| calls.rb:241:5:241:24 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:244:1:244:14 | call to singleton_g | calls.rb:240:1:242:3 | singleton_g |
+| calls.rb:245:1:245:19 | call to call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
+| calls.rb:249:9:249:28 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:253:1:253:14 | call to singleton_g | calls.rb:248:5:250:7 | singleton_g |
+| calls.rb:254:1:254:19 | call to call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
+| calls.rb:256:6:256:19 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:260:1:260:8 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:262:1:262:16 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:265:5:265:22 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:268:1:268:22 | call to singleton_g | calls.rb:264:1:266:3 | singleton_g |
+| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:248:5:250:7 | singleton_g |
+| calls.rb:270:1:270:19 | call to call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
+| calls.rb:272:6:272:19 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:276:5:276:12 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:276:5:276:21 | call to instance | calls.rb:207:5:212:7 | instance |
+| calls.rb:279:9:279:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:278:5:280:7 | singleton_h |
+| calls.rb:285:1:285:17 | call to create | calls.rb:275:1:283:3 | create |
+| calls.rb:286:1:286:22 | call to singleton_h | calls.rb:278:5:280:7 | singleton_h |
+| calls.rb:292:9:292:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:296:1:296:13 | call to singleton_i | calls.rb:291:5:293:7 | singleton_i |
+| calls.rb:297:1:297:22 | call to singleton_i | calls.rb:291:5:293:7 | singleton_i |
+| calls.rb:301:9:301:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:305:1:305:22 | call to singleton_j | calls.rb:300:5:302:7 | singleton_j |
+| calls.rb:309:9:309:31 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:310:9:310:11 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:310:9:310:20 | call to instance | calls.rb:308:5:311:7 | instance |
+| calls.rb:314:9:314:11 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:314:9:314:20 | call to instance | calls.rb:308:5:311:7 | instance |
+| calls.rb:317:5:317:7 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:317:5:317:16 | call to instance | calls.rb:308:5:311:7 | instance |
+| calls.rb:320:1:320:17 | call to singleton | calls.rb:313:5:315:7 | singleton |
+| calls.rb:324:9:324:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:330:9:330:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:336:9:336:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:343:9:343:18 | call to instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:345:9:345:18 | call to instance | calls.rb:329:5:331:7 | instance |
+| calls.rb:345:9:345:18 | call to instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:347:9:347:18 | call to instance | calls.rb:323:5:325:7 | instance |
+| calls.rb:347:9:347:18 | call to instance | calls.rb:329:5:331:7 | instance |
+| calls.rb:347:9:347:18 | call to instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:352:20:352:29 | call to instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:353:26:353:36 | call to instance | calls.rb:329:5:331:7 | instance |
+| calls.rb:353:26:353:36 | call to instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:354:26:354:36 | call to instance | calls.rb:323:5:325:7 | instance |
+| calls.rb:354:26:354:36 | call to instance | calls.rb:329:5:331:7 | instance |
+| calls.rb:354:26:354:36 | call to instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:358:6:358:11 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:359:1:359:11 | call to instance | calls.rb:323:5:325:7 | instance |
+| calls.rb:360:1:360:25 | call to pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:360:19:360:24 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:361:1:361:25 | call to pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:361:19:361:24 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:362:1:362:25 | call to pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:362:19:362:24 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:366:9:366:28 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:370:6:370:11 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:371:1:371:16 | call to add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:372:1:372:11 | call to instance | calls.rb:323:5:325:7 | instance |
+| calls.rb:372:1:372:11 | call to instance | calls.rb:365:5:367:7 | instance |
+| calls.rb:377:13:377:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:381:13:381:22 | call to singleton1 | calls.rb:376:9:378:11 | singleton1 |
+| calls.rb:386:9:386:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:390:9:390:18 | call to singleton2 | calls.rb:385:5:387:7 | singleton2 |
+| calls.rb:393:5:393:14 | call to singleton2 | calls.rb:385:5:387:7 | singleton2 |
+| calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:380:9:382:11 | call_singleton1 |
+| calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:389:5:391:7 | call_singleton2 |
+| calls.rb:402:13:402:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:407:9:407:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| hello.rb:12:5:12:24 | call to include | calls.rb:107:5:107:20 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
 | hello.rb:20:30:20:34 | call to world | hello.rb:5:5:7:7 | world |
-| modules.rb:12:5:12:26 | call to puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:22:3:22:19 | call to puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:33:3:33:25 | call to puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:44:3:44:19 | call to puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:55:3:55:30 | call to puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:89:3:89:16 | call to include | calls.rb:103:5:103:20 | include |
-| modules.rb:90:3:90:38 | call to module_eval | calls.rb:102:5:102:24 | module_eval |
-| modules.rb:90:24:90:36 | call to prepend | calls.rb:104:5:104:20 | prepend |
-| modules.rb:96:3:96:14 | call to include | calls.rb:103:5:103:20 | include |
-| modules.rb:102:3:102:16 | call to prepend | calls.rb:104:5:104:20 | prepend |
-| modules.rb:126:6:126:11 | call to new | calls.rb:110:5:110:16 | new |
-| modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:104:5:104:20 | prepend |
-| private.rb:2:3:3:5 | call to private | calls.rb:105:5:105:20 | private |
-| private.rb:10:3:10:19 | call to private | calls.rb:105:5:105:20 | private |
-| private.rb:12:3:12:9 | call to private | calls.rb:105:5:105:20 | private |
-| private.rb:34:1:34:5 | call to new | calls.rb:110:5:110:16 | new |
-| private.rb:35:1:35:5 | call to new | calls.rb:110:5:110:16 | new |
-| private.rb:36:1:36:5 | call to new | calls.rb:110:5:110:16 | new |
-| private.rb:37:1:37:5 | call to new | calls.rb:110:5:110:16 | new |
-| private.rb:38:1:38:5 | call to new | calls.rb:110:5:110:16 | new |
+| modules.rb:12:5:12:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:22:3:22:19 | call to puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:33:3:33:25 | call to puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:44:3:44:19 | call to puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:55:3:55:30 | call to puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:89:3:89:16 | call to include | calls.rb:107:5:107:20 | include |
+| modules.rb:90:3:90:38 | call to module_eval | calls.rb:106:5:106:24 | module_eval |
+| modules.rb:90:24:90:36 | call to prepend | calls.rb:108:5:108:20 | prepend |
+| modules.rb:96:3:96:14 | call to include | calls.rb:107:5:107:20 | include |
+| modules.rb:102:3:102:16 | call to prepend | calls.rb:108:5:108:20 | prepend |
+| modules.rb:126:6:126:11 | call to new | calls.rb:114:5:114:16 | new |
+| modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:108:5:108:20 | prepend |
+| private.rb:2:3:3:5 | call to private | calls.rb:109:5:109:20 | private |
+| private.rb:10:3:10:19 | call to private | calls.rb:109:5:109:20 | private |
+| private.rb:12:3:12:9 | call to private | calls.rb:109:5:109:20 | private |
+| private.rb:34:1:34:5 | call to new | calls.rb:114:5:114:16 | new |
+| private.rb:35:1:35:5 | call to new | calls.rb:114:5:114:16 | new |
+| private.rb:36:1:36:5 | call to new | calls.rb:114:5:114:16 | new |
+| private.rb:37:1:37:5 | call to new | calls.rb:114:5:114:16 | new |
+| private.rb:38:1:38:5 | call to new | calls.rb:114:5:114:16 | new |
 | private.rb:38:1:38:12 | call to public | private.rb:5:3:6:5 | public |
 | private.rb:40:1:40:15 | call to private_on_main | private.rb:31:1:32:3 | private_on_main |
-| private.rb:43:3:44:5 | call to private | calls.rb:105:5:105:20 | private |
-| private.rb:51:3:51:19 | call to private | calls.rb:105:5:105:20 | private |
-| private.rb:53:3:53:9 | call to private | calls.rb:105:5:105:20 | private |
+| private.rb:43:3:44:5 | call to private | calls.rb:109:5:109:20 | private |
+| private.rb:51:3:51:19 | call to private | calls.rb:109:5:109:20 | private |
+| private.rb:53:3:53:9 | call to private | calls.rb:109:5:109:20 | private |
 unresolvedCall
-| calls.rb:25:5:25:14 | call to instance_m |
-| calls.rb:26:5:26:19 | call to instance_m |
-| calls.rb:32:1:32:12 | call to instance_m |
-| calls.rb:36:5:36:14 | call to instance_m |
-| calls.rb:41:5:41:14 | call to instance_m |
-| calls.rb:42:5:42:19 | call to instance_m |
-| calls.rb:44:5:44:15 | call to singleton_m |
-| calls.rb:45:5:45:20 | call to singleton_m |
-| calls.rb:51:9:51:19 | call to singleton_m |
-| calls.rb:52:9:52:24 | call to singleton_m |
-| calls.rb:58:1:58:13 | call to singleton_m |
-| calls.rb:69:1:69:13 | call to singleton_m |
-| calls.rb:98:17:98:26 | call to old_puts |
-| calls.rb:115:15:115:27 | call to old_lookup |
-| calls.rb:120:13:120:25 | call to old_lookup |
-| calls.rb:126:11:126:25 | ... < ... |
-| calls.rb:128:11:128:12 | ... + ... |
-| calls.rb:143:1:143:13 | call to [] |
-| calls.rb:143:48:143:59 | call to capitalize |
-| calls.rb:145:1:145:7 | call to [] |
-| calls.rb:147:1:147:7 | call to [] |
-| calls.rb:147:28:147:39 | call to capitalize |
-| calls.rb:149:1:149:8 | call to [] |
-| calls.rb:149:4:149:5 | - ... |
-| calls.rb:149:32:149:36 | call to abs |
-| calls.rb:253:1:253:14 | call to singleton_e |
-| calls.rb:254:1:254:14 | call to singleton_g |
-| calls.rb:267:1:267:14 | call to singleton_g |
-| calls.rb:269:1:269:14 | call to singleton_g |
+| calls.rb:29:5:29:14 | call to instance_m |
+| calls.rb:30:5:30:19 | call to instance_m |
+| calls.rb:36:1:36:12 | call to instance_m |
+| calls.rb:40:5:40:14 | call to instance_m |
+| calls.rb:45:5:45:14 | call to instance_m |
+| calls.rb:46:5:46:19 | call to instance_m |
+| calls.rb:48:5:48:15 | call to singleton_m |
+| calls.rb:49:5:49:20 | call to singleton_m |
+| calls.rb:55:9:55:19 | call to singleton_m |
+| calls.rb:56:9:56:24 | call to singleton_m |
+| calls.rb:62:1:62:13 | call to singleton_m |
+| calls.rb:73:1:73:13 | call to singleton_m |
+| calls.rb:102:17:102:26 | call to old_puts |
+| calls.rb:119:15:119:27 | call to old_lookup |
+| calls.rb:124:13:124:25 | call to old_lookup |
+| calls.rb:130:11:130:25 | ... < ... |
+| calls.rb:132:11:132:12 | ... + ... |
+| calls.rb:147:1:147:13 | call to [] |
+| calls.rb:147:48:147:59 | call to capitalize |
+| calls.rb:149:1:149:7 | call to [] |
+| calls.rb:151:1:151:7 | call to [] |
+| calls.rb:151:28:151:39 | call to capitalize |
+| calls.rb:153:1:153:8 | call to [] |
+| calls.rb:153:4:153:5 | - ... |
+| calls.rb:153:32:153:36 | call to abs |
+| calls.rb:257:1:257:14 | call to singleton_e |
+| calls.rb:258:1:258:14 | call to singleton_g |
+| calls.rb:271:1:271:14 | call to singleton_g |
+| calls.rb:273:1:273:14 | call to singleton_g |
+| calls.rb:411:1:411:34 | call to call_singleton1 |
+| calls.rb:412:1:412:34 | call to call_singleton2 |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |
@@ -215,16 +230,16 @@ unresolvedCall
 | private.rb:37:1:37:14 | call to private4 |
 privateMethod
 | calls.rb:1:1:3:3 | foo |
-| calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:77:1:79:3 | call_block |
-| calls.rb:81:1:85:3 | foo |
-| calls.rb:133:1:135:3 | funny |
-| calls.rb:151:1:153:3 | indirect |
-| calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:271:1:279:3 | create |
-| calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:81:1:83:3 | call_block |
+| calls.rb:85:1:89:3 | foo |
+| calls.rb:137:1:139:3 | funny |
+| calls.rb:155:1:157:3 | indirect |
+| calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:275:1:283:3 | create |
+| calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:364:1:368:3 | add_singleton |
 | private.rb:2:11:3:5 | private1 |
 | private.rb:8:3:9:5 | private2 |
 | private.rb:14:3:15:5 | private3 |

--- a/ruby/ql/test/library-tests/modules/calls.rb
+++ b/ruby/ql/test/library-tests/modules/calls.rb
@@ -32,6 +32,10 @@ end
 M.instance_m # NoMethodError
 M.singleton_m
 
+def call_instance_m
+    instance_m # NoMethodError
+end
+
 class C
     include M
     instance_m # NoMethodError

--- a/ruby/ql/test/library-tests/modules/calls.rb
+++ b/ruby/ql/test/library-tests/modules/calls.rb
@@ -5,7 +5,13 @@ end
 foo
 
 def self.bar
-    puts "bar"
+    puts "bar1"
+end
+
+self.bar
+
+def self.bar
+    puts "bar2"
 end
 
 self.bar
@@ -34,7 +40,7 @@ class C
     singleton_m # NoMethodError
     self.singleton_m # NoMethodError
 
-    def baz 
+    def baz
         instance_m 
         self.instance_m 
         
@@ -84,7 +90,8 @@ class String
 end
 
 module Kernel
-    def puts; end
+    alias :old_puts :puts
+    def puts x; old_puts x end
 end
 
 class Module
@@ -100,11 +107,14 @@ class Object < Module
 end
 
 class Hash
-    def []; end
+    alias :old_lookup :[]
+    def [] x; old_lookup(x) end
 end
 
 class Array
-  def []; end
+  alias :old_lookup :[]
+  def [] x; old_lookup(x) end
+
   def length; end
 
   def foreach &body
@@ -168,19 +178,186 @@ private_on_main
 
 class Singletons
     def self.singleton_a
+        puts "singleton_a"
         self.singleton_b
     end
     
     def self.singleton_b
+        puts "singleton_b"
         self.singleton_c
     end
     
     def self.singleton_c
+        puts "singleton_c"
     end
     
     def self.singleton_d
+        puts "singleton_d"
         self.singleton_a
+    end
+
+    def instance
+        def self.singleton_e
+            puts "singleton_e"
+        end
+        singleton_e
+    end
+
+    class << self
+        def singleton_f
+            puts "singleton_f"
+        end
+    end
+
+    def call_singleton_g
+        self.singleton_g
     end
 end
   
 Singletons.singleton_a
+Singletons.singleton_f
+
+c1 = Singletons.new
+
+c1.instance
+c1.singleton_e
+
+def c1.singleton_g;
+    puts "singleton_g_1"
+end
+
+c1.singleton_g
+c1.call_singleton_g
+
+def c1.singleton_g;
+    puts "singleton_g_2"
+end
+
+c1.singleton_g
+c1.call_singleton_g
+
+class << c1
+    def singleton_g;
+        puts "singleton_g_3"
+    end
+end
+
+c1.singleton_g
+c1.call_singleton_g
+
+c2 = Singletons.new
+c2.singleton_e # NoMethodError
+c2.singleton_g # NoMethodError
+
+self.new # NoMethodError
+
+puts "top-level"
+
+def Singletons.singleton_g
+    puts "singleton_g"
+end
+
+Singletons.singleton_g
+c1.singleton_g
+c1.call_singleton_g
+c2.singleton_g # NoMethodError
+c3 = Singletons.new
+c3.singleton_g # NoMethodError
+
+def create(type)
+    type.new.instance
+
+    def type.singleton_h
+        puts "singleton_h"
+    end
+
+    type.singleton_h
+end
+
+create Singletons
+Singletons.singleton_h
+
+x = Singletons
+
+class << x
+    def singleton_i
+        puts "singleton_i"
+    end
+end
+
+x.singleton_i
+Singletons.singleton_i
+
+class << Singletons
+    def singleton_j
+        puts "singleton_j"
+    end
+end
+
+Singletons.singleton_j
+
+class SelfNew
+    def instance
+        puts "SelfNew#instance"
+    end
+
+    def self.singleton
+        new.instance
+    end
+
+    new.instance
+end
+
+SelfNew.singleton
+
+class C1
+    def instance
+        puts "C1#instance"
+    end
+end
+
+class C2 < C1
+    def instance
+        puts "C2#instance"
+    end
+end
+
+class C3 < C2
+    def instance
+        puts "C3#instance"
+    end
+end
+
+def pattern_dispatch x
+    case x
+    when C3
+        x.instance
+    when C2
+        x.instance
+    when C1
+        x.instance
+    else
+    end
+
+    case x
+        in C3 then x.instance
+        in C2 => c2 then c2.instance
+        in C1 => c1 then c1.instance
+    end
+end
+
+c1 = C1.new
+c1.instance
+pattern_dispatch (C1.new)
+pattern_dispatch (C2.new)
+pattern_dispatch (C3.new)
+
+def add_singleton x
+    def x.instance
+        puts "instance_on x"
+    end
+end
+
+c3 = C1.new
+add_singleton c3
+c3.instance

--- a/ruby/ql/test/library-tests/modules/calls.rb
+++ b/ruby/ql/test/library-tests/modules/calls.rb
@@ -19,8 +19,12 @@ self.bar
 self.foo
 
 module M
-    def instance_m; end
-    def self.singleton_m; end
+    def instance_m
+        singleton_m # NoMethodError
+    end
+    def self.singleton_m
+        instance_m # NoMethodError
+    end
 
     instance_m # NoMethodError
     self.instance_m # NoMethodError
@@ -303,6 +307,7 @@ Singletons.singleton_j
 class SelfNew
     def instance
         puts "SelfNew#instance"
+        new.instance # NoMethodError
     end
 
     def self.singleton
@@ -365,3 +370,43 @@ end
 c3 = C1.new
 add_singleton c3
 c3.instance
+
+class SingletonOverride1
+    class << self
+        def singleton1
+            puts "SingletonOverride1#singleton1"
+        end
+
+        def call_singleton1
+            singleton1
+        end
+    end
+
+    def self.singleton2
+        puts "SingletonOverride1#singleton2"
+    end
+
+    def self.call_singleton2
+        singleton2
+    end
+
+    singleton2
+end
+
+SingletonOverride1.call_singleton1
+SingletonOverride1.call_singleton2
+
+class SingletonOverride2 < SingletonOverride1
+    class << self
+        def singleton1
+            puts "SingletonOverride2#singleton1"
+        end
+    end
+
+    def self.singleton2
+        puts "SingletonOverride2#singleton2"
+    end
+end
+
+SingletonOverride2.call_singleton1
+SingletonOverride2.call_singleton2

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -1,41 +1,41 @@
 getMethod
-| calls.rb:21:1:30:3 | M | instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:39:1:54:3 | C | baz | calls.rb:47:5:53:7 | baz |
-| calls.rb:61:1:65:3 | D | baz | calls.rb:62:5:64:7 | baz |
-| calls.rb:87:1:90:3 | Integer | abs | calls.rb:89:5:89:16 | abs |
-| calls.rb:87:1:90:3 | Integer | bit_length | calls.rb:88:5:88:23 | bit_length |
-| calls.rb:92:1:94:3 | String | capitalize | calls.rb:93:5:93:23 | capitalize |
-| calls.rb:96:1:99:3 | Kernel | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:101:1:106:3 | Module | include | calls.rb:103:5:103:20 | include |
-| calls.rb:101:1:106:3 | Module | module_eval | calls.rb:102:5:102:24 | module_eval |
-| calls.rb:101:1:106:3 | Module | prepend | calls.rb:104:5:104:20 | prepend |
-| calls.rb:101:1:106:3 | Module | private | calls.rb:105:5:105:20 | private |
-| calls.rb:108:1:111:3 | Object | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:108:1:111:3 | Object | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:108:1:111:3 | Object | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:108:1:111:3 | Object | create | calls.rb:271:1:279:3 | create |
-| calls.rb:108:1:111:3 | Object | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:108:1:111:3 | Object | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:108:1:111:3 | Object | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:108:1:111:3 | Object | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:108:1:111:3 | Object | new | calls.rb:110:5:110:16 | new |
-| calls.rb:108:1:111:3 | Object | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:108:1:111:3 | Object | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:108:1:111:3 | Object | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:108:1:111:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
-| calls.rb:113:1:116:3 | Hash | [] | calls.rb:115:5:115:31 | [] |
-| calls.rb:118:1:131:3 | Array | [] | calls.rb:120:3:120:29 | [] |
-| calls.rb:118:1:131:3 | Array | foreach | calls.rb:124:3:130:5 | foreach |
-| calls.rb:118:1:131:3 | Array | length | calls.rb:122:3:122:17 | length |
-| calls.rb:158:1:162:3 | S | s_method | calls.rb:159:5:161:7 | s_method |
-| calls.rb:164:1:167:3 | A | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:169:1:172:3 | B | to_s | calls.rb:170:5:171:7 | to_s |
-| calls.rb:183:1:219:3 | Singletons | call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
-| calls.rb:183:1:219:3 | Singletons | instance | calls.rb:203:5:208:7 | instance |
-| calls.rb:303:1:313:3 | SelfNew | instance | calls.rb:304:5:306:7 | instance |
-| calls.rb:317:1:321:3 | C1 | instance | calls.rb:318:5:320:7 | instance |
-| calls.rb:323:1:327:3 | C2 | instance | calls.rb:324:5:326:7 | instance |
-| calls.rb:329:1:333:3 | C3 | instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:21:1:34:3 | M | instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:43:1:58:3 | C | baz | calls.rb:51:5:57:7 | baz |
+| calls.rb:65:1:69:3 | D | baz | calls.rb:66:5:68:7 | baz |
+| calls.rb:91:1:94:3 | Integer | abs | calls.rb:93:5:93:16 | abs |
+| calls.rb:91:1:94:3 | Integer | bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:96:1:98:3 | String | capitalize | calls.rb:97:5:97:23 | capitalize |
+| calls.rb:100:1:103:3 | Kernel | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:105:1:110:3 | Module | include | calls.rb:107:5:107:20 | include |
+| calls.rb:105:1:110:3 | Module | module_eval | calls.rb:106:5:106:24 | module_eval |
+| calls.rb:105:1:110:3 | Module | prepend | calls.rb:108:5:108:20 | prepend |
+| calls.rb:105:1:110:3 | Module | private | calls.rb:109:5:109:20 | private |
+| calls.rb:112:1:115:3 | Object | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:112:1:115:3 | Object | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:112:1:115:3 | Object | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:112:1:115:3 | Object | create | calls.rb:275:1:283:3 | create |
+| calls.rb:112:1:115:3 | Object | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:112:1:115:3 | Object | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:112:1:115:3 | Object | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:112:1:115:3 | Object | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:112:1:115:3 | Object | new | calls.rb:114:5:114:16 | new |
+| calls.rb:112:1:115:3 | Object | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:112:1:115:3 | Object | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:112:1:115:3 | Object | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:112:1:115:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
+| calls.rb:117:1:120:3 | Hash | [] | calls.rb:119:5:119:31 | [] |
+| calls.rb:122:1:135:3 | Array | [] | calls.rb:124:3:124:29 | [] |
+| calls.rb:122:1:135:3 | Array | foreach | calls.rb:128:3:134:5 | foreach |
+| calls.rb:122:1:135:3 | Array | length | calls.rb:126:3:126:17 | length |
+| calls.rb:162:1:166:3 | S | s_method | calls.rb:163:5:165:7 | s_method |
+| calls.rb:168:1:171:3 | A | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:173:1:176:3 | B | to_s | calls.rb:174:5:175:7 | to_s |
+| calls.rb:187:1:223:3 | Singletons | call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
+| calls.rb:187:1:223:3 | Singletons | instance | calls.rb:207:5:212:7 | instance |
+| calls.rb:307:1:318:3 | SelfNew | instance | calls.rb:308:5:311:7 | instance |
+| calls.rb:322:1:326:3 | C1 | instance | calls.rb:323:5:325:7 | instance |
+| calls.rb:328:1:332:3 | C2 | instance | calls.rb:329:5:331:7 | instance |
+| calls.rb:334:1:338:3 | C3 | instance | calls.rb:335:5:337:7 | instance |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
@@ -55,335 +55,363 @@ getMethod
 | private.rb:42:1:60:3 | F | private4 | private.rb:58:3:59:5 | private4 |
 | private.rb:42:1:60:3 | F | public | private.rb:46:3:47:5 | public |
 lookupMethod
-| calls.rb:21:1:30:3 | M | instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:39:1:54:3 | C | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:39:1:54:3 | C | baz | calls.rb:47:5:53:7 | baz |
-| calls.rb:39:1:54:3 | C | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:39:1:54:3 | C | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:39:1:54:3 | C | create | calls.rb:271:1:279:3 | create |
-| calls.rb:39:1:54:3 | C | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:39:1:54:3 | C | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:39:1:54:3 | C | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:39:1:54:3 | C | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:39:1:54:3 | C | instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:39:1:54:3 | C | new | calls.rb:110:5:110:16 | new |
-| calls.rb:39:1:54:3 | C | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:39:1:54:3 | C | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:39:1:54:3 | C | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:39:1:54:3 | C | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:39:1:54:3 | C | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:61:1:65:3 | D | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:61:1:65:3 | D | baz | calls.rb:62:5:64:7 | baz |
-| calls.rb:61:1:65:3 | D | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:61:1:65:3 | D | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:61:1:65:3 | D | create | calls.rb:271:1:279:3 | create |
-| calls.rb:61:1:65:3 | D | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:61:1:65:3 | D | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:61:1:65:3 | D | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:61:1:65:3 | D | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:61:1:65:3 | D | instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:61:1:65:3 | D | new | calls.rb:110:5:110:16 | new |
-| calls.rb:61:1:65:3 | D | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:61:1:65:3 | D | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:61:1:65:3 | D | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:61:1:65:3 | D | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:61:1:65:3 | D | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:87:1:90:3 | Integer | abs | calls.rb:89:5:89:16 | abs |
-| calls.rb:87:1:90:3 | Integer | bit_length | calls.rb:88:5:88:23 | bit_length |
-| calls.rb:87:1:90:3 | Integer | new | calls.rb:110:5:110:16 | new |
-| calls.rb:87:1:90:3 | Integer | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:87:1:90:3 | Integer | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:92:1:94:3 | String | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:92:1:94:3 | String | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:92:1:94:3 | String | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:92:1:94:3 | String | capitalize | calls.rb:93:5:93:23 | capitalize |
-| calls.rb:92:1:94:3 | String | create | calls.rb:271:1:279:3 | create |
-| calls.rb:92:1:94:3 | String | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:92:1:94:3 | String | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:92:1:94:3 | String | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:92:1:94:3 | String | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:92:1:94:3 | String | new | calls.rb:110:5:110:16 | new |
-| calls.rb:92:1:94:3 | String | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:92:1:94:3 | String | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:92:1:94:3 | String | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:92:1:94:3 | String | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:92:1:94:3 | String | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:96:1:99:3 | Kernel | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:101:1:106:3 | Module | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:101:1:106:3 | Module | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:101:1:106:3 | Module | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:101:1:106:3 | Module | create | calls.rb:271:1:279:3 | create |
-| calls.rb:101:1:106:3 | Module | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:101:1:106:3 | Module | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:101:1:106:3 | Module | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:101:1:106:3 | Module | include | calls.rb:103:5:103:20 | include |
-| calls.rb:101:1:106:3 | Module | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:101:1:106:3 | Module | module_eval | calls.rb:102:5:102:24 | module_eval |
-| calls.rb:101:1:106:3 | Module | new | calls.rb:110:5:110:16 | new |
-| calls.rb:101:1:106:3 | Module | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:101:1:106:3 | Module | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:101:1:106:3 | Module | prepend | calls.rb:104:5:104:20 | prepend |
-| calls.rb:101:1:106:3 | Module | private | calls.rb:105:5:105:20 | private |
-| calls.rb:101:1:106:3 | Module | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:101:1:106:3 | Module | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:101:1:106:3 | Module | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:108:1:111:3 | Object | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:108:1:111:3 | Object | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:108:1:111:3 | Object | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:108:1:111:3 | Object | create | calls.rb:271:1:279:3 | create |
-| calls.rb:108:1:111:3 | Object | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:108:1:111:3 | Object | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:108:1:111:3 | Object | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:108:1:111:3 | Object | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:108:1:111:3 | Object | new | calls.rb:110:5:110:16 | new |
-| calls.rb:108:1:111:3 | Object | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:108:1:111:3 | Object | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:108:1:111:3 | Object | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:108:1:111:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
-| calls.rb:108:1:111:3 | Object | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:108:1:111:3 | Object | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:113:1:116:3 | Hash | [] | calls.rb:115:5:115:31 | [] |
-| calls.rb:113:1:116:3 | Hash | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:113:1:116:3 | Hash | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:113:1:116:3 | Hash | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:113:1:116:3 | Hash | create | calls.rb:271:1:279:3 | create |
-| calls.rb:113:1:116:3 | Hash | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:113:1:116:3 | Hash | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:113:1:116:3 | Hash | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:113:1:116:3 | Hash | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:113:1:116:3 | Hash | new | calls.rb:110:5:110:16 | new |
-| calls.rb:113:1:116:3 | Hash | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:113:1:116:3 | Hash | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:113:1:116:3 | Hash | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:113:1:116:3 | Hash | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:113:1:116:3 | Hash | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:118:1:131:3 | Array | [] | calls.rb:120:3:120:29 | [] |
-| calls.rb:118:1:131:3 | Array | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:118:1:131:3 | Array | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:118:1:131:3 | Array | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:118:1:131:3 | Array | create | calls.rb:271:1:279:3 | create |
-| calls.rb:118:1:131:3 | Array | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:118:1:131:3 | Array | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:118:1:131:3 | Array | foreach | calls.rb:124:3:130:5 | foreach |
-| calls.rb:118:1:131:3 | Array | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:118:1:131:3 | Array | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:118:1:131:3 | Array | length | calls.rb:122:3:122:17 | length |
-| calls.rb:118:1:131:3 | Array | new | calls.rb:110:5:110:16 | new |
-| calls.rb:118:1:131:3 | Array | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:118:1:131:3 | Array | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:118:1:131:3 | Array | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:118:1:131:3 | Array | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:118:1:131:3 | Array | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:158:1:162:3 | S | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:158:1:162:3 | S | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:158:1:162:3 | S | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:158:1:162:3 | S | create | calls.rb:271:1:279:3 | create |
-| calls.rb:158:1:162:3 | S | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:158:1:162:3 | S | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:158:1:162:3 | S | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:158:1:162:3 | S | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:158:1:162:3 | S | new | calls.rb:110:5:110:16 | new |
-| calls.rb:158:1:162:3 | S | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:158:1:162:3 | S | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:158:1:162:3 | S | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:158:1:162:3 | S | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:158:1:162:3 | S | s_method | calls.rb:159:5:161:7 | s_method |
-| calls.rb:158:1:162:3 | S | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:164:1:167:3 | A | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:164:1:167:3 | A | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:164:1:167:3 | A | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:164:1:167:3 | A | create | calls.rb:271:1:279:3 | create |
-| calls.rb:164:1:167:3 | A | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:164:1:167:3 | A | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:164:1:167:3 | A | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:164:1:167:3 | A | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:164:1:167:3 | A | new | calls.rb:110:5:110:16 | new |
-| calls.rb:164:1:167:3 | A | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:164:1:167:3 | A | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:164:1:167:3 | A | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:164:1:167:3 | A | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:164:1:167:3 | A | s_method | calls.rb:159:5:161:7 | s_method |
-| calls.rb:164:1:167:3 | A | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:169:1:172:3 | B | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:169:1:172:3 | B | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:169:1:172:3 | B | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:169:1:172:3 | B | create | calls.rb:271:1:279:3 | create |
-| calls.rb:169:1:172:3 | B | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:169:1:172:3 | B | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:169:1:172:3 | B | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:169:1:172:3 | B | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:169:1:172:3 | B | new | calls.rb:110:5:110:16 | new |
-| calls.rb:169:1:172:3 | B | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:169:1:172:3 | B | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:169:1:172:3 | B | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:169:1:172:3 | B | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:169:1:172:3 | B | s_method | calls.rb:159:5:161:7 | s_method |
-| calls.rb:169:1:172:3 | B | to_s | calls.rb:170:5:171:7 | to_s |
-| calls.rb:183:1:219:3 | Singletons | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:183:1:219:3 | Singletons | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:183:1:219:3 | Singletons | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:183:1:219:3 | Singletons | call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
-| calls.rb:183:1:219:3 | Singletons | create | calls.rb:271:1:279:3 | create |
-| calls.rb:183:1:219:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:183:1:219:3 | Singletons | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:183:1:219:3 | Singletons | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:183:1:219:3 | Singletons | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:183:1:219:3 | Singletons | instance | calls.rb:203:5:208:7 | instance |
-| calls.rb:183:1:219:3 | Singletons | new | calls.rb:110:5:110:16 | new |
-| calls.rb:183:1:219:3 | Singletons | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:183:1:219:3 | Singletons | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:183:1:219:3 | Singletons | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:183:1:219:3 | Singletons | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:183:1:219:3 | Singletons | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:303:1:313:3 | SelfNew | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:303:1:313:3 | SelfNew | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:303:1:313:3 | SelfNew | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:303:1:313:3 | SelfNew | create | calls.rb:271:1:279:3 | create |
-| calls.rb:303:1:313:3 | SelfNew | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:303:1:313:3 | SelfNew | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:303:1:313:3 | SelfNew | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:303:1:313:3 | SelfNew | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:303:1:313:3 | SelfNew | instance | calls.rb:304:5:306:7 | instance |
-| calls.rb:303:1:313:3 | SelfNew | new | calls.rb:110:5:110:16 | new |
-| calls.rb:303:1:313:3 | SelfNew | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:303:1:313:3 | SelfNew | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:303:1:313:3 | SelfNew | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:303:1:313:3 | SelfNew | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:303:1:313:3 | SelfNew | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:317:1:321:3 | C1 | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:317:1:321:3 | C1 | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:317:1:321:3 | C1 | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:317:1:321:3 | C1 | create | calls.rb:271:1:279:3 | create |
-| calls.rb:317:1:321:3 | C1 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:317:1:321:3 | C1 | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:317:1:321:3 | C1 | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:317:1:321:3 | C1 | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:317:1:321:3 | C1 | instance | calls.rb:318:5:320:7 | instance |
-| calls.rb:317:1:321:3 | C1 | new | calls.rb:110:5:110:16 | new |
-| calls.rb:317:1:321:3 | C1 | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:317:1:321:3 | C1 | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:317:1:321:3 | C1 | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:317:1:321:3 | C1 | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:317:1:321:3 | C1 | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:323:1:327:3 | C2 | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:323:1:327:3 | C2 | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:323:1:327:3 | C2 | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:323:1:327:3 | C2 | create | calls.rb:271:1:279:3 | create |
-| calls.rb:323:1:327:3 | C2 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:323:1:327:3 | C2 | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:323:1:327:3 | C2 | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:323:1:327:3 | C2 | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:323:1:327:3 | C2 | instance | calls.rb:324:5:326:7 | instance |
-| calls.rb:323:1:327:3 | C2 | new | calls.rb:110:5:110:16 | new |
-| calls.rb:323:1:327:3 | C2 | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:323:1:327:3 | C2 | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:323:1:327:3 | C2 | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:323:1:327:3 | C2 | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:323:1:327:3 | C2 | to_s | calls.rb:165:5:166:7 | to_s |
-| calls.rb:329:1:333:3 | C3 | add_singleton | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:329:1:333:3 | C3 | call_block | calls.rb:77:1:79:3 | call_block |
-| calls.rb:329:1:333:3 | C3 | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:329:1:333:3 | C3 | create | calls.rb:271:1:279:3 | create |
-| calls.rb:329:1:333:3 | C3 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:329:1:333:3 | C3 | foo | calls.rb:81:1:85:3 | foo |
-| calls.rb:329:1:333:3 | C3 | funny | calls.rb:133:1:135:3 | funny |
-| calls.rb:329:1:333:3 | C3 | indirect | calls.rb:151:1:153:3 | indirect |
-| calls.rb:329:1:333:3 | C3 | instance | calls.rb:330:5:332:7 | instance |
-| calls.rb:329:1:333:3 | C3 | new | calls.rb:110:5:110:16 | new |
-| calls.rb:329:1:333:3 | C3 | optional_arg | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:329:1:333:3 | C3 | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:329:1:333:3 | C3 | private_on_main | calls.rb:178:1:179:3 | private_on_main |
-| calls.rb:329:1:333:3 | C3 | puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:329:1:333:3 | C3 | to_s | calls.rb:165:5:166:7 | to_s |
-| file://:0:0:0:0 | Class | include | calls.rb:103:5:103:20 | include |
-| file://:0:0:0:0 | Class | module_eval | calls.rb:102:5:102:24 | module_eval |
-| file://:0:0:0:0 | Class | new | calls.rb:110:5:110:16 | new |
-| file://:0:0:0:0 | Class | prepend | calls.rb:104:5:104:20 | prepend |
-| file://:0:0:0:0 | Class | private | calls.rb:105:5:105:20 | private |
-| file://:0:0:0:0 | Class | puts | calls.rb:98:5:98:30 | puts |
-| file://:0:0:0:0 | Class | to_s | calls.rb:165:5:166:7 | to_s |
-| file://:0:0:0:0 | Complex | new | calls.rb:110:5:110:16 | new |
-| file://:0:0:0:0 | Complex | puts | calls.rb:98:5:98:30 | puts |
-| file://:0:0:0:0 | Complex | to_s | calls.rb:165:5:166:7 | to_s |
-| file://:0:0:0:0 | FalseClass | new | calls.rb:110:5:110:16 | new |
-| file://:0:0:0:0 | FalseClass | puts | calls.rb:98:5:98:30 | puts |
-| file://:0:0:0:0 | FalseClass | to_s | calls.rb:165:5:166:7 | to_s |
-| file://:0:0:0:0 | Float | new | calls.rb:110:5:110:16 | new |
-| file://:0:0:0:0 | Float | puts | calls.rb:98:5:98:30 | puts |
-| file://:0:0:0:0 | Float | to_s | calls.rb:165:5:166:7 | to_s |
-| file://:0:0:0:0 | NilClass | new | calls.rb:110:5:110:16 | new |
-| file://:0:0:0:0 | NilClass | puts | calls.rb:98:5:98:30 | puts |
-| file://:0:0:0:0 | NilClass | to_s | calls.rb:165:5:166:7 | to_s |
-| file://:0:0:0:0 | Numeric | new | calls.rb:110:5:110:16 | new |
-| file://:0:0:0:0 | Numeric | puts | calls.rb:98:5:98:30 | puts |
-| file://:0:0:0:0 | Numeric | to_s | calls.rb:165:5:166:7 | to_s |
-| file://:0:0:0:0 | Rational | new | calls.rb:110:5:110:16 | new |
-| file://:0:0:0:0 | Rational | puts | calls.rb:98:5:98:30 | puts |
-| file://:0:0:0:0 | Rational | to_s | calls.rb:165:5:166:7 | to_s |
-| file://:0:0:0:0 | TrueClass | new | calls.rb:110:5:110:16 | new |
-| file://:0:0:0:0 | TrueClass | puts | calls.rb:98:5:98:30 | puts |
-| file://:0:0:0:0 | TrueClass | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:21:1:34:3 | M | instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:43:1:58:3 | C | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:43:1:58:3 | C | baz | calls.rb:51:5:57:7 | baz |
+| calls.rb:43:1:58:3 | C | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:43:1:58:3 | C | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:43:1:58:3 | C | create | calls.rb:275:1:283:3 | create |
+| calls.rb:43:1:58:3 | C | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:43:1:58:3 | C | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:43:1:58:3 | C | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:43:1:58:3 | C | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:43:1:58:3 | C | instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:43:1:58:3 | C | new | calls.rb:114:5:114:16 | new |
+| calls.rb:43:1:58:3 | C | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:43:1:58:3 | C | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:43:1:58:3 | C | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:43:1:58:3 | C | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:43:1:58:3 | C | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:65:1:69:3 | D | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:65:1:69:3 | D | baz | calls.rb:66:5:68:7 | baz |
+| calls.rb:65:1:69:3 | D | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:65:1:69:3 | D | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:65:1:69:3 | D | create | calls.rb:275:1:283:3 | create |
+| calls.rb:65:1:69:3 | D | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:65:1:69:3 | D | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:65:1:69:3 | D | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:65:1:69:3 | D | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:65:1:69:3 | D | instance_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:65:1:69:3 | D | new | calls.rb:114:5:114:16 | new |
+| calls.rb:65:1:69:3 | D | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:65:1:69:3 | D | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:65:1:69:3 | D | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:65:1:69:3 | D | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:65:1:69:3 | D | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:91:1:94:3 | Integer | abs | calls.rb:93:5:93:16 | abs |
+| calls.rb:91:1:94:3 | Integer | bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:91:1:94:3 | Integer | new | calls.rb:114:5:114:16 | new |
+| calls.rb:91:1:94:3 | Integer | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:91:1:94:3 | Integer | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:96:1:98:3 | String | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:96:1:98:3 | String | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:96:1:98:3 | String | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:96:1:98:3 | String | capitalize | calls.rb:97:5:97:23 | capitalize |
+| calls.rb:96:1:98:3 | String | create | calls.rb:275:1:283:3 | create |
+| calls.rb:96:1:98:3 | String | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:96:1:98:3 | String | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:96:1:98:3 | String | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:96:1:98:3 | String | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:96:1:98:3 | String | new | calls.rb:114:5:114:16 | new |
+| calls.rb:96:1:98:3 | String | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:96:1:98:3 | String | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:96:1:98:3 | String | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:96:1:98:3 | String | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:96:1:98:3 | String | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:100:1:103:3 | Kernel | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:105:1:110:3 | Module | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:105:1:110:3 | Module | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:105:1:110:3 | Module | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:105:1:110:3 | Module | create | calls.rb:275:1:283:3 | create |
+| calls.rb:105:1:110:3 | Module | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:105:1:110:3 | Module | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:105:1:110:3 | Module | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:105:1:110:3 | Module | include | calls.rb:107:5:107:20 | include |
+| calls.rb:105:1:110:3 | Module | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:105:1:110:3 | Module | module_eval | calls.rb:106:5:106:24 | module_eval |
+| calls.rb:105:1:110:3 | Module | new | calls.rb:114:5:114:16 | new |
+| calls.rb:105:1:110:3 | Module | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:105:1:110:3 | Module | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:105:1:110:3 | Module | prepend | calls.rb:108:5:108:20 | prepend |
+| calls.rb:105:1:110:3 | Module | private | calls.rb:109:5:109:20 | private |
+| calls.rb:105:1:110:3 | Module | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:105:1:110:3 | Module | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:105:1:110:3 | Module | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:112:1:115:3 | Object | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:112:1:115:3 | Object | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:112:1:115:3 | Object | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:112:1:115:3 | Object | create | calls.rb:275:1:283:3 | create |
+| calls.rb:112:1:115:3 | Object | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:112:1:115:3 | Object | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:112:1:115:3 | Object | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:112:1:115:3 | Object | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:112:1:115:3 | Object | new | calls.rb:114:5:114:16 | new |
+| calls.rb:112:1:115:3 | Object | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:112:1:115:3 | Object | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:112:1:115:3 | Object | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:112:1:115:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
+| calls.rb:112:1:115:3 | Object | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:112:1:115:3 | Object | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:117:1:120:3 | Hash | [] | calls.rb:119:5:119:31 | [] |
+| calls.rb:117:1:120:3 | Hash | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:117:1:120:3 | Hash | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:117:1:120:3 | Hash | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:117:1:120:3 | Hash | create | calls.rb:275:1:283:3 | create |
+| calls.rb:117:1:120:3 | Hash | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:117:1:120:3 | Hash | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:117:1:120:3 | Hash | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:117:1:120:3 | Hash | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:117:1:120:3 | Hash | new | calls.rb:114:5:114:16 | new |
+| calls.rb:117:1:120:3 | Hash | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:117:1:120:3 | Hash | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:117:1:120:3 | Hash | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:117:1:120:3 | Hash | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:117:1:120:3 | Hash | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:122:1:135:3 | Array | [] | calls.rb:124:3:124:29 | [] |
+| calls.rb:122:1:135:3 | Array | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:122:1:135:3 | Array | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:122:1:135:3 | Array | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:122:1:135:3 | Array | create | calls.rb:275:1:283:3 | create |
+| calls.rb:122:1:135:3 | Array | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:122:1:135:3 | Array | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:122:1:135:3 | Array | foreach | calls.rb:128:3:134:5 | foreach |
+| calls.rb:122:1:135:3 | Array | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:122:1:135:3 | Array | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:122:1:135:3 | Array | length | calls.rb:126:3:126:17 | length |
+| calls.rb:122:1:135:3 | Array | new | calls.rb:114:5:114:16 | new |
+| calls.rb:122:1:135:3 | Array | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:122:1:135:3 | Array | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:122:1:135:3 | Array | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:122:1:135:3 | Array | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:122:1:135:3 | Array | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:162:1:166:3 | S | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:162:1:166:3 | S | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:162:1:166:3 | S | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:162:1:166:3 | S | create | calls.rb:275:1:283:3 | create |
+| calls.rb:162:1:166:3 | S | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:162:1:166:3 | S | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:162:1:166:3 | S | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:162:1:166:3 | S | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:162:1:166:3 | S | new | calls.rb:114:5:114:16 | new |
+| calls.rb:162:1:166:3 | S | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:162:1:166:3 | S | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:162:1:166:3 | S | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:162:1:166:3 | S | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:162:1:166:3 | S | s_method | calls.rb:163:5:165:7 | s_method |
+| calls.rb:162:1:166:3 | S | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:168:1:171:3 | A | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:168:1:171:3 | A | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:168:1:171:3 | A | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:168:1:171:3 | A | create | calls.rb:275:1:283:3 | create |
+| calls.rb:168:1:171:3 | A | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:168:1:171:3 | A | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:168:1:171:3 | A | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:168:1:171:3 | A | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:168:1:171:3 | A | new | calls.rb:114:5:114:16 | new |
+| calls.rb:168:1:171:3 | A | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:168:1:171:3 | A | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:168:1:171:3 | A | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:168:1:171:3 | A | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:168:1:171:3 | A | s_method | calls.rb:163:5:165:7 | s_method |
+| calls.rb:168:1:171:3 | A | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:173:1:176:3 | B | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:173:1:176:3 | B | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:173:1:176:3 | B | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:173:1:176:3 | B | create | calls.rb:275:1:283:3 | create |
+| calls.rb:173:1:176:3 | B | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:173:1:176:3 | B | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:173:1:176:3 | B | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:173:1:176:3 | B | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:173:1:176:3 | B | new | calls.rb:114:5:114:16 | new |
+| calls.rb:173:1:176:3 | B | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:173:1:176:3 | B | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:173:1:176:3 | B | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:173:1:176:3 | B | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:173:1:176:3 | B | s_method | calls.rb:163:5:165:7 | s_method |
+| calls.rb:173:1:176:3 | B | to_s | calls.rb:174:5:175:7 | to_s |
+| calls.rb:187:1:223:3 | Singletons | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:187:1:223:3 | Singletons | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:187:1:223:3 | Singletons | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:187:1:223:3 | Singletons | call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
+| calls.rb:187:1:223:3 | Singletons | create | calls.rb:275:1:283:3 | create |
+| calls.rb:187:1:223:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:187:1:223:3 | Singletons | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:187:1:223:3 | Singletons | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:187:1:223:3 | Singletons | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:187:1:223:3 | Singletons | instance | calls.rb:207:5:212:7 | instance |
+| calls.rb:187:1:223:3 | Singletons | new | calls.rb:114:5:114:16 | new |
+| calls.rb:187:1:223:3 | Singletons | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:187:1:223:3 | Singletons | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:187:1:223:3 | Singletons | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:187:1:223:3 | Singletons | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:187:1:223:3 | Singletons | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:307:1:318:3 | SelfNew | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:307:1:318:3 | SelfNew | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:307:1:318:3 | SelfNew | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:307:1:318:3 | SelfNew | create | calls.rb:275:1:283:3 | create |
+| calls.rb:307:1:318:3 | SelfNew | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:307:1:318:3 | SelfNew | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:307:1:318:3 | SelfNew | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:307:1:318:3 | SelfNew | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:307:1:318:3 | SelfNew | instance | calls.rb:308:5:311:7 | instance |
+| calls.rb:307:1:318:3 | SelfNew | new | calls.rb:114:5:114:16 | new |
+| calls.rb:307:1:318:3 | SelfNew | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:307:1:318:3 | SelfNew | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:307:1:318:3 | SelfNew | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:307:1:318:3 | SelfNew | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:307:1:318:3 | SelfNew | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:322:1:326:3 | C1 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:322:1:326:3 | C1 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:322:1:326:3 | C1 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:322:1:326:3 | C1 | create | calls.rb:275:1:283:3 | create |
+| calls.rb:322:1:326:3 | C1 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:322:1:326:3 | C1 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:322:1:326:3 | C1 | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:322:1:326:3 | C1 | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:322:1:326:3 | C1 | instance | calls.rb:323:5:325:7 | instance |
+| calls.rb:322:1:326:3 | C1 | new | calls.rb:114:5:114:16 | new |
+| calls.rb:322:1:326:3 | C1 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:322:1:326:3 | C1 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:322:1:326:3 | C1 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:322:1:326:3 | C1 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:322:1:326:3 | C1 | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:328:1:332:3 | C2 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:328:1:332:3 | C2 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:328:1:332:3 | C2 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:328:1:332:3 | C2 | create | calls.rb:275:1:283:3 | create |
+| calls.rb:328:1:332:3 | C2 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:328:1:332:3 | C2 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:328:1:332:3 | C2 | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:328:1:332:3 | C2 | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:328:1:332:3 | C2 | instance | calls.rb:329:5:331:7 | instance |
+| calls.rb:328:1:332:3 | C2 | new | calls.rb:114:5:114:16 | new |
+| calls.rb:328:1:332:3 | C2 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:328:1:332:3 | C2 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:328:1:332:3 | C2 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:328:1:332:3 | C2 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:328:1:332:3 | C2 | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:334:1:338:3 | C3 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:334:1:338:3 | C3 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:334:1:338:3 | C3 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:334:1:338:3 | C3 | create | calls.rb:275:1:283:3 | create |
+| calls.rb:334:1:338:3 | C3 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:334:1:338:3 | C3 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:334:1:338:3 | C3 | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:334:1:338:3 | C3 | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:334:1:338:3 | C3 | instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:334:1:338:3 | C3 | new | calls.rb:114:5:114:16 | new |
+| calls.rb:334:1:338:3 | C3 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:334:1:338:3 | C3 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:334:1:338:3 | C3 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:334:1:338:3 | C3 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:334:1:338:3 | C3 | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:374:1:394:3 | SingletonOverride1 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:374:1:394:3 | SingletonOverride1 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:374:1:394:3 | SingletonOverride1 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:374:1:394:3 | SingletonOverride1 | create | calls.rb:275:1:283:3 | create |
+| calls.rb:374:1:394:3 | SingletonOverride1 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:374:1:394:3 | SingletonOverride1 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:374:1:394:3 | SingletonOverride1 | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:374:1:394:3 | SingletonOverride1 | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:374:1:394:3 | SingletonOverride1 | new | calls.rb:114:5:114:16 | new |
+| calls.rb:374:1:394:3 | SingletonOverride1 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:374:1:394:3 | SingletonOverride1 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:374:1:394:3 | SingletonOverride1 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:374:1:394:3 | SingletonOverride1 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:374:1:394:3 | SingletonOverride1 | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:399:1:409:3 | SingletonOverride2 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:399:1:409:3 | SingletonOverride2 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:399:1:409:3 | SingletonOverride2 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:399:1:409:3 | SingletonOverride2 | create | calls.rb:275:1:283:3 | create |
+| calls.rb:399:1:409:3 | SingletonOverride2 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:399:1:409:3 | SingletonOverride2 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:399:1:409:3 | SingletonOverride2 | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:399:1:409:3 | SingletonOverride2 | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:399:1:409:3 | SingletonOverride2 | new | calls.rb:114:5:114:16 | new |
+| calls.rb:399:1:409:3 | SingletonOverride2 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:399:1:409:3 | SingletonOverride2 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:399:1:409:3 | SingletonOverride2 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:399:1:409:3 | SingletonOverride2 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:399:1:409:3 | SingletonOverride2 | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | Class | include | calls.rb:107:5:107:20 | include |
+| file://:0:0:0:0 | Class | module_eval | calls.rb:106:5:106:24 | module_eval |
+| file://:0:0:0:0 | Class | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Class | prepend | calls.rb:108:5:108:20 | prepend |
+| file://:0:0:0:0 | Class | private | calls.rb:109:5:109:20 | private |
+| file://:0:0:0:0 | Class | puts | calls.rb:102:5:102:30 | puts |
+| file://:0:0:0:0 | Class | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | Complex | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Complex | puts | calls.rb:102:5:102:30 | puts |
+| file://:0:0:0:0 | Complex | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | FalseClass | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | FalseClass | puts | calls.rb:102:5:102:30 | puts |
+| file://:0:0:0:0 | FalseClass | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | Float | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Float | puts | calls.rb:102:5:102:30 | puts |
+| file://:0:0:0:0 | Float | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | NilClass | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | NilClass | puts | calls.rb:102:5:102:30 | puts |
+| file://:0:0:0:0 | NilClass | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | Numeric | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Numeric | puts | calls.rb:102:5:102:30 | puts |
+| file://:0:0:0:0 | Numeric | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | Rational | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Rational | puts | calls.rb:102:5:102:30 | puts |
+| file://:0:0:0:0 | Rational | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | TrueClass | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | TrueClass | puts | calls.rb:102:5:102:30 | puts |
+| file://:0:0:0:0 | TrueClass | to_s | calls.rb:169:5:170:7 | to_s |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
-| hello.rb:11:1:16:3 | Greeting | new | calls.rb:110:5:110:16 | new |
-| hello.rb:11:1:16:3 | Greeting | puts | calls.rb:98:5:98:30 | puts |
-| hello.rb:11:1:16:3 | Greeting | to_s | calls.rb:165:5:166:7 | to_s |
+| hello.rb:11:1:16:3 | Greeting | new | calls.rb:114:5:114:16 | new |
+| hello.rb:11:1:16:3 | Greeting | puts | calls.rb:102:5:102:30 | puts |
+| hello.rb:11:1:16:3 | Greeting | to_s | calls.rb:169:5:170:7 | to_s |
 | hello.rb:11:1:16:3 | Greeting | world | hello.rb:5:5:7:7 | world |
 | hello.rb:18:1:22:3 | HelloWorld | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:18:1:22:3 | HelloWorld | message | hello.rb:19:5:21:7 | message |
-| hello.rb:18:1:22:3 | HelloWorld | new | calls.rb:110:5:110:16 | new |
-| hello.rb:18:1:22:3 | HelloWorld | puts | calls.rb:98:5:98:30 | puts |
-| hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:165:5:166:7 | to_s |
+| hello.rb:18:1:22:3 | HelloWorld | new | calls.rb:114:5:114:16 | new |
+| hello.rb:18:1:22:3 | HelloWorld | puts | calls.rb:102:5:102:30 | puts |
+| hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:169:5:170:7 | to_s |
 | hello.rb:18:1:22:3 | HelloWorld | world | hello.rb:5:5:7:7 | world |
 | modules.rb:4:1:24:3 | Foo | method_in_another_definition_of_foo | modules.rb:27:3:28:5 | method_in_another_definition_of_foo |
 | modules.rb:4:1:24:3 | Foo | method_in_foo | modules.rb:16:3:17:5 | method_in_foo |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_another_definition_of_foo_bar | modules.rb:52:3:53:5 | method_in_another_definition_of_foo_bar |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_foo_bar | modules.rb:9:5:10:7 | method_in_foo_bar |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | new | calls.rb:110:5:110:16 | new |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | to_s | calls.rb:165:5:166:7 | to_s |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | new | calls.rb:110:5:110:16 | new |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | to_s | calls.rb:165:5:166:7 | to_s |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | new | calls.rb:110:5:110:16 | new |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | to_s | calls.rb:165:5:166:7 | to_s |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | to_s | calls.rb:169:5:170:7 | to_s |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | new | calls.rb:114:5:114:16 | new |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | to_s | calls.rb:169:5:170:7 | to_s |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | new | calls.rb:114:5:114:16 | new |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | to_s | calls.rb:169:5:170:7 | to_s |
 | modules.rb:37:1:46:3 | Bar | method_a | modules.rb:38:3:39:5 | method_a |
 | modules.rb:37:1:46:3 | Bar | method_b | modules.rb:41:3:42:5 | method_b |
-| modules.rb:37:1:46:3 | Bar | new | calls.rb:110:5:110:16 | new |
-| modules.rb:37:1:46:3 | Bar | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:37:1:46:3 | Bar | to_s | calls.rb:165:5:166:7 | to_s |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | new | calls.rb:110:5:110:16 | new |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | to_s | calls.rb:165:5:166:7 | to_s |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | new | calls.rb:110:5:110:16 | new |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | to_s | calls.rb:165:5:166:7 | to_s |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | new | calls.rb:110:5:110:16 | new |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | to_s | calls.rb:165:5:166:7 | to_s |
-| modules.rb:112:1:113:3 | YY | new | calls.rb:110:5:110:16 | new |
-| modules.rb:112:1:113:3 | YY | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:112:1:113:3 | YY | to_s | calls.rb:165:5:166:7 | to_s |
-| modules.rb:116:7:117:9 | XX::YY | new | calls.rb:110:5:110:16 | new |
-| modules.rb:116:7:117:9 | XX::YY | puts | calls.rb:98:5:98:30 | puts |
-| modules.rb:116:7:117:9 | XX::YY | to_s | calls.rb:165:5:166:7 | to_s |
-| modules_rec.rb:1:1:2:3 | B::A | new | calls.rb:110:5:110:16 | new |
-| modules_rec.rb:1:1:2:3 | B::A | puts | calls.rb:98:5:98:30 | puts |
-| modules_rec.rb:1:1:2:3 | B::A | to_s | calls.rb:165:5:166:7 | to_s |
-| modules_rec.rb:4:1:5:3 | A::B | new | calls.rb:110:5:110:16 | new |
-| modules_rec.rb:4:1:5:3 | A::B | puts | calls.rb:98:5:98:30 | puts |
-| modules_rec.rb:4:1:5:3 | A::B | to_s | calls.rb:165:5:166:7 | to_s |
-| private.rb:1:1:29:3 | E | new | calls.rb:110:5:110:16 | new |
+| modules.rb:37:1:46:3 | Bar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:37:1:46:3 | Bar | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:37:1:46:3 | Bar | to_s | calls.rb:169:5:170:7 | to_s |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | to_s | calls.rb:169:5:170:7 | to_s |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | to_s | calls.rb:169:5:170:7 | to_s |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | to_s | calls.rb:169:5:170:7 | to_s |
+| modules.rb:112:1:113:3 | YY | new | calls.rb:114:5:114:16 | new |
+| modules.rb:112:1:113:3 | YY | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:112:1:113:3 | YY | to_s | calls.rb:169:5:170:7 | to_s |
+| modules.rb:116:7:117:9 | XX::YY | new | calls.rb:114:5:114:16 | new |
+| modules.rb:116:7:117:9 | XX::YY | puts | calls.rb:102:5:102:30 | puts |
+| modules.rb:116:7:117:9 | XX::YY | to_s | calls.rb:169:5:170:7 | to_s |
+| modules_rec.rb:1:1:2:3 | B::A | new | calls.rb:114:5:114:16 | new |
+| modules_rec.rb:1:1:2:3 | B::A | puts | calls.rb:102:5:102:30 | puts |
+| modules_rec.rb:1:1:2:3 | B::A | to_s | calls.rb:169:5:170:7 | to_s |
+| modules_rec.rb:4:1:5:3 | A::B | new | calls.rb:114:5:114:16 | new |
+| modules_rec.rb:4:1:5:3 | A::B | puts | calls.rb:102:5:102:30 | puts |
+| modules_rec.rb:4:1:5:3 | A::B | to_s | calls.rb:169:5:170:7 | to_s |
+| private.rb:1:1:29:3 | E | new | calls.rb:114:5:114:16 | new |
 | private.rb:1:1:29:3 | E | private2 | private.rb:8:3:9:5 | private2 |
 | private.rb:1:1:29:3 | E | private3 | private.rb:14:3:15:5 | private3 |
 | private.rb:1:1:29:3 | E | private4 | private.rb:17:3:18:5 | private4 |
 | private.rb:1:1:29:3 | E | private_on_main | private.rb:31:1:32:3 | private_on_main |
 | private.rb:1:1:29:3 | E | public | private.rb:5:3:6:5 | public |
-| private.rb:1:1:29:3 | E | puts | calls.rb:98:5:98:30 | puts |
-| private.rb:1:1:29:3 | E | to_s | calls.rb:165:5:166:7 | to_s |
+| private.rb:1:1:29:3 | E | puts | calls.rb:102:5:102:30 | puts |
+| private.rb:1:1:29:3 | E | to_s | calls.rb:169:5:170:7 | to_s |
 | private.rb:42:1:60:3 | F | private2 | private.rb:49:3:50:5 | private2 |
 | private.rb:42:1:60:3 | F | private3 | private.rb:55:3:56:5 | private3 |
 | private.rb:42:1:60:3 | F | private4 | private.rb:58:3:59:5 | private4 |
@@ -401,233 +429,260 @@ enclosingMethod
 | calls.rb:14:5:14:15 | self | calls.rb:13:1:15:3 | bar |
 | calls.rb:14:10:14:15 | "bar2" | calls.rb:13:1:15:3 | bar |
 | calls.rb:14:11:14:14 | bar2 | calls.rb:13:1:15:3 | bar |
-| calls.rb:36:5:36:14 | call to instance_m | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:36:5:36:14 | self | calls.rb:35:1:37:3 | call_instance_m |
-| calls.rb:48:9:48:18 | call to instance_m | calls.rb:47:5:53:7 | baz |
-| calls.rb:48:9:48:18 | self | calls.rb:47:5:53:7 | baz |
-| calls.rb:49:9:49:12 | self | calls.rb:47:5:53:7 | baz |
-| calls.rb:49:9:49:23 | call to instance_m | calls.rb:47:5:53:7 | baz |
-| calls.rb:51:9:51:19 | call to singleton_m | calls.rb:47:5:53:7 | baz |
-| calls.rb:51:9:51:19 | self | calls.rb:47:5:53:7 | baz |
-| calls.rb:52:9:52:12 | self | calls.rb:47:5:53:7 | baz |
-| calls.rb:52:9:52:24 | call to singleton_m | calls.rb:47:5:53:7 | baz |
-| calls.rb:63:9:63:13 | call to super | calls.rb:62:5:64:7 | baz |
-| calls.rb:72:18:72:18 | a | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:72:18:72:18 | a | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:72:22:72:22 | 4 | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:72:25:72:25 | b | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:72:25:72:25 | b | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:72:28:72:28 | 5 | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:73:5:73:5 | a | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:73:5:73:16 | call to bit_length | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:74:5:74:5 | b | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:74:5:74:16 | call to bit_length | calls.rb:72:1:75:3 | optional_arg |
-| calls.rb:78:5:78:11 | yield ... | calls.rb:77:1:79:3 | call_block |
-| calls.rb:78:11:78:11 | 1 | calls.rb:77:1:79:3 | call_block |
-| calls.rb:82:5:82:7 | var | calls.rb:81:1:85:3 | foo |
-| calls.rb:82:5:82:18 | ... = ... | calls.rb:81:1:85:3 | foo |
-| calls.rb:82:11:82:14 | Hash | calls.rb:81:1:85:3 | foo |
-| calls.rb:82:11:82:18 | call to new | calls.rb:81:1:85:3 | foo |
-| calls.rb:83:5:83:7 | var | calls.rb:81:1:85:3 | foo |
-| calls.rb:83:5:83:10 | ...[...] | calls.rb:81:1:85:3 | foo |
-| calls.rb:83:9:83:9 | 1 | calls.rb:81:1:85:3 | foo |
-| calls.rb:84:5:84:29 | call to call_block | calls.rb:81:1:85:3 | foo |
-| calls.rb:84:5:84:29 | self | calls.rb:81:1:85:3 | foo |
-| calls.rb:84:16:84:29 | { ... } | calls.rb:81:1:85:3 | foo |
-| calls.rb:84:19:84:19 | x | calls.rb:81:1:85:3 | foo |
-| calls.rb:84:19:84:19 | x | calls.rb:81:1:85:3 | foo |
-| calls.rb:84:22:84:24 | var | calls.rb:81:1:85:3 | foo |
-| calls.rb:84:22:84:27 | ...[...] | calls.rb:81:1:85:3 | foo |
-| calls.rb:84:26:84:26 | x | calls.rb:81:1:85:3 | foo |
-| calls.rb:98:14:98:14 | x | calls.rb:98:5:98:30 | puts |
-| calls.rb:98:14:98:14 | x | calls.rb:98:5:98:30 | puts |
-| calls.rb:98:17:98:26 | call to old_puts | calls.rb:98:5:98:30 | puts |
-| calls.rb:98:17:98:26 | self | calls.rb:98:5:98:30 | puts |
-| calls.rb:98:26:98:26 | x | calls.rb:98:5:98:30 | puts |
-| calls.rb:115:12:115:12 | x | calls.rb:115:5:115:31 | [] |
-| calls.rb:115:12:115:12 | x | calls.rb:115:5:115:31 | [] |
-| calls.rb:115:15:115:27 | call to old_lookup | calls.rb:115:5:115:31 | [] |
-| calls.rb:115:15:115:27 | self | calls.rb:115:5:115:31 | [] |
-| calls.rb:115:26:115:26 | x | calls.rb:115:5:115:31 | [] |
-| calls.rb:120:10:120:10 | x | calls.rb:120:3:120:29 | [] |
-| calls.rb:120:10:120:10 | x | calls.rb:120:3:120:29 | [] |
-| calls.rb:120:13:120:25 | call to old_lookup | calls.rb:120:3:120:29 | [] |
-| calls.rb:120:13:120:25 | self | calls.rb:120:3:120:29 | [] |
-| calls.rb:120:24:120:24 | x | calls.rb:120:3:120:29 | [] |
-| calls.rb:124:15:124:19 | &body | calls.rb:124:3:130:5 | foreach |
-| calls.rb:124:16:124:19 | body | calls.rb:124:3:130:5 | foreach |
-| calls.rb:125:5:125:5 | x | calls.rb:124:3:130:5 | foreach |
-| calls.rb:125:5:125:9 | ... = ... | calls.rb:124:3:130:5 | foreach |
-| calls.rb:125:9:125:9 | 0 | calls.rb:124:3:130:5 | foreach |
-| calls.rb:126:5:129:7 | while ... | calls.rb:124:3:130:5 | foreach |
-| calls.rb:126:11:126:11 | x | calls.rb:124:3:130:5 | foreach |
-| calls.rb:126:11:126:25 | ... < ... | calls.rb:124:3:130:5 | foreach |
-| calls.rb:126:15:126:18 | self | calls.rb:124:3:130:5 | foreach |
-| calls.rb:126:15:126:25 | call to length | calls.rb:124:3:130:5 | foreach |
-| calls.rb:126:26:129:7 | do ... | calls.rb:124:3:130:5 | foreach |
-| calls.rb:127:9:127:24 | yield ... | calls.rb:124:3:130:5 | foreach |
-| calls.rb:127:15:127:15 | x | calls.rb:124:3:130:5 | foreach |
-| calls.rb:127:18:127:21 | self | calls.rb:124:3:130:5 | foreach |
-| calls.rb:127:18:127:24 | ...[...] | calls.rb:124:3:130:5 | foreach |
-| calls.rb:127:23:127:23 | x | calls.rb:124:3:130:5 | foreach |
-| calls.rb:128:9:128:9 | x | calls.rb:124:3:130:5 | foreach |
-| calls.rb:128:9:128:9 | x | calls.rb:124:3:130:5 | foreach |
-| calls.rb:128:9:128:14 | ... += ... | calls.rb:124:3:130:5 | foreach |
-| calls.rb:128:9:128:14 | ... = ... | calls.rb:124:3:130:5 | foreach |
-| calls.rb:128:11:128:12 | ... + ... | calls.rb:124:3:130:5 | foreach |
-| calls.rb:128:14:128:14 | 1 | calls.rb:124:3:130:5 | foreach |
-| calls.rb:134:5:134:20 | yield ... | calls.rb:133:1:135:3 | funny |
-| calls.rb:134:11:134:20 | "prefix: " | calls.rb:133:1:135:3 | funny |
-| calls.rb:134:12:134:19 | prefix:  | calls.rb:133:1:135:3 | funny |
-| calls.rb:151:14:151:15 | &b | calls.rb:151:1:153:3 | indirect |
-| calls.rb:151:15:151:15 | b | calls.rb:151:1:153:3 | indirect |
-| calls.rb:152:5:152:17 | call to call_block | calls.rb:151:1:153:3 | indirect |
-| calls.rb:152:5:152:17 | self | calls.rb:151:1:153:3 | indirect |
-| calls.rb:152:16:152:17 | &... | calls.rb:151:1:153:3 | indirect |
-| calls.rb:152:17:152:17 | b | calls.rb:151:1:153:3 | indirect |
-| calls.rb:160:9:160:12 | self | calls.rb:159:5:161:7 | s_method |
-| calls.rb:160:9:160:17 | call to to_s | calls.rb:159:5:161:7 | s_method |
-| calls.rb:185:9:185:26 | call to puts | calls.rb:184:5:187:7 | singleton_a |
-| calls.rb:185:9:185:26 | self | calls.rb:184:5:187:7 | singleton_a |
-| calls.rb:185:14:185:26 | "singleton_a" | calls.rb:184:5:187:7 | singleton_a |
-| calls.rb:185:15:185:25 | singleton_a | calls.rb:184:5:187:7 | singleton_a |
-| calls.rb:186:9:186:12 | self | calls.rb:184:5:187:7 | singleton_a |
-| calls.rb:186:9:186:24 | call to singleton_b | calls.rb:184:5:187:7 | singleton_a |
-| calls.rb:190:9:190:26 | call to puts | calls.rb:189:5:192:7 | singleton_b |
-| calls.rb:190:9:190:26 | self | calls.rb:189:5:192:7 | singleton_b |
-| calls.rb:190:14:190:26 | "singleton_b" | calls.rb:189:5:192:7 | singleton_b |
-| calls.rb:190:15:190:25 | singleton_b | calls.rb:189:5:192:7 | singleton_b |
-| calls.rb:191:9:191:12 | self | calls.rb:189:5:192:7 | singleton_b |
-| calls.rb:191:9:191:24 | call to singleton_c | calls.rb:189:5:192:7 | singleton_b |
-| calls.rb:195:9:195:26 | call to puts | calls.rb:194:5:196:7 | singleton_c |
-| calls.rb:195:9:195:26 | self | calls.rb:194:5:196:7 | singleton_c |
-| calls.rb:195:14:195:26 | "singleton_c" | calls.rb:194:5:196:7 | singleton_c |
-| calls.rb:195:15:195:25 | singleton_c | calls.rb:194:5:196:7 | singleton_c |
-| calls.rb:199:9:199:26 | call to puts | calls.rb:198:5:201:7 | singleton_d |
-| calls.rb:199:9:199:26 | self | calls.rb:198:5:201:7 | singleton_d |
-| calls.rb:199:14:199:26 | "singleton_d" | calls.rb:198:5:201:7 | singleton_d |
-| calls.rb:199:15:199:25 | singleton_d | calls.rb:198:5:201:7 | singleton_d |
-| calls.rb:200:9:200:12 | self | calls.rb:198:5:201:7 | singleton_d |
-| calls.rb:200:9:200:24 | call to singleton_a | calls.rb:198:5:201:7 | singleton_d |
-| calls.rb:204:9:206:11 | singleton_e | calls.rb:203:5:208:7 | instance |
-| calls.rb:204:13:204:16 | self | calls.rb:203:5:208:7 | instance |
-| calls.rb:205:13:205:30 | call to puts | calls.rb:204:9:206:11 | singleton_e |
-| calls.rb:205:13:205:30 | self | calls.rb:204:9:206:11 | singleton_e |
-| calls.rb:205:18:205:30 | "singleton_e" | calls.rb:204:9:206:11 | singleton_e |
-| calls.rb:205:19:205:29 | singleton_e | calls.rb:204:9:206:11 | singleton_e |
-| calls.rb:207:9:207:19 | call to singleton_e | calls.rb:203:5:208:7 | instance |
-| calls.rb:207:9:207:19 | self | calls.rb:203:5:208:7 | instance |
-| calls.rb:212:13:212:30 | call to puts | calls.rb:211:9:213:11 | singleton_f |
-| calls.rb:212:13:212:30 | self | calls.rb:211:9:213:11 | singleton_f |
-| calls.rb:212:18:212:30 | "singleton_f" | calls.rb:211:9:213:11 | singleton_f |
-| calls.rb:212:19:212:29 | singleton_f | calls.rb:211:9:213:11 | singleton_f |
-| calls.rb:217:9:217:12 | self | calls.rb:216:5:218:7 | call_singleton_g |
-| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
-| calls.rb:230:5:230:24 | call to puts | calls.rb:229:1:231:3 | singleton_g |
-| calls.rb:230:5:230:24 | self | calls.rb:229:1:231:3 | singleton_g |
-| calls.rb:230:10:230:24 | "singleton_g_1" | calls.rb:229:1:231:3 | singleton_g |
-| calls.rb:230:11:230:23 | singleton_g_1 | calls.rb:229:1:231:3 | singleton_g |
-| calls.rb:237:5:237:24 | call to puts | calls.rb:236:1:238:3 | singleton_g |
-| calls.rb:237:5:237:24 | self | calls.rb:236:1:238:3 | singleton_g |
-| calls.rb:237:10:237:24 | "singleton_g_2" | calls.rb:236:1:238:3 | singleton_g |
-| calls.rb:237:11:237:23 | singleton_g_2 | calls.rb:236:1:238:3 | singleton_g |
-| calls.rb:245:9:245:28 | call to puts | calls.rb:244:5:246:7 | singleton_g |
-| calls.rb:245:9:245:28 | self | calls.rb:244:5:246:7 | singleton_g |
-| calls.rb:245:14:245:28 | "singleton_g_3" | calls.rb:244:5:246:7 | singleton_g |
-| calls.rb:245:15:245:27 | singleton_g_3 | calls.rb:244:5:246:7 | singleton_g |
-| calls.rb:261:5:261:22 | call to puts | calls.rb:260:1:262:3 | singleton_g |
-| calls.rb:261:5:261:22 | self | calls.rb:260:1:262:3 | singleton_g |
-| calls.rb:261:10:261:22 | "singleton_g" | calls.rb:260:1:262:3 | singleton_g |
-| calls.rb:261:11:261:21 | singleton_g | calls.rb:260:1:262:3 | singleton_g |
-| calls.rb:271:12:271:15 | type | calls.rb:271:1:279:3 | create |
-| calls.rb:271:12:271:15 | type | calls.rb:271:1:279:3 | create |
-| calls.rb:272:5:272:8 | type | calls.rb:271:1:279:3 | create |
-| calls.rb:272:5:272:12 | call to new | calls.rb:271:1:279:3 | create |
-| calls.rb:272:5:272:21 | call to instance | calls.rb:271:1:279:3 | create |
-| calls.rb:274:5:276:7 | singleton_h | calls.rb:271:1:279:3 | create |
-| calls.rb:274:9:274:12 | type | calls.rb:271:1:279:3 | create |
-| calls.rb:275:9:275:26 | call to puts | calls.rb:274:5:276:7 | singleton_h |
-| calls.rb:275:9:275:26 | self | calls.rb:274:5:276:7 | singleton_h |
-| calls.rb:275:14:275:26 | "singleton_h" | calls.rb:274:5:276:7 | singleton_h |
-| calls.rb:275:15:275:25 | singleton_h | calls.rb:274:5:276:7 | singleton_h |
-| calls.rb:278:5:278:8 | type | calls.rb:271:1:279:3 | create |
-| calls.rb:278:5:278:20 | call to singleton_h | calls.rb:271:1:279:3 | create |
-| calls.rb:288:9:288:26 | call to puts | calls.rb:287:5:289:7 | singleton_i |
-| calls.rb:288:9:288:26 | self | calls.rb:287:5:289:7 | singleton_i |
-| calls.rb:288:14:288:26 | "singleton_i" | calls.rb:287:5:289:7 | singleton_i |
-| calls.rb:288:15:288:25 | singleton_i | calls.rb:287:5:289:7 | singleton_i |
-| calls.rb:297:9:297:26 | call to puts | calls.rb:296:5:298:7 | singleton_j |
-| calls.rb:297:9:297:26 | self | calls.rb:296:5:298:7 | singleton_j |
-| calls.rb:297:14:297:26 | "singleton_j" | calls.rb:296:5:298:7 | singleton_j |
-| calls.rb:297:15:297:25 | singleton_j | calls.rb:296:5:298:7 | singleton_j |
-| calls.rb:305:9:305:31 | call to puts | calls.rb:304:5:306:7 | instance |
-| calls.rb:305:9:305:31 | self | calls.rb:304:5:306:7 | instance |
-| calls.rb:305:14:305:31 | "SelfNew#instance" | calls.rb:304:5:306:7 | instance |
-| calls.rb:305:15:305:30 | SelfNew#instance | calls.rb:304:5:306:7 | instance |
-| calls.rb:309:9:309:11 | call to new | calls.rb:308:5:310:7 | singleton |
-| calls.rb:309:9:309:11 | self | calls.rb:308:5:310:7 | singleton |
-| calls.rb:309:9:309:20 | call to instance | calls.rb:308:5:310:7 | singleton |
-| calls.rb:319:9:319:26 | call to puts | calls.rb:318:5:320:7 | instance |
-| calls.rb:319:9:319:26 | self | calls.rb:318:5:320:7 | instance |
-| calls.rb:319:14:319:26 | "C1#instance" | calls.rb:318:5:320:7 | instance |
-| calls.rb:319:15:319:25 | C1#instance | calls.rb:318:5:320:7 | instance |
-| calls.rb:325:9:325:26 | call to puts | calls.rb:324:5:326:7 | instance |
-| calls.rb:325:9:325:26 | self | calls.rb:324:5:326:7 | instance |
-| calls.rb:325:14:325:26 | "C2#instance" | calls.rb:324:5:326:7 | instance |
-| calls.rb:325:15:325:25 | C2#instance | calls.rb:324:5:326:7 | instance |
-| calls.rb:331:9:331:26 | call to puts | calls.rb:330:5:332:7 | instance |
-| calls.rb:331:9:331:26 | self | calls.rb:330:5:332:7 | instance |
-| calls.rb:331:14:331:26 | "C3#instance" | calls.rb:330:5:332:7 | instance |
-| calls.rb:331:15:331:25 | C3#instance | calls.rb:330:5:332:7 | instance |
-| calls.rb:335:22:335:22 | x | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:335:22:335:22 | x | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:336:5:344:7 | case ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:336:10:336:10 | x | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:337:5:338:18 | when ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:337:10:337:11 | C3 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:337:12:338:18 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:338:9:338:9 | x | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:338:9:338:18 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:339:5:340:18 | when ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:339:10:339:11 | C2 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:339:12:340:18 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:340:9:340:9 | x | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:340:9:340:18 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:341:5:342:18 | when ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:341:10:341:11 | C1 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:341:12:342:18 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:342:9:342:9 | x | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:342:9:342:18 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:343:5:343:8 | else ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:346:5:350:7 | case ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:346:10:346:10 | x | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:347:9:347:29 | in ... then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:347:12:347:13 | C3 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:347:15:347:29 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:347:20:347:20 | x | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:347:20:347:29 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:348:9:348:36 | in ... then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:348:12:348:13 | C2 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:348:12:348:19 | ... => ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:348:18:348:19 | c2 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:348:21:348:36 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:348:26:348:27 | c2 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:348:26:348:36 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:349:9:349:36 | in ... then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:349:12:349:13 | C1 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:349:12:349:19 | ... => ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:349:18:349:19 | c1 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:349:21:349:36 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:349:26:349:27 | c1 | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:349:26:349:36 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
-| calls.rb:359:19:359:19 | x | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:359:19:359:19 | x | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:360:5:362:7 | instance | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:360:9:360:9 | x | calls.rb:359:1:363:3 | add_singleton |
-| calls.rb:361:9:361:28 | call to puts | calls.rb:360:5:362:7 | instance |
-| calls.rb:361:9:361:28 | self | calls.rb:360:5:362:7 | instance |
-| calls.rb:361:14:361:28 | "instance_on x" | calls.rb:360:5:362:7 | instance |
-| calls.rb:361:15:361:27 | instance_on x | calls.rb:360:5:362:7 | instance |
+| calls.rb:23:9:23:19 | call to singleton_m | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:23:9:23:19 | self | calls.rb:22:5:24:7 | instance_m |
+| calls.rb:26:9:26:18 | call to instance_m | calls.rb:25:5:27:7 | singleton_m |
+| calls.rb:26:9:26:18 | self | calls.rb:25:5:27:7 | singleton_m |
+| calls.rb:40:5:40:14 | call to instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:40:5:40:14 | self | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:52:9:52:18 | call to instance_m | calls.rb:51:5:57:7 | baz |
+| calls.rb:52:9:52:18 | self | calls.rb:51:5:57:7 | baz |
+| calls.rb:53:9:53:12 | self | calls.rb:51:5:57:7 | baz |
+| calls.rb:53:9:53:23 | call to instance_m | calls.rb:51:5:57:7 | baz |
+| calls.rb:55:9:55:19 | call to singleton_m | calls.rb:51:5:57:7 | baz |
+| calls.rb:55:9:55:19 | self | calls.rb:51:5:57:7 | baz |
+| calls.rb:56:9:56:12 | self | calls.rb:51:5:57:7 | baz |
+| calls.rb:56:9:56:24 | call to singleton_m | calls.rb:51:5:57:7 | baz |
+| calls.rb:67:9:67:13 | call to super | calls.rb:66:5:68:7 | baz |
+| calls.rb:76:18:76:18 | a | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:76:18:76:18 | a | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:76:22:76:22 | 4 | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:76:25:76:25 | b | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:76:25:76:25 | b | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:76:28:76:28 | 5 | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:77:5:77:5 | a | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:77:5:77:16 | call to bit_length | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:78:5:78:5 | b | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:78:5:78:16 | call to bit_length | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:81:1:83:3 | call_block |
+| calls.rb:82:11:82:11 | 1 | calls.rb:81:1:83:3 | call_block |
+| calls.rb:86:5:86:7 | var | calls.rb:85:1:89:3 | foo |
+| calls.rb:86:5:86:18 | ... = ... | calls.rb:85:1:89:3 | foo |
+| calls.rb:86:11:86:14 | Hash | calls.rb:85:1:89:3 | foo |
+| calls.rb:86:11:86:18 | call to new | calls.rb:85:1:89:3 | foo |
+| calls.rb:87:5:87:7 | var | calls.rb:85:1:89:3 | foo |
+| calls.rb:87:5:87:10 | ...[...] | calls.rb:85:1:89:3 | foo |
+| calls.rb:87:9:87:9 | 1 | calls.rb:85:1:89:3 | foo |
+| calls.rb:88:5:88:29 | call to call_block | calls.rb:85:1:89:3 | foo |
+| calls.rb:88:5:88:29 | self | calls.rb:85:1:89:3 | foo |
+| calls.rb:88:16:88:29 | { ... } | calls.rb:85:1:89:3 | foo |
+| calls.rb:88:19:88:19 | x | calls.rb:85:1:89:3 | foo |
+| calls.rb:88:19:88:19 | x | calls.rb:85:1:89:3 | foo |
+| calls.rb:88:22:88:24 | var | calls.rb:85:1:89:3 | foo |
+| calls.rb:88:22:88:27 | ...[...] | calls.rb:85:1:89:3 | foo |
+| calls.rb:88:26:88:26 | x | calls.rb:85:1:89:3 | foo |
+| calls.rb:102:14:102:14 | x | calls.rb:102:5:102:30 | puts |
+| calls.rb:102:14:102:14 | x | calls.rb:102:5:102:30 | puts |
+| calls.rb:102:17:102:26 | call to old_puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:102:17:102:26 | self | calls.rb:102:5:102:30 | puts |
+| calls.rb:102:26:102:26 | x | calls.rb:102:5:102:30 | puts |
+| calls.rb:119:12:119:12 | x | calls.rb:119:5:119:31 | [] |
+| calls.rb:119:12:119:12 | x | calls.rb:119:5:119:31 | [] |
+| calls.rb:119:15:119:27 | call to old_lookup | calls.rb:119:5:119:31 | [] |
+| calls.rb:119:15:119:27 | self | calls.rb:119:5:119:31 | [] |
+| calls.rb:119:26:119:26 | x | calls.rb:119:5:119:31 | [] |
+| calls.rb:124:10:124:10 | x | calls.rb:124:3:124:29 | [] |
+| calls.rb:124:10:124:10 | x | calls.rb:124:3:124:29 | [] |
+| calls.rb:124:13:124:25 | call to old_lookup | calls.rb:124:3:124:29 | [] |
+| calls.rb:124:13:124:25 | self | calls.rb:124:3:124:29 | [] |
+| calls.rb:124:24:124:24 | x | calls.rb:124:3:124:29 | [] |
+| calls.rb:128:15:128:19 | &body | calls.rb:128:3:134:5 | foreach |
+| calls.rb:128:16:128:19 | body | calls.rb:128:3:134:5 | foreach |
+| calls.rb:129:5:129:5 | x | calls.rb:128:3:134:5 | foreach |
+| calls.rb:129:5:129:9 | ... = ... | calls.rb:128:3:134:5 | foreach |
+| calls.rb:129:9:129:9 | 0 | calls.rb:128:3:134:5 | foreach |
+| calls.rb:130:5:133:7 | while ... | calls.rb:128:3:134:5 | foreach |
+| calls.rb:130:11:130:11 | x | calls.rb:128:3:134:5 | foreach |
+| calls.rb:130:11:130:25 | ... < ... | calls.rb:128:3:134:5 | foreach |
+| calls.rb:130:15:130:18 | self | calls.rb:128:3:134:5 | foreach |
+| calls.rb:130:15:130:25 | call to length | calls.rb:128:3:134:5 | foreach |
+| calls.rb:130:26:133:7 | do ... | calls.rb:128:3:134:5 | foreach |
+| calls.rb:131:9:131:24 | yield ... | calls.rb:128:3:134:5 | foreach |
+| calls.rb:131:15:131:15 | x | calls.rb:128:3:134:5 | foreach |
+| calls.rb:131:18:131:21 | self | calls.rb:128:3:134:5 | foreach |
+| calls.rb:131:18:131:24 | ...[...] | calls.rb:128:3:134:5 | foreach |
+| calls.rb:131:23:131:23 | x | calls.rb:128:3:134:5 | foreach |
+| calls.rb:132:9:132:9 | x | calls.rb:128:3:134:5 | foreach |
+| calls.rb:132:9:132:9 | x | calls.rb:128:3:134:5 | foreach |
+| calls.rb:132:9:132:14 | ... += ... | calls.rb:128:3:134:5 | foreach |
+| calls.rb:132:9:132:14 | ... = ... | calls.rb:128:3:134:5 | foreach |
+| calls.rb:132:11:132:12 | ... + ... | calls.rb:128:3:134:5 | foreach |
+| calls.rb:132:14:132:14 | 1 | calls.rb:128:3:134:5 | foreach |
+| calls.rb:138:5:138:20 | yield ... | calls.rb:137:1:139:3 | funny |
+| calls.rb:138:11:138:20 | "prefix: " | calls.rb:137:1:139:3 | funny |
+| calls.rb:138:12:138:19 | prefix:  | calls.rb:137:1:139:3 | funny |
+| calls.rb:155:14:155:15 | &b | calls.rb:155:1:157:3 | indirect |
+| calls.rb:155:15:155:15 | b | calls.rb:155:1:157:3 | indirect |
+| calls.rb:156:5:156:17 | call to call_block | calls.rb:155:1:157:3 | indirect |
+| calls.rb:156:5:156:17 | self | calls.rb:155:1:157:3 | indirect |
+| calls.rb:156:16:156:17 | &... | calls.rb:155:1:157:3 | indirect |
+| calls.rb:156:17:156:17 | b | calls.rb:155:1:157:3 | indirect |
+| calls.rb:164:9:164:12 | self | calls.rb:163:5:165:7 | s_method |
+| calls.rb:164:9:164:17 | call to to_s | calls.rb:163:5:165:7 | s_method |
+| calls.rb:189:9:189:26 | call to puts | calls.rb:188:5:191:7 | singleton_a |
+| calls.rb:189:9:189:26 | self | calls.rb:188:5:191:7 | singleton_a |
+| calls.rb:189:14:189:26 | "singleton_a" | calls.rb:188:5:191:7 | singleton_a |
+| calls.rb:189:15:189:25 | singleton_a | calls.rb:188:5:191:7 | singleton_a |
+| calls.rb:190:9:190:12 | self | calls.rb:188:5:191:7 | singleton_a |
+| calls.rb:190:9:190:24 | call to singleton_b | calls.rb:188:5:191:7 | singleton_a |
+| calls.rb:194:9:194:26 | call to puts | calls.rb:193:5:196:7 | singleton_b |
+| calls.rb:194:9:194:26 | self | calls.rb:193:5:196:7 | singleton_b |
+| calls.rb:194:14:194:26 | "singleton_b" | calls.rb:193:5:196:7 | singleton_b |
+| calls.rb:194:15:194:25 | singleton_b | calls.rb:193:5:196:7 | singleton_b |
+| calls.rb:195:9:195:12 | self | calls.rb:193:5:196:7 | singleton_b |
+| calls.rb:195:9:195:24 | call to singleton_c | calls.rb:193:5:196:7 | singleton_b |
+| calls.rb:199:9:199:26 | call to puts | calls.rb:198:5:200:7 | singleton_c |
+| calls.rb:199:9:199:26 | self | calls.rb:198:5:200:7 | singleton_c |
+| calls.rb:199:14:199:26 | "singleton_c" | calls.rb:198:5:200:7 | singleton_c |
+| calls.rb:199:15:199:25 | singleton_c | calls.rb:198:5:200:7 | singleton_c |
+| calls.rb:203:9:203:26 | call to puts | calls.rb:202:5:205:7 | singleton_d |
+| calls.rb:203:9:203:26 | self | calls.rb:202:5:205:7 | singleton_d |
+| calls.rb:203:14:203:26 | "singleton_d" | calls.rb:202:5:205:7 | singleton_d |
+| calls.rb:203:15:203:25 | singleton_d | calls.rb:202:5:205:7 | singleton_d |
+| calls.rb:204:9:204:12 | self | calls.rb:202:5:205:7 | singleton_d |
+| calls.rb:204:9:204:24 | call to singleton_a | calls.rb:202:5:205:7 | singleton_d |
+| calls.rb:208:9:210:11 | singleton_e | calls.rb:207:5:212:7 | instance |
+| calls.rb:208:13:208:16 | self | calls.rb:207:5:212:7 | instance |
+| calls.rb:209:13:209:30 | call to puts | calls.rb:208:9:210:11 | singleton_e |
+| calls.rb:209:13:209:30 | self | calls.rb:208:9:210:11 | singleton_e |
+| calls.rb:209:18:209:30 | "singleton_e" | calls.rb:208:9:210:11 | singleton_e |
+| calls.rb:209:19:209:29 | singleton_e | calls.rb:208:9:210:11 | singleton_e |
+| calls.rb:211:9:211:19 | call to singleton_e | calls.rb:207:5:212:7 | instance |
+| calls.rb:211:9:211:19 | self | calls.rb:207:5:212:7 | instance |
+| calls.rb:216:13:216:30 | call to puts | calls.rb:215:9:217:11 | singleton_f |
+| calls.rb:216:13:216:30 | self | calls.rb:215:9:217:11 | singleton_f |
+| calls.rb:216:18:216:30 | "singleton_f" | calls.rb:215:9:217:11 | singleton_f |
+| calls.rb:216:19:216:29 | singleton_f | calls.rb:215:9:217:11 | singleton_f |
+| calls.rb:221:9:221:12 | self | calls.rb:220:5:222:7 | call_singleton_g |
+| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
+| calls.rb:234:5:234:24 | call to puts | calls.rb:233:1:235:3 | singleton_g |
+| calls.rb:234:5:234:24 | self | calls.rb:233:1:235:3 | singleton_g |
+| calls.rb:234:10:234:24 | "singleton_g_1" | calls.rb:233:1:235:3 | singleton_g |
+| calls.rb:234:11:234:23 | singleton_g_1 | calls.rb:233:1:235:3 | singleton_g |
+| calls.rb:241:5:241:24 | call to puts | calls.rb:240:1:242:3 | singleton_g |
+| calls.rb:241:5:241:24 | self | calls.rb:240:1:242:3 | singleton_g |
+| calls.rb:241:10:241:24 | "singleton_g_2" | calls.rb:240:1:242:3 | singleton_g |
+| calls.rb:241:11:241:23 | singleton_g_2 | calls.rb:240:1:242:3 | singleton_g |
+| calls.rb:249:9:249:28 | call to puts | calls.rb:248:5:250:7 | singleton_g |
+| calls.rb:249:9:249:28 | self | calls.rb:248:5:250:7 | singleton_g |
+| calls.rb:249:14:249:28 | "singleton_g_3" | calls.rb:248:5:250:7 | singleton_g |
+| calls.rb:249:15:249:27 | singleton_g_3 | calls.rb:248:5:250:7 | singleton_g |
+| calls.rb:265:5:265:22 | call to puts | calls.rb:264:1:266:3 | singleton_g |
+| calls.rb:265:5:265:22 | self | calls.rb:264:1:266:3 | singleton_g |
+| calls.rb:265:10:265:22 | "singleton_g" | calls.rb:264:1:266:3 | singleton_g |
+| calls.rb:265:11:265:21 | singleton_g | calls.rb:264:1:266:3 | singleton_g |
+| calls.rb:275:12:275:15 | type | calls.rb:275:1:283:3 | create |
+| calls.rb:275:12:275:15 | type | calls.rb:275:1:283:3 | create |
+| calls.rb:276:5:276:8 | type | calls.rb:275:1:283:3 | create |
+| calls.rb:276:5:276:12 | call to new | calls.rb:275:1:283:3 | create |
+| calls.rb:276:5:276:21 | call to instance | calls.rb:275:1:283:3 | create |
+| calls.rb:278:5:280:7 | singleton_h | calls.rb:275:1:283:3 | create |
+| calls.rb:278:9:278:12 | type | calls.rb:275:1:283:3 | create |
+| calls.rb:279:9:279:26 | call to puts | calls.rb:278:5:280:7 | singleton_h |
+| calls.rb:279:9:279:26 | self | calls.rb:278:5:280:7 | singleton_h |
+| calls.rb:279:14:279:26 | "singleton_h" | calls.rb:278:5:280:7 | singleton_h |
+| calls.rb:279:15:279:25 | singleton_h | calls.rb:278:5:280:7 | singleton_h |
+| calls.rb:282:5:282:8 | type | calls.rb:275:1:283:3 | create |
+| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:275:1:283:3 | create |
+| calls.rb:292:9:292:26 | call to puts | calls.rb:291:5:293:7 | singleton_i |
+| calls.rb:292:9:292:26 | self | calls.rb:291:5:293:7 | singleton_i |
+| calls.rb:292:14:292:26 | "singleton_i" | calls.rb:291:5:293:7 | singleton_i |
+| calls.rb:292:15:292:25 | singleton_i | calls.rb:291:5:293:7 | singleton_i |
+| calls.rb:301:9:301:26 | call to puts | calls.rb:300:5:302:7 | singleton_j |
+| calls.rb:301:9:301:26 | self | calls.rb:300:5:302:7 | singleton_j |
+| calls.rb:301:14:301:26 | "singleton_j" | calls.rb:300:5:302:7 | singleton_j |
+| calls.rb:301:15:301:25 | singleton_j | calls.rb:300:5:302:7 | singleton_j |
+| calls.rb:309:9:309:31 | call to puts | calls.rb:308:5:311:7 | instance |
+| calls.rb:309:9:309:31 | self | calls.rb:308:5:311:7 | instance |
+| calls.rb:309:14:309:31 | "SelfNew#instance" | calls.rb:308:5:311:7 | instance |
+| calls.rb:309:15:309:30 | SelfNew#instance | calls.rb:308:5:311:7 | instance |
+| calls.rb:310:9:310:11 | call to new | calls.rb:308:5:311:7 | instance |
+| calls.rb:310:9:310:11 | self | calls.rb:308:5:311:7 | instance |
+| calls.rb:310:9:310:20 | call to instance | calls.rb:308:5:311:7 | instance |
+| calls.rb:314:9:314:11 | call to new | calls.rb:313:5:315:7 | singleton |
+| calls.rb:314:9:314:11 | self | calls.rb:313:5:315:7 | singleton |
+| calls.rb:314:9:314:20 | call to instance | calls.rb:313:5:315:7 | singleton |
+| calls.rb:324:9:324:26 | call to puts | calls.rb:323:5:325:7 | instance |
+| calls.rb:324:9:324:26 | self | calls.rb:323:5:325:7 | instance |
+| calls.rb:324:14:324:26 | "C1#instance" | calls.rb:323:5:325:7 | instance |
+| calls.rb:324:15:324:25 | C1#instance | calls.rb:323:5:325:7 | instance |
+| calls.rb:330:9:330:26 | call to puts | calls.rb:329:5:331:7 | instance |
+| calls.rb:330:9:330:26 | self | calls.rb:329:5:331:7 | instance |
+| calls.rb:330:14:330:26 | "C2#instance" | calls.rb:329:5:331:7 | instance |
+| calls.rb:330:15:330:25 | C2#instance | calls.rb:329:5:331:7 | instance |
+| calls.rb:336:9:336:26 | call to puts | calls.rb:335:5:337:7 | instance |
+| calls.rb:336:9:336:26 | self | calls.rb:335:5:337:7 | instance |
+| calls.rb:336:14:336:26 | "C3#instance" | calls.rb:335:5:337:7 | instance |
+| calls.rb:336:15:336:25 | C3#instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:340:22:340:22 | x | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:340:22:340:22 | x | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:341:5:349:7 | case ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:341:10:341:10 | x | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:342:5:343:18 | when ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:342:10:342:11 | C3 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:342:12:343:18 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:343:9:343:9 | x | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:343:9:343:18 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:344:5:345:18 | when ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:344:10:344:11 | C2 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:344:12:345:18 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:345:9:345:9 | x | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:345:9:345:18 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:346:5:347:18 | when ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:346:10:346:11 | C1 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:346:12:347:18 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:347:9:347:9 | x | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:347:9:347:18 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:348:5:348:8 | else ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:351:5:355:7 | case ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:351:10:351:10 | x | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:352:9:352:29 | in ... then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:352:12:352:13 | C3 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:352:15:352:29 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:352:20:352:20 | x | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:352:20:352:29 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:353:9:353:36 | in ... then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:353:12:353:13 | C2 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:353:12:353:19 | ... => ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:353:18:353:19 | c2 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:353:21:353:36 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:353:26:353:27 | c2 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:353:26:353:36 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:354:9:354:36 | in ... then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:354:12:354:13 | C1 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:354:12:354:19 | ... => ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:354:18:354:19 | c1 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:354:21:354:36 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:354:26:354:27 | c1 | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:354:26:354:36 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:364:19:364:19 | x | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:364:19:364:19 | x | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:365:5:367:7 | instance | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:365:9:365:9 | x | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:366:9:366:28 | call to puts | calls.rb:365:5:367:7 | instance |
+| calls.rb:366:9:366:28 | self | calls.rb:365:5:367:7 | instance |
+| calls.rb:366:14:366:28 | "instance_on x" | calls.rb:365:5:367:7 | instance |
+| calls.rb:366:15:366:27 | instance_on x | calls.rb:365:5:367:7 | instance |
+| calls.rb:377:13:377:48 | call to puts | calls.rb:376:9:378:11 | singleton1 |
+| calls.rb:377:13:377:48 | self | calls.rb:376:9:378:11 | singleton1 |
+| calls.rb:377:18:377:48 | "SingletonOverride1#singleton1" | calls.rb:376:9:378:11 | singleton1 |
+| calls.rb:377:19:377:47 | SingletonOverride1#singleton1 | calls.rb:376:9:378:11 | singleton1 |
+| calls.rb:381:13:381:22 | call to singleton1 | calls.rb:380:9:382:11 | call_singleton1 |
+| calls.rb:381:13:381:22 | self | calls.rb:380:9:382:11 | call_singleton1 |
+| calls.rb:386:9:386:44 | call to puts | calls.rb:385:5:387:7 | singleton2 |
+| calls.rb:386:9:386:44 | self | calls.rb:385:5:387:7 | singleton2 |
+| calls.rb:386:14:386:44 | "SingletonOverride1#singleton2" | calls.rb:385:5:387:7 | singleton2 |
+| calls.rb:386:15:386:43 | SingletonOverride1#singleton2 | calls.rb:385:5:387:7 | singleton2 |
+| calls.rb:390:9:390:18 | call to singleton2 | calls.rb:389:5:391:7 | call_singleton2 |
+| calls.rb:390:9:390:18 | self | calls.rb:389:5:391:7 | call_singleton2 |
+| calls.rb:402:13:402:48 | call to puts | calls.rb:401:9:403:11 | singleton1 |
+| calls.rb:402:13:402:48 | self | calls.rb:401:9:403:11 | singleton1 |
+| calls.rb:402:18:402:48 | "SingletonOverride2#singleton1" | calls.rb:401:9:403:11 | singleton1 |
+| calls.rb:402:19:402:47 | SingletonOverride2#singleton1 | calls.rb:401:9:403:11 | singleton1 |
+| calls.rb:407:9:407:44 | call to puts | calls.rb:406:5:408:7 | singleton2 |
+| calls.rb:407:9:407:44 | self | calls.rb:406:5:408:7 | singleton2 |
+| calls.rb:407:14:407:44 | "SingletonOverride2#singleton2" | calls.rb:406:5:408:7 | singleton2 |
+| calls.rb:407:15:407:43 | SingletonOverride2#singleton2 | calls.rb:406:5:408:7 | singleton2 |
 | hello.rb:3:9:3:22 | return | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:16:3:22 | "hello" | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:17:3:21 | hello | hello.rb:2:5:4:7 | hello |

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -1,40 +1,41 @@
 getMethod
 | calls.rb:21:1:30:3 | M | instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:35:1:50:3 | C | baz | calls.rb:43:5:49:7 | baz |
-| calls.rb:57:1:61:3 | D | baz | calls.rb:58:5:60:7 | baz |
-| calls.rb:83:1:86:3 | Integer | abs | calls.rb:85:5:85:16 | abs |
-| calls.rb:83:1:86:3 | Integer | bit_length | calls.rb:84:5:84:23 | bit_length |
-| calls.rb:88:1:90:3 | String | capitalize | calls.rb:89:5:89:23 | capitalize |
-| calls.rb:92:1:95:3 | Kernel | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:97:1:102:3 | Module | include | calls.rb:99:5:99:20 | include |
-| calls.rb:97:1:102:3 | Module | module_eval | calls.rb:98:5:98:24 | module_eval |
-| calls.rb:97:1:102:3 | Module | prepend | calls.rb:100:5:100:20 | prepend |
-| calls.rb:97:1:102:3 | Module | private | calls.rb:101:5:101:20 | private |
-| calls.rb:104:1:107:3 | Object | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:104:1:107:3 | Object | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:104:1:107:3 | Object | create | calls.rb:267:1:275:3 | create |
-| calls.rb:104:1:107:3 | Object | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:104:1:107:3 | Object | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:104:1:107:3 | Object | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:104:1:107:3 | Object | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:104:1:107:3 | Object | new | calls.rb:106:5:106:16 | new |
-| calls.rb:104:1:107:3 | Object | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:104:1:107:3 | Object | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:104:1:107:3 | Object | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:104:1:107:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
-| calls.rb:109:1:112:3 | Hash | [] | calls.rb:111:5:111:31 | [] |
-| calls.rb:114:1:127:3 | Array | [] | calls.rb:116:3:116:29 | [] |
-| calls.rb:114:1:127:3 | Array | foreach | calls.rb:120:3:126:5 | foreach |
-| calls.rb:114:1:127:3 | Array | length | calls.rb:118:3:118:17 | length |
-| calls.rb:154:1:158:3 | S | s_method | calls.rb:155:5:157:7 | s_method |
-| calls.rb:160:1:163:3 | A | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:165:1:168:3 | B | to_s | calls.rb:166:5:167:7 | to_s |
-| calls.rb:179:1:215:3 | Singletons | call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
-| calls.rb:179:1:215:3 | Singletons | instance | calls.rb:199:5:204:7 | instance |
-| calls.rb:299:1:309:3 | SelfNew | instance | calls.rb:300:5:302:7 | instance |
-| calls.rb:313:1:317:3 | C1 | instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:319:1:323:3 | C2 | instance | calls.rb:320:5:322:7 | instance |
-| calls.rb:325:1:329:3 | C3 | instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:39:1:54:3 | C | baz | calls.rb:47:5:53:7 | baz |
+| calls.rb:61:1:65:3 | D | baz | calls.rb:62:5:64:7 | baz |
+| calls.rb:87:1:90:3 | Integer | abs | calls.rb:89:5:89:16 | abs |
+| calls.rb:87:1:90:3 | Integer | bit_length | calls.rb:88:5:88:23 | bit_length |
+| calls.rb:92:1:94:3 | String | capitalize | calls.rb:93:5:93:23 | capitalize |
+| calls.rb:96:1:99:3 | Kernel | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:101:1:106:3 | Module | include | calls.rb:103:5:103:20 | include |
+| calls.rb:101:1:106:3 | Module | module_eval | calls.rb:102:5:102:24 | module_eval |
+| calls.rb:101:1:106:3 | Module | prepend | calls.rb:104:5:104:20 | prepend |
+| calls.rb:101:1:106:3 | Module | private | calls.rb:105:5:105:20 | private |
+| calls.rb:108:1:111:3 | Object | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:108:1:111:3 | Object | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:108:1:111:3 | Object | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:108:1:111:3 | Object | create | calls.rb:271:1:279:3 | create |
+| calls.rb:108:1:111:3 | Object | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:108:1:111:3 | Object | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:108:1:111:3 | Object | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:108:1:111:3 | Object | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:108:1:111:3 | Object | new | calls.rb:110:5:110:16 | new |
+| calls.rb:108:1:111:3 | Object | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:108:1:111:3 | Object | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:108:1:111:3 | Object | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:108:1:111:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
+| calls.rb:113:1:116:3 | Hash | [] | calls.rb:115:5:115:31 | [] |
+| calls.rb:118:1:131:3 | Array | [] | calls.rb:120:3:120:29 | [] |
+| calls.rb:118:1:131:3 | Array | foreach | calls.rb:124:3:130:5 | foreach |
+| calls.rb:118:1:131:3 | Array | length | calls.rb:122:3:122:17 | length |
+| calls.rb:158:1:162:3 | S | s_method | calls.rb:159:5:161:7 | s_method |
+| calls.rb:164:1:167:3 | A | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:169:1:172:3 | B | to_s | calls.rb:170:5:171:7 | to_s |
+| calls.rb:183:1:219:3 | Singletons | call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
+| calls.rb:183:1:219:3 | Singletons | instance | calls.rb:203:5:208:7 | instance |
+| calls.rb:303:1:313:3 | SelfNew | instance | calls.rb:304:5:306:7 | instance |
+| calls.rb:317:1:321:3 | C1 | instance | calls.rb:318:5:320:7 | instance |
+| calls.rb:323:1:327:3 | C2 | instance | calls.rb:324:5:326:7 | instance |
+| calls.rb:329:1:333:3 | C3 | instance | calls.rb:330:5:332:7 | instance |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
@@ -55,319 +56,334 @@ getMethod
 | private.rb:42:1:60:3 | F | public | private.rb:46:3:47:5 | public |
 lookupMethod
 | calls.rb:21:1:30:3 | M | instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:35:1:50:3 | C | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:35:1:50:3 | C | baz | calls.rb:43:5:49:7 | baz |
-| calls.rb:35:1:50:3 | C | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:35:1:50:3 | C | create | calls.rb:267:1:275:3 | create |
-| calls.rb:35:1:50:3 | C | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:35:1:50:3 | C | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:35:1:50:3 | C | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:35:1:50:3 | C | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:35:1:50:3 | C | instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:35:1:50:3 | C | new | calls.rb:106:5:106:16 | new |
-| calls.rb:35:1:50:3 | C | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:35:1:50:3 | C | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:35:1:50:3 | C | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:35:1:50:3 | C | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:35:1:50:3 | C | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:57:1:61:3 | D | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:57:1:61:3 | D | baz | calls.rb:58:5:60:7 | baz |
-| calls.rb:57:1:61:3 | D | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:57:1:61:3 | D | create | calls.rb:267:1:275:3 | create |
-| calls.rb:57:1:61:3 | D | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:57:1:61:3 | D | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:57:1:61:3 | D | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:57:1:61:3 | D | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:57:1:61:3 | D | instance_m | calls.rb:22:5:22:23 | instance_m |
-| calls.rb:57:1:61:3 | D | new | calls.rb:106:5:106:16 | new |
-| calls.rb:57:1:61:3 | D | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:57:1:61:3 | D | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:57:1:61:3 | D | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:57:1:61:3 | D | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:57:1:61:3 | D | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:83:1:86:3 | Integer | abs | calls.rb:85:5:85:16 | abs |
-| calls.rb:83:1:86:3 | Integer | bit_length | calls.rb:84:5:84:23 | bit_length |
-| calls.rb:83:1:86:3 | Integer | new | calls.rb:106:5:106:16 | new |
-| calls.rb:83:1:86:3 | Integer | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:83:1:86:3 | Integer | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:88:1:90:3 | String | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:88:1:90:3 | String | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:88:1:90:3 | String | capitalize | calls.rb:89:5:89:23 | capitalize |
-| calls.rb:88:1:90:3 | String | create | calls.rb:267:1:275:3 | create |
-| calls.rb:88:1:90:3 | String | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:88:1:90:3 | String | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:88:1:90:3 | String | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:88:1:90:3 | String | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:88:1:90:3 | String | new | calls.rb:106:5:106:16 | new |
-| calls.rb:88:1:90:3 | String | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:88:1:90:3 | String | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:88:1:90:3 | String | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:88:1:90:3 | String | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:88:1:90:3 | String | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:92:1:95:3 | Kernel | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:97:1:102:3 | Module | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:97:1:102:3 | Module | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:97:1:102:3 | Module | create | calls.rb:267:1:275:3 | create |
-| calls.rb:97:1:102:3 | Module | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:97:1:102:3 | Module | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:97:1:102:3 | Module | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:97:1:102:3 | Module | include | calls.rb:99:5:99:20 | include |
-| calls.rb:97:1:102:3 | Module | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:97:1:102:3 | Module | module_eval | calls.rb:98:5:98:24 | module_eval |
-| calls.rb:97:1:102:3 | Module | new | calls.rb:106:5:106:16 | new |
-| calls.rb:97:1:102:3 | Module | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:97:1:102:3 | Module | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:97:1:102:3 | Module | prepend | calls.rb:100:5:100:20 | prepend |
-| calls.rb:97:1:102:3 | Module | private | calls.rb:101:5:101:20 | private |
-| calls.rb:97:1:102:3 | Module | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:97:1:102:3 | Module | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:97:1:102:3 | Module | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:104:1:107:3 | Object | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:104:1:107:3 | Object | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:104:1:107:3 | Object | create | calls.rb:267:1:275:3 | create |
-| calls.rb:104:1:107:3 | Object | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:104:1:107:3 | Object | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:104:1:107:3 | Object | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:104:1:107:3 | Object | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:104:1:107:3 | Object | new | calls.rb:106:5:106:16 | new |
-| calls.rb:104:1:107:3 | Object | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:104:1:107:3 | Object | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:104:1:107:3 | Object | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:104:1:107:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
-| calls.rb:104:1:107:3 | Object | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:104:1:107:3 | Object | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:109:1:112:3 | Hash | [] | calls.rb:111:5:111:31 | [] |
-| calls.rb:109:1:112:3 | Hash | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:109:1:112:3 | Hash | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:109:1:112:3 | Hash | create | calls.rb:267:1:275:3 | create |
-| calls.rb:109:1:112:3 | Hash | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:109:1:112:3 | Hash | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:109:1:112:3 | Hash | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:109:1:112:3 | Hash | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:109:1:112:3 | Hash | new | calls.rb:106:5:106:16 | new |
-| calls.rb:109:1:112:3 | Hash | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:109:1:112:3 | Hash | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:109:1:112:3 | Hash | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:109:1:112:3 | Hash | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:109:1:112:3 | Hash | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:114:1:127:3 | Array | [] | calls.rb:116:3:116:29 | [] |
-| calls.rb:114:1:127:3 | Array | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:114:1:127:3 | Array | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:114:1:127:3 | Array | create | calls.rb:267:1:275:3 | create |
-| calls.rb:114:1:127:3 | Array | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:114:1:127:3 | Array | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:114:1:127:3 | Array | foreach | calls.rb:120:3:126:5 | foreach |
-| calls.rb:114:1:127:3 | Array | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:114:1:127:3 | Array | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:114:1:127:3 | Array | length | calls.rb:118:3:118:17 | length |
-| calls.rb:114:1:127:3 | Array | new | calls.rb:106:5:106:16 | new |
-| calls.rb:114:1:127:3 | Array | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:114:1:127:3 | Array | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:114:1:127:3 | Array | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:114:1:127:3 | Array | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:114:1:127:3 | Array | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:154:1:158:3 | S | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:154:1:158:3 | S | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:154:1:158:3 | S | create | calls.rb:267:1:275:3 | create |
-| calls.rb:154:1:158:3 | S | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:154:1:158:3 | S | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:154:1:158:3 | S | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:154:1:158:3 | S | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:154:1:158:3 | S | new | calls.rb:106:5:106:16 | new |
-| calls.rb:154:1:158:3 | S | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:154:1:158:3 | S | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:154:1:158:3 | S | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:154:1:158:3 | S | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:154:1:158:3 | S | s_method | calls.rb:155:5:157:7 | s_method |
-| calls.rb:154:1:158:3 | S | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:160:1:163:3 | A | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:160:1:163:3 | A | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:160:1:163:3 | A | create | calls.rb:267:1:275:3 | create |
-| calls.rb:160:1:163:3 | A | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:160:1:163:3 | A | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:160:1:163:3 | A | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:160:1:163:3 | A | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:160:1:163:3 | A | new | calls.rb:106:5:106:16 | new |
-| calls.rb:160:1:163:3 | A | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:160:1:163:3 | A | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:160:1:163:3 | A | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:160:1:163:3 | A | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:160:1:163:3 | A | s_method | calls.rb:155:5:157:7 | s_method |
-| calls.rb:160:1:163:3 | A | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:165:1:168:3 | B | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:165:1:168:3 | B | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:165:1:168:3 | B | create | calls.rb:267:1:275:3 | create |
-| calls.rb:165:1:168:3 | B | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:165:1:168:3 | B | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:165:1:168:3 | B | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:165:1:168:3 | B | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:165:1:168:3 | B | new | calls.rb:106:5:106:16 | new |
-| calls.rb:165:1:168:3 | B | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:165:1:168:3 | B | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:165:1:168:3 | B | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:165:1:168:3 | B | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:165:1:168:3 | B | s_method | calls.rb:155:5:157:7 | s_method |
-| calls.rb:165:1:168:3 | B | to_s | calls.rb:166:5:167:7 | to_s |
-| calls.rb:179:1:215:3 | Singletons | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:179:1:215:3 | Singletons | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:179:1:215:3 | Singletons | call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
-| calls.rb:179:1:215:3 | Singletons | create | calls.rb:267:1:275:3 | create |
-| calls.rb:179:1:215:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:179:1:215:3 | Singletons | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:179:1:215:3 | Singletons | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:179:1:215:3 | Singletons | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:179:1:215:3 | Singletons | instance | calls.rb:199:5:204:7 | instance |
-| calls.rb:179:1:215:3 | Singletons | new | calls.rb:106:5:106:16 | new |
-| calls.rb:179:1:215:3 | Singletons | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:179:1:215:3 | Singletons | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:179:1:215:3 | Singletons | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:179:1:215:3 | Singletons | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:179:1:215:3 | Singletons | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:299:1:309:3 | SelfNew | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:299:1:309:3 | SelfNew | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:299:1:309:3 | SelfNew | create | calls.rb:267:1:275:3 | create |
-| calls.rb:299:1:309:3 | SelfNew | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:299:1:309:3 | SelfNew | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:299:1:309:3 | SelfNew | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:299:1:309:3 | SelfNew | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:299:1:309:3 | SelfNew | instance | calls.rb:300:5:302:7 | instance |
-| calls.rb:299:1:309:3 | SelfNew | new | calls.rb:106:5:106:16 | new |
-| calls.rb:299:1:309:3 | SelfNew | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:299:1:309:3 | SelfNew | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:299:1:309:3 | SelfNew | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:299:1:309:3 | SelfNew | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:299:1:309:3 | SelfNew | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:313:1:317:3 | C1 | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:313:1:317:3 | C1 | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:313:1:317:3 | C1 | create | calls.rb:267:1:275:3 | create |
-| calls.rb:313:1:317:3 | C1 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:313:1:317:3 | C1 | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:313:1:317:3 | C1 | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:313:1:317:3 | C1 | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:313:1:317:3 | C1 | instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:313:1:317:3 | C1 | new | calls.rb:106:5:106:16 | new |
-| calls.rb:313:1:317:3 | C1 | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:313:1:317:3 | C1 | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:313:1:317:3 | C1 | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:313:1:317:3 | C1 | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:313:1:317:3 | C1 | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:319:1:323:3 | C2 | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:319:1:323:3 | C2 | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:319:1:323:3 | C2 | create | calls.rb:267:1:275:3 | create |
-| calls.rb:319:1:323:3 | C2 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:319:1:323:3 | C2 | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:319:1:323:3 | C2 | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:319:1:323:3 | C2 | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:319:1:323:3 | C2 | instance | calls.rb:320:5:322:7 | instance |
-| calls.rb:319:1:323:3 | C2 | new | calls.rb:106:5:106:16 | new |
-| calls.rb:319:1:323:3 | C2 | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:319:1:323:3 | C2 | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:319:1:323:3 | C2 | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:319:1:323:3 | C2 | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:319:1:323:3 | C2 | to_s | calls.rb:161:5:162:7 | to_s |
-| calls.rb:325:1:329:3 | C3 | add_singleton | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:325:1:329:3 | C3 | call_block | calls.rb:73:1:75:3 | call_block |
-| calls.rb:325:1:329:3 | C3 | create | calls.rb:267:1:275:3 | create |
-| calls.rb:325:1:329:3 | C3 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:325:1:329:3 | C3 | foo | calls.rb:77:1:81:3 | foo |
-| calls.rb:325:1:329:3 | C3 | funny | calls.rb:129:1:131:3 | funny |
-| calls.rb:325:1:329:3 | C3 | indirect | calls.rb:147:1:149:3 | indirect |
-| calls.rb:325:1:329:3 | C3 | instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:325:1:329:3 | C3 | new | calls.rb:106:5:106:16 | new |
-| calls.rb:325:1:329:3 | C3 | optional_arg | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:325:1:329:3 | C3 | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:325:1:329:3 | C3 | private_on_main | calls.rb:174:1:175:3 | private_on_main |
-| calls.rb:325:1:329:3 | C3 | puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:325:1:329:3 | C3 | to_s | calls.rb:161:5:162:7 | to_s |
-| file://:0:0:0:0 | Class | include | calls.rb:99:5:99:20 | include |
-| file://:0:0:0:0 | Class | module_eval | calls.rb:98:5:98:24 | module_eval |
-| file://:0:0:0:0 | Class | new | calls.rb:106:5:106:16 | new |
-| file://:0:0:0:0 | Class | prepend | calls.rb:100:5:100:20 | prepend |
-| file://:0:0:0:0 | Class | private | calls.rb:101:5:101:20 | private |
-| file://:0:0:0:0 | Class | puts | calls.rb:94:5:94:30 | puts |
-| file://:0:0:0:0 | Class | to_s | calls.rb:161:5:162:7 | to_s |
-| file://:0:0:0:0 | Complex | new | calls.rb:106:5:106:16 | new |
-| file://:0:0:0:0 | Complex | puts | calls.rb:94:5:94:30 | puts |
-| file://:0:0:0:0 | Complex | to_s | calls.rb:161:5:162:7 | to_s |
-| file://:0:0:0:0 | FalseClass | new | calls.rb:106:5:106:16 | new |
-| file://:0:0:0:0 | FalseClass | puts | calls.rb:94:5:94:30 | puts |
-| file://:0:0:0:0 | FalseClass | to_s | calls.rb:161:5:162:7 | to_s |
-| file://:0:0:0:0 | Float | new | calls.rb:106:5:106:16 | new |
-| file://:0:0:0:0 | Float | puts | calls.rb:94:5:94:30 | puts |
-| file://:0:0:0:0 | Float | to_s | calls.rb:161:5:162:7 | to_s |
-| file://:0:0:0:0 | NilClass | new | calls.rb:106:5:106:16 | new |
-| file://:0:0:0:0 | NilClass | puts | calls.rb:94:5:94:30 | puts |
-| file://:0:0:0:0 | NilClass | to_s | calls.rb:161:5:162:7 | to_s |
-| file://:0:0:0:0 | Numeric | new | calls.rb:106:5:106:16 | new |
-| file://:0:0:0:0 | Numeric | puts | calls.rb:94:5:94:30 | puts |
-| file://:0:0:0:0 | Numeric | to_s | calls.rb:161:5:162:7 | to_s |
-| file://:0:0:0:0 | Rational | new | calls.rb:106:5:106:16 | new |
-| file://:0:0:0:0 | Rational | puts | calls.rb:94:5:94:30 | puts |
-| file://:0:0:0:0 | Rational | to_s | calls.rb:161:5:162:7 | to_s |
-| file://:0:0:0:0 | TrueClass | new | calls.rb:106:5:106:16 | new |
-| file://:0:0:0:0 | TrueClass | puts | calls.rb:94:5:94:30 | puts |
-| file://:0:0:0:0 | TrueClass | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:39:1:54:3 | C | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:39:1:54:3 | C | baz | calls.rb:47:5:53:7 | baz |
+| calls.rb:39:1:54:3 | C | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:39:1:54:3 | C | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:39:1:54:3 | C | create | calls.rb:271:1:279:3 | create |
+| calls.rb:39:1:54:3 | C | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:39:1:54:3 | C | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:39:1:54:3 | C | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:39:1:54:3 | C | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:39:1:54:3 | C | instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:39:1:54:3 | C | new | calls.rb:110:5:110:16 | new |
+| calls.rb:39:1:54:3 | C | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:39:1:54:3 | C | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:39:1:54:3 | C | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:39:1:54:3 | C | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:39:1:54:3 | C | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:61:1:65:3 | D | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:61:1:65:3 | D | baz | calls.rb:62:5:64:7 | baz |
+| calls.rb:61:1:65:3 | D | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:61:1:65:3 | D | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:61:1:65:3 | D | create | calls.rb:271:1:279:3 | create |
+| calls.rb:61:1:65:3 | D | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:61:1:65:3 | D | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:61:1:65:3 | D | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:61:1:65:3 | D | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:61:1:65:3 | D | instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:61:1:65:3 | D | new | calls.rb:110:5:110:16 | new |
+| calls.rb:61:1:65:3 | D | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:61:1:65:3 | D | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:61:1:65:3 | D | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:61:1:65:3 | D | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:61:1:65:3 | D | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:87:1:90:3 | Integer | abs | calls.rb:89:5:89:16 | abs |
+| calls.rb:87:1:90:3 | Integer | bit_length | calls.rb:88:5:88:23 | bit_length |
+| calls.rb:87:1:90:3 | Integer | new | calls.rb:110:5:110:16 | new |
+| calls.rb:87:1:90:3 | Integer | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:87:1:90:3 | Integer | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:92:1:94:3 | String | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:92:1:94:3 | String | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:92:1:94:3 | String | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:92:1:94:3 | String | capitalize | calls.rb:93:5:93:23 | capitalize |
+| calls.rb:92:1:94:3 | String | create | calls.rb:271:1:279:3 | create |
+| calls.rb:92:1:94:3 | String | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:92:1:94:3 | String | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:92:1:94:3 | String | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:92:1:94:3 | String | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:92:1:94:3 | String | new | calls.rb:110:5:110:16 | new |
+| calls.rb:92:1:94:3 | String | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:92:1:94:3 | String | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:92:1:94:3 | String | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:92:1:94:3 | String | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:92:1:94:3 | String | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:96:1:99:3 | Kernel | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:101:1:106:3 | Module | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:101:1:106:3 | Module | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:101:1:106:3 | Module | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:101:1:106:3 | Module | create | calls.rb:271:1:279:3 | create |
+| calls.rb:101:1:106:3 | Module | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:101:1:106:3 | Module | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:101:1:106:3 | Module | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:101:1:106:3 | Module | include | calls.rb:103:5:103:20 | include |
+| calls.rb:101:1:106:3 | Module | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:101:1:106:3 | Module | module_eval | calls.rb:102:5:102:24 | module_eval |
+| calls.rb:101:1:106:3 | Module | new | calls.rb:110:5:110:16 | new |
+| calls.rb:101:1:106:3 | Module | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:101:1:106:3 | Module | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:101:1:106:3 | Module | prepend | calls.rb:104:5:104:20 | prepend |
+| calls.rb:101:1:106:3 | Module | private | calls.rb:105:5:105:20 | private |
+| calls.rb:101:1:106:3 | Module | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:101:1:106:3 | Module | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:101:1:106:3 | Module | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:108:1:111:3 | Object | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:108:1:111:3 | Object | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:108:1:111:3 | Object | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:108:1:111:3 | Object | create | calls.rb:271:1:279:3 | create |
+| calls.rb:108:1:111:3 | Object | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:108:1:111:3 | Object | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:108:1:111:3 | Object | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:108:1:111:3 | Object | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:108:1:111:3 | Object | new | calls.rb:110:5:110:16 | new |
+| calls.rb:108:1:111:3 | Object | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:108:1:111:3 | Object | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:108:1:111:3 | Object | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:108:1:111:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
+| calls.rb:108:1:111:3 | Object | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:108:1:111:3 | Object | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:113:1:116:3 | Hash | [] | calls.rb:115:5:115:31 | [] |
+| calls.rb:113:1:116:3 | Hash | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:113:1:116:3 | Hash | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:113:1:116:3 | Hash | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:113:1:116:3 | Hash | create | calls.rb:271:1:279:3 | create |
+| calls.rb:113:1:116:3 | Hash | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:113:1:116:3 | Hash | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:113:1:116:3 | Hash | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:113:1:116:3 | Hash | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:113:1:116:3 | Hash | new | calls.rb:110:5:110:16 | new |
+| calls.rb:113:1:116:3 | Hash | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:113:1:116:3 | Hash | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:113:1:116:3 | Hash | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:113:1:116:3 | Hash | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:113:1:116:3 | Hash | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:118:1:131:3 | Array | [] | calls.rb:120:3:120:29 | [] |
+| calls.rb:118:1:131:3 | Array | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:118:1:131:3 | Array | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:118:1:131:3 | Array | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:118:1:131:3 | Array | create | calls.rb:271:1:279:3 | create |
+| calls.rb:118:1:131:3 | Array | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:118:1:131:3 | Array | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:118:1:131:3 | Array | foreach | calls.rb:124:3:130:5 | foreach |
+| calls.rb:118:1:131:3 | Array | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:118:1:131:3 | Array | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:118:1:131:3 | Array | length | calls.rb:122:3:122:17 | length |
+| calls.rb:118:1:131:3 | Array | new | calls.rb:110:5:110:16 | new |
+| calls.rb:118:1:131:3 | Array | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:118:1:131:3 | Array | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:118:1:131:3 | Array | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:118:1:131:3 | Array | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:118:1:131:3 | Array | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:158:1:162:3 | S | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:158:1:162:3 | S | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:158:1:162:3 | S | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:158:1:162:3 | S | create | calls.rb:271:1:279:3 | create |
+| calls.rb:158:1:162:3 | S | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:158:1:162:3 | S | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:158:1:162:3 | S | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:158:1:162:3 | S | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:158:1:162:3 | S | new | calls.rb:110:5:110:16 | new |
+| calls.rb:158:1:162:3 | S | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:158:1:162:3 | S | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:158:1:162:3 | S | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:158:1:162:3 | S | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:158:1:162:3 | S | s_method | calls.rb:159:5:161:7 | s_method |
+| calls.rb:158:1:162:3 | S | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:164:1:167:3 | A | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:164:1:167:3 | A | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:164:1:167:3 | A | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:164:1:167:3 | A | create | calls.rb:271:1:279:3 | create |
+| calls.rb:164:1:167:3 | A | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:164:1:167:3 | A | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:164:1:167:3 | A | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:164:1:167:3 | A | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:164:1:167:3 | A | new | calls.rb:110:5:110:16 | new |
+| calls.rb:164:1:167:3 | A | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:164:1:167:3 | A | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:164:1:167:3 | A | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:164:1:167:3 | A | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:164:1:167:3 | A | s_method | calls.rb:159:5:161:7 | s_method |
+| calls.rb:164:1:167:3 | A | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:169:1:172:3 | B | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:169:1:172:3 | B | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:169:1:172:3 | B | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:169:1:172:3 | B | create | calls.rb:271:1:279:3 | create |
+| calls.rb:169:1:172:3 | B | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:169:1:172:3 | B | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:169:1:172:3 | B | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:169:1:172:3 | B | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:169:1:172:3 | B | new | calls.rb:110:5:110:16 | new |
+| calls.rb:169:1:172:3 | B | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:169:1:172:3 | B | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:169:1:172:3 | B | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:169:1:172:3 | B | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:169:1:172:3 | B | s_method | calls.rb:159:5:161:7 | s_method |
+| calls.rb:169:1:172:3 | B | to_s | calls.rb:170:5:171:7 | to_s |
+| calls.rb:183:1:219:3 | Singletons | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:183:1:219:3 | Singletons | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:183:1:219:3 | Singletons | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:183:1:219:3 | Singletons | call_singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
+| calls.rb:183:1:219:3 | Singletons | create | calls.rb:271:1:279:3 | create |
+| calls.rb:183:1:219:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:183:1:219:3 | Singletons | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:183:1:219:3 | Singletons | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:183:1:219:3 | Singletons | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:183:1:219:3 | Singletons | instance | calls.rb:203:5:208:7 | instance |
+| calls.rb:183:1:219:3 | Singletons | new | calls.rb:110:5:110:16 | new |
+| calls.rb:183:1:219:3 | Singletons | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:183:1:219:3 | Singletons | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:183:1:219:3 | Singletons | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:183:1:219:3 | Singletons | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:183:1:219:3 | Singletons | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:303:1:313:3 | SelfNew | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:303:1:313:3 | SelfNew | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:303:1:313:3 | SelfNew | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:303:1:313:3 | SelfNew | create | calls.rb:271:1:279:3 | create |
+| calls.rb:303:1:313:3 | SelfNew | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:303:1:313:3 | SelfNew | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:303:1:313:3 | SelfNew | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:303:1:313:3 | SelfNew | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:303:1:313:3 | SelfNew | instance | calls.rb:304:5:306:7 | instance |
+| calls.rb:303:1:313:3 | SelfNew | new | calls.rb:110:5:110:16 | new |
+| calls.rb:303:1:313:3 | SelfNew | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:303:1:313:3 | SelfNew | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:303:1:313:3 | SelfNew | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:303:1:313:3 | SelfNew | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:303:1:313:3 | SelfNew | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:317:1:321:3 | C1 | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:317:1:321:3 | C1 | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:317:1:321:3 | C1 | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:317:1:321:3 | C1 | create | calls.rb:271:1:279:3 | create |
+| calls.rb:317:1:321:3 | C1 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:317:1:321:3 | C1 | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:317:1:321:3 | C1 | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:317:1:321:3 | C1 | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:317:1:321:3 | C1 | instance | calls.rb:318:5:320:7 | instance |
+| calls.rb:317:1:321:3 | C1 | new | calls.rb:110:5:110:16 | new |
+| calls.rb:317:1:321:3 | C1 | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:317:1:321:3 | C1 | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:317:1:321:3 | C1 | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:317:1:321:3 | C1 | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:317:1:321:3 | C1 | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:323:1:327:3 | C2 | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:323:1:327:3 | C2 | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:323:1:327:3 | C2 | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:323:1:327:3 | C2 | create | calls.rb:271:1:279:3 | create |
+| calls.rb:323:1:327:3 | C2 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:323:1:327:3 | C2 | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:323:1:327:3 | C2 | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:323:1:327:3 | C2 | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:323:1:327:3 | C2 | instance | calls.rb:324:5:326:7 | instance |
+| calls.rb:323:1:327:3 | C2 | new | calls.rb:110:5:110:16 | new |
+| calls.rb:323:1:327:3 | C2 | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:323:1:327:3 | C2 | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:323:1:327:3 | C2 | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:323:1:327:3 | C2 | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:323:1:327:3 | C2 | to_s | calls.rb:165:5:166:7 | to_s |
+| calls.rb:329:1:333:3 | C3 | add_singleton | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:329:1:333:3 | C3 | call_block | calls.rb:77:1:79:3 | call_block |
+| calls.rb:329:1:333:3 | C3 | call_instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:329:1:333:3 | C3 | create | calls.rb:271:1:279:3 | create |
+| calls.rb:329:1:333:3 | C3 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:329:1:333:3 | C3 | foo | calls.rb:81:1:85:3 | foo |
+| calls.rb:329:1:333:3 | C3 | funny | calls.rb:133:1:135:3 | funny |
+| calls.rb:329:1:333:3 | C3 | indirect | calls.rb:151:1:153:3 | indirect |
+| calls.rb:329:1:333:3 | C3 | instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:329:1:333:3 | C3 | new | calls.rb:110:5:110:16 | new |
+| calls.rb:329:1:333:3 | C3 | optional_arg | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:329:1:333:3 | C3 | pattern_dispatch | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:329:1:333:3 | C3 | private_on_main | calls.rb:178:1:179:3 | private_on_main |
+| calls.rb:329:1:333:3 | C3 | puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:329:1:333:3 | C3 | to_s | calls.rb:165:5:166:7 | to_s |
+| file://:0:0:0:0 | Class | include | calls.rb:103:5:103:20 | include |
+| file://:0:0:0:0 | Class | module_eval | calls.rb:102:5:102:24 | module_eval |
+| file://:0:0:0:0 | Class | new | calls.rb:110:5:110:16 | new |
+| file://:0:0:0:0 | Class | prepend | calls.rb:104:5:104:20 | prepend |
+| file://:0:0:0:0 | Class | private | calls.rb:105:5:105:20 | private |
+| file://:0:0:0:0 | Class | puts | calls.rb:98:5:98:30 | puts |
+| file://:0:0:0:0 | Class | to_s | calls.rb:165:5:166:7 | to_s |
+| file://:0:0:0:0 | Complex | new | calls.rb:110:5:110:16 | new |
+| file://:0:0:0:0 | Complex | puts | calls.rb:98:5:98:30 | puts |
+| file://:0:0:0:0 | Complex | to_s | calls.rb:165:5:166:7 | to_s |
+| file://:0:0:0:0 | FalseClass | new | calls.rb:110:5:110:16 | new |
+| file://:0:0:0:0 | FalseClass | puts | calls.rb:98:5:98:30 | puts |
+| file://:0:0:0:0 | FalseClass | to_s | calls.rb:165:5:166:7 | to_s |
+| file://:0:0:0:0 | Float | new | calls.rb:110:5:110:16 | new |
+| file://:0:0:0:0 | Float | puts | calls.rb:98:5:98:30 | puts |
+| file://:0:0:0:0 | Float | to_s | calls.rb:165:5:166:7 | to_s |
+| file://:0:0:0:0 | NilClass | new | calls.rb:110:5:110:16 | new |
+| file://:0:0:0:0 | NilClass | puts | calls.rb:98:5:98:30 | puts |
+| file://:0:0:0:0 | NilClass | to_s | calls.rb:165:5:166:7 | to_s |
+| file://:0:0:0:0 | Numeric | new | calls.rb:110:5:110:16 | new |
+| file://:0:0:0:0 | Numeric | puts | calls.rb:98:5:98:30 | puts |
+| file://:0:0:0:0 | Numeric | to_s | calls.rb:165:5:166:7 | to_s |
+| file://:0:0:0:0 | Rational | new | calls.rb:110:5:110:16 | new |
+| file://:0:0:0:0 | Rational | puts | calls.rb:98:5:98:30 | puts |
+| file://:0:0:0:0 | Rational | to_s | calls.rb:165:5:166:7 | to_s |
+| file://:0:0:0:0 | TrueClass | new | calls.rb:110:5:110:16 | new |
+| file://:0:0:0:0 | TrueClass | puts | calls.rb:98:5:98:30 | puts |
+| file://:0:0:0:0 | TrueClass | to_s | calls.rb:165:5:166:7 | to_s |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
-| hello.rb:11:1:16:3 | Greeting | new | calls.rb:106:5:106:16 | new |
-| hello.rb:11:1:16:3 | Greeting | puts | calls.rb:94:5:94:30 | puts |
-| hello.rb:11:1:16:3 | Greeting | to_s | calls.rb:161:5:162:7 | to_s |
+| hello.rb:11:1:16:3 | Greeting | new | calls.rb:110:5:110:16 | new |
+| hello.rb:11:1:16:3 | Greeting | puts | calls.rb:98:5:98:30 | puts |
+| hello.rb:11:1:16:3 | Greeting | to_s | calls.rb:165:5:166:7 | to_s |
 | hello.rb:11:1:16:3 | Greeting | world | hello.rb:5:5:7:7 | world |
 | hello.rb:18:1:22:3 | HelloWorld | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:18:1:22:3 | HelloWorld | message | hello.rb:19:5:21:7 | message |
-| hello.rb:18:1:22:3 | HelloWorld | new | calls.rb:106:5:106:16 | new |
-| hello.rb:18:1:22:3 | HelloWorld | puts | calls.rb:94:5:94:30 | puts |
-| hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:161:5:162:7 | to_s |
+| hello.rb:18:1:22:3 | HelloWorld | new | calls.rb:110:5:110:16 | new |
+| hello.rb:18:1:22:3 | HelloWorld | puts | calls.rb:98:5:98:30 | puts |
+| hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:165:5:166:7 | to_s |
 | hello.rb:18:1:22:3 | HelloWorld | world | hello.rb:5:5:7:7 | world |
 | modules.rb:4:1:24:3 | Foo | method_in_another_definition_of_foo | modules.rb:27:3:28:5 | method_in_another_definition_of_foo |
 | modules.rb:4:1:24:3 | Foo | method_in_foo | modules.rb:16:3:17:5 | method_in_foo |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_another_definition_of_foo_bar | modules.rb:52:3:53:5 | method_in_another_definition_of_foo_bar |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_foo_bar | modules.rb:9:5:10:7 | method_in_foo_bar |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | new | calls.rb:106:5:106:16 | new |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | to_s | calls.rb:161:5:162:7 | to_s |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | new | calls.rb:106:5:106:16 | new |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | to_s | calls.rb:161:5:162:7 | to_s |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | new | calls.rb:106:5:106:16 | new |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | to_s | calls.rb:161:5:162:7 | to_s |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | new | calls.rb:110:5:110:16 | new |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | to_s | calls.rb:165:5:166:7 | to_s |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | new | calls.rb:110:5:110:16 | new |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | to_s | calls.rb:165:5:166:7 | to_s |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | new | calls.rb:110:5:110:16 | new |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | to_s | calls.rb:165:5:166:7 | to_s |
 | modules.rb:37:1:46:3 | Bar | method_a | modules.rb:38:3:39:5 | method_a |
 | modules.rb:37:1:46:3 | Bar | method_b | modules.rb:41:3:42:5 | method_b |
-| modules.rb:37:1:46:3 | Bar | new | calls.rb:106:5:106:16 | new |
-| modules.rb:37:1:46:3 | Bar | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:37:1:46:3 | Bar | to_s | calls.rb:161:5:162:7 | to_s |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | new | calls.rb:106:5:106:16 | new |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | to_s | calls.rb:161:5:162:7 | to_s |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | new | calls.rb:106:5:106:16 | new |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | to_s | calls.rb:161:5:162:7 | to_s |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | new | calls.rb:106:5:106:16 | new |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | to_s | calls.rb:161:5:162:7 | to_s |
-| modules.rb:112:1:113:3 | YY | new | calls.rb:106:5:106:16 | new |
-| modules.rb:112:1:113:3 | YY | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:112:1:113:3 | YY | to_s | calls.rb:161:5:162:7 | to_s |
-| modules.rb:116:7:117:9 | XX::YY | new | calls.rb:106:5:106:16 | new |
-| modules.rb:116:7:117:9 | XX::YY | puts | calls.rb:94:5:94:30 | puts |
-| modules.rb:116:7:117:9 | XX::YY | to_s | calls.rb:161:5:162:7 | to_s |
-| modules_rec.rb:1:1:2:3 | B::A | new | calls.rb:106:5:106:16 | new |
-| modules_rec.rb:1:1:2:3 | B::A | puts | calls.rb:94:5:94:30 | puts |
-| modules_rec.rb:1:1:2:3 | B::A | to_s | calls.rb:161:5:162:7 | to_s |
-| modules_rec.rb:4:1:5:3 | A::B | new | calls.rb:106:5:106:16 | new |
-| modules_rec.rb:4:1:5:3 | A::B | puts | calls.rb:94:5:94:30 | puts |
-| modules_rec.rb:4:1:5:3 | A::B | to_s | calls.rb:161:5:162:7 | to_s |
-| private.rb:1:1:29:3 | E | new | calls.rb:106:5:106:16 | new |
+| modules.rb:37:1:46:3 | Bar | new | calls.rb:110:5:110:16 | new |
+| modules.rb:37:1:46:3 | Bar | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:37:1:46:3 | Bar | to_s | calls.rb:165:5:166:7 | to_s |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | new | calls.rb:110:5:110:16 | new |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | to_s | calls.rb:165:5:166:7 | to_s |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | new | calls.rb:110:5:110:16 | new |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | to_s | calls.rb:165:5:166:7 | to_s |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | new | calls.rb:110:5:110:16 | new |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | to_s | calls.rb:165:5:166:7 | to_s |
+| modules.rb:112:1:113:3 | YY | new | calls.rb:110:5:110:16 | new |
+| modules.rb:112:1:113:3 | YY | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:112:1:113:3 | YY | to_s | calls.rb:165:5:166:7 | to_s |
+| modules.rb:116:7:117:9 | XX::YY | new | calls.rb:110:5:110:16 | new |
+| modules.rb:116:7:117:9 | XX::YY | puts | calls.rb:98:5:98:30 | puts |
+| modules.rb:116:7:117:9 | XX::YY | to_s | calls.rb:165:5:166:7 | to_s |
+| modules_rec.rb:1:1:2:3 | B::A | new | calls.rb:110:5:110:16 | new |
+| modules_rec.rb:1:1:2:3 | B::A | puts | calls.rb:98:5:98:30 | puts |
+| modules_rec.rb:1:1:2:3 | B::A | to_s | calls.rb:165:5:166:7 | to_s |
+| modules_rec.rb:4:1:5:3 | A::B | new | calls.rb:110:5:110:16 | new |
+| modules_rec.rb:4:1:5:3 | A::B | puts | calls.rb:98:5:98:30 | puts |
+| modules_rec.rb:4:1:5:3 | A::B | to_s | calls.rb:165:5:166:7 | to_s |
+| private.rb:1:1:29:3 | E | new | calls.rb:110:5:110:16 | new |
 | private.rb:1:1:29:3 | E | private2 | private.rb:8:3:9:5 | private2 |
 | private.rb:1:1:29:3 | E | private3 | private.rb:14:3:15:5 | private3 |
 | private.rb:1:1:29:3 | E | private4 | private.rb:17:3:18:5 | private4 |
 | private.rb:1:1:29:3 | E | private_on_main | private.rb:31:1:32:3 | private_on_main |
 | private.rb:1:1:29:3 | E | public | private.rb:5:3:6:5 | public |
-| private.rb:1:1:29:3 | E | puts | calls.rb:94:5:94:30 | puts |
-| private.rb:1:1:29:3 | E | to_s | calls.rb:161:5:162:7 | to_s |
+| private.rb:1:1:29:3 | E | puts | calls.rb:98:5:98:30 | puts |
+| private.rb:1:1:29:3 | E | to_s | calls.rb:165:5:166:7 | to_s |
 | private.rb:42:1:60:3 | F | private2 | private.rb:49:3:50:5 | private2 |
 | private.rb:42:1:60:3 | F | private3 | private.rb:55:3:56:5 | private3 |
 | private.rb:42:1:60:3 | F | private4 | private.rb:58:3:59:5 | private4 |
@@ -385,231 +401,233 @@ enclosingMethod
 | calls.rb:14:5:14:15 | self | calls.rb:13:1:15:3 | bar |
 | calls.rb:14:10:14:15 | "bar2" | calls.rb:13:1:15:3 | bar |
 | calls.rb:14:11:14:14 | bar2 | calls.rb:13:1:15:3 | bar |
-| calls.rb:44:9:44:18 | call to instance_m | calls.rb:43:5:49:7 | baz |
-| calls.rb:44:9:44:18 | self | calls.rb:43:5:49:7 | baz |
-| calls.rb:45:9:45:12 | self | calls.rb:43:5:49:7 | baz |
-| calls.rb:45:9:45:23 | call to instance_m | calls.rb:43:5:49:7 | baz |
-| calls.rb:47:9:47:19 | call to singleton_m | calls.rb:43:5:49:7 | baz |
-| calls.rb:47:9:47:19 | self | calls.rb:43:5:49:7 | baz |
-| calls.rb:48:9:48:12 | self | calls.rb:43:5:49:7 | baz |
-| calls.rb:48:9:48:24 | call to singleton_m | calls.rb:43:5:49:7 | baz |
-| calls.rb:59:9:59:13 | call to super | calls.rb:58:5:60:7 | baz |
-| calls.rb:68:18:68:18 | a | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:68:18:68:18 | a | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:68:22:68:22 | 4 | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:68:25:68:25 | b | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:68:25:68:25 | b | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:68:28:68:28 | 5 | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:69:5:69:5 | a | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:69:5:69:16 | call to bit_length | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:70:5:70:5 | b | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:70:5:70:16 | call to bit_length | calls.rb:68:1:71:3 | optional_arg |
-| calls.rb:74:5:74:11 | yield ... | calls.rb:73:1:75:3 | call_block |
-| calls.rb:74:11:74:11 | 1 | calls.rb:73:1:75:3 | call_block |
-| calls.rb:78:5:78:7 | var | calls.rb:77:1:81:3 | foo |
-| calls.rb:78:5:78:18 | ... = ... | calls.rb:77:1:81:3 | foo |
-| calls.rb:78:11:78:14 | Hash | calls.rb:77:1:81:3 | foo |
-| calls.rb:78:11:78:18 | call to new | calls.rb:77:1:81:3 | foo |
-| calls.rb:79:5:79:7 | var | calls.rb:77:1:81:3 | foo |
-| calls.rb:79:5:79:10 | ...[...] | calls.rb:77:1:81:3 | foo |
-| calls.rb:79:9:79:9 | 1 | calls.rb:77:1:81:3 | foo |
-| calls.rb:80:5:80:29 | call to call_block | calls.rb:77:1:81:3 | foo |
-| calls.rb:80:5:80:29 | self | calls.rb:77:1:81:3 | foo |
-| calls.rb:80:16:80:29 | { ... } | calls.rb:77:1:81:3 | foo |
-| calls.rb:80:19:80:19 | x | calls.rb:77:1:81:3 | foo |
-| calls.rb:80:19:80:19 | x | calls.rb:77:1:81:3 | foo |
-| calls.rb:80:22:80:24 | var | calls.rb:77:1:81:3 | foo |
-| calls.rb:80:22:80:27 | ...[...] | calls.rb:77:1:81:3 | foo |
-| calls.rb:80:26:80:26 | x | calls.rb:77:1:81:3 | foo |
-| calls.rb:94:14:94:14 | x | calls.rb:94:5:94:30 | puts |
-| calls.rb:94:14:94:14 | x | calls.rb:94:5:94:30 | puts |
-| calls.rb:94:17:94:26 | call to old_puts | calls.rb:94:5:94:30 | puts |
-| calls.rb:94:17:94:26 | self | calls.rb:94:5:94:30 | puts |
-| calls.rb:94:26:94:26 | x | calls.rb:94:5:94:30 | puts |
-| calls.rb:111:12:111:12 | x | calls.rb:111:5:111:31 | [] |
-| calls.rb:111:12:111:12 | x | calls.rb:111:5:111:31 | [] |
-| calls.rb:111:15:111:27 | call to old_lookup | calls.rb:111:5:111:31 | [] |
-| calls.rb:111:15:111:27 | self | calls.rb:111:5:111:31 | [] |
-| calls.rb:111:26:111:26 | x | calls.rb:111:5:111:31 | [] |
-| calls.rb:116:10:116:10 | x | calls.rb:116:3:116:29 | [] |
-| calls.rb:116:10:116:10 | x | calls.rb:116:3:116:29 | [] |
-| calls.rb:116:13:116:25 | call to old_lookup | calls.rb:116:3:116:29 | [] |
-| calls.rb:116:13:116:25 | self | calls.rb:116:3:116:29 | [] |
-| calls.rb:116:24:116:24 | x | calls.rb:116:3:116:29 | [] |
-| calls.rb:120:15:120:19 | &body | calls.rb:120:3:126:5 | foreach |
-| calls.rb:120:16:120:19 | body | calls.rb:120:3:126:5 | foreach |
-| calls.rb:121:5:121:5 | x | calls.rb:120:3:126:5 | foreach |
-| calls.rb:121:5:121:9 | ... = ... | calls.rb:120:3:126:5 | foreach |
-| calls.rb:121:9:121:9 | 0 | calls.rb:120:3:126:5 | foreach |
-| calls.rb:122:5:125:7 | while ... | calls.rb:120:3:126:5 | foreach |
-| calls.rb:122:11:122:11 | x | calls.rb:120:3:126:5 | foreach |
-| calls.rb:122:11:122:25 | ... < ... | calls.rb:120:3:126:5 | foreach |
-| calls.rb:122:15:122:18 | self | calls.rb:120:3:126:5 | foreach |
-| calls.rb:122:15:122:25 | call to length | calls.rb:120:3:126:5 | foreach |
-| calls.rb:122:26:125:7 | do ... | calls.rb:120:3:126:5 | foreach |
-| calls.rb:123:9:123:24 | yield ... | calls.rb:120:3:126:5 | foreach |
-| calls.rb:123:15:123:15 | x | calls.rb:120:3:126:5 | foreach |
-| calls.rb:123:18:123:21 | self | calls.rb:120:3:126:5 | foreach |
-| calls.rb:123:18:123:24 | ...[...] | calls.rb:120:3:126:5 | foreach |
-| calls.rb:123:23:123:23 | x | calls.rb:120:3:126:5 | foreach |
-| calls.rb:124:9:124:9 | x | calls.rb:120:3:126:5 | foreach |
-| calls.rb:124:9:124:9 | x | calls.rb:120:3:126:5 | foreach |
-| calls.rb:124:9:124:14 | ... += ... | calls.rb:120:3:126:5 | foreach |
-| calls.rb:124:9:124:14 | ... = ... | calls.rb:120:3:126:5 | foreach |
-| calls.rb:124:11:124:12 | ... + ... | calls.rb:120:3:126:5 | foreach |
-| calls.rb:124:14:124:14 | 1 | calls.rb:120:3:126:5 | foreach |
-| calls.rb:130:5:130:20 | yield ... | calls.rb:129:1:131:3 | funny |
-| calls.rb:130:11:130:20 | "prefix: " | calls.rb:129:1:131:3 | funny |
-| calls.rb:130:12:130:19 | prefix:  | calls.rb:129:1:131:3 | funny |
-| calls.rb:147:14:147:15 | &b | calls.rb:147:1:149:3 | indirect |
-| calls.rb:147:15:147:15 | b | calls.rb:147:1:149:3 | indirect |
-| calls.rb:148:5:148:17 | call to call_block | calls.rb:147:1:149:3 | indirect |
-| calls.rb:148:5:148:17 | self | calls.rb:147:1:149:3 | indirect |
-| calls.rb:148:16:148:17 | &... | calls.rb:147:1:149:3 | indirect |
-| calls.rb:148:17:148:17 | b | calls.rb:147:1:149:3 | indirect |
-| calls.rb:156:9:156:12 | self | calls.rb:155:5:157:7 | s_method |
-| calls.rb:156:9:156:17 | call to to_s | calls.rb:155:5:157:7 | s_method |
-| calls.rb:181:9:181:26 | call to puts | calls.rb:180:5:183:7 | singleton_a |
-| calls.rb:181:9:181:26 | self | calls.rb:180:5:183:7 | singleton_a |
-| calls.rb:181:14:181:26 | "singleton_a" | calls.rb:180:5:183:7 | singleton_a |
-| calls.rb:181:15:181:25 | singleton_a | calls.rb:180:5:183:7 | singleton_a |
-| calls.rb:182:9:182:12 | self | calls.rb:180:5:183:7 | singleton_a |
-| calls.rb:182:9:182:24 | call to singleton_b | calls.rb:180:5:183:7 | singleton_a |
-| calls.rb:186:9:186:26 | call to puts | calls.rb:185:5:188:7 | singleton_b |
-| calls.rb:186:9:186:26 | self | calls.rb:185:5:188:7 | singleton_b |
-| calls.rb:186:14:186:26 | "singleton_b" | calls.rb:185:5:188:7 | singleton_b |
-| calls.rb:186:15:186:25 | singleton_b | calls.rb:185:5:188:7 | singleton_b |
-| calls.rb:187:9:187:12 | self | calls.rb:185:5:188:7 | singleton_b |
-| calls.rb:187:9:187:24 | call to singleton_c | calls.rb:185:5:188:7 | singleton_b |
-| calls.rb:191:9:191:26 | call to puts | calls.rb:190:5:192:7 | singleton_c |
-| calls.rb:191:9:191:26 | self | calls.rb:190:5:192:7 | singleton_c |
-| calls.rb:191:14:191:26 | "singleton_c" | calls.rb:190:5:192:7 | singleton_c |
-| calls.rb:191:15:191:25 | singleton_c | calls.rb:190:5:192:7 | singleton_c |
-| calls.rb:195:9:195:26 | call to puts | calls.rb:194:5:197:7 | singleton_d |
-| calls.rb:195:9:195:26 | self | calls.rb:194:5:197:7 | singleton_d |
-| calls.rb:195:14:195:26 | "singleton_d" | calls.rb:194:5:197:7 | singleton_d |
-| calls.rb:195:15:195:25 | singleton_d | calls.rb:194:5:197:7 | singleton_d |
-| calls.rb:196:9:196:12 | self | calls.rb:194:5:197:7 | singleton_d |
-| calls.rb:196:9:196:24 | call to singleton_a | calls.rb:194:5:197:7 | singleton_d |
-| calls.rb:200:9:202:11 | singleton_e | calls.rb:199:5:204:7 | instance |
-| calls.rb:200:13:200:16 | self | calls.rb:199:5:204:7 | instance |
-| calls.rb:201:13:201:30 | call to puts | calls.rb:200:9:202:11 | singleton_e |
-| calls.rb:201:13:201:30 | self | calls.rb:200:9:202:11 | singleton_e |
-| calls.rb:201:18:201:30 | "singleton_e" | calls.rb:200:9:202:11 | singleton_e |
-| calls.rb:201:19:201:29 | singleton_e | calls.rb:200:9:202:11 | singleton_e |
-| calls.rb:203:9:203:19 | call to singleton_e | calls.rb:199:5:204:7 | instance |
-| calls.rb:203:9:203:19 | self | calls.rb:199:5:204:7 | instance |
-| calls.rb:208:13:208:30 | call to puts | calls.rb:207:9:209:11 | singleton_f |
-| calls.rb:208:13:208:30 | self | calls.rb:207:9:209:11 | singleton_f |
-| calls.rb:208:18:208:30 | "singleton_f" | calls.rb:207:9:209:11 | singleton_f |
-| calls.rb:208:19:208:29 | singleton_f | calls.rb:207:9:209:11 | singleton_f |
-| calls.rb:213:9:213:12 | self | calls.rb:212:5:214:7 | call_singleton_g |
-| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
-| calls.rb:226:5:226:24 | call to puts | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:226:5:226:24 | self | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:226:10:226:24 | "singleton_g_1" | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:226:11:226:23 | singleton_g_1 | calls.rb:225:1:227:3 | singleton_g |
-| calls.rb:233:5:233:24 | call to puts | calls.rb:232:1:234:3 | singleton_g |
-| calls.rb:233:5:233:24 | self | calls.rb:232:1:234:3 | singleton_g |
-| calls.rb:233:10:233:24 | "singleton_g_2" | calls.rb:232:1:234:3 | singleton_g |
-| calls.rb:233:11:233:23 | singleton_g_2 | calls.rb:232:1:234:3 | singleton_g |
-| calls.rb:241:9:241:28 | call to puts | calls.rb:240:5:242:7 | singleton_g |
-| calls.rb:241:9:241:28 | self | calls.rb:240:5:242:7 | singleton_g |
-| calls.rb:241:14:241:28 | "singleton_g_3" | calls.rb:240:5:242:7 | singleton_g |
-| calls.rb:241:15:241:27 | singleton_g_3 | calls.rb:240:5:242:7 | singleton_g |
-| calls.rb:257:5:257:22 | call to puts | calls.rb:256:1:258:3 | singleton_g |
-| calls.rb:257:5:257:22 | self | calls.rb:256:1:258:3 | singleton_g |
-| calls.rb:257:10:257:22 | "singleton_g" | calls.rb:256:1:258:3 | singleton_g |
-| calls.rb:257:11:257:21 | singleton_g | calls.rb:256:1:258:3 | singleton_g |
-| calls.rb:267:12:267:15 | type | calls.rb:267:1:275:3 | create |
-| calls.rb:267:12:267:15 | type | calls.rb:267:1:275:3 | create |
-| calls.rb:268:5:268:8 | type | calls.rb:267:1:275:3 | create |
-| calls.rb:268:5:268:12 | call to new | calls.rb:267:1:275:3 | create |
-| calls.rb:268:5:268:21 | call to instance | calls.rb:267:1:275:3 | create |
-| calls.rb:270:5:272:7 | singleton_h | calls.rb:267:1:275:3 | create |
-| calls.rb:270:9:270:12 | type | calls.rb:267:1:275:3 | create |
-| calls.rb:271:9:271:26 | call to puts | calls.rb:270:5:272:7 | singleton_h |
-| calls.rb:271:9:271:26 | self | calls.rb:270:5:272:7 | singleton_h |
-| calls.rb:271:14:271:26 | "singleton_h" | calls.rb:270:5:272:7 | singleton_h |
-| calls.rb:271:15:271:25 | singleton_h | calls.rb:270:5:272:7 | singleton_h |
-| calls.rb:274:5:274:8 | type | calls.rb:267:1:275:3 | create |
-| calls.rb:274:5:274:20 | call to singleton_h | calls.rb:267:1:275:3 | create |
-| calls.rb:284:9:284:26 | call to puts | calls.rb:283:5:285:7 | singleton_i |
-| calls.rb:284:9:284:26 | self | calls.rb:283:5:285:7 | singleton_i |
-| calls.rb:284:14:284:26 | "singleton_i" | calls.rb:283:5:285:7 | singleton_i |
-| calls.rb:284:15:284:25 | singleton_i | calls.rb:283:5:285:7 | singleton_i |
-| calls.rb:293:9:293:26 | call to puts | calls.rb:292:5:294:7 | singleton_j |
-| calls.rb:293:9:293:26 | self | calls.rb:292:5:294:7 | singleton_j |
-| calls.rb:293:14:293:26 | "singleton_j" | calls.rb:292:5:294:7 | singleton_j |
-| calls.rb:293:15:293:25 | singleton_j | calls.rb:292:5:294:7 | singleton_j |
-| calls.rb:301:9:301:31 | call to puts | calls.rb:300:5:302:7 | instance |
-| calls.rb:301:9:301:31 | self | calls.rb:300:5:302:7 | instance |
-| calls.rb:301:14:301:31 | "SelfNew#instance" | calls.rb:300:5:302:7 | instance |
-| calls.rb:301:15:301:30 | SelfNew#instance | calls.rb:300:5:302:7 | instance |
-| calls.rb:305:9:305:11 | call to new | calls.rb:304:5:306:7 | singleton |
-| calls.rb:305:9:305:11 | self | calls.rb:304:5:306:7 | singleton |
-| calls.rb:305:9:305:20 | call to instance | calls.rb:304:5:306:7 | singleton |
-| calls.rb:315:9:315:26 | call to puts | calls.rb:314:5:316:7 | instance |
-| calls.rb:315:9:315:26 | self | calls.rb:314:5:316:7 | instance |
-| calls.rb:315:14:315:26 | "C1#instance" | calls.rb:314:5:316:7 | instance |
-| calls.rb:315:15:315:25 | C1#instance | calls.rb:314:5:316:7 | instance |
-| calls.rb:321:9:321:26 | call to puts | calls.rb:320:5:322:7 | instance |
-| calls.rb:321:9:321:26 | self | calls.rb:320:5:322:7 | instance |
-| calls.rb:321:14:321:26 | "C2#instance" | calls.rb:320:5:322:7 | instance |
-| calls.rb:321:15:321:25 | C2#instance | calls.rb:320:5:322:7 | instance |
-| calls.rb:327:9:327:26 | call to puts | calls.rb:326:5:328:7 | instance |
-| calls.rb:327:9:327:26 | self | calls.rb:326:5:328:7 | instance |
-| calls.rb:327:14:327:26 | "C3#instance" | calls.rb:326:5:328:7 | instance |
-| calls.rb:327:15:327:25 | C3#instance | calls.rb:326:5:328:7 | instance |
-| calls.rb:331:22:331:22 | x | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:331:22:331:22 | x | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:332:5:340:7 | case ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:332:10:332:10 | x | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:333:5:334:18 | when ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:333:10:333:11 | C3 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:333:12:334:18 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:334:9:334:9 | x | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:334:9:334:18 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:335:5:336:18 | when ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:335:10:335:11 | C2 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:335:12:336:18 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:336:9:336:9 | x | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:336:9:336:18 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:337:5:338:18 | when ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:337:10:337:11 | C1 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:337:12:338:18 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:338:9:338:9 | x | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:338:9:338:18 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:339:5:339:8 | else ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:342:5:346:7 | case ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:342:10:342:10 | x | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:343:9:343:29 | in ... then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:343:12:343:13 | C3 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:343:15:343:29 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:343:20:343:20 | x | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:343:20:343:29 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:344:9:344:36 | in ... then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:344:12:344:13 | C2 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:344:12:344:19 | ... => ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:344:18:344:19 | c2 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:344:21:344:36 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:344:26:344:27 | c2 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:344:26:344:36 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:345:9:345:36 | in ... then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:345:12:345:13 | C1 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:345:12:345:19 | ... => ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:345:18:345:19 | c1 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:345:21:345:36 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:345:26:345:27 | c1 | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:345:26:345:36 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
-| calls.rb:355:19:355:19 | x | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:355:19:355:19 | x | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:356:5:358:7 | instance | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:356:9:356:9 | x | calls.rb:355:1:359:3 | add_singleton |
-| calls.rb:357:9:357:28 | call to puts | calls.rb:356:5:358:7 | instance |
-| calls.rb:357:9:357:28 | self | calls.rb:356:5:358:7 | instance |
-| calls.rb:357:14:357:28 | "instance_on x" | calls.rb:356:5:358:7 | instance |
-| calls.rb:357:15:357:27 | instance_on x | calls.rb:356:5:358:7 | instance |
+| calls.rb:36:5:36:14 | call to instance_m | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:36:5:36:14 | self | calls.rb:35:1:37:3 | call_instance_m |
+| calls.rb:48:9:48:18 | call to instance_m | calls.rb:47:5:53:7 | baz |
+| calls.rb:48:9:48:18 | self | calls.rb:47:5:53:7 | baz |
+| calls.rb:49:9:49:12 | self | calls.rb:47:5:53:7 | baz |
+| calls.rb:49:9:49:23 | call to instance_m | calls.rb:47:5:53:7 | baz |
+| calls.rb:51:9:51:19 | call to singleton_m | calls.rb:47:5:53:7 | baz |
+| calls.rb:51:9:51:19 | self | calls.rb:47:5:53:7 | baz |
+| calls.rb:52:9:52:12 | self | calls.rb:47:5:53:7 | baz |
+| calls.rb:52:9:52:24 | call to singleton_m | calls.rb:47:5:53:7 | baz |
+| calls.rb:63:9:63:13 | call to super | calls.rb:62:5:64:7 | baz |
+| calls.rb:72:18:72:18 | a | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:72:18:72:18 | a | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:72:22:72:22 | 4 | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:72:25:72:25 | b | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:72:25:72:25 | b | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:72:28:72:28 | 5 | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:73:5:73:5 | a | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:73:5:73:16 | call to bit_length | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:74:5:74:5 | b | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:74:5:74:16 | call to bit_length | calls.rb:72:1:75:3 | optional_arg |
+| calls.rb:78:5:78:11 | yield ... | calls.rb:77:1:79:3 | call_block |
+| calls.rb:78:11:78:11 | 1 | calls.rb:77:1:79:3 | call_block |
+| calls.rb:82:5:82:7 | var | calls.rb:81:1:85:3 | foo |
+| calls.rb:82:5:82:18 | ... = ... | calls.rb:81:1:85:3 | foo |
+| calls.rb:82:11:82:14 | Hash | calls.rb:81:1:85:3 | foo |
+| calls.rb:82:11:82:18 | call to new | calls.rb:81:1:85:3 | foo |
+| calls.rb:83:5:83:7 | var | calls.rb:81:1:85:3 | foo |
+| calls.rb:83:5:83:10 | ...[...] | calls.rb:81:1:85:3 | foo |
+| calls.rb:83:9:83:9 | 1 | calls.rb:81:1:85:3 | foo |
+| calls.rb:84:5:84:29 | call to call_block | calls.rb:81:1:85:3 | foo |
+| calls.rb:84:5:84:29 | self | calls.rb:81:1:85:3 | foo |
+| calls.rb:84:16:84:29 | { ... } | calls.rb:81:1:85:3 | foo |
+| calls.rb:84:19:84:19 | x | calls.rb:81:1:85:3 | foo |
+| calls.rb:84:19:84:19 | x | calls.rb:81:1:85:3 | foo |
+| calls.rb:84:22:84:24 | var | calls.rb:81:1:85:3 | foo |
+| calls.rb:84:22:84:27 | ...[...] | calls.rb:81:1:85:3 | foo |
+| calls.rb:84:26:84:26 | x | calls.rb:81:1:85:3 | foo |
+| calls.rb:98:14:98:14 | x | calls.rb:98:5:98:30 | puts |
+| calls.rb:98:14:98:14 | x | calls.rb:98:5:98:30 | puts |
+| calls.rb:98:17:98:26 | call to old_puts | calls.rb:98:5:98:30 | puts |
+| calls.rb:98:17:98:26 | self | calls.rb:98:5:98:30 | puts |
+| calls.rb:98:26:98:26 | x | calls.rb:98:5:98:30 | puts |
+| calls.rb:115:12:115:12 | x | calls.rb:115:5:115:31 | [] |
+| calls.rb:115:12:115:12 | x | calls.rb:115:5:115:31 | [] |
+| calls.rb:115:15:115:27 | call to old_lookup | calls.rb:115:5:115:31 | [] |
+| calls.rb:115:15:115:27 | self | calls.rb:115:5:115:31 | [] |
+| calls.rb:115:26:115:26 | x | calls.rb:115:5:115:31 | [] |
+| calls.rb:120:10:120:10 | x | calls.rb:120:3:120:29 | [] |
+| calls.rb:120:10:120:10 | x | calls.rb:120:3:120:29 | [] |
+| calls.rb:120:13:120:25 | call to old_lookup | calls.rb:120:3:120:29 | [] |
+| calls.rb:120:13:120:25 | self | calls.rb:120:3:120:29 | [] |
+| calls.rb:120:24:120:24 | x | calls.rb:120:3:120:29 | [] |
+| calls.rb:124:15:124:19 | &body | calls.rb:124:3:130:5 | foreach |
+| calls.rb:124:16:124:19 | body | calls.rb:124:3:130:5 | foreach |
+| calls.rb:125:5:125:5 | x | calls.rb:124:3:130:5 | foreach |
+| calls.rb:125:5:125:9 | ... = ... | calls.rb:124:3:130:5 | foreach |
+| calls.rb:125:9:125:9 | 0 | calls.rb:124:3:130:5 | foreach |
+| calls.rb:126:5:129:7 | while ... | calls.rb:124:3:130:5 | foreach |
+| calls.rb:126:11:126:11 | x | calls.rb:124:3:130:5 | foreach |
+| calls.rb:126:11:126:25 | ... < ... | calls.rb:124:3:130:5 | foreach |
+| calls.rb:126:15:126:18 | self | calls.rb:124:3:130:5 | foreach |
+| calls.rb:126:15:126:25 | call to length | calls.rb:124:3:130:5 | foreach |
+| calls.rb:126:26:129:7 | do ... | calls.rb:124:3:130:5 | foreach |
+| calls.rb:127:9:127:24 | yield ... | calls.rb:124:3:130:5 | foreach |
+| calls.rb:127:15:127:15 | x | calls.rb:124:3:130:5 | foreach |
+| calls.rb:127:18:127:21 | self | calls.rb:124:3:130:5 | foreach |
+| calls.rb:127:18:127:24 | ...[...] | calls.rb:124:3:130:5 | foreach |
+| calls.rb:127:23:127:23 | x | calls.rb:124:3:130:5 | foreach |
+| calls.rb:128:9:128:9 | x | calls.rb:124:3:130:5 | foreach |
+| calls.rb:128:9:128:9 | x | calls.rb:124:3:130:5 | foreach |
+| calls.rb:128:9:128:14 | ... += ... | calls.rb:124:3:130:5 | foreach |
+| calls.rb:128:9:128:14 | ... = ... | calls.rb:124:3:130:5 | foreach |
+| calls.rb:128:11:128:12 | ... + ... | calls.rb:124:3:130:5 | foreach |
+| calls.rb:128:14:128:14 | 1 | calls.rb:124:3:130:5 | foreach |
+| calls.rb:134:5:134:20 | yield ... | calls.rb:133:1:135:3 | funny |
+| calls.rb:134:11:134:20 | "prefix: " | calls.rb:133:1:135:3 | funny |
+| calls.rb:134:12:134:19 | prefix:  | calls.rb:133:1:135:3 | funny |
+| calls.rb:151:14:151:15 | &b | calls.rb:151:1:153:3 | indirect |
+| calls.rb:151:15:151:15 | b | calls.rb:151:1:153:3 | indirect |
+| calls.rb:152:5:152:17 | call to call_block | calls.rb:151:1:153:3 | indirect |
+| calls.rb:152:5:152:17 | self | calls.rb:151:1:153:3 | indirect |
+| calls.rb:152:16:152:17 | &... | calls.rb:151:1:153:3 | indirect |
+| calls.rb:152:17:152:17 | b | calls.rb:151:1:153:3 | indirect |
+| calls.rb:160:9:160:12 | self | calls.rb:159:5:161:7 | s_method |
+| calls.rb:160:9:160:17 | call to to_s | calls.rb:159:5:161:7 | s_method |
+| calls.rb:185:9:185:26 | call to puts | calls.rb:184:5:187:7 | singleton_a |
+| calls.rb:185:9:185:26 | self | calls.rb:184:5:187:7 | singleton_a |
+| calls.rb:185:14:185:26 | "singleton_a" | calls.rb:184:5:187:7 | singleton_a |
+| calls.rb:185:15:185:25 | singleton_a | calls.rb:184:5:187:7 | singleton_a |
+| calls.rb:186:9:186:12 | self | calls.rb:184:5:187:7 | singleton_a |
+| calls.rb:186:9:186:24 | call to singleton_b | calls.rb:184:5:187:7 | singleton_a |
+| calls.rb:190:9:190:26 | call to puts | calls.rb:189:5:192:7 | singleton_b |
+| calls.rb:190:9:190:26 | self | calls.rb:189:5:192:7 | singleton_b |
+| calls.rb:190:14:190:26 | "singleton_b" | calls.rb:189:5:192:7 | singleton_b |
+| calls.rb:190:15:190:25 | singleton_b | calls.rb:189:5:192:7 | singleton_b |
+| calls.rb:191:9:191:12 | self | calls.rb:189:5:192:7 | singleton_b |
+| calls.rb:191:9:191:24 | call to singleton_c | calls.rb:189:5:192:7 | singleton_b |
+| calls.rb:195:9:195:26 | call to puts | calls.rb:194:5:196:7 | singleton_c |
+| calls.rb:195:9:195:26 | self | calls.rb:194:5:196:7 | singleton_c |
+| calls.rb:195:14:195:26 | "singleton_c" | calls.rb:194:5:196:7 | singleton_c |
+| calls.rb:195:15:195:25 | singleton_c | calls.rb:194:5:196:7 | singleton_c |
+| calls.rb:199:9:199:26 | call to puts | calls.rb:198:5:201:7 | singleton_d |
+| calls.rb:199:9:199:26 | self | calls.rb:198:5:201:7 | singleton_d |
+| calls.rb:199:14:199:26 | "singleton_d" | calls.rb:198:5:201:7 | singleton_d |
+| calls.rb:199:15:199:25 | singleton_d | calls.rb:198:5:201:7 | singleton_d |
+| calls.rb:200:9:200:12 | self | calls.rb:198:5:201:7 | singleton_d |
+| calls.rb:200:9:200:24 | call to singleton_a | calls.rb:198:5:201:7 | singleton_d |
+| calls.rb:204:9:206:11 | singleton_e | calls.rb:203:5:208:7 | instance |
+| calls.rb:204:13:204:16 | self | calls.rb:203:5:208:7 | instance |
+| calls.rb:205:13:205:30 | call to puts | calls.rb:204:9:206:11 | singleton_e |
+| calls.rb:205:13:205:30 | self | calls.rb:204:9:206:11 | singleton_e |
+| calls.rb:205:18:205:30 | "singleton_e" | calls.rb:204:9:206:11 | singleton_e |
+| calls.rb:205:19:205:29 | singleton_e | calls.rb:204:9:206:11 | singleton_e |
+| calls.rb:207:9:207:19 | call to singleton_e | calls.rb:203:5:208:7 | instance |
+| calls.rb:207:9:207:19 | self | calls.rb:203:5:208:7 | instance |
+| calls.rb:212:13:212:30 | call to puts | calls.rb:211:9:213:11 | singleton_f |
+| calls.rb:212:13:212:30 | self | calls.rb:211:9:213:11 | singleton_f |
+| calls.rb:212:18:212:30 | "singleton_f" | calls.rb:211:9:213:11 | singleton_f |
+| calls.rb:212:19:212:29 | singleton_f | calls.rb:211:9:213:11 | singleton_f |
+| calls.rb:217:9:217:12 | self | calls.rb:216:5:218:7 | call_singleton_g |
+| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:216:5:218:7 | call_singleton_g |
+| calls.rb:230:5:230:24 | call to puts | calls.rb:229:1:231:3 | singleton_g |
+| calls.rb:230:5:230:24 | self | calls.rb:229:1:231:3 | singleton_g |
+| calls.rb:230:10:230:24 | "singleton_g_1" | calls.rb:229:1:231:3 | singleton_g |
+| calls.rb:230:11:230:23 | singleton_g_1 | calls.rb:229:1:231:3 | singleton_g |
+| calls.rb:237:5:237:24 | call to puts | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:237:5:237:24 | self | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:237:10:237:24 | "singleton_g_2" | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:237:11:237:23 | singleton_g_2 | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:245:9:245:28 | call to puts | calls.rb:244:5:246:7 | singleton_g |
+| calls.rb:245:9:245:28 | self | calls.rb:244:5:246:7 | singleton_g |
+| calls.rb:245:14:245:28 | "singleton_g_3" | calls.rb:244:5:246:7 | singleton_g |
+| calls.rb:245:15:245:27 | singleton_g_3 | calls.rb:244:5:246:7 | singleton_g |
+| calls.rb:261:5:261:22 | call to puts | calls.rb:260:1:262:3 | singleton_g |
+| calls.rb:261:5:261:22 | self | calls.rb:260:1:262:3 | singleton_g |
+| calls.rb:261:10:261:22 | "singleton_g" | calls.rb:260:1:262:3 | singleton_g |
+| calls.rb:261:11:261:21 | singleton_g | calls.rb:260:1:262:3 | singleton_g |
+| calls.rb:271:12:271:15 | type | calls.rb:271:1:279:3 | create |
+| calls.rb:271:12:271:15 | type | calls.rb:271:1:279:3 | create |
+| calls.rb:272:5:272:8 | type | calls.rb:271:1:279:3 | create |
+| calls.rb:272:5:272:12 | call to new | calls.rb:271:1:279:3 | create |
+| calls.rb:272:5:272:21 | call to instance | calls.rb:271:1:279:3 | create |
+| calls.rb:274:5:276:7 | singleton_h | calls.rb:271:1:279:3 | create |
+| calls.rb:274:9:274:12 | type | calls.rb:271:1:279:3 | create |
+| calls.rb:275:9:275:26 | call to puts | calls.rb:274:5:276:7 | singleton_h |
+| calls.rb:275:9:275:26 | self | calls.rb:274:5:276:7 | singleton_h |
+| calls.rb:275:14:275:26 | "singleton_h" | calls.rb:274:5:276:7 | singleton_h |
+| calls.rb:275:15:275:25 | singleton_h | calls.rb:274:5:276:7 | singleton_h |
+| calls.rb:278:5:278:8 | type | calls.rb:271:1:279:3 | create |
+| calls.rb:278:5:278:20 | call to singleton_h | calls.rb:271:1:279:3 | create |
+| calls.rb:288:9:288:26 | call to puts | calls.rb:287:5:289:7 | singleton_i |
+| calls.rb:288:9:288:26 | self | calls.rb:287:5:289:7 | singleton_i |
+| calls.rb:288:14:288:26 | "singleton_i" | calls.rb:287:5:289:7 | singleton_i |
+| calls.rb:288:15:288:25 | singleton_i | calls.rb:287:5:289:7 | singleton_i |
+| calls.rb:297:9:297:26 | call to puts | calls.rb:296:5:298:7 | singleton_j |
+| calls.rb:297:9:297:26 | self | calls.rb:296:5:298:7 | singleton_j |
+| calls.rb:297:14:297:26 | "singleton_j" | calls.rb:296:5:298:7 | singleton_j |
+| calls.rb:297:15:297:25 | singleton_j | calls.rb:296:5:298:7 | singleton_j |
+| calls.rb:305:9:305:31 | call to puts | calls.rb:304:5:306:7 | instance |
+| calls.rb:305:9:305:31 | self | calls.rb:304:5:306:7 | instance |
+| calls.rb:305:14:305:31 | "SelfNew#instance" | calls.rb:304:5:306:7 | instance |
+| calls.rb:305:15:305:30 | SelfNew#instance | calls.rb:304:5:306:7 | instance |
+| calls.rb:309:9:309:11 | call to new | calls.rb:308:5:310:7 | singleton |
+| calls.rb:309:9:309:11 | self | calls.rb:308:5:310:7 | singleton |
+| calls.rb:309:9:309:20 | call to instance | calls.rb:308:5:310:7 | singleton |
+| calls.rb:319:9:319:26 | call to puts | calls.rb:318:5:320:7 | instance |
+| calls.rb:319:9:319:26 | self | calls.rb:318:5:320:7 | instance |
+| calls.rb:319:14:319:26 | "C1#instance" | calls.rb:318:5:320:7 | instance |
+| calls.rb:319:15:319:25 | C1#instance | calls.rb:318:5:320:7 | instance |
+| calls.rb:325:9:325:26 | call to puts | calls.rb:324:5:326:7 | instance |
+| calls.rb:325:9:325:26 | self | calls.rb:324:5:326:7 | instance |
+| calls.rb:325:14:325:26 | "C2#instance" | calls.rb:324:5:326:7 | instance |
+| calls.rb:325:15:325:25 | C2#instance | calls.rb:324:5:326:7 | instance |
+| calls.rb:331:9:331:26 | call to puts | calls.rb:330:5:332:7 | instance |
+| calls.rb:331:9:331:26 | self | calls.rb:330:5:332:7 | instance |
+| calls.rb:331:14:331:26 | "C3#instance" | calls.rb:330:5:332:7 | instance |
+| calls.rb:331:15:331:25 | C3#instance | calls.rb:330:5:332:7 | instance |
+| calls.rb:335:22:335:22 | x | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:335:22:335:22 | x | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:336:5:344:7 | case ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:336:10:336:10 | x | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:337:5:338:18 | when ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:337:10:337:11 | C3 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:337:12:338:18 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:338:9:338:9 | x | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:338:9:338:18 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:339:5:340:18 | when ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:339:10:339:11 | C2 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:339:12:340:18 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:340:9:340:9 | x | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:340:9:340:18 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:341:5:342:18 | when ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:341:10:341:11 | C1 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:341:12:342:18 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:342:9:342:9 | x | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:342:9:342:18 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:343:5:343:8 | else ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:346:5:350:7 | case ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:346:10:346:10 | x | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:347:9:347:29 | in ... then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:347:12:347:13 | C3 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:347:15:347:29 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:347:20:347:20 | x | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:347:20:347:29 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:348:9:348:36 | in ... then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:348:12:348:13 | C2 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:348:12:348:19 | ... => ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:348:18:348:19 | c2 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:348:21:348:36 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:348:26:348:27 | c2 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:348:26:348:36 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:349:9:349:36 | in ... then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:349:12:349:13 | C1 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:349:12:349:19 | ... => ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:349:18:349:19 | c1 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:349:21:349:36 | then ... | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:349:26:349:27 | c1 | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:349:26:349:36 | call to instance | calls.rb:335:1:351:3 | pattern_dispatch |
+| calls.rb:359:19:359:19 | x | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:359:19:359:19 | x | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:360:5:362:7 | instance | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:360:9:360:9 | x | calls.rb:359:1:363:3 | add_singleton |
+| calls.rb:361:9:361:28 | call to puts | calls.rb:360:5:362:7 | instance |
+| calls.rb:361:9:361:28 | self | calls.rb:360:5:362:7 | instance |
+| calls.rb:361:14:361:28 | "instance_on x" | calls.rb:360:5:362:7 | instance |
+| calls.rb:361:15:361:27 | instance_on x | calls.rb:360:5:362:7 | instance |
 | hello.rb:3:9:3:22 | return | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:16:3:22 | "hello" | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:17:3:21 | hello | hello.rb:2:5:4:7 | hello |

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -1,31 +1,40 @@
 getMethod
-| calls.rb:15:1:24:3 | M | instance_m | calls.rb:16:5:16:23 | instance_m |
-| calls.rb:29:1:44:3 | C | baz | calls.rb:37:5:43:7 | baz |
-| calls.rb:51:1:55:3 | D | baz | calls.rb:52:5:54:7 | baz |
-| calls.rb:77:1:80:3 | Integer | abs | calls.rb:79:5:79:16 | abs |
-| calls.rb:77:1:80:3 | Integer | bit_length | calls.rb:78:5:78:23 | bit_length |
-| calls.rb:82:1:84:3 | String | capitalize | calls.rb:83:5:83:23 | capitalize |
-| calls.rb:86:1:88:3 | Kernel | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:90:1:95:3 | Module | include | calls.rb:92:5:92:20 | include |
-| calls.rb:90:1:95:3 | Module | module_eval | calls.rb:91:5:91:24 | module_eval |
-| calls.rb:90:1:95:3 | Module | prepend | calls.rb:93:5:93:20 | prepend |
-| calls.rb:90:1:95:3 | Module | private | calls.rb:94:5:94:20 | private |
-| calls.rb:97:1:100:3 | Object | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:97:1:100:3 | Object | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:97:1:100:3 | Object | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:97:1:100:3 | Object | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:97:1:100:3 | Object | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:97:1:100:3 | Object | new | calls.rb:99:5:99:16 | new |
-| calls.rb:97:1:100:3 | Object | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:97:1:100:3 | Object | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:97:1:100:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
-| calls.rb:102:1:104:3 | Hash | [] | calls.rb:103:5:103:15 | [] |
-| calls.rb:106:1:117:3 | Array | [] | calls.rb:107:3:107:13 | [] |
-| calls.rb:106:1:117:3 | Array | foreach | calls.rb:110:3:116:5 | foreach |
-| calls.rb:106:1:117:3 | Array | length | calls.rb:108:3:108:17 | length |
-| calls.rb:144:1:148:3 | S | s_method | calls.rb:145:5:147:7 | s_method |
-| calls.rb:150:1:153:3 | A | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:155:1:158:3 | B | to_s | calls.rb:156:5:157:7 | to_s |
+| calls.rb:21:1:30:3 | M | instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:35:1:50:3 | C | baz | calls.rb:43:5:49:7 | baz |
+| calls.rb:57:1:61:3 | D | baz | calls.rb:58:5:60:7 | baz |
+| calls.rb:83:1:86:3 | Integer | abs | calls.rb:85:5:85:16 | abs |
+| calls.rb:83:1:86:3 | Integer | bit_length | calls.rb:84:5:84:23 | bit_length |
+| calls.rb:88:1:90:3 | String | capitalize | calls.rb:89:5:89:23 | capitalize |
+| calls.rb:92:1:95:3 | Kernel | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:97:1:102:3 | Module | include | calls.rb:99:5:99:20 | include |
+| calls.rb:97:1:102:3 | Module | module_eval | calls.rb:98:5:98:24 | module_eval |
+| calls.rb:97:1:102:3 | Module | prepend | calls.rb:100:5:100:20 | prepend |
+| calls.rb:97:1:102:3 | Module | private | calls.rb:101:5:101:20 | private |
+| calls.rb:104:1:107:3 | Object | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:104:1:107:3 | Object | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:104:1:107:3 | Object | create | calls.rb:267:1:275:3 | create |
+| calls.rb:104:1:107:3 | Object | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:104:1:107:3 | Object | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:104:1:107:3 | Object | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:104:1:107:3 | Object | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:104:1:107:3 | Object | new | calls.rb:106:5:106:16 | new |
+| calls.rb:104:1:107:3 | Object | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:104:1:107:3 | Object | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:104:1:107:3 | Object | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:104:1:107:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
+| calls.rb:109:1:112:3 | Hash | [] | calls.rb:111:5:111:31 | [] |
+| calls.rb:114:1:127:3 | Array | [] | calls.rb:116:3:116:29 | [] |
+| calls.rb:114:1:127:3 | Array | foreach | calls.rb:120:3:126:5 | foreach |
+| calls.rb:114:1:127:3 | Array | length | calls.rb:118:3:118:17 | length |
+| calls.rb:154:1:158:3 | S | s_method | calls.rb:155:5:157:7 | s_method |
+| calls.rb:160:1:163:3 | A | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:165:1:168:3 | B | to_s | calls.rb:166:5:167:7 | to_s |
+| calls.rb:179:1:215:3 | Singletons | call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
+| calls.rb:179:1:215:3 | Singletons | instance | calls.rb:199:5:204:7 | instance |
+| calls.rb:299:1:309:3 | SelfNew | instance | calls.rb:300:5:302:7 | instance |
+| calls.rb:313:1:317:3 | C1 | instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:319:1:323:3 | C2 | instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:325:1:329:3 | C3 | instance | calls.rb:326:5:328:7 | instance |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
@@ -45,229 +54,320 @@ getMethod
 | private.rb:42:1:60:3 | F | private4 | private.rb:58:3:59:5 | private4 |
 | private.rb:42:1:60:3 | F | public | private.rb:46:3:47:5 | public |
 lookupMethod
-| calls.rb:15:1:24:3 | M | instance_m | calls.rb:16:5:16:23 | instance_m |
-| calls.rb:29:1:44:3 | C | baz | calls.rb:37:5:43:7 | baz |
-| calls.rb:29:1:44:3 | C | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:29:1:44:3 | C | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:29:1:44:3 | C | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:29:1:44:3 | C | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:29:1:44:3 | C | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:29:1:44:3 | C | instance_m | calls.rb:16:5:16:23 | instance_m |
-| calls.rb:29:1:44:3 | C | new | calls.rb:99:5:99:16 | new |
-| calls.rb:29:1:44:3 | C | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:29:1:44:3 | C | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:29:1:44:3 | C | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:29:1:44:3 | C | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:51:1:55:3 | D | baz | calls.rb:52:5:54:7 | baz |
-| calls.rb:51:1:55:3 | D | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:51:1:55:3 | D | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:51:1:55:3 | D | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:51:1:55:3 | D | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:51:1:55:3 | D | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:51:1:55:3 | D | instance_m | calls.rb:16:5:16:23 | instance_m |
-| calls.rb:51:1:55:3 | D | new | calls.rb:99:5:99:16 | new |
-| calls.rb:51:1:55:3 | D | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:51:1:55:3 | D | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:51:1:55:3 | D | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:51:1:55:3 | D | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:77:1:80:3 | Integer | abs | calls.rb:79:5:79:16 | abs |
-| calls.rb:77:1:80:3 | Integer | bit_length | calls.rb:78:5:78:23 | bit_length |
-| calls.rb:77:1:80:3 | Integer | new | calls.rb:99:5:99:16 | new |
-| calls.rb:77:1:80:3 | Integer | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:77:1:80:3 | Integer | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:82:1:84:3 | String | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:82:1:84:3 | String | capitalize | calls.rb:83:5:83:23 | capitalize |
-| calls.rb:82:1:84:3 | String | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:82:1:84:3 | String | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:82:1:84:3 | String | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:82:1:84:3 | String | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:82:1:84:3 | String | new | calls.rb:99:5:99:16 | new |
-| calls.rb:82:1:84:3 | String | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:82:1:84:3 | String | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:82:1:84:3 | String | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:82:1:84:3 | String | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:86:1:88:3 | Kernel | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:90:1:95:3 | Module | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:90:1:95:3 | Module | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:90:1:95:3 | Module | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:90:1:95:3 | Module | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:90:1:95:3 | Module | include | calls.rb:92:5:92:20 | include |
-| calls.rb:90:1:95:3 | Module | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:90:1:95:3 | Module | module_eval | calls.rb:91:5:91:24 | module_eval |
-| calls.rb:90:1:95:3 | Module | new | calls.rb:99:5:99:16 | new |
-| calls.rb:90:1:95:3 | Module | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:90:1:95:3 | Module | prepend | calls.rb:93:5:93:20 | prepend |
-| calls.rb:90:1:95:3 | Module | private | calls.rb:94:5:94:20 | private |
-| calls.rb:90:1:95:3 | Module | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:90:1:95:3 | Module | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:90:1:95:3 | Module | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:97:1:100:3 | Object | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:97:1:100:3 | Object | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:97:1:100:3 | Object | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:97:1:100:3 | Object | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:97:1:100:3 | Object | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:97:1:100:3 | Object | new | calls.rb:99:5:99:16 | new |
-| calls.rb:97:1:100:3 | Object | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:97:1:100:3 | Object | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:97:1:100:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
-| calls.rb:97:1:100:3 | Object | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:97:1:100:3 | Object | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:102:1:104:3 | Hash | [] | calls.rb:103:5:103:15 | [] |
-| calls.rb:102:1:104:3 | Hash | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:102:1:104:3 | Hash | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:102:1:104:3 | Hash | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:102:1:104:3 | Hash | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:102:1:104:3 | Hash | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:102:1:104:3 | Hash | new | calls.rb:99:5:99:16 | new |
-| calls.rb:102:1:104:3 | Hash | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:102:1:104:3 | Hash | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:102:1:104:3 | Hash | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:102:1:104:3 | Hash | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:106:1:117:3 | Array | [] | calls.rb:107:3:107:13 | [] |
-| calls.rb:106:1:117:3 | Array | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:106:1:117:3 | Array | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:106:1:117:3 | Array | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:106:1:117:3 | Array | foreach | calls.rb:110:3:116:5 | foreach |
-| calls.rb:106:1:117:3 | Array | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:106:1:117:3 | Array | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:106:1:117:3 | Array | length | calls.rb:108:3:108:17 | length |
-| calls.rb:106:1:117:3 | Array | new | calls.rb:99:5:99:16 | new |
-| calls.rb:106:1:117:3 | Array | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:106:1:117:3 | Array | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:106:1:117:3 | Array | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:106:1:117:3 | Array | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:144:1:148:3 | S | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:144:1:148:3 | S | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:144:1:148:3 | S | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:144:1:148:3 | S | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:144:1:148:3 | S | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:144:1:148:3 | S | new | calls.rb:99:5:99:16 | new |
-| calls.rb:144:1:148:3 | S | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:144:1:148:3 | S | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:144:1:148:3 | S | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:144:1:148:3 | S | s_method | calls.rb:145:5:147:7 | s_method |
-| calls.rb:144:1:148:3 | S | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:150:1:153:3 | A | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:150:1:153:3 | A | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:150:1:153:3 | A | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:150:1:153:3 | A | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:150:1:153:3 | A | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:150:1:153:3 | A | new | calls.rb:99:5:99:16 | new |
-| calls.rb:150:1:153:3 | A | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:150:1:153:3 | A | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:150:1:153:3 | A | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:150:1:153:3 | A | s_method | calls.rb:145:5:147:7 | s_method |
-| calls.rb:150:1:153:3 | A | to_s | calls.rb:151:5:152:7 | to_s |
-| calls.rb:155:1:158:3 | B | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:155:1:158:3 | B | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:155:1:158:3 | B | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:155:1:158:3 | B | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:155:1:158:3 | B | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:155:1:158:3 | B | new | calls.rb:99:5:99:16 | new |
-| calls.rb:155:1:158:3 | B | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:155:1:158:3 | B | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:155:1:158:3 | B | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:155:1:158:3 | B | s_method | calls.rb:145:5:147:7 | s_method |
-| calls.rb:155:1:158:3 | B | to_s | calls.rb:156:5:157:7 | to_s |
-| calls.rb:169:1:184:3 | Singletons | call_block | calls.rb:67:1:69:3 | call_block |
-| calls.rb:169:1:184:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:169:1:184:3 | Singletons | foo | calls.rb:71:1:75:3 | foo |
-| calls.rb:169:1:184:3 | Singletons | funny | calls.rb:119:1:121:3 | funny |
-| calls.rb:169:1:184:3 | Singletons | indirect | calls.rb:137:1:139:3 | indirect |
-| calls.rb:169:1:184:3 | Singletons | new | calls.rb:99:5:99:16 | new |
-| calls.rb:169:1:184:3 | Singletons | optional_arg | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:169:1:184:3 | Singletons | private_on_main | calls.rb:164:1:165:3 | private_on_main |
-| calls.rb:169:1:184:3 | Singletons | puts | calls.rb:87:5:87:17 | puts |
-| calls.rb:169:1:184:3 | Singletons | to_s | calls.rb:151:5:152:7 | to_s |
-| file://:0:0:0:0 | Class | include | calls.rb:92:5:92:20 | include |
-| file://:0:0:0:0 | Class | module_eval | calls.rb:91:5:91:24 | module_eval |
-| file://:0:0:0:0 | Class | new | calls.rb:99:5:99:16 | new |
-| file://:0:0:0:0 | Class | prepend | calls.rb:93:5:93:20 | prepend |
-| file://:0:0:0:0 | Class | private | calls.rb:94:5:94:20 | private |
-| file://:0:0:0:0 | Class | puts | calls.rb:87:5:87:17 | puts |
-| file://:0:0:0:0 | Class | to_s | calls.rb:151:5:152:7 | to_s |
-| file://:0:0:0:0 | Complex | new | calls.rb:99:5:99:16 | new |
-| file://:0:0:0:0 | Complex | puts | calls.rb:87:5:87:17 | puts |
-| file://:0:0:0:0 | Complex | to_s | calls.rb:151:5:152:7 | to_s |
-| file://:0:0:0:0 | FalseClass | new | calls.rb:99:5:99:16 | new |
-| file://:0:0:0:0 | FalseClass | puts | calls.rb:87:5:87:17 | puts |
-| file://:0:0:0:0 | FalseClass | to_s | calls.rb:151:5:152:7 | to_s |
-| file://:0:0:0:0 | Float | new | calls.rb:99:5:99:16 | new |
-| file://:0:0:0:0 | Float | puts | calls.rb:87:5:87:17 | puts |
-| file://:0:0:0:0 | Float | to_s | calls.rb:151:5:152:7 | to_s |
-| file://:0:0:0:0 | NilClass | new | calls.rb:99:5:99:16 | new |
-| file://:0:0:0:0 | NilClass | puts | calls.rb:87:5:87:17 | puts |
-| file://:0:0:0:0 | NilClass | to_s | calls.rb:151:5:152:7 | to_s |
-| file://:0:0:0:0 | Numeric | new | calls.rb:99:5:99:16 | new |
-| file://:0:0:0:0 | Numeric | puts | calls.rb:87:5:87:17 | puts |
-| file://:0:0:0:0 | Numeric | to_s | calls.rb:151:5:152:7 | to_s |
-| file://:0:0:0:0 | Rational | new | calls.rb:99:5:99:16 | new |
-| file://:0:0:0:0 | Rational | puts | calls.rb:87:5:87:17 | puts |
-| file://:0:0:0:0 | Rational | to_s | calls.rb:151:5:152:7 | to_s |
-| file://:0:0:0:0 | TrueClass | new | calls.rb:99:5:99:16 | new |
-| file://:0:0:0:0 | TrueClass | puts | calls.rb:87:5:87:17 | puts |
-| file://:0:0:0:0 | TrueClass | to_s | calls.rb:151:5:152:7 | to_s |
+| calls.rb:21:1:30:3 | M | instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:35:1:50:3 | C | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:35:1:50:3 | C | baz | calls.rb:43:5:49:7 | baz |
+| calls.rb:35:1:50:3 | C | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:35:1:50:3 | C | create | calls.rb:267:1:275:3 | create |
+| calls.rb:35:1:50:3 | C | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:35:1:50:3 | C | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:35:1:50:3 | C | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:35:1:50:3 | C | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:35:1:50:3 | C | instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:35:1:50:3 | C | new | calls.rb:106:5:106:16 | new |
+| calls.rb:35:1:50:3 | C | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:35:1:50:3 | C | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:35:1:50:3 | C | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:35:1:50:3 | C | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:35:1:50:3 | C | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:57:1:61:3 | D | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:57:1:61:3 | D | baz | calls.rb:58:5:60:7 | baz |
+| calls.rb:57:1:61:3 | D | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:57:1:61:3 | D | create | calls.rb:267:1:275:3 | create |
+| calls.rb:57:1:61:3 | D | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:57:1:61:3 | D | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:57:1:61:3 | D | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:57:1:61:3 | D | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:57:1:61:3 | D | instance_m | calls.rb:22:5:22:23 | instance_m |
+| calls.rb:57:1:61:3 | D | new | calls.rb:106:5:106:16 | new |
+| calls.rb:57:1:61:3 | D | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:57:1:61:3 | D | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:57:1:61:3 | D | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:57:1:61:3 | D | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:57:1:61:3 | D | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:83:1:86:3 | Integer | abs | calls.rb:85:5:85:16 | abs |
+| calls.rb:83:1:86:3 | Integer | bit_length | calls.rb:84:5:84:23 | bit_length |
+| calls.rb:83:1:86:3 | Integer | new | calls.rb:106:5:106:16 | new |
+| calls.rb:83:1:86:3 | Integer | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:83:1:86:3 | Integer | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:88:1:90:3 | String | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:88:1:90:3 | String | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:88:1:90:3 | String | capitalize | calls.rb:89:5:89:23 | capitalize |
+| calls.rb:88:1:90:3 | String | create | calls.rb:267:1:275:3 | create |
+| calls.rb:88:1:90:3 | String | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:88:1:90:3 | String | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:88:1:90:3 | String | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:88:1:90:3 | String | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:88:1:90:3 | String | new | calls.rb:106:5:106:16 | new |
+| calls.rb:88:1:90:3 | String | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:88:1:90:3 | String | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:88:1:90:3 | String | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:88:1:90:3 | String | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:88:1:90:3 | String | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:92:1:95:3 | Kernel | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:97:1:102:3 | Module | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:97:1:102:3 | Module | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:97:1:102:3 | Module | create | calls.rb:267:1:275:3 | create |
+| calls.rb:97:1:102:3 | Module | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:97:1:102:3 | Module | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:97:1:102:3 | Module | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:97:1:102:3 | Module | include | calls.rb:99:5:99:20 | include |
+| calls.rb:97:1:102:3 | Module | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:97:1:102:3 | Module | module_eval | calls.rb:98:5:98:24 | module_eval |
+| calls.rb:97:1:102:3 | Module | new | calls.rb:106:5:106:16 | new |
+| calls.rb:97:1:102:3 | Module | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:97:1:102:3 | Module | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:97:1:102:3 | Module | prepend | calls.rb:100:5:100:20 | prepend |
+| calls.rb:97:1:102:3 | Module | private | calls.rb:101:5:101:20 | private |
+| calls.rb:97:1:102:3 | Module | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:97:1:102:3 | Module | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:97:1:102:3 | Module | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:104:1:107:3 | Object | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:104:1:107:3 | Object | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:104:1:107:3 | Object | create | calls.rb:267:1:275:3 | create |
+| calls.rb:104:1:107:3 | Object | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:104:1:107:3 | Object | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:104:1:107:3 | Object | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:104:1:107:3 | Object | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:104:1:107:3 | Object | new | calls.rb:106:5:106:16 | new |
+| calls.rb:104:1:107:3 | Object | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:104:1:107:3 | Object | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:104:1:107:3 | Object | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:104:1:107:3 | Object | private_on_main | private.rb:31:1:32:3 | private_on_main |
+| calls.rb:104:1:107:3 | Object | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:104:1:107:3 | Object | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:109:1:112:3 | Hash | [] | calls.rb:111:5:111:31 | [] |
+| calls.rb:109:1:112:3 | Hash | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:109:1:112:3 | Hash | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:109:1:112:3 | Hash | create | calls.rb:267:1:275:3 | create |
+| calls.rb:109:1:112:3 | Hash | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:109:1:112:3 | Hash | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:109:1:112:3 | Hash | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:109:1:112:3 | Hash | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:109:1:112:3 | Hash | new | calls.rb:106:5:106:16 | new |
+| calls.rb:109:1:112:3 | Hash | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:109:1:112:3 | Hash | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:109:1:112:3 | Hash | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:109:1:112:3 | Hash | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:109:1:112:3 | Hash | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:114:1:127:3 | Array | [] | calls.rb:116:3:116:29 | [] |
+| calls.rb:114:1:127:3 | Array | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:114:1:127:3 | Array | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:114:1:127:3 | Array | create | calls.rb:267:1:275:3 | create |
+| calls.rb:114:1:127:3 | Array | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:114:1:127:3 | Array | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:114:1:127:3 | Array | foreach | calls.rb:120:3:126:5 | foreach |
+| calls.rb:114:1:127:3 | Array | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:114:1:127:3 | Array | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:114:1:127:3 | Array | length | calls.rb:118:3:118:17 | length |
+| calls.rb:114:1:127:3 | Array | new | calls.rb:106:5:106:16 | new |
+| calls.rb:114:1:127:3 | Array | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:114:1:127:3 | Array | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:114:1:127:3 | Array | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:114:1:127:3 | Array | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:114:1:127:3 | Array | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:154:1:158:3 | S | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:154:1:158:3 | S | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:154:1:158:3 | S | create | calls.rb:267:1:275:3 | create |
+| calls.rb:154:1:158:3 | S | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:154:1:158:3 | S | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:154:1:158:3 | S | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:154:1:158:3 | S | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:154:1:158:3 | S | new | calls.rb:106:5:106:16 | new |
+| calls.rb:154:1:158:3 | S | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:154:1:158:3 | S | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:154:1:158:3 | S | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:154:1:158:3 | S | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:154:1:158:3 | S | s_method | calls.rb:155:5:157:7 | s_method |
+| calls.rb:154:1:158:3 | S | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:160:1:163:3 | A | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:160:1:163:3 | A | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:160:1:163:3 | A | create | calls.rb:267:1:275:3 | create |
+| calls.rb:160:1:163:3 | A | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:160:1:163:3 | A | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:160:1:163:3 | A | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:160:1:163:3 | A | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:160:1:163:3 | A | new | calls.rb:106:5:106:16 | new |
+| calls.rb:160:1:163:3 | A | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:160:1:163:3 | A | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:160:1:163:3 | A | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:160:1:163:3 | A | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:160:1:163:3 | A | s_method | calls.rb:155:5:157:7 | s_method |
+| calls.rb:160:1:163:3 | A | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:165:1:168:3 | B | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:165:1:168:3 | B | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:165:1:168:3 | B | create | calls.rb:267:1:275:3 | create |
+| calls.rb:165:1:168:3 | B | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:165:1:168:3 | B | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:165:1:168:3 | B | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:165:1:168:3 | B | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:165:1:168:3 | B | new | calls.rb:106:5:106:16 | new |
+| calls.rb:165:1:168:3 | B | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:165:1:168:3 | B | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:165:1:168:3 | B | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:165:1:168:3 | B | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:165:1:168:3 | B | s_method | calls.rb:155:5:157:7 | s_method |
+| calls.rb:165:1:168:3 | B | to_s | calls.rb:166:5:167:7 | to_s |
+| calls.rb:179:1:215:3 | Singletons | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:179:1:215:3 | Singletons | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:179:1:215:3 | Singletons | call_singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
+| calls.rb:179:1:215:3 | Singletons | create | calls.rb:267:1:275:3 | create |
+| calls.rb:179:1:215:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:179:1:215:3 | Singletons | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:179:1:215:3 | Singletons | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:179:1:215:3 | Singletons | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:179:1:215:3 | Singletons | instance | calls.rb:199:5:204:7 | instance |
+| calls.rb:179:1:215:3 | Singletons | new | calls.rb:106:5:106:16 | new |
+| calls.rb:179:1:215:3 | Singletons | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:179:1:215:3 | Singletons | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:179:1:215:3 | Singletons | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:179:1:215:3 | Singletons | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:179:1:215:3 | Singletons | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:299:1:309:3 | SelfNew | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:299:1:309:3 | SelfNew | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:299:1:309:3 | SelfNew | create | calls.rb:267:1:275:3 | create |
+| calls.rb:299:1:309:3 | SelfNew | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:299:1:309:3 | SelfNew | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:299:1:309:3 | SelfNew | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:299:1:309:3 | SelfNew | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:299:1:309:3 | SelfNew | instance | calls.rb:300:5:302:7 | instance |
+| calls.rb:299:1:309:3 | SelfNew | new | calls.rb:106:5:106:16 | new |
+| calls.rb:299:1:309:3 | SelfNew | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:299:1:309:3 | SelfNew | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:299:1:309:3 | SelfNew | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:299:1:309:3 | SelfNew | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:299:1:309:3 | SelfNew | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:313:1:317:3 | C1 | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:313:1:317:3 | C1 | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:313:1:317:3 | C1 | create | calls.rb:267:1:275:3 | create |
+| calls.rb:313:1:317:3 | C1 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:313:1:317:3 | C1 | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:313:1:317:3 | C1 | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:313:1:317:3 | C1 | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:313:1:317:3 | C1 | instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:313:1:317:3 | C1 | new | calls.rb:106:5:106:16 | new |
+| calls.rb:313:1:317:3 | C1 | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:313:1:317:3 | C1 | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:313:1:317:3 | C1 | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:313:1:317:3 | C1 | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:313:1:317:3 | C1 | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:319:1:323:3 | C2 | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:319:1:323:3 | C2 | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:319:1:323:3 | C2 | create | calls.rb:267:1:275:3 | create |
+| calls.rb:319:1:323:3 | C2 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:319:1:323:3 | C2 | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:319:1:323:3 | C2 | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:319:1:323:3 | C2 | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:319:1:323:3 | C2 | instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:319:1:323:3 | C2 | new | calls.rb:106:5:106:16 | new |
+| calls.rb:319:1:323:3 | C2 | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:319:1:323:3 | C2 | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:319:1:323:3 | C2 | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:319:1:323:3 | C2 | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:319:1:323:3 | C2 | to_s | calls.rb:161:5:162:7 | to_s |
+| calls.rb:325:1:329:3 | C3 | add_singleton | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:325:1:329:3 | C3 | call_block | calls.rb:73:1:75:3 | call_block |
+| calls.rb:325:1:329:3 | C3 | create | calls.rb:267:1:275:3 | create |
+| calls.rb:325:1:329:3 | C3 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:325:1:329:3 | C3 | foo | calls.rb:77:1:81:3 | foo |
+| calls.rb:325:1:329:3 | C3 | funny | calls.rb:129:1:131:3 | funny |
+| calls.rb:325:1:329:3 | C3 | indirect | calls.rb:147:1:149:3 | indirect |
+| calls.rb:325:1:329:3 | C3 | instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:325:1:329:3 | C3 | new | calls.rb:106:5:106:16 | new |
+| calls.rb:325:1:329:3 | C3 | optional_arg | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:325:1:329:3 | C3 | pattern_dispatch | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:325:1:329:3 | C3 | private_on_main | calls.rb:174:1:175:3 | private_on_main |
+| calls.rb:325:1:329:3 | C3 | puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:325:1:329:3 | C3 | to_s | calls.rb:161:5:162:7 | to_s |
+| file://:0:0:0:0 | Class | include | calls.rb:99:5:99:20 | include |
+| file://:0:0:0:0 | Class | module_eval | calls.rb:98:5:98:24 | module_eval |
+| file://:0:0:0:0 | Class | new | calls.rb:106:5:106:16 | new |
+| file://:0:0:0:0 | Class | prepend | calls.rb:100:5:100:20 | prepend |
+| file://:0:0:0:0 | Class | private | calls.rb:101:5:101:20 | private |
+| file://:0:0:0:0 | Class | puts | calls.rb:94:5:94:30 | puts |
+| file://:0:0:0:0 | Class | to_s | calls.rb:161:5:162:7 | to_s |
+| file://:0:0:0:0 | Complex | new | calls.rb:106:5:106:16 | new |
+| file://:0:0:0:0 | Complex | puts | calls.rb:94:5:94:30 | puts |
+| file://:0:0:0:0 | Complex | to_s | calls.rb:161:5:162:7 | to_s |
+| file://:0:0:0:0 | FalseClass | new | calls.rb:106:5:106:16 | new |
+| file://:0:0:0:0 | FalseClass | puts | calls.rb:94:5:94:30 | puts |
+| file://:0:0:0:0 | FalseClass | to_s | calls.rb:161:5:162:7 | to_s |
+| file://:0:0:0:0 | Float | new | calls.rb:106:5:106:16 | new |
+| file://:0:0:0:0 | Float | puts | calls.rb:94:5:94:30 | puts |
+| file://:0:0:0:0 | Float | to_s | calls.rb:161:5:162:7 | to_s |
+| file://:0:0:0:0 | NilClass | new | calls.rb:106:5:106:16 | new |
+| file://:0:0:0:0 | NilClass | puts | calls.rb:94:5:94:30 | puts |
+| file://:0:0:0:0 | NilClass | to_s | calls.rb:161:5:162:7 | to_s |
+| file://:0:0:0:0 | Numeric | new | calls.rb:106:5:106:16 | new |
+| file://:0:0:0:0 | Numeric | puts | calls.rb:94:5:94:30 | puts |
+| file://:0:0:0:0 | Numeric | to_s | calls.rb:161:5:162:7 | to_s |
+| file://:0:0:0:0 | Rational | new | calls.rb:106:5:106:16 | new |
+| file://:0:0:0:0 | Rational | puts | calls.rb:94:5:94:30 | puts |
+| file://:0:0:0:0 | Rational | to_s | calls.rb:161:5:162:7 | to_s |
+| file://:0:0:0:0 | TrueClass | new | calls.rb:106:5:106:16 | new |
+| file://:0:0:0:0 | TrueClass | puts | calls.rb:94:5:94:30 | puts |
+| file://:0:0:0:0 | TrueClass | to_s | calls.rb:161:5:162:7 | to_s |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
-| hello.rb:11:1:16:3 | Greeting | new | calls.rb:99:5:99:16 | new |
-| hello.rb:11:1:16:3 | Greeting | puts | calls.rb:87:5:87:17 | puts |
-| hello.rb:11:1:16:3 | Greeting | to_s | calls.rb:151:5:152:7 | to_s |
+| hello.rb:11:1:16:3 | Greeting | new | calls.rb:106:5:106:16 | new |
+| hello.rb:11:1:16:3 | Greeting | puts | calls.rb:94:5:94:30 | puts |
+| hello.rb:11:1:16:3 | Greeting | to_s | calls.rb:161:5:162:7 | to_s |
 | hello.rb:11:1:16:3 | Greeting | world | hello.rb:5:5:7:7 | world |
 | hello.rb:18:1:22:3 | HelloWorld | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:18:1:22:3 | HelloWorld | message | hello.rb:19:5:21:7 | message |
-| hello.rb:18:1:22:3 | HelloWorld | new | calls.rb:99:5:99:16 | new |
-| hello.rb:18:1:22:3 | HelloWorld | puts | calls.rb:87:5:87:17 | puts |
-| hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:151:5:152:7 | to_s |
+| hello.rb:18:1:22:3 | HelloWorld | new | calls.rb:106:5:106:16 | new |
+| hello.rb:18:1:22:3 | HelloWorld | puts | calls.rb:94:5:94:30 | puts |
+| hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:161:5:162:7 | to_s |
 | hello.rb:18:1:22:3 | HelloWorld | world | hello.rb:5:5:7:7 | world |
 | modules.rb:4:1:24:3 | Foo | method_in_another_definition_of_foo | modules.rb:27:3:28:5 | method_in_another_definition_of_foo |
 | modules.rb:4:1:24:3 | Foo | method_in_foo | modules.rb:16:3:17:5 | method_in_foo |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_another_definition_of_foo_bar | modules.rb:52:3:53:5 | method_in_another_definition_of_foo_bar |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_foo_bar | modules.rb:9:5:10:7 | method_in_foo_bar |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | new | calls.rb:99:5:99:16 | new |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | to_s | calls.rb:151:5:152:7 | to_s |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | new | calls.rb:99:5:99:16 | new |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | to_s | calls.rb:151:5:152:7 | to_s |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | new | calls.rb:99:5:99:16 | new |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | to_s | calls.rb:151:5:152:7 | to_s |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | new | calls.rb:106:5:106:16 | new |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | to_s | calls.rb:161:5:162:7 | to_s |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | new | calls.rb:106:5:106:16 | new |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | to_s | calls.rb:161:5:162:7 | to_s |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | new | calls.rb:106:5:106:16 | new |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | to_s | calls.rb:161:5:162:7 | to_s |
 | modules.rb:37:1:46:3 | Bar | method_a | modules.rb:38:3:39:5 | method_a |
 | modules.rb:37:1:46:3 | Bar | method_b | modules.rb:41:3:42:5 | method_b |
-| modules.rb:37:1:46:3 | Bar | new | calls.rb:99:5:99:16 | new |
-| modules.rb:37:1:46:3 | Bar | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:37:1:46:3 | Bar | to_s | calls.rb:151:5:152:7 | to_s |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | new | calls.rb:99:5:99:16 | new |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | to_s | calls.rb:151:5:152:7 | to_s |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | new | calls.rb:99:5:99:16 | new |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | to_s | calls.rb:151:5:152:7 | to_s |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | new | calls.rb:99:5:99:16 | new |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | to_s | calls.rb:151:5:152:7 | to_s |
-| modules.rb:112:1:113:3 | YY | new | calls.rb:99:5:99:16 | new |
-| modules.rb:112:1:113:3 | YY | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:112:1:113:3 | YY | to_s | calls.rb:151:5:152:7 | to_s |
-| modules.rb:116:7:117:9 | XX::YY | new | calls.rb:99:5:99:16 | new |
-| modules.rb:116:7:117:9 | XX::YY | puts | calls.rb:87:5:87:17 | puts |
-| modules.rb:116:7:117:9 | XX::YY | to_s | calls.rb:151:5:152:7 | to_s |
-| modules_rec.rb:1:1:2:3 | B::A | new | calls.rb:99:5:99:16 | new |
-| modules_rec.rb:1:1:2:3 | B::A | puts | calls.rb:87:5:87:17 | puts |
-| modules_rec.rb:1:1:2:3 | B::A | to_s | calls.rb:151:5:152:7 | to_s |
-| modules_rec.rb:4:1:5:3 | A::B | new | calls.rb:99:5:99:16 | new |
-| modules_rec.rb:4:1:5:3 | A::B | puts | calls.rb:87:5:87:17 | puts |
-| modules_rec.rb:4:1:5:3 | A::B | to_s | calls.rb:151:5:152:7 | to_s |
-| private.rb:1:1:29:3 | E | new | calls.rb:99:5:99:16 | new |
+| modules.rb:37:1:46:3 | Bar | new | calls.rb:106:5:106:16 | new |
+| modules.rb:37:1:46:3 | Bar | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:37:1:46:3 | Bar | to_s | calls.rb:161:5:162:7 | to_s |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | new | calls.rb:106:5:106:16 | new |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | to_s | calls.rb:161:5:162:7 | to_s |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | new | calls.rb:106:5:106:16 | new |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | to_s | calls.rb:161:5:162:7 | to_s |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | new | calls.rb:106:5:106:16 | new |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | to_s | calls.rb:161:5:162:7 | to_s |
+| modules.rb:112:1:113:3 | YY | new | calls.rb:106:5:106:16 | new |
+| modules.rb:112:1:113:3 | YY | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:112:1:113:3 | YY | to_s | calls.rb:161:5:162:7 | to_s |
+| modules.rb:116:7:117:9 | XX::YY | new | calls.rb:106:5:106:16 | new |
+| modules.rb:116:7:117:9 | XX::YY | puts | calls.rb:94:5:94:30 | puts |
+| modules.rb:116:7:117:9 | XX::YY | to_s | calls.rb:161:5:162:7 | to_s |
+| modules_rec.rb:1:1:2:3 | B::A | new | calls.rb:106:5:106:16 | new |
+| modules_rec.rb:1:1:2:3 | B::A | puts | calls.rb:94:5:94:30 | puts |
+| modules_rec.rb:1:1:2:3 | B::A | to_s | calls.rb:161:5:162:7 | to_s |
+| modules_rec.rb:4:1:5:3 | A::B | new | calls.rb:106:5:106:16 | new |
+| modules_rec.rb:4:1:5:3 | A::B | puts | calls.rb:94:5:94:30 | puts |
+| modules_rec.rb:4:1:5:3 | A::B | to_s | calls.rb:161:5:162:7 | to_s |
+| private.rb:1:1:29:3 | E | new | calls.rb:106:5:106:16 | new |
 | private.rb:1:1:29:3 | E | private2 | private.rb:8:3:9:5 | private2 |
 | private.rb:1:1:29:3 | E | private3 | private.rb:14:3:15:5 | private3 |
 | private.rb:1:1:29:3 | E | private4 | private.rb:17:3:18:5 | private4 |
 | private.rb:1:1:29:3 | E | private_on_main | private.rb:31:1:32:3 | private_on_main |
 | private.rb:1:1:29:3 | E | public | private.rb:5:3:6:5 | public |
-| private.rb:1:1:29:3 | E | puts | calls.rb:87:5:87:17 | puts |
-| private.rb:1:1:29:3 | E | to_s | calls.rb:151:5:152:7 | to_s |
+| private.rb:1:1:29:3 | E | puts | calls.rb:94:5:94:30 | puts |
+| private.rb:1:1:29:3 | E | to_s | calls.rb:161:5:162:7 | to_s |
 | private.rb:42:1:60:3 | F | private2 | private.rb:49:3:50:5 | private2 |
 | private.rb:42:1:60:3 | F | private3 | private.rb:55:3:56:5 | private3 |
 | private.rb:42:1:60:3 | F | private4 | private.rb:58:3:59:5 | private4 |
@@ -277,85 +377,239 @@ enclosingMethod
 | calls.rb:2:5:2:14 | self | calls.rb:1:1:3:3 | foo |
 | calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:3:3 | foo |
 | calls.rb:2:11:2:13 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:8:5:8:14 | call to puts | calls.rb:7:1:9:3 | bar |
-| calls.rb:8:5:8:14 | self | calls.rb:7:1:9:3 | bar |
-| calls.rb:8:10:8:14 | "bar" | calls.rb:7:1:9:3 | bar |
-| calls.rb:8:11:8:13 | bar | calls.rb:7:1:9:3 | bar |
-| calls.rb:38:9:38:18 | call to instance_m | calls.rb:37:5:43:7 | baz |
-| calls.rb:38:9:38:18 | self | calls.rb:37:5:43:7 | baz |
-| calls.rb:39:9:39:12 | self | calls.rb:37:5:43:7 | baz |
-| calls.rb:39:9:39:23 | call to instance_m | calls.rb:37:5:43:7 | baz |
-| calls.rb:41:9:41:19 | call to singleton_m | calls.rb:37:5:43:7 | baz |
-| calls.rb:41:9:41:19 | self | calls.rb:37:5:43:7 | baz |
-| calls.rb:42:9:42:12 | self | calls.rb:37:5:43:7 | baz |
-| calls.rb:42:9:42:24 | call to singleton_m | calls.rb:37:5:43:7 | baz |
-| calls.rb:53:9:53:13 | call to super | calls.rb:52:5:54:7 | baz |
-| calls.rb:62:18:62:18 | a | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:62:18:62:18 | a | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:62:22:62:22 | 4 | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:62:25:62:25 | b | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:62:25:62:25 | b | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:62:28:62:28 | 5 | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:63:5:63:5 | a | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:63:5:63:16 | call to bit_length | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:64:5:64:5 | b | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:64:5:64:16 | call to bit_length | calls.rb:62:1:65:3 | optional_arg |
-| calls.rb:68:5:68:11 | yield ... | calls.rb:67:1:69:3 | call_block |
-| calls.rb:68:11:68:11 | 1 | calls.rb:67:1:69:3 | call_block |
-| calls.rb:72:5:72:7 | var | calls.rb:71:1:75:3 | foo |
-| calls.rb:72:5:72:18 | ... = ... | calls.rb:71:1:75:3 | foo |
-| calls.rb:72:11:72:14 | Hash | calls.rb:71:1:75:3 | foo |
-| calls.rb:72:11:72:18 | call to new | calls.rb:71:1:75:3 | foo |
-| calls.rb:73:5:73:7 | var | calls.rb:71:1:75:3 | foo |
-| calls.rb:73:5:73:10 | ...[...] | calls.rb:71:1:75:3 | foo |
-| calls.rb:73:9:73:9 | 1 | calls.rb:71:1:75:3 | foo |
-| calls.rb:74:5:74:29 | call to call_block | calls.rb:71:1:75:3 | foo |
-| calls.rb:74:5:74:29 | self | calls.rb:71:1:75:3 | foo |
-| calls.rb:74:16:74:29 | { ... } | calls.rb:71:1:75:3 | foo |
-| calls.rb:74:19:74:19 | x | calls.rb:71:1:75:3 | foo |
-| calls.rb:74:19:74:19 | x | calls.rb:71:1:75:3 | foo |
-| calls.rb:74:22:74:24 | var | calls.rb:71:1:75:3 | foo |
-| calls.rb:74:22:74:27 | ...[...] | calls.rb:71:1:75:3 | foo |
-| calls.rb:74:26:74:26 | x | calls.rb:71:1:75:3 | foo |
-| calls.rb:110:15:110:19 | &body | calls.rb:110:3:116:5 | foreach |
-| calls.rb:110:16:110:19 | body | calls.rb:110:3:116:5 | foreach |
-| calls.rb:111:5:111:5 | x | calls.rb:110:3:116:5 | foreach |
-| calls.rb:111:5:111:9 | ... = ... | calls.rb:110:3:116:5 | foreach |
-| calls.rb:111:9:111:9 | 0 | calls.rb:110:3:116:5 | foreach |
-| calls.rb:112:5:115:7 | while ... | calls.rb:110:3:116:5 | foreach |
-| calls.rb:112:11:112:11 | x | calls.rb:110:3:116:5 | foreach |
-| calls.rb:112:11:112:25 | ... < ... | calls.rb:110:3:116:5 | foreach |
-| calls.rb:112:15:112:18 | self | calls.rb:110:3:116:5 | foreach |
-| calls.rb:112:15:112:25 | call to length | calls.rb:110:3:116:5 | foreach |
-| calls.rb:112:26:115:7 | do ... | calls.rb:110:3:116:5 | foreach |
-| calls.rb:113:9:113:24 | yield ... | calls.rb:110:3:116:5 | foreach |
-| calls.rb:113:15:113:15 | x | calls.rb:110:3:116:5 | foreach |
-| calls.rb:113:18:113:21 | self | calls.rb:110:3:116:5 | foreach |
-| calls.rb:113:18:113:24 | ...[...] | calls.rb:110:3:116:5 | foreach |
-| calls.rb:113:23:113:23 | x | calls.rb:110:3:116:5 | foreach |
-| calls.rb:114:9:114:9 | x | calls.rb:110:3:116:5 | foreach |
-| calls.rb:114:9:114:9 | x | calls.rb:110:3:116:5 | foreach |
-| calls.rb:114:9:114:14 | ... += ... | calls.rb:110:3:116:5 | foreach |
-| calls.rb:114:9:114:14 | ... = ... | calls.rb:110:3:116:5 | foreach |
-| calls.rb:114:11:114:12 | ... + ... | calls.rb:110:3:116:5 | foreach |
-| calls.rb:114:14:114:14 | 1 | calls.rb:110:3:116:5 | foreach |
-| calls.rb:120:5:120:20 | yield ... | calls.rb:119:1:121:3 | funny |
-| calls.rb:120:11:120:20 | "prefix: " | calls.rb:119:1:121:3 | funny |
-| calls.rb:120:12:120:19 | prefix:  | calls.rb:119:1:121:3 | funny |
-| calls.rb:137:14:137:15 | &b | calls.rb:137:1:139:3 | indirect |
-| calls.rb:137:15:137:15 | b | calls.rb:137:1:139:3 | indirect |
-| calls.rb:138:5:138:17 | call to call_block | calls.rb:137:1:139:3 | indirect |
-| calls.rb:138:5:138:17 | self | calls.rb:137:1:139:3 | indirect |
-| calls.rb:138:16:138:17 | &... | calls.rb:137:1:139:3 | indirect |
-| calls.rb:138:17:138:17 | b | calls.rb:137:1:139:3 | indirect |
-| calls.rb:146:9:146:12 | self | calls.rb:145:5:147:7 | s_method |
-| calls.rb:146:9:146:17 | call to to_s | calls.rb:145:5:147:7 | s_method |
-| calls.rb:171:9:171:12 | self | calls.rb:170:5:172:7 | singleton_a |
-| calls.rb:171:9:171:24 | call to singleton_b | calls.rb:170:5:172:7 | singleton_a |
-| calls.rb:175:9:175:12 | self | calls.rb:174:5:176:7 | singleton_b |
-| calls.rb:175:9:175:24 | call to singleton_c | calls.rb:174:5:176:7 | singleton_b |
-| calls.rb:182:9:182:12 | self | calls.rb:181:5:183:7 | singleton_d |
-| calls.rb:182:9:182:24 | call to singleton_a | calls.rb:181:5:183:7 | singleton_d |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:7:1:9:3 | bar |
+| calls.rb:8:5:8:15 | self | calls.rb:7:1:9:3 | bar |
+| calls.rb:8:10:8:15 | "bar1" | calls.rb:7:1:9:3 | bar |
+| calls.rb:8:11:8:14 | bar1 | calls.rb:7:1:9:3 | bar |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:13:1:15:3 | bar |
+| calls.rb:14:5:14:15 | self | calls.rb:13:1:15:3 | bar |
+| calls.rb:14:10:14:15 | "bar2" | calls.rb:13:1:15:3 | bar |
+| calls.rb:14:11:14:14 | bar2 | calls.rb:13:1:15:3 | bar |
+| calls.rb:44:9:44:18 | call to instance_m | calls.rb:43:5:49:7 | baz |
+| calls.rb:44:9:44:18 | self | calls.rb:43:5:49:7 | baz |
+| calls.rb:45:9:45:12 | self | calls.rb:43:5:49:7 | baz |
+| calls.rb:45:9:45:23 | call to instance_m | calls.rb:43:5:49:7 | baz |
+| calls.rb:47:9:47:19 | call to singleton_m | calls.rb:43:5:49:7 | baz |
+| calls.rb:47:9:47:19 | self | calls.rb:43:5:49:7 | baz |
+| calls.rb:48:9:48:12 | self | calls.rb:43:5:49:7 | baz |
+| calls.rb:48:9:48:24 | call to singleton_m | calls.rb:43:5:49:7 | baz |
+| calls.rb:59:9:59:13 | call to super | calls.rb:58:5:60:7 | baz |
+| calls.rb:68:18:68:18 | a | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:68:18:68:18 | a | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:68:22:68:22 | 4 | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:68:25:68:25 | b | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:68:25:68:25 | b | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:68:28:68:28 | 5 | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:69:5:69:5 | a | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:69:5:69:16 | call to bit_length | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:70:5:70:5 | b | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:70:5:70:16 | call to bit_length | calls.rb:68:1:71:3 | optional_arg |
+| calls.rb:74:5:74:11 | yield ... | calls.rb:73:1:75:3 | call_block |
+| calls.rb:74:11:74:11 | 1 | calls.rb:73:1:75:3 | call_block |
+| calls.rb:78:5:78:7 | var | calls.rb:77:1:81:3 | foo |
+| calls.rb:78:5:78:18 | ... = ... | calls.rb:77:1:81:3 | foo |
+| calls.rb:78:11:78:14 | Hash | calls.rb:77:1:81:3 | foo |
+| calls.rb:78:11:78:18 | call to new | calls.rb:77:1:81:3 | foo |
+| calls.rb:79:5:79:7 | var | calls.rb:77:1:81:3 | foo |
+| calls.rb:79:5:79:10 | ...[...] | calls.rb:77:1:81:3 | foo |
+| calls.rb:79:9:79:9 | 1 | calls.rb:77:1:81:3 | foo |
+| calls.rb:80:5:80:29 | call to call_block | calls.rb:77:1:81:3 | foo |
+| calls.rb:80:5:80:29 | self | calls.rb:77:1:81:3 | foo |
+| calls.rb:80:16:80:29 | { ... } | calls.rb:77:1:81:3 | foo |
+| calls.rb:80:19:80:19 | x | calls.rb:77:1:81:3 | foo |
+| calls.rb:80:19:80:19 | x | calls.rb:77:1:81:3 | foo |
+| calls.rb:80:22:80:24 | var | calls.rb:77:1:81:3 | foo |
+| calls.rb:80:22:80:27 | ...[...] | calls.rb:77:1:81:3 | foo |
+| calls.rb:80:26:80:26 | x | calls.rb:77:1:81:3 | foo |
+| calls.rb:94:14:94:14 | x | calls.rb:94:5:94:30 | puts |
+| calls.rb:94:14:94:14 | x | calls.rb:94:5:94:30 | puts |
+| calls.rb:94:17:94:26 | call to old_puts | calls.rb:94:5:94:30 | puts |
+| calls.rb:94:17:94:26 | self | calls.rb:94:5:94:30 | puts |
+| calls.rb:94:26:94:26 | x | calls.rb:94:5:94:30 | puts |
+| calls.rb:111:12:111:12 | x | calls.rb:111:5:111:31 | [] |
+| calls.rb:111:12:111:12 | x | calls.rb:111:5:111:31 | [] |
+| calls.rb:111:15:111:27 | call to old_lookup | calls.rb:111:5:111:31 | [] |
+| calls.rb:111:15:111:27 | self | calls.rb:111:5:111:31 | [] |
+| calls.rb:111:26:111:26 | x | calls.rb:111:5:111:31 | [] |
+| calls.rb:116:10:116:10 | x | calls.rb:116:3:116:29 | [] |
+| calls.rb:116:10:116:10 | x | calls.rb:116:3:116:29 | [] |
+| calls.rb:116:13:116:25 | call to old_lookup | calls.rb:116:3:116:29 | [] |
+| calls.rb:116:13:116:25 | self | calls.rb:116:3:116:29 | [] |
+| calls.rb:116:24:116:24 | x | calls.rb:116:3:116:29 | [] |
+| calls.rb:120:15:120:19 | &body | calls.rb:120:3:126:5 | foreach |
+| calls.rb:120:16:120:19 | body | calls.rb:120:3:126:5 | foreach |
+| calls.rb:121:5:121:5 | x | calls.rb:120:3:126:5 | foreach |
+| calls.rb:121:5:121:9 | ... = ... | calls.rb:120:3:126:5 | foreach |
+| calls.rb:121:9:121:9 | 0 | calls.rb:120:3:126:5 | foreach |
+| calls.rb:122:5:125:7 | while ... | calls.rb:120:3:126:5 | foreach |
+| calls.rb:122:11:122:11 | x | calls.rb:120:3:126:5 | foreach |
+| calls.rb:122:11:122:25 | ... < ... | calls.rb:120:3:126:5 | foreach |
+| calls.rb:122:15:122:18 | self | calls.rb:120:3:126:5 | foreach |
+| calls.rb:122:15:122:25 | call to length | calls.rb:120:3:126:5 | foreach |
+| calls.rb:122:26:125:7 | do ... | calls.rb:120:3:126:5 | foreach |
+| calls.rb:123:9:123:24 | yield ... | calls.rb:120:3:126:5 | foreach |
+| calls.rb:123:15:123:15 | x | calls.rb:120:3:126:5 | foreach |
+| calls.rb:123:18:123:21 | self | calls.rb:120:3:126:5 | foreach |
+| calls.rb:123:18:123:24 | ...[...] | calls.rb:120:3:126:5 | foreach |
+| calls.rb:123:23:123:23 | x | calls.rb:120:3:126:5 | foreach |
+| calls.rb:124:9:124:9 | x | calls.rb:120:3:126:5 | foreach |
+| calls.rb:124:9:124:9 | x | calls.rb:120:3:126:5 | foreach |
+| calls.rb:124:9:124:14 | ... += ... | calls.rb:120:3:126:5 | foreach |
+| calls.rb:124:9:124:14 | ... = ... | calls.rb:120:3:126:5 | foreach |
+| calls.rb:124:11:124:12 | ... + ... | calls.rb:120:3:126:5 | foreach |
+| calls.rb:124:14:124:14 | 1 | calls.rb:120:3:126:5 | foreach |
+| calls.rb:130:5:130:20 | yield ... | calls.rb:129:1:131:3 | funny |
+| calls.rb:130:11:130:20 | "prefix: " | calls.rb:129:1:131:3 | funny |
+| calls.rb:130:12:130:19 | prefix:  | calls.rb:129:1:131:3 | funny |
+| calls.rb:147:14:147:15 | &b | calls.rb:147:1:149:3 | indirect |
+| calls.rb:147:15:147:15 | b | calls.rb:147:1:149:3 | indirect |
+| calls.rb:148:5:148:17 | call to call_block | calls.rb:147:1:149:3 | indirect |
+| calls.rb:148:5:148:17 | self | calls.rb:147:1:149:3 | indirect |
+| calls.rb:148:16:148:17 | &... | calls.rb:147:1:149:3 | indirect |
+| calls.rb:148:17:148:17 | b | calls.rb:147:1:149:3 | indirect |
+| calls.rb:156:9:156:12 | self | calls.rb:155:5:157:7 | s_method |
+| calls.rb:156:9:156:17 | call to to_s | calls.rb:155:5:157:7 | s_method |
+| calls.rb:181:9:181:26 | call to puts | calls.rb:180:5:183:7 | singleton_a |
+| calls.rb:181:9:181:26 | self | calls.rb:180:5:183:7 | singleton_a |
+| calls.rb:181:14:181:26 | "singleton_a" | calls.rb:180:5:183:7 | singleton_a |
+| calls.rb:181:15:181:25 | singleton_a | calls.rb:180:5:183:7 | singleton_a |
+| calls.rb:182:9:182:12 | self | calls.rb:180:5:183:7 | singleton_a |
+| calls.rb:182:9:182:24 | call to singleton_b | calls.rb:180:5:183:7 | singleton_a |
+| calls.rb:186:9:186:26 | call to puts | calls.rb:185:5:188:7 | singleton_b |
+| calls.rb:186:9:186:26 | self | calls.rb:185:5:188:7 | singleton_b |
+| calls.rb:186:14:186:26 | "singleton_b" | calls.rb:185:5:188:7 | singleton_b |
+| calls.rb:186:15:186:25 | singleton_b | calls.rb:185:5:188:7 | singleton_b |
+| calls.rb:187:9:187:12 | self | calls.rb:185:5:188:7 | singleton_b |
+| calls.rb:187:9:187:24 | call to singleton_c | calls.rb:185:5:188:7 | singleton_b |
+| calls.rb:191:9:191:26 | call to puts | calls.rb:190:5:192:7 | singleton_c |
+| calls.rb:191:9:191:26 | self | calls.rb:190:5:192:7 | singleton_c |
+| calls.rb:191:14:191:26 | "singleton_c" | calls.rb:190:5:192:7 | singleton_c |
+| calls.rb:191:15:191:25 | singleton_c | calls.rb:190:5:192:7 | singleton_c |
+| calls.rb:195:9:195:26 | call to puts | calls.rb:194:5:197:7 | singleton_d |
+| calls.rb:195:9:195:26 | self | calls.rb:194:5:197:7 | singleton_d |
+| calls.rb:195:14:195:26 | "singleton_d" | calls.rb:194:5:197:7 | singleton_d |
+| calls.rb:195:15:195:25 | singleton_d | calls.rb:194:5:197:7 | singleton_d |
+| calls.rb:196:9:196:12 | self | calls.rb:194:5:197:7 | singleton_d |
+| calls.rb:196:9:196:24 | call to singleton_a | calls.rb:194:5:197:7 | singleton_d |
+| calls.rb:200:9:202:11 | singleton_e | calls.rb:199:5:204:7 | instance |
+| calls.rb:200:13:200:16 | self | calls.rb:199:5:204:7 | instance |
+| calls.rb:201:13:201:30 | call to puts | calls.rb:200:9:202:11 | singleton_e |
+| calls.rb:201:13:201:30 | self | calls.rb:200:9:202:11 | singleton_e |
+| calls.rb:201:18:201:30 | "singleton_e" | calls.rb:200:9:202:11 | singleton_e |
+| calls.rb:201:19:201:29 | singleton_e | calls.rb:200:9:202:11 | singleton_e |
+| calls.rb:203:9:203:19 | call to singleton_e | calls.rb:199:5:204:7 | instance |
+| calls.rb:203:9:203:19 | self | calls.rb:199:5:204:7 | instance |
+| calls.rb:208:13:208:30 | call to puts | calls.rb:207:9:209:11 | singleton_f |
+| calls.rb:208:13:208:30 | self | calls.rb:207:9:209:11 | singleton_f |
+| calls.rb:208:18:208:30 | "singleton_f" | calls.rb:207:9:209:11 | singleton_f |
+| calls.rb:208:19:208:29 | singleton_f | calls.rb:207:9:209:11 | singleton_f |
+| calls.rb:213:9:213:12 | self | calls.rb:212:5:214:7 | call_singleton_g |
+| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:212:5:214:7 | call_singleton_g |
+| calls.rb:226:5:226:24 | call to puts | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:226:5:226:24 | self | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:226:10:226:24 | "singleton_g_1" | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:226:11:226:23 | singleton_g_1 | calls.rb:225:1:227:3 | singleton_g |
+| calls.rb:233:5:233:24 | call to puts | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:233:5:233:24 | self | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:233:10:233:24 | "singleton_g_2" | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:233:11:233:23 | singleton_g_2 | calls.rb:232:1:234:3 | singleton_g |
+| calls.rb:241:9:241:28 | call to puts | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:241:9:241:28 | self | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:241:14:241:28 | "singleton_g_3" | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:241:15:241:27 | singleton_g_3 | calls.rb:240:5:242:7 | singleton_g |
+| calls.rb:257:5:257:22 | call to puts | calls.rb:256:1:258:3 | singleton_g |
+| calls.rb:257:5:257:22 | self | calls.rb:256:1:258:3 | singleton_g |
+| calls.rb:257:10:257:22 | "singleton_g" | calls.rb:256:1:258:3 | singleton_g |
+| calls.rb:257:11:257:21 | singleton_g | calls.rb:256:1:258:3 | singleton_g |
+| calls.rb:267:12:267:15 | type | calls.rb:267:1:275:3 | create |
+| calls.rb:267:12:267:15 | type | calls.rb:267:1:275:3 | create |
+| calls.rb:268:5:268:8 | type | calls.rb:267:1:275:3 | create |
+| calls.rb:268:5:268:12 | call to new | calls.rb:267:1:275:3 | create |
+| calls.rb:268:5:268:21 | call to instance | calls.rb:267:1:275:3 | create |
+| calls.rb:270:5:272:7 | singleton_h | calls.rb:267:1:275:3 | create |
+| calls.rb:270:9:270:12 | type | calls.rb:267:1:275:3 | create |
+| calls.rb:271:9:271:26 | call to puts | calls.rb:270:5:272:7 | singleton_h |
+| calls.rb:271:9:271:26 | self | calls.rb:270:5:272:7 | singleton_h |
+| calls.rb:271:14:271:26 | "singleton_h" | calls.rb:270:5:272:7 | singleton_h |
+| calls.rb:271:15:271:25 | singleton_h | calls.rb:270:5:272:7 | singleton_h |
+| calls.rb:274:5:274:8 | type | calls.rb:267:1:275:3 | create |
+| calls.rb:274:5:274:20 | call to singleton_h | calls.rb:267:1:275:3 | create |
+| calls.rb:284:9:284:26 | call to puts | calls.rb:283:5:285:7 | singleton_i |
+| calls.rb:284:9:284:26 | self | calls.rb:283:5:285:7 | singleton_i |
+| calls.rb:284:14:284:26 | "singleton_i" | calls.rb:283:5:285:7 | singleton_i |
+| calls.rb:284:15:284:25 | singleton_i | calls.rb:283:5:285:7 | singleton_i |
+| calls.rb:293:9:293:26 | call to puts | calls.rb:292:5:294:7 | singleton_j |
+| calls.rb:293:9:293:26 | self | calls.rb:292:5:294:7 | singleton_j |
+| calls.rb:293:14:293:26 | "singleton_j" | calls.rb:292:5:294:7 | singleton_j |
+| calls.rb:293:15:293:25 | singleton_j | calls.rb:292:5:294:7 | singleton_j |
+| calls.rb:301:9:301:31 | call to puts | calls.rb:300:5:302:7 | instance |
+| calls.rb:301:9:301:31 | self | calls.rb:300:5:302:7 | instance |
+| calls.rb:301:14:301:31 | "SelfNew#instance" | calls.rb:300:5:302:7 | instance |
+| calls.rb:301:15:301:30 | SelfNew#instance | calls.rb:300:5:302:7 | instance |
+| calls.rb:305:9:305:11 | call to new | calls.rb:304:5:306:7 | singleton |
+| calls.rb:305:9:305:11 | self | calls.rb:304:5:306:7 | singleton |
+| calls.rb:305:9:305:20 | call to instance | calls.rb:304:5:306:7 | singleton |
+| calls.rb:315:9:315:26 | call to puts | calls.rb:314:5:316:7 | instance |
+| calls.rb:315:9:315:26 | self | calls.rb:314:5:316:7 | instance |
+| calls.rb:315:14:315:26 | "C1#instance" | calls.rb:314:5:316:7 | instance |
+| calls.rb:315:15:315:25 | C1#instance | calls.rb:314:5:316:7 | instance |
+| calls.rb:321:9:321:26 | call to puts | calls.rb:320:5:322:7 | instance |
+| calls.rb:321:9:321:26 | self | calls.rb:320:5:322:7 | instance |
+| calls.rb:321:14:321:26 | "C2#instance" | calls.rb:320:5:322:7 | instance |
+| calls.rb:321:15:321:25 | C2#instance | calls.rb:320:5:322:7 | instance |
+| calls.rb:327:9:327:26 | call to puts | calls.rb:326:5:328:7 | instance |
+| calls.rb:327:9:327:26 | self | calls.rb:326:5:328:7 | instance |
+| calls.rb:327:14:327:26 | "C3#instance" | calls.rb:326:5:328:7 | instance |
+| calls.rb:327:15:327:25 | C3#instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:331:22:331:22 | x | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:331:22:331:22 | x | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:332:5:340:7 | case ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:332:10:332:10 | x | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:333:5:334:18 | when ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:333:10:333:11 | C3 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:333:12:334:18 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:334:9:334:9 | x | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:334:9:334:18 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:335:5:336:18 | when ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:335:10:335:11 | C2 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:335:12:336:18 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:336:9:336:9 | x | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:336:9:336:18 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:337:5:338:18 | when ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:337:10:337:11 | C1 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:337:12:338:18 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:338:9:338:9 | x | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:338:9:338:18 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:339:5:339:8 | else ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:342:5:346:7 | case ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:342:10:342:10 | x | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:343:9:343:29 | in ... then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:343:12:343:13 | C3 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:343:15:343:29 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:343:20:343:20 | x | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:343:20:343:29 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:344:9:344:36 | in ... then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:344:12:344:13 | C2 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:344:12:344:19 | ... => ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:344:18:344:19 | c2 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:344:21:344:36 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:344:26:344:27 | c2 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:344:26:344:36 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:345:9:345:36 | in ... then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:345:12:345:13 | C1 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:345:12:345:19 | ... => ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:345:18:345:19 | c1 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:345:21:345:36 | then ... | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:345:26:345:27 | c1 | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:345:26:345:36 | call to instance | calls.rb:331:1:347:3 | pattern_dispatch |
+| calls.rb:355:19:355:19 | x | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:355:19:355:19 | x | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:356:5:358:7 | instance | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:356:9:356:9 | x | calls.rb:355:1:359:3 | add_singleton |
+| calls.rb:357:9:357:28 | call to puts | calls.rb:356:5:358:7 | instance |
+| calls.rb:357:9:357:28 | self | calls.rb:356:5:358:7 | instance |
+| calls.rb:357:14:357:28 | "instance_on x" | calls.rb:356:5:358:7 | instance |
+| calls.rb:357:15:357:27 | instance_on x | calls.rb:356:5:358:7 | instance |
 | hello.rb:3:9:3:22 | return | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:16:3:22 | "hello" | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:17:3:21 | hello | hello.rb:2:5:4:7 | hello |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -1,22 +1,22 @@
 getModule
 | calls.rb:21:1:30:3 | M |
-| calls.rb:35:1:50:3 | C |
-| calls.rb:57:1:61:3 | D |
-| calls.rb:83:1:86:3 | Integer |
-| calls.rb:88:1:90:3 | String |
-| calls.rb:92:1:95:3 | Kernel |
-| calls.rb:97:1:102:3 | Module |
-| calls.rb:104:1:107:3 | Object |
-| calls.rb:109:1:112:3 | Hash |
-| calls.rb:114:1:127:3 | Array |
-| calls.rb:154:1:158:3 | S |
-| calls.rb:160:1:163:3 | A |
-| calls.rb:165:1:168:3 | B |
-| calls.rb:179:1:215:3 | Singletons |
-| calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:313:1:317:3 | C1 |
-| calls.rb:319:1:323:3 | C2 |
-| calls.rb:325:1:329:3 | C3 |
+| calls.rb:39:1:54:3 | C |
+| calls.rb:61:1:65:3 | D |
+| calls.rb:87:1:90:3 | Integer |
+| calls.rb:92:1:94:3 | String |
+| calls.rb:96:1:99:3 | Kernel |
+| calls.rb:101:1:106:3 | Module |
+| calls.rb:108:1:111:3 | Object |
+| calls.rb:113:1:116:3 | Hash |
+| calls.rb:118:1:131:3 | Array |
+| calls.rb:158:1:162:3 | S |
+| calls.rb:164:1:167:3 | A |
+| calls.rb:169:1:172:3 | B |
+| calls.rb:183:1:219:3 | Singletons |
+| calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:317:1:321:3 | C1 |
+| calls.rb:323:1:327:3 | C2 |
+| calls.rb:329:1:333:3 | C3 |
 | file://:0:0:0:0 | BasicObject |
 | file://:0:0:0:0 | Class |
 | file://:0:0:0:0 | Complex |
@@ -67,29 +67,29 @@ getModule
 | private.rb:42:1:60:3 | F |
 getADeclaration
 | calls.rb:21:1:30:3 | M | calls.rb:21:1:30:3 | M |
-| calls.rb:35:1:50:3 | C | calls.rb:35:1:50:3 | C |
-| calls.rb:57:1:61:3 | D | calls.rb:57:1:61:3 | D |
-| calls.rb:83:1:86:3 | Integer | calls.rb:83:1:86:3 | Integer |
-| calls.rb:88:1:90:3 | String | calls.rb:88:1:90:3 | String |
-| calls.rb:92:1:95:3 | Kernel | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:97:1:102:3 | Module | calls.rb:97:1:102:3 | Module |
-| calls.rb:104:1:107:3 | Object | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:104:1:107:3 | Object | calls.rb:104:1:107:3 | Object |
-| calls.rb:104:1:107:3 | Object | hello.rb:1:1:22:3 | hello.rb |
-| calls.rb:104:1:107:3 | Object | modules.rb:1:1:129:4 | modules.rb |
-| calls.rb:104:1:107:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
-| calls.rb:104:1:107:3 | Object | private.rb:1:1:60:3 | private.rb |
-| calls.rb:109:1:112:3 | Hash | calls.rb:109:1:112:3 | Hash |
-| calls.rb:114:1:127:3 | Array | calls.rb:114:1:127:3 | Array |
-| calls.rb:154:1:158:3 | S | calls.rb:154:1:158:3 | S |
-| calls.rb:160:1:163:3 | A | calls.rb:160:1:163:3 | A |
-| calls.rb:160:1:163:3 | A | modules_rec.rb:7:1:9:3 | A |
-| calls.rb:165:1:168:3 | B | calls.rb:165:1:168:3 | B |
-| calls.rb:179:1:215:3 | Singletons | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:299:1:309:3 | SelfNew | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:313:1:317:3 | C1 | calls.rb:313:1:317:3 | C1 |
-| calls.rb:319:1:323:3 | C2 | calls.rb:319:1:323:3 | C2 |
-| calls.rb:325:1:329:3 | C3 | calls.rb:325:1:329:3 | C3 |
+| calls.rb:39:1:54:3 | C | calls.rb:39:1:54:3 | C |
+| calls.rb:61:1:65:3 | D | calls.rb:61:1:65:3 | D |
+| calls.rb:87:1:90:3 | Integer | calls.rb:87:1:90:3 | Integer |
+| calls.rb:92:1:94:3 | String | calls.rb:92:1:94:3 | String |
+| calls.rb:96:1:99:3 | Kernel | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:101:1:106:3 | Module | calls.rb:101:1:106:3 | Module |
+| calls.rb:108:1:111:3 | Object | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:108:1:111:3 | Object | calls.rb:108:1:111:3 | Object |
+| calls.rb:108:1:111:3 | Object | hello.rb:1:1:22:3 | hello.rb |
+| calls.rb:108:1:111:3 | Object | modules.rb:1:1:129:4 | modules.rb |
+| calls.rb:108:1:111:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| calls.rb:108:1:111:3 | Object | private.rb:1:1:60:3 | private.rb |
+| calls.rb:113:1:116:3 | Hash | calls.rb:113:1:116:3 | Hash |
+| calls.rb:118:1:131:3 | Array | calls.rb:118:1:131:3 | Array |
+| calls.rb:158:1:162:3 | S | calls.rb:158:1:162:3 | S |
+| calls.rb:164:1:167:3 | A | calls.rb:164:1:167:3 | A |
+| calls.rb:164:1:167:3 | A | modules_rec.rb:7:1:9:3 | A |
+| calls.rb:169:1:172:3 | B | calls.rb:169:1:172:3 | B |
+| calls.rb:183:1:219:3 | Singletons | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:303:1:313:3 | SelfNew | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:317:1:321:3 | C1 | calls.rb:317:1:321:3 | C1 |
+| calls.rb:323:1:327:3 | C2 | calls.rb:323:1:327:3 | C2 |
+| calls.rb:329:1:333:3 | C3 | calls.rb:329:1:333:3 | C3 |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
@@ -131,101 +131,101 @@ getADeclaration
 | private.rb:1:1:29:3 | E | private.rb:1:1:29:3 | E |
 | private.rb:42:1:60:3 | F | private.rb:42:1:60:3 | F |
 getSuperClass
-| calls.rb:35:1:50:3 | C | calls.rb:104:1:107:3 | Object |
-| calls.rb:57:1:61:3 | D | calls.rb:35:1:50:3 | C |
-| calls.rb:83:1:86:3 | Integer | file://:0:0:0:0 | Numeric |
-| calls.rb:88:1:90:3 | String | calls.rb:104:1:107:3 | Object |
-| calls.rb:97:1:102:3 | Module | calls.rb:104:1:107:3 | Object |
-| calls.rb:104:1:107:3 | Object | file://:0:0:0:0 | BasicObject |
-| calls.rb:109:1:112:3 | Hash | calls.rb:104:1:107:3 | Object |
-| calls.rb:114:1:127:3 | Array | calls.rb:104:1:107:3 | Object |
-| calls.rb:154:1:158:3 | S | calls.rb:104:1:107:3 | Object |
-| calls.rb:160:1:163:3 | A | calls.rb:154:1:158:3 | S |
-| calls.rb:160:1:163:3 | A | calls.rb:165:1:168:3 | B |
-| calls.rb:165:1:168:3 | B | calls.rb:154:1:158:3 | S |
-| calls.rb:179:1:215:3 | Singletons | calls.rb:104:1:107:3 | Object |
-| calls.rb:299:1:309:3 | SelfNew | calls.rb:104:1:107:3 | Object |
-| calls.rb:313:1:317:3 | C1 | calls.rb:104:1:107:3 | Object |
-| calls.rb:319:1:323:3 | C2 | calls.rb:313:1:317:3 | C1 |
-| calls.rb:325:1:329:3 | C3 | calls.rb:319:1:323:3 | C2 |
-| file://:0:0:0:0 | Class | calls.rb:97:1:102:3 | Module |
+| calls.rb:39:1:54:3 | C | calls.rb:108:1:111:3 | Object |
+| calls.rb:61:1:65:3 | D | calls.rb:39:1:54:3 | C |
+| calls.rb:87:1:90:3 | Integer | file://:0:0:0:0 | Numeric |
+| calls.rb:92:1:94:3 | String | calls.rb:108:1:111:3 | Object |
+| calls.rb:101:1:106:3 | Module | calls.rb:108:1:111:3 | Object |
+| calls.rb:108:1:111:3 | Object | file://:0:0:0:0 | BasicObject |
+| calls.rb:113:1:116:3 | Hash | calls.rb:108:1:111:3 | Object |
+| calls.rb:118:1:131:3 | Array | calls.rb:108:1:111:3 | Object |
+| calls.rb:158:1:162:3 | S | calls.rb:108:1:111:3 | Object |
+| calls.rb:164:1:167:3 | A | calls.rb:158:1:162:3 | S |
+| calls.rb:164:1:167:3 | A | calls.rb:169:1:172:3 | B |
+| calls.rb:169:1:172:3 | B | calls.rb:158:1:162:3 | S |
+| calls.rb:183:1:219:3 | Singletons | calls.rb:108:1:111:3 | Object |
+| calls.rb:303:1:313:3 | SelfNew | calls.rb:108:1:111:3 | Object |
+| calls.rb:317:1:321:3 | C1 | calls.rb:108:1:111:3 | Object |
+| calls.rb:323:1:327:3 | C2 | calls.rb:317:1:321:3 | C1 |
+| calls.rb:329:1:333:3 | C3 | calls.rb:323:1:327:3 | C2 |
+| file://:0:0:0:0 | Class | calls.rb:101:1:106:3 | Module |
 | file://:0:0:0:0 | Complex | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | FalseClass | calls.rb:104:1:107:3 | Object |
+| file://:0:0:0:0 | FalseClass | calls.rb:108:1:111:3 | Object |
 | file://:0:0:0:0 | Float | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | NilClass | calls.rb:104:1:107:3 | Object |
-| file://:0:0:0:0 | Numeric | calls.rb:104:1:107:3 | Object |
+| file://:0:0:0:0 | NilClass | calls.rb:108:1:111:3 | Object |
+| file://:0:0:0:0 | Numeric | calls.rb:108:1:111:3 | Object |
 | file://:0:0:0:0 | Rational | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | TrueClass | calls.rb:104:1:107:3 | Object |
-| hello.rb:11:1:16:3 | Greeting | calls.rb:104:1:107:3 | Object |
+| file://:0:0:0:0 | TrueClass | calls.rb:108:1:111:3 | Object |
+| hello.rb:11:1:16:3 | Greeting | calls.rb:108:1:111:3 | Object |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:11:1:16:3 | Greeting |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:104:1:107:3 | Object |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:104:1:107:3 | Object |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:104:1:107:3 | Object |
-| modules.rb:37:1:46:3 | Bar | calls.rb:104:1:107:3 | Object |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | calls.rb:104:1:107:3 | Object |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | calls.rb:104:1:107:3 | Object |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | calls.rb:104:1:107:3 | Object |
-| modules.rb:112:1:113:3 | YY | calls.rb:104:1:107:3 | Object |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:108:1:111:3 | Object |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:108:1:111:3 | Object |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:108:1:111:3 | Object |
+| modules.rb:37:1:46:3 | Bar | calls.rb:108:1:111:3 | Object |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | calls.rb:108:1:111:3 | Object |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | calls.rb:108:1:111:3 | Object |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | calls.rb:108:1:111:3 | Object |
+| modules.rb:112:1:113:3 | YY | calls.rb:108:1:111:3 | Object |
 | modules.rb:116:7:117:9 | XX::YY | modules.rb:112:1:113:3 | YY |
-| modules_rec.rb:1:1:2:3 | B::A | calls.rb:104:1:107:3 | Object |
-| modules_rec.rb:4:1:5:3 | A::B | calls.rb:104:1:107:3 | Object |
-| private.rb:1:1:29:3 | E | calls.rb:104:1:107:3 | Object |
+| modules_rec.rb:1:1:2:3 | B::A | calls.rb:108:1:111:3 | Object |
+| modules_rec.rb:4:1:5:3 | A::B | calls.rb:108:1:111:3 | Object |
+| private.rb:1:1:29:3 | E | calls.rb:108:1:111:3 | Object |
 getAPrependedModule
-| calls.rb:104:1:107:3 | Object | calls.rb:160:1:163:3 | A |
-| calls.rb:160:1:163:3 | A | modules_rec.rb:4:1:5:3 | A::B |
+| calls.rb:108:1:111:3 | Object | calls.rb:164:1:167:3 | A |
+| calls.rb:164:1:167:3 | A | modules_rec.rb:4:1:5:3 | A::B |
 | modules.rb:101:1:105:3 | PrependTest | modules.rb:63:1:81:3 | Test |
 getAnIncludedModule
-| calls.rb:35:1:50:3 | C | calls.rb:21:1:30:3 | M |
-| calls.rb:104:1:107:3 | Object | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:39:1:54:3 | C | calls.rb:21:1:30:3 | M |
+| calls.rb:108:1:111:3 | Object | calls.rb:96:1:99:3 | Kernel |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:1:1:8:3 | EnglishWords |
 | modules.rb:88:1:93:3 | IncludeTest | modules.rb:63:1:81:3 | Test |
 | modules.rb:95:1:99:3 | IncludeTest2 | modules.rb:63:1:81:3 | Test |
 resolveConstantReadAccess
 | calls.rb:32:1:32:1 | M | M |
 | calls.rb:33:1:33:1 | M | M |
-| calls.rb:36:13:36:13 | M | M |
-| calls.rb:52:5:52:5 | C | C |
-| calls.rb:57:11:57:11 | C | C |
-| calls.rb:63:5:63:5 | D | D |
-| calls.rb:78:11:78:14 | Hash | Hash |
-| calls.rb:104:16:104:21 | Module | Module |
-| calls.rb:105:13:105:18 | Kernel | Kernel |
-| calls.rb:139:1:139:13 | Array | Array |
-| calls.rb:141:1:141:7 | Array | Array |
-| calls.rb:143:1:143:7 | Array | Array |
-| calls.rb:145:1:145:8 | Array | Array |
-| calls.rb:160:11:160:11 | S | S |
-| calls.rb:165:11:165:11 | S | S |
-| calls.rb:170:1:170:1 | S | S |
-| calls.rb:171:1:171:1 | A | A |
-| calls.rb:172:1:172:1 | B | B |
-| calls.rb:217:1:217:10 | Singletons | Singletons |
-| calls.rb:218:1:218:10 | Singletons | Singletons |
-| calls.rb:220:6:220:15 | Singletons | Singletons |
-| calls.rb:248:6:248:15 | Singletons | Singletons |
-| calls.rb:256:5:256:14 | Singletons | Singletons |
-| calls.rb:260:1:260:10 | Singletons | Singletons |
-| calls.rb:264:6:264:15 | Singletons | Singletons |
-| calls.rb:277:8:277:17 | Singletons | Singletons |
-| calls.rb:278:1:278:10 | Singletons | Singletons |
-| calls.rb:280:5:280:14 | Singletons | Singletons |
-| calls.rb:289:1:289:10 | Singletons | Singletons |
-| calls.rb:291:10:291:19 | Singletons | Singletons |
-| calls.rb:297:1:297:10 | Singletons | Singletons |
-| calls.rb:311:1:311:7 | SelfNew | SelfNew |
-| calls.rb:319:12:319:13 | C1 | C1 |
-| calls.rb:325:12:325:13 | C2 | C2 |
-| calls.rb:333:10:333:11 | C3 | C3 |
-| calls.rb:335:10:335:11 | C2 | C2 |
-| calls.rb:337:10:337:11 | C1 | C1 |
-| calls.rb:343:12:343:13 | C3 | C3 |
-| calls.rb:344:12:344:13 | C2 | C2 |
-| calls.rb:345:12:345:13 | C1 | C1 |
-| calls.rb:349:6:349:7 | C1 | C1 |
-| calls.rb:351:19:351:20 | C1 | C1 |
-| calls.rb:352:19:352:20 | C2 | C2 |
-| calls.rb:353:19:353:20 | C3 | C3 |
-| calls.rb:361:6:361:7 | C1 | C1 |
+| calls.rb:40:13:40:13 | M | M |
+| calls.rb:56:5:56:5 | C | C |
+| calls.rb:61:11:61:11 | C | C |
+| calls.rb:67:5:67:5 | D | D |
+| calls.rb:82:11:82:14 | Hash | Hash |
+| calls.rb:108:16:108:21 | Module | Module |
+| calls.rb:109:13:109:18 | Kernel | Kernel |
+| calls.rb:143:1:143:13 | Array | Array |
+| calls.rb:145:1:145:7 | Array | Array |
+| calls.rb:147:1:147:7 | Array | Array |
+| calls.rb:149:1:149:8 | Array | Array |
+| calls.rb:164:11:164:11 | S | S |
+| calls.rb:169:11:169:11 | S | S |
+| calls.rb:174:1:174:1 | S | S |
+| calls.rb:175:1:175:1 | A | A |
+| calls.rb:176:1:176:1 | B | B |
+| calls.rb:221:1:221:10 | Singletons | Singletons |
+| calls.rb:222:1:222:10 | Singletons | Singletons |
+| calls.rb:224:6:224:15 | Singletons | Singletons |
+| calls.rb:252:6:252:15 | Singletons | Singletons |
+| calls.rb:260:5:260:14 | Singletons | Singletons |
+| calls.rb:264:1:264:10 | Singletons | Singletons |
+| calls.rb:268:6:268:15 | Singletons | Singletons |
+| calls.rb:281:8:281:17 | Singletons | Singletons |
+| calls.rb:282:1:282:10 | Singletons | Singletons |
+| calls.rb:284:5:284:14 | Singletons | Singletons |
+| calls.rb:293:1:293:10 | Singletons | Singletons |
+| calls.rb:295:10:295:19 | Singletons | Singletons |
+| calls.rb:301:1:301:10 | Singletons | Singletons |
+| calls.rb:315:1:315:7 | SelfNew | SelfNew |
+| calls.rb:323:12:323:13 | C1 | C1 |
+| calls.rb:329:12:329:13 | C2 | C2 |
+| calls.rb:337:10:337:11 | C3 | C3 |
+| calls.rb:339:10:339:11 | C2 | C2 |
+| calls.rb:341:10:341:11 | C1 | C1 |
+| calls.rb:347:12:347:13 | C3 | C3 |
+| calls.rb:348:12:348:13 | C2 | C2 |
+| calls.rb:349:12:349:13 | C1 | C1 |
+| calls.rb:353:6:353:7 | C1 | C1 |
+| calls.rb:355:19:355:20 | C1 | C1 |
+| calls.rb:356:19:356:20 | C2 | C2 |
+| calls.rb:357:19:357:20 | C3 | C3 |
+| calls.rb:365:6:365:7 | C1 | C1 |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
 | modules.rb:48:8:48:10 | Foo | Foo |
@@ -259,23 +259,23 @@ resolveConstantReadAccess
 | private.rb:38:1:38:1 | E | E |
 resolveConstantWriteAccess
 | calls.rb:21:1:30:3 | M | M |
-| calls.rb:35:1:50:3 | C | C |
-| calls.rb:57:1:61:3 | D | D |
-| calls.rb:83:1:86:3 | Integer | Integer |
-| calls.rb:88:1:90:3 | String | String |
-| calls.rb:92:1:95:3 | Kernel | Kernel |
-| calls.rb:97:1:102:3 | Module | Module |
-| calls.rb:104:1:107:3 | Object | Object |
-| calls.rb:109:1:112:3 | Hash | Hash |
-| calls.rb:114:1:127:3 | Array | Array |
-| calls.rb:154:1:158:3 | S | S |
-| calls.rb:160:1:163:3 | A | A |
-| calls.rb:165:1:168:3 | B | B |
-| calls.rb:179:1:215:3 | Singletons | Singletons |
-| calls.rb:299:1:309:3 | SelfNew | SelfNew |
-| calls.rb:313:1:317:3 | C1 | C1 |
-| calls.rb:319:1:323:3 | C2 | C2 |
-| calls.rb:325:1:329:3 | C3 | C3 |
+| calls.rb:39:1:54:3 | C | C |
+| calls.rb:61:1:65:3 | D | D |
+| calls.rb:87:1:90:3 | Integer | Integer |
+| calls.rb:92:1:94:3 | String | String |
+| calls.rb:96:1:99:3 | Kernel | Kernel |
+| calls.rb:101:1:106:3 | Module | Module |
+| calls.rb:108:1:111:3 | Object | Object |
+| calls.rb:113:1:116:3 | Hash | Hash |
+| calls.rb:118:1:131:3 | Array | Array |
+| calls.rb:158:1:162:3 | S | S |
+| calls.rb:164:1:167:3 | A | A |
+| calls.rb:169:1:172:3 | B | B |
+| calls.rb:183:1:219:3 | Singletons | Singletons |
+| calls.rb:303:1:313:3 | SelfNew | SelfNew |
+| calls.rb:317:1:321:3 | C1 | C1 |
+| calls.rb:323:1:327:3 | C2 | C2 |
+| calls.rb:329:1:333:3 | C3 | C3 |
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |
@@ -328,32 +328,32 @@ resolveConstantWriteAccess
 | private.rb:1:1:29:3 | E | E |
 | private.rb:42:1:60:3 | F | F |
 enclosingModule
-| calls.rb:1:1:3:3 | foo | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:2:5:2:14 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:2:11:2:13 | foo | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:5:1:5:3 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:7:1:9:3 | bar | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:7:5:7:8 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:8:5:8:15 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:11:1:11:4 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:13:1:15:3 | bar | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:13:5:13:8 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:14:5:14:15 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:17:1:17:4 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:19:1:19:4 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:21:1:30:3 | M | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:1:1:3:3 | foo | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:5:1:5:3 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:7:1:9:3 | bar | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:7:5:7:8 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:8:5:8:15 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:11:1:11:4 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:13:1:15:3 | bar | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:13:5:13:8 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:14:5:14:15 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:17:1:17:4 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:19:1:19:4 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:21:1:30:3 | M | calls.rb:1:1:367:11 | calls.rb |
 | calls.rb:22:5:22:23 | instance_m | calls.rb:21:1:30:3 | M |
 | calls.rb:23:5:23:29 | singleton_m | calls.rb:21:1:30:3 | M |
 | calls.rb:23:9:23:12 | self | calls.rb:21:1:30:3 | M |
@@ -365,570 +365,573 @@ enclosingModule
 | calls.rb:28:5:28:15 | self | calls.rb:21:1:30:3 | M |
 | calls.rb:29:5:29:8 | self | calls.rb:21:1:30:3 | M |
 | calls.rb:29:5:29:20 | call to singleton_m | calls.rb:21:1:30:3 | M |
-| calls.rb:32:1:32:1 | M | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:32:1:32:12 | call to instance_m | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:33:1:33:1 | M | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:33:1:33:13 | call to singleton_m | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:35:1:50:3 | C | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:36:5:36:13 | call to include | calls.rb:35:1:50:3 | C |
-| calls.rb:36:5:36:13 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:36:13:36:13 | M | calls.rb:35:1:50:3 | C |
-| calls.rb:37:5:37:14 | call to instance_m | calls.rb:35:1:50:3 | C |
-| calls.rb:37:5:37:14 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:38:5:38:8 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:38:5:38:19 | call to instance_m | calls.rb:35:1:50:3 | C |
-| calls.rb:40:5:40:15 | call to singleton_m | calls.rb:35:1:50:3 | C |
-| calls.rb:40:5:40:15 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:41:5:41:8 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:41:5:41:20 | call to singleton_m | calls.rb:35:1:50:3 | C |
-| calls.rb:43:5:49:7 | baz | calls.rb:35:1:50:3 | C |
-| calls.rb:44:9:44:18 | call to instance_m | calls.rb:35:1:50:3 | C |
-| calls.rb:44:9:44:18 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:45:9:45:12 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:45:9:45:23 | call to instance_m | calls.rb:35:1:50:3 | C |
-| calls.rb:47:9:47:19 | call to singleton_m | calls.rb:35:1:50:3 | C |
-| calls.rb:47:9:47:19 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:48:9:48:12 | self | calls.rb:35:1:50:3 | C |
-| calls.rb:48:9:48:24 | call to singleton_m | calls.rb:35:1:50:3 | C |
-| calls.rb:52:1:52:1 | c | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:52:1:52:9 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:52:5:52:5 | C | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:52:5:52:9 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:53:1:53:1 | c | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:53:1:53:5 | call to baz | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:54:1:54:1 | c | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:54:1:54:13 | call to singleton_m | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:55:1:55:1 | c | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:55:1:55:12 | call to instance_m | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:57:1:61:3 | D | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:57:11:57:11 | C | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:58:5:60:7 | baz | calls.rb:57:1:61:3 | D |
-| calls.rb:59:9:59:13 | call to super | calls.rb:57:1:61:3 | D |
-| calls.rb:63:1:63:1 | d | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:63:1:63:9 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:63:5:63:5 | D | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:63:5:63:9 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:64:1:64:1 | d | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:64:1:64:5 | call to baz | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:65:1:65:1 | d | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:65:1:65:13 | call to singleton_m | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:66:1:66:1 | d | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:66:1:66:12 | call to instance_m | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:68:1:71:3 | optional_arg | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:68:18:68:18 | a | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:68:18:68:18 | a | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:68:22:68:22 | 4 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:68:25:68:25 | b | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:68:25:68:25 | b | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:68:28:68:28 | 5 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:69:5:69:5 | a | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:69:5:69:16 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:70:5:70:5 | b | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:70:5:70:16 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:73:1:75:3 | call_block | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:74:5:74:11 | yield ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:74:11:74:11 | 1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:77:1:81:3 | foo | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:78:5:78:7 | var | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:78:5:78:18 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:78:11:78:14 | Hash | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:78:11:78:18 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:79:5:79:7 | var | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:79:5:79:10 | ...[...] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:79:9:79:9 | 1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:80:5:80:29 | call to call_block | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:80:5:80:29 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:80:16:80:29 | { ... } | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:80:19:80:19 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:80:19:80:19 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:80:22:80:24 | var | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:80:22:80:27 | ...[...] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:80:26:80:26 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:83:1:86:3 | Integer | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:84:5:84:23 | bit_length | calls.rb:83:1:86:3 | Integer |
-| calls.rb:85:5:85:16 | abs | calls.rb:83:1:86:3 | Integer |
-| calls.rb:88:1:90:3 | String | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:89:5:89:23 | capitalize | calls.rb:88:1:90:3 | String |
-| calls.rb:92:1:95:3 | Kernel | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:93:5:93:25 | alias ... | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:93:11:93:19 | :old_puts | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:93:11:93:19 | old_puts | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:93:21:93:25 | :puts | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:93:21:93:25 | puts | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:94:5:94:30 | puts | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:94:14:94:14 | x | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:94:14:94:14 | x | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:94:17:94:26 | call to old_puts | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:94:17:94:26 | self | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:94:26:94:26 | x | calls.rb:92:1:95:3 | Kernel |
-| calls.rb:97:1:102:3 | Module | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:98:5:98:24 | module_eval | calls.rb:97:1:102:3 | Module |
-| calls.rb:99:5:99:20 | include | calls.rb:97:1:102:3 | Module |
-| calls.rb:100:5:100:20 | prepend | calls.rb:97:1:102:3 | Module |
-| calls.rb:101:5:101:20 | private | calls.rb:97:1:102:3 | Module |
-| calls.rb:104:1:107:3 | Object | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:104:16:104:21 | Module | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:105:5:105:18 | call to include | calls.rb:104:1:107:3 | Object |
-| calls.rb:105:5:105:18 | self | calls.rb:104:1:107:3 | Object |
-| calls.rb:105:13:105:18 | Kernel | calls.rb:104:1:107:3 | Object |
-| calls.rb:106:5:106:16 | new | calls.rb:104:1:107:3 | Object |
-| calls.rb:109:1:112:3 | Hash | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:110:5:110:25 | alias ... | calls.rb:109:1:112:3 | Hash |
-| calls.rb:110:11:110:21 | :old_lookup | calls.rb:109:1:112:3 | Hash |
-| calls.rb:110:11:110:21 | old_lookup | calls.rb:109:1:112:3 | Hash |
-| calls.rb:110:23:110:25 | :[] | calls.rb:109:1:112:3 | Hash |
-| calls.rb:110:23:110:25 | [] | calls.rb:109:1:112:3 | Hash |
-| calls.rb:111:5:111:31 | [] | calls.rb:109:1:112:3 | Hash |
-| calls.rb:111:12:111:12 | x | calls.rb:109:1:112:3 | Hash |
-| calls.rb:111:12:111:12 | x | calls.rb:109:1:112:3 | Hash |
-| calls.rb:111:15:111:27 | call to old_lookup | calls.rb:109:1:112:3 | Hash |
-| calls.rb:111:15:111:27 | self | calls.rb:109:1:112:3 | Hash |
-| calls.rb:111:26:111:26 | x | calls.rb:109:1:112:3 | Hash |
-| calls.rb:114:1:127:3 | Array | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:115:3:115:23 | alias ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:115:9:115:19 | :old_lookup | calls.rb:114:1:127:3 | Array |
-| calls.rb:115:9:115:19 | old_lookup | calls.rb:114:1:127:3 | Array |
-| calls.rb:115:21:115:23 | :[] | calls.rb:114:1:127:3 | Array |
-| calls.rb:115:21:115:23 | [] | calls.rb:114:1:127:3 | Array |
-| calls.rb:116:3:116:29 | [] | calls.rb:114:1:127:3 | Array |
-| calls.rb:116:10:116:10 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:116:10:116:10 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:116:13:116:25 | call to old_lookup | calls.rb:114:1:127:3 | Array |
-| calls.rb:116:13:116:25 | self | calls.rb:114:1:127:3 | Array |
-| calls.rb:116:24:116:24 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:118:3:118:17 | length | calls.rb:114:1:127:3 | Array |
-| calls.rb:120:3:126:5 | foreach | calls.rb:114:1:127:3 | Array |
-| calls.rb:120:15:120:19 | &body | calls.rb:114:1:127:3 | Array |
-| calls.rb:120:16:120:19 | body | calls.rb:114:1:127:3 | Array |
-| calls.rb:121:5:121:5 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:121:5:121:9 | ... = ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:121:9:121:9 | 0 | calls.rb:114:1:127:3 | Array |
-| calls.rb:122:5:125:7 | while ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:122:11:122:11 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:122:11:122:25 | ... < ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:122:15:122:18 | self | calls.rb:114:1:127:3 | Array |
-| calls.rb:122:15:122:25 | call to length | calls.rb:114:1:127:3 | Array |
-| calls.rb:122:26:125:7 | do ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:123:9:123:24 | yield ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:123:15:123:15 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:123:18:123:21 | self | calls.rb:114:1:127:3 | Array |
-| calls.rb:123:18:123:24 | ...[...] | calls.rb:114:1:127:3 | Array |
-| calls.rb:123:23:123:23 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:124:9:124:9 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:124:9:124:9 | x | calls.rb:114:1:127:3 | Array |
-| calls.rb:124:9:124:14 | ... += ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:124:9:124:14 | ... = ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:124:11:124:12 | ... + ... | calls.rb:114:1:127:3 | Array |
-| calls.rb:124:14:124:14 | 1 | calls.rb:114:1:127:3 | Array |
-| calls.rb:129:1:131:3 | funny | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:130:5:130:20 | yield ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:130:11:130:20 | "prefix: " | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:130:12:130:19 | prefix:  | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:1:133:30 | call to funny | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:1:133:30 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:7:133:30 | { ... } | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:10:133:10 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:10:133:10 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:13:133:29 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:13:133:29 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:18:133:18 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:133:18:133:29 | call to capitalize | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:135:1:135:3 | "a" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:135:1:135:14 | call to capitalize | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:135:2:135:2 | a | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:136:1:136:1 | 1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:136:1:136:12 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:137:1:137:1 | 1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:137:1:137:5 | call to abs | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:1:139:13 | Array | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:1:139:13 | [...] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:1:139:13 | call to [] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:1:139:62 | call to foreach | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:2:139:4 | "a" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:3:139:3 | a | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:6:139:8 | "b" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:7:139:7 | b | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:10:139:12 | "c" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:11:139:11 | c | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:23:139:62 | { ... } | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:26:139:26 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:26:139:26 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:29:139:29 | v | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:29:139:29 | v | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:32:139:61 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:32:139:61 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:37:139:61 | "#{...} -> #{...}" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:38:139:41 | #{...} | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:40:139:40 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:42:139:45 |  ->  | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:46:139:60 | #{...} | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:48:139:48 | v | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:139:48:139:59 | call to capitalize | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:1:141:7 | Array | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:1:141:7 | [...] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:1:141:7 | call to [] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:1:141:35 | call to foreach | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:2:141:2 | 1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:4:141:4 | 2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:6:141:6 | 3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:17:141:35 | { ... } | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:20:141:20 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:20:141:20 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:23:141:23 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:141:23:141:34 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:1:143:7 | Array | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:1:143:7 | [...] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:1:143:7 | call to [] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:1:143:40 | call to foreach | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:2:143:2 | 1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:4:143:4 | 2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:6:143:6 | 3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:17:143:40 | { ... } | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:20:143:20 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:20:143:20 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:23:143:39 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:23:143:39 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:28:143:28 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:143:28:143:39 | call to capitalize | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:1:145:8 | Array | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:1:145:8 | [...] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:1:145:8 | call to [] | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:1:145:37 | call to foreach | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:2:145:2 | 1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:4:145:5 | - ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:5:145:5 | 2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:7:145:7 | 3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:18:145:37 | { ... } | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:21:145:21 | _ | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:21:145:21 | _ | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:24:145:24 | v | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:24:145:24 | v | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:27:145:36 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:27:145:36 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:32:145:32 | v | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:145:32:145:36 | call to abs | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:147:1:149:3 | indirect | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:147:14:147:15 | &b | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:147:15:147:15 | b | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:148:5:148:17 | call to call_block | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:148:5:148:17 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:148:16:148:17 | &... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:148:17:148:17 | b | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:151:1:151:28 | call to indirect | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:151:1:151:28 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:151:10:151:28 | { ... } | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:151:13:151:13 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:151:13:151:13 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:151:16:151:16 | i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:151:16:151:27 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:154:1:158:3 | S | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:155:5:157:7 | s_method | calls.rb:154:1:158:3 | S |
-| calls.rb:156:9:156:12 | self | calls.rb:154:1:158:3 | S |
-| calls.rb:156:9:156:17 | call to to_s | calls.rb:154:1:158:3 | S |
-| calls.rb:160:1:163:3 | A | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:160:11:160:11 | S | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:161:5:162:7 | to_s | calls.rb:160:1:163:3 | A |
-| calls.rb:165:1:168:3 | B | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:165:11:165:11 | S | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:166:5:167:7 | to_s | calls.rb:165:1:168:3 | B |
-| calls.rb:170:1:170:1 | S | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:170:1:170:5 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:170:1:170:14 | call to s_method | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:171:1:171:1 | A | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:171:1:171:5 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:171:1:171:14 | call to s_method | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:172:1:172:1 | B | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:172:1:172:5 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:172:1:172:14 | call to s_method | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:174:1:175:3 | private_on_main | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:177:1:177:15 | call to private_on_main | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:177:1:177:15 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:179:1:215:3 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:180:5:183:7 | singleton_a | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:180:9:180:12 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:181:9:181:26 | call to puts | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:181:9:181:26 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:181:14:181:26 | "singleton_a" | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:181:15:181:25 | singleton_a | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:182:9:182:12 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:182:9:182:24 | call to singleton_b | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:185:5:188:7 | singleton_b | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:185:9:185:12 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:186:9:186:26 | call to puts | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:186:9:186:26 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:186:14:186:26 | "singleton_b" | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:186:15:186:25 | singleton_b | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:187:9:187:12 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:187:9:187:24 | call to singleton_c | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:190:5:192:7 | singleton_c | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:190:9:190:12 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:191:9:191:26 | call to puts | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:191:9:191:26 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:191:14:191:26 | "singleton_c" | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:191:15:191:25 | singleton_c | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:194:5:197:7 | singleton_d | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:194:9:194:12 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:195:9:195:26 | call to puts | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:195:9:195:26 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:195:14:195:26 | "singleton_d" | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:195:15:195:25 | singleton_d | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:196:9:196:12 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:196:9:196:24 | call to singleton_a | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:199:5:204:7 | instance | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:200:9:202:11 | singleton_e | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:200:13:200:16 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:201:13:201:30 | call to puts | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:201:13:201:30 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:201:18:201:30 | "singleton_e" | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:201:19:201:29 | singleton_e | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:203:9:203:19 | call to singleton_e | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:203:9:203:19 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:206:5:210:7 | class << ... | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:206:14:206:17 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:207:9:209:11 | singleton_f | calls.rb:206:5:210:7 | class << ... |
-| calls.rb:208:13:208:30 | call to puts | calls.rb:206:5:210:7 | class << ... |
-| calls.rb:208:13:208:30 | self | calls.rb:206:5:210:7 | class << ... |
-| calls.rb:208:18:208:30 | "singleton_f" | calls.rb:206:5:210:7 | class << ... |
-| calls.rb:208:19:208:29 | singleton_f | calls.rb:206:5:210:7 | class << ... |
-| calls.rb:212:5:214:7 | call_singleton_g | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:213:9:213:12 | self | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:179:1:215:3 | Singletons |
-| calls.rb:217:1:217:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:217:1:217:22 | call to singleton_a | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:218:1:218:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:218:1:218:22 | call to singleton_f | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:220:1:220:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:220:1:220:19 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:220:6:220:15 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:220:6:220:19 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:222:1:222:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:222:1:222:11 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:223:1:223:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:223:1:223:14 | call to singleton_e | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:225:1:227:3 | singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:225:5:225:6 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:226:5:226:24 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:226:5:226:24 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:226:10:226:24 | "singleton_g_1" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:226:11:226:23 | singleton_g_1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:229:1:229:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:229:1:229:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:230:1:230:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:230:1:230:19 | call to call_singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:232:1:234:3 | singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:232:5:232:6 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:233:5:233:24 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:233:5:233:24 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:233:10:233:24 | "singleton_g_2" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:233:11:233:23 | singleton_g_2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:236:1:236:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:236:1:236:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:237:1:237:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:237:1:237:19 | call to call_singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:239:1:243:3 | class << ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:239:10:239:11 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:240:5:242:7 | singleton_g | calls.rb:239:1:243:3 | class << ... |
-| calls.rb:241:9:241:28 | call to puts | calls.rb:239:1:243:3 | class << ... |
-| calls.rb:241:9:241:28 | self | calls.rb:239:1:243:3 | class << ... |
-| calls.rb:241:14:241:28 | "singleton_g_3" | calls.rb:239:1:243:3 | class << ... |
-| calls.rb:241:15:241:27 | singleton_g_3 | calls.rb:239:1:243:3 | class << ... |
-| calls.rb:245:1:245:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:245:1:245:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:246:1:246:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:246:1:246:19 | call to call_singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:248:1:248:2 | c2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:248:1:248:19 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:248:6:248:15 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:248:6:248:19 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:249:1:249:2 | c2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:249:1:249:14 | call to singleton_e | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:250:1:250:2 | c2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:250:1:250:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:252:1:252:4 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:252:1:252:8 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:254:1:254:16 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:254:1:254:16 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:254:6:254:16 | "top-level" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:254:7:254:15 | top-level | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:256:1:258:3 | singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:256:5:256:14 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:257:5:257:22 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:257:5:257:22 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:257:10:257:22 | "singleton_g" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:257:11:257:21 | singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:260:1:260:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:260:1:260:22 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:261:1:261:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:262:1:262:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:262:1:262:19 | call to call_singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:263:1:263:2 | c2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:263:1:263:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:264:1:264:2 | c3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:264:1:264:19 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:264:6:264:15 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:264:6:264:19 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:265:1:265:2 | c3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:265:1:265:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:267:1:275:3 | create | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:267:12:267:15 | type | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:267:12:267:15 | type | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:268:5:268:8 | type | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:268:5:268:12 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:268:5:268:21 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:270:5:272:7 | singleton_h | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:270:9:270:12 | type | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:271:9:271:26 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:271:9:271:26 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:271:14:271:26 | "singleton_h" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:271:15:271:25 | singleton_h | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:274:5:274:8 | type | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:274:5:274:20 | call to singleton_h | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:277:1:277:17 | call to create | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:277:1:277:17 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:277:8:277:17 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:278:1:278:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:278:1:278:22 | call to singleton_h | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:280:1:280:1 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:280:1:280:14 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:280:5:280:14 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:282:1:286:3 | class << ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:282:10:282:10 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:283:5:285:7 | singleton_i | calls.rb:282:1:286:3 | class << ... |
-| calls.rb:284:9:284:26 | call to puts | calls.rb:282:1:286:3 | class << ... |
-| calls.rb:284:9:284:26 | self | calls.rb:282:1:286:3 | class << ... |
-| calls.rb:284:14:284:26 | "singleton_i" | calls.rb:282:1:286:3 | class << ... |
-| calls.rb:284:15:284:25 | singleton_i | calls.rb:282:1:286:3 | class << ... |
-| calls.rb:288:1:288:1 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:288:1:288:13 | call to singleton_i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:289:1:289:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:289:1:289:22 | call to singleton_i | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:291:1:295:3 | class << ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:291:10:291:19 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:292:5:294:7 | singleton_j | calls.rb:291:1:295:3 | class << ... |
-| calls.rb:293:9:293:26 | call to puts | calls.rb:291:1:295:3 | class << ... |
-| calls.rb:293:9:293:26 | self | calls.rb:291:1:295:3 | class << ... |
-| calls.rb:293:14:293:26 | "singleton_j" | calls.rb:291:1:295:3 | class << ... |
-| calls.rb:293:15:293:25 | singleton_j | calls.rb:291:1:295:3 | class << ... |
-| calls.rb:297:1:297:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:297:1:297:22 | call to singleton_j | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:299:1:309:3 | SelfNew | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:300:5:302:7 | instance | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:301:9:301:31 | call to puts | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:301:9:301:31 | self | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:301:14:301:31 | "SelfNew#instance" | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:301:15:301:30 | SelfNew#instance | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:304:5:306:7 | singleton | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:304:9:304:12 | self | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:305:9:305:11 | call to new | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:305:9:305:11 | self | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:305:9:305:20 | call to instance | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:308:5:308:7 | call to new | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:308:5:308:7 | self | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:308:5:308:16 | call to instance | calls.rb:299:1:309:3 | SelfNew |
-| calls.rb:311:1:311:7 | SelfNew | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:311:1:311:17 | call to singleton | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:313:1:317:3 | C1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:314:5:316:7 | instance | calls.rb:313:1:317:3 | C1 |
-| calls.rb:315:9:315:26 | call to puts | calls.rb:313:1:317:3 | C1 |
-| calls.rb:315:9:315:26 | self | calls.rb:313:1:317:3 | C1 |
-| calls.rb:315:14:315:26 | "C1#instance" | calls.rb:313:1:317:3 | C1 |
-| calls.rb:315:15:315:25 | C1#instance | calls.rb:313:1:317:3 | C1 |
-| calls.rb:319:1:323:3 | C2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:319:12:319:13 | C1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:320:5:322:7 | instance | calls.rb:319:1:323:3 | C2 |
-| calls.rb:321:9:321:26 | call to puts | calls.rb:319:1:323:3 | C2 |
-| calls.rb:321:9:321:26 | self | calls.rb:319:1:323:3 | C2 |
-| calls.rb:321:14:321:26 | "C2#instance" | calls.rb:319:1:323:3 | C2 |
-| calls.rb:321:15:321:25 | C2#instance | calls.rb:319:1:323:3 | C2 |
-| calls.rb:325:1:329:3 | C3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:325:12:325:13 | C2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:326:5:328:7 | instance | calls.rb:325:1:329:3 | C3 |
-| calls.rb:327:9:327:26 | call to puts | calls.rb:325:1:329:3 | C3 |
-| calls.rb:327:9:327:26 | self | calls.rb:325:1:329:3 | C3 |
-| calls.rb:327:14:327:26 | "C3#instance" | calls.rb:325:1:329:3 | C3 |
-| calls.rb:327:15:327:25 | C3#instance | calls.rb:325:1:329:3 | C3 |
-| calls.rb:331:1:347:3 | pattern_dispatch | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:331:22:331:22 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:331:22:331:22 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:332:5:340:7 | case ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:332:10:332:10 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:333:5:334:18 | when ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:333:10:333:11 | C3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:333:12:334:18 | then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:334:9:334:9 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:334:9:334:18 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:335:5:336:18 | when ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:335:10:335:11 | C2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:335:12:336:18 | then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:336:9:336:9 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:336:9:336:18 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:337:5:338:18 | when ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:337:10:337:11 | C1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:337:12:338:18 | then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:338:9:338:9 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:338:9:338:18 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:339:5:339:8 | else ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:342:5:346:7 | case ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:342:10:342:10 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:343:9:343:29 | in ... then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:343:12:343:13 | C3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:343:15:343:29 | then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:343:20:343:20 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:343:20:343:29 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:344:9:344:36 | in ... then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:344:12:344:13 | C2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:344:12:344:19 | ... => ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:344:18:344:19 | c2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:344:21:344:36 | then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:344:26:344:27 | c2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:344:26:344:36 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:345:9:345:36 | in ... then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:345:12:345:13 | C1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:345:12:345:19 | ... => ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:345:18:345:19 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:345:21:345:36 | then ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:345:26:345:27 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:345:26:345:36 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:349:1:349:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:349:1:349:11 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:349:6:349:7 | C1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:349:6:349:11 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:350:1:350:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:350:1:350:11 | call to instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:351:1:351:25 | call to pattern_dispatch | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:351:1:351:25 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:351:18:351:25 | ( ... ) | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:351:19:351:20 | C1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:351:19:351:24 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:352:1:352:25 | call to pattern_dispatch | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:352:1:352:25 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:352:18:352:25 | ( ... ) | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:352:19:352:20 | C2 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:352:19:352:24 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:353:1:353:25 | call to pattern_dispatch | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:353:1:353:25 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:353:18:353:25 | ( ... ) | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:353:19:353:20 | C3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:353:19:353:24 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:355:1:359:3 | add_singleton | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:355:19:355:19 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:355:19:355:19 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:356:5:358:7 | instance | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:356:9:356:9 | x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:357:9:357:28 | call to puts | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:357:9:357:28 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:357:14:357:28 | "instance_on x" | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:357:15:357:27 | instance_on x | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:361:1:361:2 | c3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:361:1:361:11 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:361:6:361:7 | C1 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:361:6:361:11 | call to new | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:362:1:362:16 | call to add_singleton | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:362:1:362:16 | self | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:362:15:362:16 | c3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:363:1:363:2 | c3 | calls.rb:1:1:363:11 | calls.rb |
-| calls.rb:363:1:363:11 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:32:1:32:1 | M | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:32:1:32:12 | call to instance_m | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:33:1:33:1 | M | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:33:1:33:13 | call to singleton_m | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:35:1:37:3 | call_instance_m | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:36:5:36:14 | call to instance_m | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:36:5:36:14 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:39:1:54:3 | C | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:40:5:40:13 | call to include | calls.rb:39:1:54:3 | C |
+| calls.rb:40:5:40:13 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:40:13:40:13 | M | calls.rb:39:1:54:3 | C |
+| calls.rb:41:5:41:14 | call to instance_m | calls.rb:39:1:54:3 | C |
+| calls.rb:41:5:41:14 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:42:5:42:8 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:42:5:42:19 | call to instance_m | calls.rb:39:1:54:3 | C |
+| calls.rb:44:5:44:15 | call to singleton_m | calls.rb:39:1:54:3 | C |
+| calls.rb:44:5:44:15 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:45:5:45:8 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:45:5:45:20 | call to singleton_m | calls.rb:39:1:54:3 | C |
+| calls.rb:47:5:53:7 | baz | calls.rb:39:1:54:3 | C |
+| calls.rb:48:9:48:18 | call to instance_m | calls.rb:39:1:54:3 | C |
+| calls.rb:48:9:48:18 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:49:9:49:12 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:49:9:49:23 | call to instance_m | calls.rb:39:1:54:3 | C |
+| calls.rb:51:9:51:19 | call to singleton_m | calls.rb:39:1:54:3 | C |
+| calls.rb:51:9:51:19 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:52:9:52:12 | self | calls.rb:39:1:54:3 | C |
+| calls.rb:52:9:52:24 | call to singleton_m | calls.rb:39:1:54:3 | C |
+| calls.rb:56:1:56:1 | c | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:56:1:56:9 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:56:5:56:5 | C | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:56:5:56:9 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:57:1:57:1 | c | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:57:1:57:5 | call to baz | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:58:1:58:1 | c | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:58:1:58:13 | call to singleton_m | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:59:1:59:1 | c | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:59:1:59:12 | call to instance_m | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:61:1:65:3 | D | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:61:11:61:11 | C | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:62:5:64:7 | baz | calls.rb:61:1:65:3 | D |
+| calls.rb:63:9:63:13 | call to super | calls.rb:61:1:65:3 | D |
+| calls.rb:67:1:67:1 | d | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:67:1:67:9 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:67:5:67:5 | D | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:67:5:67:9 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:68:1:68:1 | d | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:68:1:68:5 | call to baz | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:69:1:69:1 | d | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:69:1:69:13 | call to singleton_m | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:70:1:70:1 | d | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:70:1:70:12 | call to instance_m | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:72:1:75:3 | optional_arg | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:72:18:72:18 | a | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:72:18:72:18 | a | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:72:22:72:22 | 4 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:72:25:72:25 | b | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:72:25:72:25 | b | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:72:28:72:28 | 5 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:73:5:73:5 | a | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:73:5:73:16 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:74:5:74:5 | b | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:74:5:74:16 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:77:1:79:3 | call_block | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:78:5:78:11 | yield ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:78:11:78:11 | 1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:81:1:85:3 | foo | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:82:5:82:7 | var | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:82:5:82:18 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:82:11:82:14 | Hash | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:82:11:82:18 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:83:5:83:7 | var | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:83:5:83:10 | ...[...] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:83:9:83:9 | 1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:84:5:84:29 | call to call_block | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:84:5:84:29 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:84:16:84:29 | { ... } | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:84:19:84:19 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:84:19:84:19 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:84:22:84:24 | var | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:84:22:84:27 | ...[...] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:84:26:84:26 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:87:1:90:3 | Integer | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:88:5:88:23 | bit_length | calls.rb:87:1:90:3 | Integer |
+| calls.rb:89:5:89:16 | abs | calls.rb:87:1:90:3 | Integer |
+| calls.rb:92:1:94:3 | String | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:93:5:93:23 | capitalize | calls.rb:92:1:94:3 | String |
+| calls.rb:96:1:99:3 | Kernel | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:97:5:97:25 | alias ... | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:97:11:97:19 | :old_puts | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:97:11:97:19 | old_puts | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:97:21:97:25 | :puts | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:97:21:97:25 | puts | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:98:5:98:30 | puts | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:98:14:98:14 | x | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:98:14:98:14 | x | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:98:17:98:26 | call to old_puts | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:98:17:98:26 | self | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:98:26:98:26 | x | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:101:1:106:3 | Module | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:102:5:102:24 | module_eval | calls.rb:101:1:106:3 | Module |
+| calls.rb:103:5:103:20 | include | calls.rb:101:1:106:3 | Module |
+| calls.rb:104:5:104:20 | prepend | calls.rb:101:1:106:3 | Module |
+| calls.rb:105:5:105:20 | private | calls.rb:101:1:106:3 | Module |
+| calls.rb:108:1:111:3 | Object | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:108:16:108:21 | Module | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:109:5:109:18 | call to include | calls.rb:108:1:111:3 | Object |
+| calls.rb:109:5:109:18 | self | calls.rb:108:1:111:3 | Object |
+| calls.rb:109:13:109:18 | Kernel | calls.rb:108:1:111:3 | Object |
+| calls.rb:110:5:110:16 | new | calls.rb:108:1:111:3 | Object |
+| calls.rb:113:1:116:3 | Hash | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:114:5:114:25 | alias ... | calls.rb:113:1:116:3 | Hash |
+| calls.rb:114:11:114:21 | :old_lookup | calls.rb:113:1:116:3 | Hash |
+| calls.rb:114:11:114:21 | old_lookup | calls.rb:113:1:116:3 | Hash |
+| calls.rb:114:23:114:25 | :[] | calls.rb:113:1:116:3 | Hash |
+| calls.rb:114:23:114:25 | [] | calls.rb:113:1:116:3 | Hash |
+| calls.rb:115:5:115:31 | [] | calls.rb:113:1:116:3 | Hash |
+| calls.rb:115:12:115:12 | x | calls.rb:113:1:116:3 | Hash |
+| calls.rb:115:12:115:12 | x | calls.rb:113:1:116:3 | Hash |
+| calls.rb:115:15:115:27 | call to old_lookup | calls.rb:113:1:116:3 | Hash |
+| calls.rb:115:15:115:27 | self | calls.rb:113:1:116:3 | Hash |
+| calls.rb:115:26:115:26 | x | calls.rb:113:1:116:3 | Hash |
+| calls.rb:118:1:131:3 | Array | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:119:3:119:23 | alias ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:119:9:119:19 | :old_lookup | calls.rb:118:1:131:3 | Array |
+| calls.rb:119:9:119:19 | old_lookup | calls.rb:118:1:131:3 | Array |
+| calls.rb:119:21:119:23 | :[] | calls.rb:118:1:131:3 | Array |
+| calls.rb:119:21:119:23 | [] | calls.rb:118:1:131:3 | Array |
+| calls.rb:120:3:120:29 | [] | calls.rb:118:1:131:3 | Array |
+| calls.rb:120:10:120:10 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:120:10:120:10 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:120:13:120:25 | call to old_lookup | calls.rb:118:1:131:3 | Array |
+| calls.rb:120:13:120:25 | self | calls.rb:118:1:131:3 | Array |
+| calls.rb:120:24:120:24 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:122:3:122:17 | length | calls.rb:118:1:131:3 | Array |
+| calls.rb:124:3:130:5 | foreach | calls.rb:118:1:131:3 | Array |
+| calls.rb:124:15:124:19 | &body | calls.rb:118:1:131:3 | Array |
+| calls.rb:124:16:124:19 | body | calls.rb:118:1:131:3 | Array |
+| calls.rb:125:5:125:5 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:125:5:125:9 | ... = ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:125:9:125:9 | 0 | calls.rb:118:1:131:3 | Array |
+| calls.rb:126:5:129:7 | while ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:126:11:126:11 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:126:11:126:25 | ... < ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:126:15:126:18 | self | calls.rb:118:1:131:3 | Array |
+| calls.rb:126:15:126:25 | call to length | calls.rb:118:1:131:3 | Array |
+| calls.rb:126:26:129:7 | do ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:127:9:127:24 | yield ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:127:15:127:15 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:127:18:127:21 | self | calls.rb:118:1:131:3 | Array |
+| calls.rb:127:18:127:24 | ...[...] | calls.rb:118:1:131:3 | Array |
+| calls.rb:127:23:127:23 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:128:9:128:9 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:128:9:128:9 | x | calls.rb:118:1:131:3 | Array |
+| calls.rb:128:9:128:14 | ... += ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:128:9:128:14 | ... = ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:128:11:128:12 | ... + ... | calls.rb:118:1:131:3 | Array |
+| calls.rb:128:14:128:14 | 1 | calls.rb:118:1:131:3 | Array |
+| calls.rb:133:1:135:3 | funny | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:134:5:134:20 | yield ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:134:11:134:20 | "prefix: " | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:134:12:134:19 | prefix:  | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:1:137:30 | call to funny | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:1:137:30 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:7:137:30 | { ... } | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:10:137:10 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:10:137:10 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:13:137:29 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:13:137:29 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:18:137:18 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:137:18:137:29 | call to capitalize | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:139:1:139:3 | "a" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:139:1:139:14 | call to capitalize | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:139:2:139:2 | a | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:140:1:140:1 | 1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:140:1:140:12 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:141:1:141:1 | 1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:141:1:141:5 | call to abs | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:1:143:13 | Array | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:1:143:13 | [...] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:1:143:13 | call to [] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:1:143:62 | call to foreach | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:2:143:4 | "a" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:3:143:3 | a | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:6:143:8 | "b" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:7:143:7 | b | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:10:143:12 | "c" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:11:143:11 | c | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:23:143:62 | { ... } | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:26:143:26 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:26:143:26 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:29:143:29 | v | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:29:143:29 | v | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:32:143:61 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:32:143:61 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:37:143:61 | "#{...} -> #{...}" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:38:143:41 | #{...} | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:40:143:40 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:42:143:45 |  ->  | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:46:143:60 | #{...} | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:48:143:48 | v | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:143:48:143:59 | call to capitalize | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:1:145:7 | Array | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:1:145:7 | [...] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:1:145:7 | call to [] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:1:145:35 | call to foreach | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:2:145:2 | 1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:4:145:4 | 2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:6:145:6 | 3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:17:145:35 | { ... } | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:20:145:20 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:20:145:20 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:23:145:23 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:145:23:145:34 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:1:147:7 | Array | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:1:147:7 | [...] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:1:147:7 | call to [] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:1:147:40 | call to foreach | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:2:147:2 | 1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:4:147:4 | 2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:6:147:6 | 3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:17:147:40 | { ... } | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:20:147:20 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:20:147:20 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:23:147:39 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:23:147:39 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:28:147:28 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:147:28:147:39 | call to capitalize | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:1:149:8 | Array | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:1:149:8 | [...] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:1:149:8 | call to [] | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:1:149:37 | call to foreach | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:2:149:2 | 1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:4:149:5 | - ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:5:149:5 | 2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:7:149:7 | 3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:18:149:37 | { ... } | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:21:149:21 | _ | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:21:149:21 | _ | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:24:149:24 | v | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:24:149:24 | v | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:27:149:36 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:27:149:36 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:32:149:32 | v | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:149:32:149:36 | call to abs | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:151:1:153:3 | indirect | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:151:14:151:15 | &b | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:151:15:151:15 | b | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:152:5:152:17 | call to call_block | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:152:5:152:17 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:152:16:152:17 | &... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:152:17:152:17 | b | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:155:1:155:28 | call to indirect | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:155:1:155:28 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:155:10:155:28 | { ... } | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:155:13:155:13 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:155:13:155:13 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:155:16:155:16 | i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:155:16:155:27 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:158:1:162:3 | S | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:159:5:161:7 | s_method | calls.rb:158:1:162:3 | S |
+| calls.rb:160:9:160:12 | self | calls.rb:158:1:162:3 | S |
+| calls.rb:160:9:160:17 | call to to_s | calls.rb:158:1:162:3 | S |
+| calls.rb:164:1:167:3 | A | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:164:11:164:11 | S | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:165:5:166:7 | to_s | calls.rb:164:1:167:3 | A |
+| calls.rb:169:1:172:3 | B | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:169:11:169:11 | S | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:170:5:171:7 | to_s | calls.rb:169:1:172:3 | B |
+| calls.rb:174:1:174:1 | S | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:174:1:174:5 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:174:1:174:14 | call to s_method | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:175:1:175:1 | A | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:175:1:175:5 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:175:1:175:14 | call to s_method | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:176:1:176:1 | B | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:176:1:176:5 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:176:1:176:14 | call to s_method | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:178:1:179:3 | private_on_main | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:181:1:181:15 | call to private_on_main | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:181:1:181:15 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:183:1:219:3 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:184:5:187:7 | singleton_a | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:184:9:184:12 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:185:9:185:26 | call to puts | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:185:9:185:26 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:185:14:185:26 | "singleton_a" | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:185:15:185:25 | singleton_a | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:186:9:186:12 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:186:9:186:24 | call to singleton_b | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:189:5:192:7 | singleton_b | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:189:9:189:12 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:190:9:190:26 | call to puts | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:190:9:190:26 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:190:14:190:26 | "singleton_b" | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:190:15:190:25 | singleton_b | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:191:9:191:12 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:191:9:191:24 | call to singleton_c | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:194:5:196:7 | singleton_c | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:194:9:194:12 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:195:9:195:26 | call to puts | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:195:9:195:26 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:195:14:195:26 | "singleton_c" | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:195:15:195:25 | singleton_c | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:198:5:201:7 | singleton_d | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:198:9:198:12 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:199:9:199:26 | call to puts | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:199:9:199:26 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:199:14:199:26 | "singleton_d" | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:199:15:199:25 | singleton_d | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:200:9:200:12 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:200:9:200:24 | call to singleton_a | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:203:5:208:7 | instance | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:204:9:206:11 | singleton_e | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:204:13:204:16 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:205:13:205:30 | call to puts | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:205:13:205:30 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:205:18:205:30 | "singleton_e" | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:205:19:205:29 | singleton_e | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:207:9:207:19 | call to singleton_e | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:207:9:207:19 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:210:5:214:7 | class << ... | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:210:14:210:17 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:211:9:213:11 | singleton_f | calls.rb:210:5:214:7 | class << ... |
+| calls.rb:212:13:212:30 | call to puts | calls.rb:210:5:214:7 | class << ... |
+| calls.rb:212:13:212:30 | self | calls.rb:210:5:214:7 | class << ... |
+| calls.rb:212:18:212:30 | "singleton_f" | calls.rb:210:5:214:7 | class << ... |
+| calls.rb:212:19:212:29 | singleton_f | calls.rb:210:5:214:7 | class << ... |
+| calls.rb:216:5:218:7 | call_singleton_g | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:217:9:217:12 | self | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:183:1:219:3 | Singletons |
+| calls.rb:221:1:221:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:221:1:221:22 | call to singleton_a | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:222:1:222:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:222:1:222:22 | call to singleton_f | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:224:1:224:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:224:1:224:19 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:224:6:224:15 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:224:6:224:19 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:226:1:226:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:226:1:226:11 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:227:1:227:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:227:1:227:14 | call to singleton_e | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:229:1:231:3 | singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:229:5:229:6 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:230:5:230:24 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:230:5:230:24 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:230:10:230:24 | "singleton_g_1" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:230:11:230:23 | singleton_g_1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:233:1:233:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:233:1:233:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:234:1:234:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:234:1:234:19 | call to call_singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:236:1:238:3 | singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:236:5:236:6 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:237:5:237:24 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:237:5:237:24 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:237:10:237:24 | "singleton_g_2" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:237:11:237:23 | singleton_g_2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:240:1:240:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:240:1:240:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:241:1:241:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:241:1:241:19 | call to call_singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:243:1:247:3 | class << ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:243:10:243:11 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:244:5:246:7 | singleton_g | calls.rb:243:1:247:3 | class << ... |
+| calls.rb:245:9:245:28 | call to puts | calls.rb:243:1:247:3 | class << ... |
+| calls.rb:245:9:245:28 | self | calls.rb:243:1:247:3 | class << ... |
+| calls.rb:245:14:245:28 | "singleton_g_3" | calls.rb:243:1:247:3 | class << ... |
+| calls.rb:245:15:245:27 | singleton_g_3 | calls.rb:243:1:247:3 | class << ... |
+| calls.rb:249:1:249:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:249:1:249:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:250:1:250:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:250:1:250:19 | call to call_singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:252:1:252:2 | c2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:252:1:252:19 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:252:6:252:15 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:252:6:252:19 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:253:1:253:2 | c2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:253:1:253:14 | call to singleton_e | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:254:1:254:2 | c2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:254:1:254:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:256:1:256:4 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:256:1:256:8 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:258:1:258:16 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:258:1:258:16 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:258:6:258:16 | "top-level" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:258:7:258:15 | top-level | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:260:1:262:3 | singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:260:5:260:14 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:261:5:261:22 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:261:5:261:22 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:261:10:261:22 | "singleton_g" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:261:11:261:21 | singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:264:1:264:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:264:1:264:22 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:265:1:265:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:265:1:265:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:266:1:266:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:266:1:266:19 | call to call_singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:267:1:267:2 | c2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:267:1:267:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:268:1:268:2 | c3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:268:1:268:19 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:268:6:268:15 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:268:6:268:19 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:269:1:269:2 | c3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:271:1:279:3 | create | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:271:12:271:15 | type | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:271:12:271:15 | type | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:272:5:272:8 | type | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:272:5:272:12 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:272:5:272:21 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:274:5:276:7 | singleton_h | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:274:9:274:12 | type | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:275:9:275:26 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:275:9:275:26 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:275:14:275:26 | "singleton_h" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:275:15:275:25 | singleton_h | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:278:5:278:8 | type | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:278:5:278:20 | call to singleton_h | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:281:1:281:17 | call to create | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:281:1:281:17 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:281:8:281:17 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:282:1:282:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:282:1:282:22 | call to singleton_h | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:284:1:284:1 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:284:1:284:14 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:284:5:284:14 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:286:1:290:3 | class << ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:286:10:286:10 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:287:5:289:7 | singleton_i | calls.rb:286:1:290:3 | class << ... |
+| calls.rb:288:9:288:26 | call to puts | calls.rb:286:1:290:3 | class << ... |
+| calls.rb:288:9:288:26 | self | calls.rb:286:1:290:3 | class << ... |
+| calls.rb:288:14:288:26 | "singleton_i" | calls.rb:286:1:290:3 | class << ... |
+| calls.rb:288:15:288:25 | singleton_i | calls.rb:286:1:290:3 | class << ... |
+| calls.rb:292:1:292:1 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:292:1:292:13 | call to singleton_i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:293:1:293:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:293:1:293:22 | call to singleton_i | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:295:1:299:3 | class << ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:295:10:295:19 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:296:5:298:7 | singleton_j | calls.rb:295:1:299:3 | class << ... |
+| calls.rb:297:9:297:26 | call to puts | calls.rb:295:1:299:3 | class << ... |
+| calls.rb:297:9:297:26 | self | calls.rb:295:1:299:3 | class << ... |
+| calls.rb:297:14:297:26 | "singleton_j" | calls.rb:295:1:299:3 | class << ... |
+| calls.rb:297:15:297:25 | singleton_j | calls.rb:295:1:299:3 | class << ... |
+| calls.rb:301:1:301:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:301:1:301:22 | call to singleton_j | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:303:1:313:3 | SelfNew | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:304:5:306:7 | instance | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:305:9:305:31 | call to puts | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:305:9:305:31 | self | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:305:14:305:31 | "SelfNew#instance" | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:305:15:305:30 | SelfNew#instance | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:308:5:310:7 | singleton | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:308:9:308:12 | self | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:309:9:309:11 | call to new | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:309:9:309:11 | self | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:309:9:309:20 | call to instance | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:312:5:312:7 | call to new | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:312:5:312:7 | self | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:312:5:312:16 | call to instance | calls.rb:303:1:313:3 | SelfNew |
+| calls.rb:315:1:315:7 | SelfNew | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:315:1:315:17 | call to singleton | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:317:1:321:3 | C1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:318:5:320:7 | instance | calls.rb:317:1:321:3 | C1 |
+| calls.rb:319:9:319:26 | call to puts | calls.rb:317:1:321:3 | C1 |
+| calls.rb:319:9:319:26 | self | calls.rb:317:1:321:3 | C1 |
+| calls.rb:319:14:319:26 | "C1#instance" | calls.rb:317:1:321:3 | C1 |
+| calls.rb:319:15:319:25 | C1#instance | calls.rb:317:1:321:3 | C1 |
+| calls.rb:323:1:327:3 | C2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:323:12:323:13 | C1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:324:5:326:7 | instance | calls.rb:323:1:327:3 | C2 |
+| calls.rb:325:9:325:26 | call to puts | calls.rb:323:1:327:3 | C2 |
+| calls.rb:325:9:325:26 | self | calls.rb:323:1:327:3 | C2 |
+| calls.rb:325:14:325:26 | "C2#instance" | calls.rb:323:1:327:3 | C2 |
+| calls.rb:325:15:325:25 | C2#instance | calls.rb:323:1:327:3 | C2 |
+| calls.rb:329:1:333:3 | C3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:329:12:329:13 | C2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:330:5:332:7 | instance | calls.rb:329:1:333:3 | C3 |
+| calls.rb:331:9:331:26 | call to puts | calls.rb:329:1:333:3 | C3 |
+| calls.rb:331:9:331:26 | self | calls.rb:329:1:333:3 | C3 |
+| calls.rb:331:14:331:26 | "C3#instance" | calls.rb:329:1:333:3 | C3 |
+| calls.rb:331:15:331:25 | C3#instance | calls.rb:329:1:333:3 | C3 |
+| calls.rb:335:1:351:3 | pattern_dispatch | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:335:22:335:22 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:335:22:335:22 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:336:5:344:7 | case ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:336:10:336:10 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:337:5:338:18 | when ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:337:10:337:11 | C3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:337:12:338:18 | then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:338:9:338:9 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:338:9:338:18 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:339:5:340:18 | when ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:339:10:339:11 | C2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:339:12:340:18 | then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:340:9:340:9 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:340:9:340:18 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:341:5:342:18 | when ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:341:10:341:11 | C1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:341:12:342:18 | then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:342:9:342:9 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:342:9:342:18 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:343:5:343:8 | else ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:346:5:350:7 | case ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:346:10:346:10 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:347:9:347:29 | in ... then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:347:12:347:13 | C3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:347:15:347:29 | then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:347:20:347:20 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:347:20:347:29 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:348:9:348:36 | in ... then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:348:12:348:13 | C2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:348:12:348:19 | ... => ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:348:18:348:19 | c2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:348:21:348:36 | then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:348:26:348:27 | c2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:348:26:348:36 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:349:9:349:36 | in ... then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:349:12:349:13 | C1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:349:12:349:19 | ... => ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:349:18:349:19 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:349:21:349:36 | then ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:349:26:349:27 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:349:26:349:36 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:353:1:353:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:353:1:353:11 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:353:6:353:7 | C1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:353:6:353:11 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:354:1:354:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:354:1:354:11 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:355:1:355:25 | call to pattern_dispatch | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:355:1:355:25 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:355:18:355:25 | ( ... ) | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:355:19:355:20 | C1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:355:19:355:24 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:356:1:356:25 | call to pattern_dispatch | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:356:1:356:25 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:356:18:356:25 | ( ... ) | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:356:19:356:20 | C2 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:356:19:356:24 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:357:1:357:25 | call to pattern_dispatch | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:357:1:357:25 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:357:18:357:25 | ( ... ) | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:357:19:357:20 | C3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:357:19:357:24 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:359:1:363:3 | add_singleton | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:359:19:359:19 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:359:19:359:19 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:360:5:362:7 | instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:360:9:360:9 | x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:361:9:361:28 | call to puts | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:361:9:361:28 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:361:14:361:28 | "instance_on x" | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:361:15:361:27 | instance_on x | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:365:1:365:2 | c3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:365:1:365:11 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:365:6:365:7 | C1 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:365:6:365:11 | call to new | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:366:1:366:16 | call to add_singleton | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:366:1:366:16 | self | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:366:15:366:16 | c3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:367:1:367:2 | c3 | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:367:1:367:11 | call to instance | calls.rb:1:1:367:11 | calls.rb |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:22:3 | hello.rb |
 | hello.rb:2:5:4:7 | hello | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:3:9:3:22 | return | hello.rb:1:1:8:3 | EnglishWords |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -1,22 +1,24 @@
 getModule
-| calls.rb:21:1:30:3 | M |
-| calls.rb:39:1:54:3 | C |
-| calls.rb:61:1:65:3 | D |
-| calls.rb:87:1:90:3 | Integer |
-| calls.rb:92:1:94:3 | String |
-| calls.rb:96:1:99:3 | Kernel |
-| calls.rb:101:1:106:3 | Module |
-| calls.rb:108:1:111:3 | Object |
-| calls.rb:113:1:116:3 | Hash |
-| calls.rb:118:1:131:3 | Array |
-| calls.rb:158:1:162:3 | S |
-| calls.rb:164:1:167:3 | A |
-| calls.rb:169:1:172:3 | B |
-| calls.rb:183:1:219:3 | Singletons |
-| calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:317:1:321:3 | C1 |
-| calls.rb:323:1:327:3 | C2 |
-| calls.rb:329:1:333:3 | C3 |
+| calls.rb:21:1:34:3 | M |
+| calls.rb:43:1:58:3 | C |
+| calls.rb:65:1:69:3 | D |
+| calls.rb:91:1:94:3 | Integer |
+| calls.rb:96:1:98:3 | String |
+| calls.rb:100:1:103:3 | Kernel |
+| calls.rb:105:1:110:3 | Module |
+| calls.rb:112:1:115:3 | Object |
+| calls.rb:117:1:120:3 | Hash |
+| calls.rb:122:1:135:3 | Array |
+| calls.rb:162:1:166:3 | S |
+| calls.rb:168:1:171:3 | A |
+| calls.rb:173:1:176:3 | B |
+| calls.rb:187:1:223:3 | Singletons |
+| calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:322:1:326:3 | C1 |
+| calls.rb:328:1:332:3 | C2 |
+| calls.rb:334:1:338:3 | C3 |
+| calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:399:1:409:3 | SingletonOverride2 |
 | file://:0:0:0:0 | BasicObject |
 | file://:0:0:0:0 | Class |
 | file://:0:0:0:0 | Complex |
@@ -66,30 +68,32 @@ getModule
 | private.rb:1:1:29:3 | E |
 | private.rb:42:1:60:3 | F |
 getADeclaration
-| calls.rb:21:1:30:3 | M | calls.rb:21:1:30:3 | M |
-| calls.rb:39:1:54:3 | C | calls.rb:39:1:54:3 | C |
-| calls.rb:61:1:65:3 | D | calls.rb:61:1:65:3 | D |
-| calls.rb:87:1:90:3 | Integer | calls.rb:87:1:90:3 | Integer |
-| calls.rb:92:1:94:3 | String | calls.rb:92:1:94:3 | String |
-| calls.rb:96:1:99:3 | Kernel | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:101:1:106:3 | Module | calls.rb:101:1:106:3 | Module |
-| calls.rb:108:1:111:3 | Object | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:108:1:111:3 | Object | calls.rb:108:1:111:3 | Object |
-| calls.rb:108:1:111:3 | Object | hello.rb:1:1:22:3 | hello.rb |
-| calls.rb:108:1:111:3 | Object | modules.rb:1:1:129:4 | modules.rb |
-| calls.rb:108:1:111:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
-| calls.rb:108:1:111:3 | Object | private.rb:1:1:60:3 | private.rb |
-| calls.rb:113:1:116:3 | Hash | calls.rb:113:1:116:3 | Hash |
-| calls.rb:118:1:131:3 | Array | calls.rb:118:1:131:3 | Array |
-| calls.rb:158:1:162:3 | S | calls.rb:158:1:162:3 | S |
-| calls.rb:164:1:167:3 | A | calls.rb:164:1:167:3 | A |
-| calls.rb:164:1:167:3 | A | modules_rec.rb:7:1:9:3 | A |
-| calls.rb:169:1:172:3 | B | calls.rb:169:1:172:3 | B |
-| calls.rb:183:1:219:3 | Singletons | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:303:1:313:3 | SelfNew | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:317:1:321:3 | C1 | calls.rb:317:1:321:3 | C1 |
-| calls.rb:323:1:327:3 | C2 | calls.rb:323:1:327:3 | C2 |
-| calls.rb:329:1:333:3 | C3 | calls.rb:329:1:333:3 | C3 |
+| calls.rb:21:1:34:3 | M | calls.rb:21:1:34:3 | M |
+| calls.rb:43:1:58:3 | C | calls.rb:43:1:58:3 | C |
+| calls.rb:65:1:69:3 | D | calls.rb:65:1:69:3 | D |
+| calls.rb:91:1:94:3 | Integer | calls.rb:91:1:94:3 | Integer |
+| calls.rb:96:1:98:3 | String | calls.rb:96:1:98:3 | String |
+| calls.rb:100:1:103:3 | Kernel | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:105:1:110:3 | Module | calls.rb:105:1:110:3 | Module |
+| calls.rb:112:1:115:3 | Object | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:112:1:115:3 | Object | calls.rb:112:1:115:3 | Object |
+| calls.rb:112:1:115:3 | Object | hello.rb:1:1:22:3 | hello.rb |
+| calls.rb:112:1:115:3 | Object | modules.rb:1:1:129:4 | modules.rb |
+| calls.rb:112:1:115:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| calls.rb:112:1:115:3 | Object | private.rb:1:1:60:3 | private.rb |
+| calls.rb:117:1:120:3 | Hash | calls.rb:117:1:120:3 | Hash |
+| calls.rb:122:1:135:3 | Array | calls.rb:122:1:135:3 | Array |
+| calls.rb:162:1:166:3 | S | calls.rb:162:1:166:3 | S |
+| calls.rb:168:1:171:3 | A | calls.rb:168:1:171:3 | A |
+| calls.rb:168:1:171:3 | A | modules_rec.rb:7:1:9:3 | A |
+| calls.rb:173:1:176:3 | B | calls.rb:173:1:176:3 | B |
+| calls.rb:187:1:223:3 | Singletons | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:307:1:318:3 | SelfNew | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:322:1:326:3 | C1 | calls.rb:322:1:326:3 | C1 |
+| calls.rb:328:1:332:3 | C2 | calls.rb:328:1:332:3 | C2 |
+| calls.rb:334:1:338:3 | C3 | calls.rb:334:1:338:3 | C3 |
+| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:399:1:409:3 | SingletonOverride2 |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
@@ -131,101 +135,108 @@ getADeclaration
 | private.rb:1:1:29:3 | E | private.rb:1:1:29:3 | E |
 | private.rb:42:1:60:3 | F | private.rb:42:1:60:3 | F |
 getSuperClass
-| calls.rb:39:1:54:3 | C | calls.rb:108:1:111:3 | Object |
-| calls.rb:61:1:65:3 | D | calls.rb:39:1:54:3 | C |
-| calls.rb:87:1:90:3 | Integer | file://:0:0:0:0 | Numeric |
-| calls.rb:92:1:94:3 | String | calls.rb:108:1:111:3 | Object |
-| calls.rb:101:1:106:3 | Module | calls.rb:108:1:111:3 | Object |
-| calls.rb:108:1:111:3 | Object | file://:0:0:0:0 | BasicObject |
-| calls.rb:113:1:116:3 | Hash | calls.rb:108:1:111:3 | Object |
-| calls.rb:118:1:131:3 | Array | calls.rb:108:1:111:3 | Object |
-| calls.rb:158:1:162:3 | S | calls.rb:108:1:111:3 | Object |
-| calls.rb:164:1:167:3 | A | calls.rb:158:1:162:3 | S |
-| calls.rb:164:1:167:3 | A | calls.rb:169:1:172:3 | B |
-| calls.rb:169:1:172:3 | B | calls.rb:158:1:162:3 | S |
-| calls.rb:183:1:219:3 | Singletons | calls.rb:108:1:111:3 | Object |
-| calls.rb:303:1:313:3 | SelfNew | calls.rb:108:1:111:3 | Object |
-| calls.rb:317:1:321:3 | C1 | calls.rb:108:1:111:3 | Object |
-| calls.rb:323:1:327:3 | C2 | calls.rb:317:1:321:3 | C1 |
-| calls.rb:329:1:333:3 | C3 | calls.rb:323:1:327:3 | C2 |
-| file://:0:0:0:0 | Class | calls.rb:101:1:106:3 | Module |
+| calls.rb:43:1:58:3 | C | calls.rb:112:1:115:3 | Object |
+| calls.rb:65:1:69:3 | D | calls.rb:43:1:58:3 | C |
+| calls.rb:91:1:94:3 | Integer | file://:0:0:0:0 | Numeric |
+| calls.rb:96:1:98:3 | String | calls.rb:112:1:115:3 | Object |
+| calls.rb:105:1:110:3 | Module | calls.rb:112:1:115:3 | Object |
+| calls.rb:112:1:115:3 | Object | file://:0:0:0:0 | BasicObject |
+| calls.rb:117:1:120:3 | Hash | calls.rb:112:1:115:3 | Object |
+| calls.rb:122:1:135:3 | Array | calls.rb:112:1:115:3 | Object |
+| calls.rb:162:1:166:3 | S | calls.rb:112:1:115:3 | Object |
+| calls.rb:168:1:171:3 | A | calls.rb:162:1:166:3 | S |
+| calls.rb:168:1:171:3 | A | calls.rb:173:1:176:3 | B |
+| calls.rb:173:1:176:3 | B | calls.rb:162:1:166:3 | S |
+| calls.rb:187:1:223:3 | Singletons | calls.rb:112:1:115:3 | Object |
+| calls.rb:307:1:318:3 | SelfNew | calls.rb:112:1:115:3 | Object |
+| calls.rb:322:1:326:3 | C1 | calls.rb:112:1:115:3 | Object |
+| calls.rb:328:1:332:3 | C2 | calls.rb:322:1:326:3 | C1 |
+| calls.rb:334:1:338:3 | C3 | calls.rb:328:1:332:3 | C2 |
+| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:112:1:115:3 | Object |
+| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:374:1:394:3 | SingletonOverride1 |
+| file://:0:0:0:0 | Class | calls.rb:105:1:110:3 | Module |
 | file://:0:0:0:0 | Complex | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | FalseClass | calls.rb:108:1:111:3 | Object |
+| file://:0:0:0:0 | FalseClass | calls.rb:112:1:115:3 | Object |
 | file://:0:0:0:0 | Float | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | NilClass | calls.rb:108:1:111:3 | Object |
-| file://:0:0:0:0 | Numeric | calls.rb:108:1:111:3 | Object |
+| file://:0:0:0:0 | NilClass | calls.rb:112:1:115:3 | Object |
+| file://:0:0:0:0 | Numeric | calls.rb:112:1:115:3 | Object |
 | file://:0:0:0:0 | Rational | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | TrueClass | calls.rb:108:1:111:3 | Object |
-| hello.rb:11:1:16:3 | Greeting | calls.rb:108:1:111:3 | Object |
+| file://:0:0:0:0 | TrueClass | calls.rb:112:1:115:3 | Object |
+| hello.rb:11:1:16:3 | Greeting | calls.rb:112:1:115:3 | Object |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:11:1:16:3 | Greeting |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:108:1:111:3 | Object |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:108:1:111:3 | Object |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:108:1:111:3 | Object |
-| modules.rb:37:1:46:3 | Bar | calls.rb:108:1:111:3 | Object |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | calls.rb:108:1:111:3 | Object |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | calls.rb:108:1:111:3 | Object |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | calls.rb:108:1:111:3 | Object |
-| modules.rb:112:1:113:3 | YY | calls.rb:108:1:111:3 | Object |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:112:1:115:3 | Object |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:112:1:115:3 | Object |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:112:1:115:3 | Object |
+| modules.rb:37:1:46:3 | Bar | calls.rb:112:1:115:3 | Object |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | calls.rb:112:1:115:3 | Object |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | calls.rb:112:1:115:3 | Object |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | calls.rb:112:1:115:3 | Object |
+| modules.rb:112:1:113:3 | YY | calls.rb:112:1:115:3 | Object |
 | modules.rb:116:7:117:9 | XX::YY | modules.rb:112:1:113:3 | YY |
-| modules_rec.rb:1:1:2:3 | B::A | calls.rb:108:1:111:3 | Object |
-| modules_rec.rb:4:1:5:3 | A::B | calls.rb:108:1:111:3 | Object |
-| private.rb:1:1:29:3 | E | calls.rb:108:1:111:3 | Object |
+| modules_rec.rb:1:1:2:3 | B::A | calls.rb:112:1:115:3 | Object |
+| modules_rec.rb:4:1:5:3 | A::B | calls.rb:112:1:115:3 | Object |
+| private.rb:1:1:29:3 | E | calls.rb:112:1:115:3 | Object |
 getAPrependedModule
-| calls.rb:108:1:111:3 | Object | calls.rb:164:1:167:3 | A |
-| calls.rb:164:1:167:3 | A | modules_rec.rb:4:1:5:3 | A::B |
+| calls.rb:112:1:115:3 | Object | calls.rb:168:1:171:3 | A |
+| calls.rb:168:1:171:3 | A | modules_rec.rb:4:1:5:3 | A::B |
 | modules.rb:101:1:105:3 | PrependTest | modules.rb:63:1:81:3 | Test |
 getAnIncludedModule
-| calls.rb:39:1:54:3 | C | calls.rb:21:1:30:3 | M |
-| calls.rb:108:1:111:3 | Object | calls.rb:96:1:99:3 | Kernel |
+| calls.rb:43:1:58:3 | C | calls.rb:21:1:34:3 | M |
+| calls.rb:112:1:115:3 | Object | calls.rb:100:1:103:3 | Kernel |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:1:1:8:3 | EnglishWords |
 | modules.rb:88:1:93:3 | IncludeTest | modules.rb:63:1:81:3 | Test |
 | modules.rb:95:1:99:3 | IncludeTest2 | modules.rb:63:1:81:3 | Test |
 resolveConstantReadAccess
-| calls.rb:32:1:32:1 | M | M |
-| calls.rb:33:1:33:1 | M | M |
-| calls.rb:40:13:40:13 | M | M |
-| calls.rb:56:5:56:5 | C | C |
-| calls.rb:61:11:61:11 | C | C |
-| calls.rb:67:5:67:5 | D | D |
-| calls.rb:82:11:82:14 | Hash | Hash |
-| calls.rb:108:16:108:21 | Module | Module |
-| calls.rb:109:13:109:18 | Kernel | Kernel |
-| calls.rb:143:1:143:13 | Array | Array |
-| calls.rb:145:1:145:7 | Array | Array |
-| calls.rb:147:1:147:7 | Array | Array |
-| calls.rb:149:1:149:8 | Array | Array |
-| calls.rb:164:11:164:11 | S | S |
-| calls.rb:169:11:169:11 | S | S |
-| calls.rb:174:1:174:1 | S | S |
-| calls.rb:175:1:175:1 | A | A |
-| calls.rb:176:1:176:1 | B | B |
-| calls.rb:221:1:221:10 | Singletons | Singletons |
-| calls.rb:222:1:222:10 | Singletons | Singletons |
-| calls.rb:224:6:224:15 | Singletons | Singletons |
-| calls.rb:252:6:252:15 | Singletons | Singletons |
-| calls.rb:260:5:260:14 | Singletons | Singletons |
-| calls.rb:264:1:264:10 | Singletons | Singletons |
-| calls.rb:268:6:268:15 | Singletons | Singletons |
-| calls.rb:281:8:281:17 | Singletons | Singletons |
-| calls.rb:282:1:282:10 | Singletons | Singletons |
-| calls.rb:284:5:284:14 | Singletons | Singletons |
-| calls.rb:293:1:293:10 | Singletons | Singletons |
-| calls.rb:295:10:295:19 | Singletons | Singletons |
-| calls.rb:301:1:301:10 | Singletons | Singletons |
-| calls.rb:315:1:315:7 | SelfNew | SelfNew |
-| calls.rb:323:12:323:13 | C1 | C1 |
-| calls.rb:329:12:329:13 | C2 | C2 |
-| calls.rb:337:10:337:11 | C3 | C3 |
-| calls.rb:339:10:339:11 | C2 | C2 |
-| calls.rb:341:10:341:11 | C1 | C1 |
-| calls.rb:347:12:347:13 | C3 | C3 |
-| calls.rb:348:12:348:13 | C2 | C2 |
-| calls.rb:349:12:349:13 | C1 | C1 |
-| calls.rb:353:6:353:7 | C1 | C1 |
-| calls.rb:355:19:355:20 | C1 | C1 |
-| calls.rb:356:19:356:20 | C2 | C2 |
-| calls.rb:357:19:357:20 | C3 | C3 |
-| calls.rb:365:6:365:7 | C1 | C1 |
+| calls.rb:36:1:36:1 | M | M |
+| calls.rb:37:1:37:1 | M | M |
+| calls.rb:44:13:44:13 | M | M |
+| calls.rb:60:5:60:5 | C | C |
+| calls.rb:65:11:65:11 | C | C |
+| calls.rb:71:5:71:5 | D | D |
+| calls.rb:86:11:86:14 | Hash | Hash |
+| calls.rb:112:16:112:21 | Module | Module |
+| calls.rb:113:13:113:18 | Kernel | Kernel |
+| calls.rb:147:1:147:13 | Array | Array |
+| calls.rb:149:1:149:7 | Array | Array |
+| calls.rb:151:1:151:7 | Array | Array |
+| calls.rb:153:1:153:8 | Array | Array |
+| calls.rb:168:11:168:11 | S | S |
+| calls.rb:173:11:173:11 | S | S |
+| calls.rb:178:1:178:1 | S | S |
+| calls.rb:179:1:179:1 | A | A |
+| calls.rb:180:1:180:1 | B | B |
+| calls.rb:225:1:225:10 | Singletons | Singletons |
+| calls.rb:226:1:226:10 | Singletons | Singletons |
+| calls.rb:228:6:228:15 | Singletons | Singletons |
+| calls.rb:256:6:256:15 | Singletons | Singletons |
+| calls.rb:264:5:264:14 | Singletons | Singletons |
+| calls.rb:268:1:268:10 | Singletons | Singletons |
+| calls.rb:272:6:272:15 | Singletons | Singletons |
+| calls.rb:285:8:285:17 | Singletons | Singletons |
+| calls.rb:286:1:286:10 | Singletons | Singletons |
+| calls.rb:288:5:288:14 | Singletons | Singletons |
+| calls.rb:297:1:297:10 | Singletons | Singletons |
+| calls.rb:299:10:299:19 | Singletons | Singletons |
+| calls.rb:305:1:305:10 | Singletons | Singletons |
+| calls.rb:320:1:320:7 | SelfNew | SelfNew |
+| calls.rb:328:12:328:13 | C1 | C1 |
+| calls.rb:334:12:334:13 | C2 | C2 |
+| calls.rb:342:10:342:11 | C3 | C3 |
+| calls.rb:344:10:344:11 | C2 | C2 |
+| calls.rb:346:10:346:11 | C1 | C1 |
+| calls.rb:352:12:352:13 | C3 | C3 |
+| calls.rb:353:12:353:13 | C2 | C2 |
+| calls.rb:354:12:354:13 | C1 | C1 |
+| calls.rb:358:6:358:7 | C1 | C1 |
+| calls.rb:360:19:360:20 | C1 | C1 |
+| calls.rb:361:19:361:20 | C2 | C2 |
+| calls.rb:362:19:362:20 | C3 | C3 |
+| calls.rb:370:6:370:7 | C1 | C1 |
+| calls.rb:396:1:396:18 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:397:1:397:18 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:399:28:399:45 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:411:1:411:18 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:412:1:412:18 | SingletonOverride2 | SingletonOverride2 |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
 | modules.rb:48:8:48:10 | Foo | Foo |
@@ -258,24 +269,26 @@ resolveConstantReadAccess
 | private.rb:37:1:37:1 | E | E |
 | private.rb:38:1:38:1 | E | E |
 resolveConstantWriteAccess
-| calls.rb:21:1:30:3 | M | M |
-| calls.rb:39:1:54:3 | C | C |
-| calls.rb:61:1:65:3 | D | D |
-| calls.rb:87:1:90:3 | Integer | Integer |
-| calls.rb:92:1:94:3 | String | String |
-| calls.rb:96:1:99:3 | Kernel | Kernel |
-| calls.rb:101:1:106:3 | Module | Module |
-| calls.rb:108:1:111:3 | Object | Object |
-| calls.rb:113:1:116:3 | Hash | Hash |
-| calls.rb:118:1:131:3 | Array | Array |
-| calls.rb:158:1:162:3 | S | S |
-| calls.rb:164:1:167:3 | A | A |
-| calls.rb:169:1:172:3 | B | B |
-| calls.rb:183:1:219:3 | Singletons | Singletons |
-| calls.rb:303:1:313:3 | SelfNew | SelfNew |
-| calls.rb:317:1:321:3 | C1 | C1 |
-| calls.rb:323:1:327:3 | C2 | C2 |
-| calls.rb:329:1:333:3 | C3 | C3 |
+| calls.rb:21:1:34:3 | M | M |
+| calls.rb:43:1:58:3 | C | C |
+| calls.rb:65:1:69:3 | D | D |
+| calls.rb:91:1:94:3 | Integer | Integer |
+| calls.rb:96:1:98:3 | String | String |
+| calls.rb:100:1:103:3 | Kernel | Kernel |
+| calls.rb:105:1:110:3 | Module | Module |
+| calls.rb:112:1:115:3 | Object | Object |
+| calls.rb:117:1:120:3 | Hash | Hash |
+| calls.rb:122:1:135:3 | Array | Array |
+| calls.rb:162:1:166:3 | S | S |
+| calls.rb:168:1:171:3 | A | A |
+| calls.rb:173:1:176:3 | B | B |
+| calls.rb:187:1:223:3 | Singletons | Singletons |
+| calls.rb:307:1:318:3 | SelfNew | SelfNew |
+| calls.rb:322:1:326:3 | C1 | C1 |
+| calls.rb:328:1:332:3 | C2 | C2 |
+| calls.rb:334:1:338:3 | C3 | C3 |
+| calls.rb:374:1:394:3 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:399:1:409:3 | SingletonOverride2 | SingletonOverride2 |
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |
@@ -328,610 +341,663 @@ resolveConstantWriteAccess
 | private.rb:1:1:29:3 | E | E |
 | private.rb:42:1:60:3 | F | F |
 enclosingModule
-| calls.rb:1:1:3:3 | foo | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:2:5:2:14 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:2:11:2:13 | foo | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:5:1:5:3 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:7:1:9:3 | bar | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:7:5:7:8 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:8:5:8:15 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:11:1:11:4 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:13:1:15:3 | bar | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:13:5:13:8 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:14:5:14:15 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:17:1:17:4 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:19:1:19:4 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:21:1:30:3 | M | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:22:5:22:23 | instance_m | calls.rb:21:1:30:3 | M |
-| calls.rb:23:5:23:29 | singleton_m | calls.rb:21:1:30:3 | M |
-| calls.rb:23:9:23:12 | self | calls.rb:21:1:30:3 | M |
-| calls.rb:25:5:25:14 | call to instance_m | calls.rb:21:1:30:3 | M |
-| calls.rb:25:5:25:14 | self | calls.rb:21:1:30:3 | M |
-| calls.rb:26:5:26:8 | self | calls.rb:21:1:30:3 | M |
-| calls.rb:26:5:26:19 | call to instance_m | calls.rb:21:1:30:3 | M |
-| calls.rb:28:5:28:15 | call to singleton_m | calls.rb:21:1:30:3 | M |
-| calls.rb:28:5:28:15 | self | calls.rb:21:1:30:3 | M |
-| calls.rb:29:5:29:8 | self | calls.rb:21:1:30:3 | M |
-| calls.rb:29:5:29:20 | call to singleton_m | calls.rb:21:1:30:3 | M |
-| calls.rb:32:1:32:1 | M | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:32:1:32:12 | call to instance_m | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:33:1:33:1 | M | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:33:1:33:13 | call to singleton_m | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:35:1:37:3 | call_instance_m | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:36:5:36:14 | call to instance_m | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:36:5:36:14 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:39:1:54:3 | C | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:40:5:40:13 | call to include | calls.rb:39:1:54:3 | C |
-| calls.rb:40:5:40:13 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:40:13:40:13 | M | calls.rb:39:1:54:3 | C |
-| calls.rb:41:5:41:14 | call to instance_m | calls.rb:39:1:54:3 | C |
-| calls.rb:41:5:41:14 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:42:5:42:8 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:42:5:42:19 | call to instance_m | calls.rb:39:1:54:3 | C |
-| calls.rb:44:5:44:15 | call to singleton_m | calls.rb:39:1:54:3 | C |
-| calls.rb:44:5:44:15 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:45:5:45:8 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:45:5:45:20 | call to singleton_m | calls.rb:39:1:54:3 | C |
-| calls.rb:47:5:53:7 | baz | calls.rb:39:1:54:3 | C |
-| calls.rb:48:9:48:18 | call to instance_m | calls.rb:39:1:54:3 | C |
-| calls.rb:48:9:48:18 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:49:9:49:12 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:49:9:49:23 | call to instance_m | calls.rb:39:1:54:3 | C |
-| calls.rb:51:9:51:19 | call to singleton_m | calls.rb:39:1:54:3 | C |
-| calls.rb:51:9:51:19 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:52:9:52:12 | self | calls.rb:39:1:54:3 | C |
-| calls.rb:52:9:52:24 | call to singleton_m | calls.rb:39:1:54:3 | C |
-| calls.rb:56:1:56:1 | c | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:56:1:56:9 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:56:5:56:5 | C | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:56:5:56:9 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:57:1:57:1 | c | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:57:1:57:5 | call to baz | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:58:1:58:1 | c | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:58:1:58:13 | call to singleton_m | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:59:1:59:1 | c | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:59:1:59:12 | call to instance_m | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:61:1:65:3 | D | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:61:11:61:11 | C | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:62:5:64:7 | baz | calls.rb:61:1:65:3 | D |
-| calls.rb:63:9:63:13 | call to super | calls.rb:61:1:65:3 | D |
-| calls.rb:67:1:67:1 | d | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:67:1:67:9 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:67:5:67:5 | D | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:67:5:67:9 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:68:1:68:1 | d | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:68:1:68:5 | call to baz | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:69:1:69:1 | d | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:69:1:69:13 | call to singleton_m | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:70:1:70:1 | d | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:70:1:70:12 | call to instance_m | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:72:1:75:3 | optional_arg | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:72:18:72:18 | a | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:72:18:72:18 | a | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:72:22:72:22 | 4 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:72:25:72:25 | b | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:72:25:72:25 | b | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:72:28:72:28 | 5 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:73:5:73:5 | a | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:73:5:73:16 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:74:5:74:5 | b | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:74:5:74:16 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:77:1:79:3 | call_block | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:78:5:78:11 | yield ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:78:11:78:11 | 1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:81:1:85:3 | foo | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:82:5:82:7 | var | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:82:5:82:18 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:82:11:82:14 | Hash | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:82:11:82:18 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:83:5:83:7 | var | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:83:5:83:10 | ...[...] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:83:9:83:9 | 1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:84:5:84:29 | call to call_block | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:84:5:84:29 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:84:16:84:29 | { ... } | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:84:19:84:19 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:84:19:84:19 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:84:22:84:24 | var | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:84:22:84:27 | ...[...] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:84:26:84:26 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:87:1:90:3 | Integer | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:88:5:88:23 | bit_length | calls.rb:87:1:90:3 | Integer |
-| calls.rb:89:5:89:16 | abs | calls.rb:87:1:90:3 | Integer |
-| calls.rb:92:1:94:3 | String | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:93:5:93:23 | capitalize | calls.rb:92:1:94:3 | String |
-| calls.rb:96:1:99:3 | Kernel | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:97:5:97:25 | alias ... | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:97:11:97:19 | :old_puts | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:97:11:97:19 | old_puts | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:97:21:97:25 | :puts | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:97:21:97:25 | puts | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:98:5:98:30 | puts | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:98:14:98:14 | x | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:98:14:98:14 | x | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:98:17:98:26 | call to old_puts | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:98:17:98:26 | self | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:98:26:98:26 | x | calls.rb:96:1:99:3 | Kernel |
-| calls.rb:101:1:106:3 | Module | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:102:5:102:24 | module_eval | calls.rb:101:1:106:3 | Module |
-| calls.rb:103:5:103:20 | include | calls.rb:101:1:106:3 | Module |
-| calls.rb:104:5:104:20 | prepend | calls.rb:101:1:106:3 | Module |
-| calls.rb:105:5:105:20 | private | calls.rb:101:1:106:3 | Module |
-| calls.rb:108:1:111:3 | Object | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:108:16:108:21 | Module | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:109:5:109:18 | call to include | calls.rb:108:1:111:3 | Object |
-| calls.rb:109:5:109:18 | self | calls.rb:108:1:111:3 | Object |
-| calls.rb:109:13:109:18 | Kernel | calls.rb:108:1:111:3 | Object |
-| calls.rb:110:5:110:16 | new | calls.rb:108:1:111:3 | Object |
-| calls.rb:113:1:116:3 | Hash | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:114:5:114:25 | alias ... | calls.rb:113:1:116:3 | Hash |
-| calls.rb:114:11:114:21 | :old_lookup | calls.rb:113:1:116:3 | Hash |
-| calls.rb:114:11:114:21 | old_lookup | calls.rb:113:1:116:3 | Hash |
-| calls.rb:114:23:114:25 | :[] | calls.rb:113:1:116:3 | Hash |
-| calls.rb:114:23:114:25 | [] | calls.rb:113:1:116:3 | Hash |
-| calls.rb:115:5:115:31 | [] | calls.rb:113:1:116:3 | Hash |
-| calls.rb:115:12:115:12 | x | calls.rb:113:1:116:3 | Hash |
-| calls.rb:115:12:115:12 | x | calls.rb:113:1:116:3 | Hash |
-| calls.rb:115:15:115:27 | call to old_lookup | calls.rb:113:1:116:3 | Hash |
-| calls.rb:115:15:115:27 | self | calls.rb:113:1:116:3 | Hash |
-| calls.rb:115:26:115:26 | x | calls.rb:113:1:116:3 | Hash |
-| calls.rb:118:1:131:3 | Array | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:119:3:119:23 | alias ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:119:9:119:19 | :old_lookup | calls.rb:118:1:131:3 | Array |
-| calls.rb:119:9:119:19 | old_lookup | calls.rb:118:1:131:3 | Array |
-| calls.rb:119:21:119:23 | :[] | calls.rb:118:1:131:3 | Array |
-| calls.rb:119:21:119:23 | [] | calls.rb:118:1:131:3 | Array |
-| calls.rb:120:3:120:29 | [] | calls.rb:118:1:131:3 | Array |
-| calls.rb:120:10:120:10 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:120:10:120:10 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:120:13:120:25 | call to old_lookup | calls.rb:118:1:131:3 | Array |
-| calls.rb:120:13:120:25 | self | calls.rb:118:1:131:3 | Array |
-| calls.rb:120:24:120:24 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:122:3:122:17 | length | calls.rb:118:1:131:3 | Array |
-| calls.rb:124:3:130:5 | foreach | calls.rb:118:1:131:3 | Array |
-| calls.rb:124:15:124:19 | &body | calls.rb:118:1:131:3 | Array |
-| calls.rb:124:16:124:19 | body | calls.rb:118:1:131:3 | Array |
-| calls.rb:125:5:125:5 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:125:5:125:9 | ... = ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:125:9:125:9 | 0 | calls.rb:118:1:131:3 | Array |
-| calls.rb:126:5:129:7 | while ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:126:11:126:11 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:126:11:126:25 | ... < ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:126:15:126:18 | self | calls.rb:118:1:131:3 | Array |
-| calls.rb:126:15:126:25 | call to length | calls.rb:118:1:131:3 | Array |
-| calls.rb:126:26:129:7 | do ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:127:9:127:24 | yield ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:127:15:127:15 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:127:18:127:21 | self | calls.rb:118:1:131:3 | Array |
-| calls.rb:127:18:127:24 | ...[...] | calls.rb:118:1:131:3 | Array |
-| calls.rb:127:23:127:23 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:128:9:128:9 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:128:9:128:9 | x | calls.rb:118:1:131:3 | Array |
-| calls.rb:128:9:128:14 | ... += ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:128:9:128:14 | ... = ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:128:11:128:12 | ... + ... | calls.rb:118:1:131:3 | Array |
-| calls.rb:128:14:128:14 | 1 | calls.rb:118:1:131:3 | Array |
-| calls.rb:133:1:135:3 | funny | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:134:5:134:20 | yield ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:134:11:134:20 | "prefix: " | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:134:12:134:19 | prefix:  | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:1:137:30 | call to funny | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:1:137:30 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:7:137:30 | { ... } | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:10:137:10 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:10:137:10 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:13:137:29 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:13:137:29 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:18:137:18 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:137:18:137:29 | call to capitalize | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:139:1:139:3 | "a" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:139:1:139:14 | call to capitalize | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:139:2:139:2 | a | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:140:1:140:1 | 1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:140:1:140:12 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:141:1:141:1 | 1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:141:1:141:5 | call to abs | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:1:143:13 | Array | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:1:143:13 | [...] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:1:143:13 | call to [] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:1:143:62 | call to foreach | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:2:143:4 | "a" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:3:143:3 | a | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:6:143:8 | "b" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:7:143:7 | b | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:10:143:12 | "c" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:11:143:11 | c | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:23:143:62 | { ... } | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:26:143:26 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:26:143:26 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:29:143:29 | v | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:29:143:29 | v | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:32:143:61 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:32:143:61 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:37:143:61 | "#{...} -> #{...}" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:38:143:41 | #{...} | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:40:143:40 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:42:143:45 |  ->  | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:46:143:60 | #{...} | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:48:143:48 | v | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:143:48:143:59 | call to capitalize | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:1:145:7 | Array | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:1:145:7 | [...] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:1:145:7 | call to [] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:1:145:35 | call to foreach | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:2:145:2 | 1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:4:145:4 | 2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:6:145:6 | 3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:17:145:35 | { ... } | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:20:145:20 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:20:145:20 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:23:145:23 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:145:23:145:34 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:1:147:7 | Array | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:1:147:7 | [...] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:1:147:7 | call to [] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:1:147:40 | call to foreach | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:2:147:2 | 1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:4:147:4 | 2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:6:147:6 | 3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:17:147:40 | { ... } | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:20:147:20 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:20:147:20 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:23:147:39 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:23:147:39 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:28:147:28 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:147:28:147:39 | call to capitalize | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:1:149:8 | Array | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:1:149:8 | [...] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:1:149:8 | call to [] | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:1:149:37 | call to foreach | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:2:149:2 | 1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:4:149:5 | - ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:5:149:5 | 2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:7:149:7 | 3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:18:149:37 | { ... } | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:21:149:21 | _ | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:21:149:21 | _ | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:24:149:24 | v | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:24:149:24 | v | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:27:149:36 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:27:149:36 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:32:149:32 | v | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:149:32:149:36 | call to abs | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:151:1:153:3 | indirect | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:151:14:151:15 | &b | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:151:15:151:15 | b | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:152:5:152:17 | call to call_block | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:152:5:152:17 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:152:16:152:17 | &... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:152:17:152:17 | b | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:155:1:155:28 | call to indirect | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:155:1:155:28 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:155:10:155:28 | { ... } | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:155:13:155:13 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:155:13:155:13 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:155:16:155:16 | i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:155:16:155:27 | call to bit_length | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:158:1:162:3 | S | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:159:5:161:7 | s_method | calls.rb:158:1:162:3 | S |
-| calls.rb:160:9:160:12 | self | calls.rb:158:1:162:3 | S |
-| calls.rb:160:9:160:17 | call to to_s | calls.rb:158:1:162:3 | S |
-| calls.rb:164:1:167:3 | A | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:164:11:164:11 | S | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:165:5:166:7 | to_s | calls.rb:164:1:167:3 | A |
-| calls.rb:169:1:172:3 | B | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:169:11:169:11 | S | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:170:5:171:7 | to_s | calls.rb:169:1:172:3 | B |
-| calls.rb:174:1:174:1 | S | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:174:1:174:5 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:174:1:174:14 | call to s_method | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:175:1:175:1 | A | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:175:1:175:5 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:175:1:175:14 | call to s_method | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:176:1:176:1 | B | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:176:1:176:5 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:176:1:176:14 | call to s_method | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:178:1:179:3 | private_on_main | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:181:1:181:15 | call to private_on_main | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:181:1:181:15 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:183:1:219:3 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:184:5:187:7 | singleton_a | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:184:9:184:12 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:185:9:185:26 | call to puts | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:185:9:185:26 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:185:14:185:26 | "singleton_a" | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:185:15:185:25 | singleton_a | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:186:9:186:12 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:186:9:186:24 | call to singleton_b | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:189:5:192:7 | singleton_b | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:189:9:189:12 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:190:9:190:26 | call to puts | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:190:9:190:26 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:190:14:190:26 | "singleton_b" | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:190:15:190:25 | singleton_b | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:191:9:191:12 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:191:9:191:24 | call to singleton_c | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:194:5:196:7 | singleton_c | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:194:9:194:12 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:195:9:195:26 | call to puts | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:195:9:195:26 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:195:14:195:26 | "singleton_c" | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:195:15:195:25 | singleton_c | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:198:5:201:7 | singleton_d | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:198:9:198:12 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:199:9:199:26 | call to puts | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:199:9:199:26 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:199:14:199:26 | "singleton_d" | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:199:15:199:25 | singleton_d | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:200:9:200:12 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:200:9:200:24 | call to singleton_a | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:203:5:208:7 | instance | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:204:9:206:11 | singleton_e | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:204:13:204:16 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:205:13:205:30 | call to puts | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:205:13:205:30 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:205:18:205:30 | "singleton_e" | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:205:19:205:29 | singleton_e | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:207:9:207:19 | call to singleton_e | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:207:9:207:19 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:210:5:214:7 | class << ... | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:210:14:210:17 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:211:9:213:11 | singleton_f | calls.rb:210:5:214:7 | class << ... |
-| calls.rb:212:13:212:30 | call to puts | calls.rb:210:5:214:7 | class << ... |
-| calls.rb:212:13:212:30 | self | calls.rb:210:5:214:7 | class << ... |
-| calls.rb:212:18:212:30 | "singleton_f" | calls.rb:210:5:214:7 | class << ... |
-| calls.rb:212:19:212:29 | singleton_f | calls.rb:210:5:214:7 | class << ... |
-| calls.rb:216:5:218:7 | call_singleton_g | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:217:9:217:12 | self | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:217:9:217:24 | call to singleton_g | calls.rb:183:1:219:3 | Singletons |
-| calls.rb:221:1:221:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:221:1:221:22 | call to singleton_a | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:222:1:222:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:222:1:222:22 | call to singleton_f | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:224:1:224:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:224:1:224:19 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:224:6:224:15 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:224:6:224:19 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:226:1:226:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:226:1:226:11 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:227:1:227:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:227:1:227:14 | call to singleton_e | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:229:1:231:3 | singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:229:5:229:6 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:230:5:230:24 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:230:5:230:24 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:230:10:230:24 | "singleton_g_1" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:230:11:230:23 | singleton_g_1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:233:1:233:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:233:1:233:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:234:1:234:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:234:1:234:19 | call to call_singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:236:1:238:3 | singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:236:5:236:6 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:237:5:237:24 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:237:5:237:24 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:237:10:237:24 | "singleton_g_2" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:237:11:237:23 | singleton_g_2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:240:1:240:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:240:1:240:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:241:1:241:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:241:1:241:19 | call to call_singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:243:1:247:3 | class << ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:243:10:243:11 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:244:5:246:7 | singleton_g | calls.rb:243:1:247:3 | class << ... |
-| calls.rb:245:9:245:28 | call to puts | calls.rb:243:1:247:3 | class << ... |
-| calls.rb:245:9:245:28 | self | calls.rb:243:1:247:3 | class << ... |
-| calls.rb:245:14:245:28 | "singleton_g_3" | calls.rb:243:1:247:3 | class << ... |
-| calls.rb:245:15:245:27 | singleton_g_3 | calls.rb:243:1:247:3 | class << ... |
-| calls.rb:249:1:249:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:249:1:249:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:250:1:250:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:250:1:250:19 | call to call_singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:252:1:252:2 | c2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:252:1:252:19 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:252:6:252:15 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:252:6:252:19 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:253:1:253:2 | c2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:253:1:253:14 | call to singleton_e | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:254:1:254:2 | c2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:254:1:254:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:256:1:256:4 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:256:1:256:8 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:258:1:258:16 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:258:1:258:16 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:258:6:258:16 | "top-level" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:258:7:258:15 | top-level | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:260:1:262:3 | singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:260:5:260:14 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:261:5:261:22 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:261:5:261:22 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:261:10:261:22 | "singleton_g" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:261:11:261:21 | singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:264:1:264:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:264:1:264:22 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:265:1:265:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:265:1:265:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:266:1:266:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:266:1:266:19 | call to call_singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:267:1:267:2 | c2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:267:1:267:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:268:1:268:2 | c3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:268:1:268:19 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:268:6:268:15 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:268:6:268:19 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:269:1:269:2 | c3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:271:1:279:3 | create | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:271:12:271:15 | type | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:271:12:271:15 | type | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:272:5:272:8 | type | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:272:5:272:12 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:272:5:272:21 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:274:5:276:7 | singleton_h | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:274:9:274:12 | type | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:275:9:275:26 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:275:9:275:26 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:275:14:275:26 | "singleton_h" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:275:15:275:25 | singleton_h | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:278:5:278:8 | type | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:278:5:278:20 | call to singleton_h | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:281:1:281:17 | call to create | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:281:1:281:17 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:281:8:281:17 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:282:1:282:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:282:1:282:22 | call to singleton_h | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:284:1:284:1 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:284:1:284:14 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:284:5:284:14 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:286:1:290:3 | class << ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:286:10:286:10 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:287:5:289:7 | singleton_i | calls.rb:286:1:290:3 | class << ... |
-| calls.rb:288:9:288:26 | call to puts | calls.rb:286:1:290:3 | class << ... |
-| calls.rb:288:9:288:26 | self | calls.rb:286:1:290:3 | class << ... |
-| calls.rb:288:14:288:26 | "singleton_i" | calls.rb:286:1:290:3 | class << ... |
-| calls.rb:288:15:288:25 | singleton_i | calls.rb:286:1:290:3 | class << ... |
-| calls.rb:292:1:292:1 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:292:1:292:13 | call to singleton_i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:293:1:293:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:293:1:293:22 | call to singleton_i | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:295:1:299:3 | class << ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:295:10:295:19 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:296:5:298:7 | singleton_j | calls.rb:295:1:299:3 | class << ... |
-| calls.rb:297:9:297:26 | call to puts | calls.rb:295:1:299:3 | class << ... |
-| calls.rb:297:9:297:26 | self | calls.rb:295:1:299:3 | class << ... |
-| calls.rb:297:14:297:26 | "singleton_j" | calls.rb:295:1:299:3 | class << ... |
-| calls.rb:297:15:297:25 | singleton_j | calls.rb:295:1:299:3 | class << ... |
-| calls.rb:301:1:301:10 | Singletons | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:301:1:301:22 | call to singleton_j | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:303:1:313:3 | SelfNew | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:304:5:306:7 | instance | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:305:9:305:31 | call to puts | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:305:9:305:31 | self | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:305:14:305:31 | "SelfNew#instance" | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:305:15:305:30 | SelfNew#instance | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:308:5:310:7 | singleton | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:308:9:308:12 | self | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:309:9:309:11 | call to new | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:309:9:309:11 | self | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:309:9:309:20 | call to instance | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:312:5:312:7 | call to new | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:312:5:312:7 | self | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:312:5:312:16 | call to instance | calls.rb:303:1:313:3 | SelfNew |
-| calls.rb:315:1:315:7 | SelfNew | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:315:1:315:17 | call to singleton | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:317:1:321:3 | C1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:318:5:320:7 | instance | calls.rb:317:1:321:3 | C1 |
-| calls.rb:319:9:319:26 | call to puts | calls.rb:317:1:321:3 | C1 |
-| calls.rb:319:9:319:26 | self | calls.rb:317:1:321:3 | C1 |
-| calls.rb:319:14:319:26 | "C1#instance" | calls.rb:317:1:321:3 | C1 |
-| calls.rb:319:15:319:25 | C1#instance | calls.rb:317:1:321:3 | C1 |
-| calls.rb:323:1:327:3 | C2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:323:12:323:13 | C1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:324:5:326:7 | instance | calls.rb:323:1:327:3 | C2 |
-| calls.rb:325:9:325:26 | call to puts | calls.rb:323:1:327:3 | C2 |
-| calls.rb:325:9:325:26 | self | calls.rb:323:1:327:3 | C2 |
-| calls.rb:325:14:325:26 | "C2#instance" | calls.rb:323:1:327:3 | C2 |
-| calls.rb:325:15:325:25 | C2#instance | calls.rb:323:1:327:3 | C2 |
-| calls.rb:329:1:333:3 | C3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:329:12:329:13 | C2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:330:5:332:7 | instance | calls.rb:329:1:333:3 | C3 |
-| calls.rb:331:9:331:26 | call to puts | calls.rb:329:1:333:3 | C3 |
-| calls.rb:331:9:331:26 | self | calls.rb:329:1:333:3 | C3 |
-| calls.rb:331:14:331:26 | "C3#instance" | calls.rb:329:1:333:3 | C3 |
-| calls.rb:331:15:331:25 | C3#instance | calls.rb:329:1:333:3 | C3 |
-| calls.rb:335:1:351:3 | pattern_dispatch | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:335:22:335:22 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:335:22:335:22 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:336:5:344:7 | case ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:336:10:336:10 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:337:5:338:18 | when ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:337:10:337:11 | C3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:337:12:338:18 | then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:338:9:338:9 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:338:9:338:18 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:339:5:340:18 | when ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:339:10:339:11 | C2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:339:12:340:18 | then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:340:9:340:9 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:340:9:340:18 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:341:5:342:18 | when ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:341:10:341:11 | C1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:341:12:342:18 | then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:342:9:342:9 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:342:9:342:18 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:343:5:343:8 | else ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:346:5:350:7 | case ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:346:10:346:10 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:347:9:347:29 | in ... then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:347:12:347:13 | C3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:347:15:347:29 | then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:347:20:347:20 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:347:20:347:29 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:348:9:348:36 | in ... then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:348:12:348:13 | C2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:348:12:348:19 | ... => ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:348:18:348:19 | c2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:348:21:348:36 | then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:348:26:348:27 | c2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:348:26:348:36 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:349:9:349:36 | in ... then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:349:12:349:13 | C1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:349:12:349:19 | ... => ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:349:18:349:19 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:349:21:349:36 | then ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:349:26:349:27 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:349:26:349:36 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:353:1:353:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:353:1:353:11 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:353:6:353:7 | C1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:353:6:353:11 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:354:1:354:2 | c1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:354:1:354:11 | call to instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:355:1:355:25 | call to pattern_dispatch | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:355:1:355:25 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:355:18:355:25 | ( ... ) | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:355:19:355:20 | C1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:355:19:355:24 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:356:1:356:25 | call to pattern_dispatch | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:356:1:356:25 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:356:18:356:25 | ( ... ) | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:356:19:356:20 | C2 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:356:19:356:24 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:357:1:357:25 | call to pattern_dispatch | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:357:1:357:25 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:357:18:357:25 | ( ... ) | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:357:19:357:20 | C3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:357:19:357:24 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:359:1:363:3 | add_singleton | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:359:19:359:19 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:359:19:359:19 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:360:5:362:7 | instance | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:360:9:360:9 | x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:361:9:361:28 | call to puts | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:361:9:361:28 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:361:14:361:28 | "instance_on x" | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:361:15:361:27 | instance_on x | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:365:1:365:2 | c3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:365:1:365:11 | ... = ... | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:365:6:365:7 | C1 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:365:6:365:11 | call to new | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:366:1:366:16 | call to add_singleton | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:366:1:366:16 | self | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:366:15:366:16 | c3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:367:1:367:2 | c3 | calls.rb:1:1:367:11 | calls.rb |
-| calls.rb:367:1:367:11 | call to instance | calls.rb:1:1:367:11 | calls.rb |
+| calls.rb:1:1:3:3 | foo | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:5:1:5:3 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:7:1:9:3 | bar | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:7:5:7:8 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:8:5:8:15 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:11:1:11:4 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:13:1:15:3 | bar | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:13:5:13:8 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:14:5:14:15 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:17:1:17:4 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:19:1:19:4 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:21:1:34:3 | M | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:22:5:24:7 | instance_m | calls.rb:21:1:34:3 | M |
+| calls.rb:23:9:23:19 | call to singleton_m | calls.rb:21:1:34:3 | M |
+| calls.rb:23:9:23:19 | self | calls.rb:21:1:34:3 | M |
+| calls.rb:25:5:27:7 | singleton_m | calls.rb:21:1:34:3 | M |
+| calls.rb:25:9:25:12 | self | calls.rb:21:1:34:3 | M |
+| calls.rb:26:9:26:18 | call to instance_m | calls.rb:21:1:34:3 | M |
+| calls.rb:26:9:26:18 | self | calls.rb:21:1:34:3 | M |
+| calls.rb:29:5:29:14 | call to instance_m | calls.rb:21:1:34:3 | M |
+| calls.rb:29:5:29:14 | self | calls.rb:21:1:34:3 | M |
+| calls.rb:30:5:30:8 | self | calls.rb:21:1:34:3 | M |
+| calls.rb:30:5:30:19 | call to instance_m | calls.rb:21:1:34:3 | M |
+| calls.rb:32:5:32:15 | call to singleton_m | calls.rb:21:1:34:3 | M |
+| calls.rb:32:5:32:15 | self | calls.rb:21:1:34:3 | M |
+| calls.rb:33:5:33:8 | self | calls.rb:21:1:34:3 | M |
+| calls.rb:33:5:33:20 | call to singleton_m | calls.rb:21:1:34:3 | M |
+| calls.rb:36:1:36:1 | M | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:37:1:37:1 | M | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:40:5:40:14 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:43:1:58:3 | C | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:44:5:44:13 | call to include | calls.rb:43:1:58:3 | C |
+| calls.rb:44:5:44:13 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:44:13:44:13 | M | calls.rb:43:1:58:3 | C |
+| calls.rb:45:5:45:14 | call to instance_m | calls.rb:43:1:58:3 | C |
+| calls.rb:45:5:45:14 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:46:5:46:8 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:46:5:46:19 | call to instance_m | calls.rb:43:1:58:3 | C |
+| calls.rb:48:5:48:15 | call to singleton_m | calls.rb:43:1:58:3 | C |
+| calls.rb:48:5:48:15 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:49:5:49:8 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:49:5:49:20 | call to singleton_m | calls.rb:43:1:58:3 | C |
+| calls.rb:51:5:57:7 | baz | calls.rb:43:1:58:3 | C |
+| calls.rb:52:9:52:18 | call to instance_m | calls.rb:43:1:58:3 | C |
+| calls.rb:52:9:52:18 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:53:9:53:12 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:53:9:53:23 | call to instance_m | calls.rb:43:1:58:3 | C |
+| calls.rb:55:9:55:19 | call to singleton_m | calls.rb:43:1:58:3 | C |
+| calls.rb:55:9:55:19 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:56:9:56:12 | self | calls.rb:43:1:58:3 | C |
+| calls.rb:56:9:56:24 | call to singleton_m | calls.rb:43:1:58:3 | C |
+| calls.rb:60:1:60:1 | c | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:60:5:60:5 | C | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:61:1:61:1 | c | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:62:1:62:1 | c | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:63:1:63:1 | c | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:65:1:69:3 | D | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:65:11:65:11 | C | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:66:5:68:7 | baz | calls.rb:65:1:69:3 | D |
+| calls.rb:67:9:67:13 | call to super | calls.rb:65:1:69:3 | D |
+| calls.rb:71:1:71:1 | d | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:71:5:71:5 | D | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:72:1:72:1 | d | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:73:1:73:1 | d | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:74:1:74:1 | d | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:77:5:77:5 | a | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:78:5:78:5 | b | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:85:1:89:3 | foo | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:86:5:86:7 | var | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:87:5:87:7 | var | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:88:5:88:29 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:88:22:88:24 | var | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:88:26:88:26 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:92:5:92:23 | bit_length | calls.rb:91:1:94:3 | Integer |
+| calls.rb:93:5:93:16 | abs | calls.rb:91:1:94:3 | Integer |
+| calls.rb:96:1:98:3 | String | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:97:5:97:23 | capitalize | calls.rb:96:1:98:3 | String |
+| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:101:5:101:25 | alias ... | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:101:11:101:19 | :old_puts | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:101:11:101:19 | old_puts | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:101:21:101:25 | :puts | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:101:21:101:25 | puts | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:102:5:102:30 | puts | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:102:14:102:14 | x | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:102:14:102:14 | x | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:102:17:102:26 | call to old_puts | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:102:17:102:26 | self | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:102:26:102:26 | x | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:105:1:110:3 | Module | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:106:5:106:24 | module_eval | calls.rb:105:1:110:3 | Module |
+| calls.rb:107:5:107:20 | include | calls.rb:105:1:110:3 | Module |
+| calls.rb:108:5:108:20 | prepend | calls.rb:105:1:110:3 | Module |
+| calls.rb:109:5:109:20 | private | calls.rb:105:1:110:3 | Module |
+| calls.rb:112:1:115:3 | Object | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:112:16:112:21 | Module | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:113:5:113:18 | call to include | calls.rb:112:1:115:3 | Object |
+| calls.rb:113:5:113:18 | self | calls.rb:112:1:115:3 | Object |
+| calls.rb:113:13:113:18 | Kernel | calls.rb:112:1:115:3 | Object |
+| calls.rb:114:5:114:16 | new | calls.rb:112:1:115:3 | Object |
+| calls.rb:117:1:120:3 | Hash | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:118:5:118:25 | alias ... | calls.rb:117:1:120:3 | Hash |
+| calls.rb:118:11:118:21 | :old_lookup | calls.rb:117:1:120:3 | Hash |
+| calls.rb:118:11:118:21 | old_lookup | calls.rb:117:1:120:3 | Hash |
+| calls.rb:118:23:118:25 | :[] | calls.rb:117:1:120:3 | Hash |
+| calls.rb:118:23:118:25 | [] | calls.rb:117:1:120:3 | Hash |
+| calls.rb:119:5:119:31 | [] | calls.rb:117:1:120:3 | Hash |
+| calls.rb:119:12:119:12 | x | calls.rb:117:1:120:3 | Hash |
+| calls.rb:119:12:119:12 | x | calls.rb:117:1:120:3 | Hash |
+| calls.rb:119:15:119:27 | call to old_lookup | calls.rb:117:1:120:3 | Hash |
+| calls.rb:119:15:119:27 | self | calls.rb:117:1:120:3 | Hash |
+| calls.rb:119:26:119:26 | x | calls.rb:117:1:120:3 | Hash |
+| calls.rb:122:1:135:3 | Array | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:123:3:123:23 | alias ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:123:9:123:19 | :old_lookup | calls.rb:122:1:135:3 | Array |
+| calls.rb:123:9:123:19 | old_lookup | calls.rb:122:1:135:3 | Array |
+| calls.rb:123:21:123:23 | :[] | calls.rb:122:1:135:3 | Array |
+| calls.rb:123:21:123:23 | [] | calls.rb:122:1:135:3 | Array |
+| calls.rb:124:3:124:29 | [] | calls.rb:122:1:135:3 | Array |
+| calls.rb:124:10:124:10 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:124:10:124:10 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:124:13:124:25 | call to old_lookup | calls.rb:122:1:135:3 | Array |
+| calls.rb:124:13:124:25 | self | calls.rb:122:1:135:3 | Array |
+| calls.rb:124:24:124:24 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:126:3:126:17 | length | calls.rb:122:1:135:3 | Array |
+| calls.rb:128:3:134:5 | foreach | calls.rb:122:1:135:3 | Array |
+| calls.rb:128:15:128:19 | &body | calls.rb:122:1:135:3 | Array |
+| calls.rb:128:16:128:19 | body | calls.rb:122:1:135:3 | Array |
+| calls.rb:129:5:129:5 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:129:5:129:9 | ... = ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:129:9:129:9 | 0 | calls.rb:122:1:135:3 | Array |
+| calls.rb:130:5:133:7 | while ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:130:11:130:11 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:130:11:130:25 | ... < ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:130:15:130:18 | self | calls.rb:122:1:135:3 | Array |
+| calls.rb:130:15:130:25 | call to length | calls.rb:122:1:135:3 | Array |
+| calls.rb:130:26:133:7 | do ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:131:9:131:24 | yield ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:131:15:131:15 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:131:18:131:21 | self | calls.rb:122:1:135:3 | Array |
+| calls.rb:131:18:131:24 | ...[...] | calls.rb:122:1:135:3 | Array |
+| calls.rb:131:23:131:23 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:132:9:132:9 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:132:9:132:9 | x | calls.rb:122:1:135:3 | Array |
+| calls.rb:132:9:132:14 | ... += ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:132:9:132:14 | ... = ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:132:11:132:12 | ... + ... | calls.rb:122:1:135:3 | Array |
+| calls.rb:132:14:132:14 | 1 | calls.rb:122:1:135:3 | Array |
+| calls.rb:137:1:139:3 | funny | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:138:5:138:20 | yield ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:138:11:138:20 | "prefix: " | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:138:12:138:19 | prefix:  | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:1:141:30 | call to funny | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:1:141:30 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:7:141:30 | { ... } | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:10:141:10 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:10:141:10 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:13:141:29 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:13:141:29 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:18:141:18 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:141:18:141:29 | call to capitalize | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:143:1:143:3 | "a" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:143:1:143:14 | call to capitalize | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:143:2:143:2 | a | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:144:1:144:1 | 1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:144:1:144:12 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:145:1:145:1 | 1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:145:1:145:5 | call to abs | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:1:147:13 | Array | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:1:147:13 | [...] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:1:147:13 | call to [] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:1:147:62 | call to foreach | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:2:147:4 | "a" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:3:147:3 | a | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:6:147:8 | "b" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:7:147:7 | b | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:10:147:12 | "c" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:11:147:11 | c | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:23:147:62 | { ... } | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:26:147:26 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:26:147:26 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:29:147:29 | v | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:29:147:29 | v | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:32:147:61 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:32:147:61 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:37:147:61 | "#{...} -> #{...}" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:38:147:41 | #{...} | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:40:147:40 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:42:147:45 |  ->  | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:46:147:60 | #{...} | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:48:147:48 | v | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:147:48:147:59 | call to capitalize | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:1:149:7 | Array | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:1:149:7 | [...] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:1:149:7 | call to [] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:1:149:35 | call to foreach | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:2:149:2 | 1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:4:149:4 | 2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:6:149:6 | 3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:17:149:35 | { ... } | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:20:149:20 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:20:149:20 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:23:149:23 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:149:23:149:34 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:1:151:7 | Array | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:1:151:7 | [...] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:1:151:7 | call to [] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:1:151:40 | call to foreach | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:2:151:2 | 1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:4:151:4 | 2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:6:151:6 | 3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:17:151:40 | { ... } | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:20:151:20 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:20:151:20 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:23:151:39 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:23:151:39 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:28:151:28 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:151:28:151:39 | call to capitalize | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:1:153:8 | Array | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:1:153:8 | [...] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:1:153:8 | call to [] | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:1:153:37 | call to foreach | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:2:153:2 | 1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:4:153:5 | - ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:5:153:5 | 2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:7:153:7 | 3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:18:153:37 | { ... } | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:21:153:21 | _ | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:21:153:21 | _ | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:24:153:24 | v | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:24:153:24 | v | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:27:153:36 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:27:153:36 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:32:153:32 | v | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:153:32:153:36 | call to abs | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:155:1:157:3 | indirect | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:155:14:155:15 | &b | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:155:15:155:15 | b | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:156:5:156:17 | call to call_block | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:156:5:156:17 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:156:16:156:17 | &... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:156:17:156:17 | b | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:159:1:159:28 | call to indirect | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:159:1:159:28 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:159:10:159:28 | { ... } | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:159:13:159:13 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:159:13:159:13 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:159:16:159:16 | i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:159:16:159:27 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:162:1:166:3 | S | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:163:5:165:7 | s_method | calls.rb:162:1:166:3 | S |
+| calls.rb:164:9:164:12 | self | calls.rb:162:1:166:3 | S |
+| calls.rb:164:9:164:17 | call to to_s | calls.rb:162:1:166:3 | S |
+| calls.rb:168:1:171:3 | A | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:168:11:168:11 | S | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:169:5:170:7 | to_s | calls.rb:168:1:171:3 | A |
+| calls.rb:173:1:176:3 | B | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:173:11:173:11 | S | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:174:5:175:7 | to_s | calls.rb:173:1:176:3 | B |
+| calls.rb:178:1:178:1 | S | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:178:1:178:5 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:178:1:178:14 | call to s_method | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:179:1:179:1 | A | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:179:1:179:5 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:179:1:179:14 | call to s_method | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:180:1:180:1 | B | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:180:1:180:5 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:180:1:180:14 | call to s_method | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:182:1:183:3 | private_on_main | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:185:1:185:15 | call to private_on_main | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:185:1:185:15 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:187:1:223:3 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:188:5:191:7 | singleton_a | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:188:9:188:12 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:189:9:189:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:189:9:189:26 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:189:14:189:26 | "singleton_a" | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:189:15:189:25 | singleton_a | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:190:9:190:12 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:190:9:190:24 | call to singleton_b | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:193:5:196:7 | singleton_b | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:193:9:193:12 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:194:9:194:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:194:9:194:26 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:194:14:194:26 | "singleton_b" | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:194:15:194:25 | singleton_b | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:195:9:195:12 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:195:9:195:24 | call to singleton_c | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:198:5:200:7 | singleton_c | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:198:9:198:12 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:199:9:199:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:199:9:199:26 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:199:14:199:26 | "singleton_c" | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:199:15:199:25 | singleton_c | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:202:5:205:7 | singleton_d | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:202:9:202:12 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:203:9:203:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:203:9:203:26 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:203:14:203:26 | "singleton_d" | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:203:15:203:25 | singleton_d | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:204:9:204:12 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:204:9:204:24 | call to singleton_a | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:207:5:212:7 | instance | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:208:9:210:11 | singleton_e | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:208:13:208:16 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:209:13:209:30 | call to puts | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:209:13:209:30 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:209:18:209:30 | "singleton_e" | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:209:19:209:29 | singleton_e | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:211:9:211:19 | call to singleton_e | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:211:9:211:19 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:214:5:218:7 | class << ... | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:214:14:214:17 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:215:9:217:11 | singleton_f | calls.rb:214:5:218:7 | class << ... |
+| calls.rb:216:13:216:30 | call to puts | calls.rb:214:5:218:7 | class << ... |
+| calls.rb:216:13:216:30 | self | calls.rb:214:5:218:7 | class << ... |
+| calls.rb:216:18:216:30 | "singleton_f" | calls.rb:214:5:218:7 | class << ... |
+| calls.rb:216:19:216:29 | singleton_f | calls.rb:214:5:218:7 | class << ... |
+| calls.rb:220:5:222:7 | call_singleton_g | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:221:9:221:12 | self | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:187:1:223:3 | Singletons |
+| calls.rb:225:1:225:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:225:1:225:22 | call to singleton_a | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:226:1:226:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:226:1:226:22 | call to singleton_f | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:228:1:228:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:228:1:228:19 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:228:6:228:15 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:228:6:228:19 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:230:1:230:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:230:1:230:11 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:231:1:231:14 | call to singleton_e | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:233:1:235:3 | singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:233:5:233:6 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:234:5:234:24 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:234:5:234:24 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:234:10:234:24 | "singleton_g_1" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:234:11:234:23 | singleton_g_1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:237:1:237:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:237:1:237:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:238:1:238:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:238:1:238:19 | call to call_singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:240:1:242:3 | singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:240:5:240:6 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:241:5:241:24 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:241:5:241:24 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:241:10:241:24 | "singleton_g_2" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:241:11:241:23 | singleton_g_2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:244:1:244:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:244:1:244:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:245:1:245:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:245:1:245:19 | call to call_singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:247:1:251:3 | class << ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:247:10:247:11 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:248:5:250:7 | singleton_g | calls.rb:247:1:251:3 | class << ... |
+| calls.rb:249:9:249:28 | call to puts | calls.rb:247:1:251:3 | class << ... |
+| calls.rb:249:9:249:28 | self | calls.rb:247:1:251:3 | class << ... |
+| calls.rb:249:14:249:28 | "singleton_g_3" | calls.rb:247:1:251:3 | class << ... |
+| calls.rb:249:15:249:27 | singleton_g_3 | calls.rb:247:1:251:3 | class << ... |
+| calls.rb:253:1:253:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:253:1:253:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:254:1:254:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:254:1:254:19 | call to call_singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:256:1:256:2 | c2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:256:1:256:19 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:256:6:256:15 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:256:6:256:19 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:257:1:257:2 | c2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:257:1:257:14 | call to singleton_e | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:258:1:258:2 | c2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:258:1:258:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:260:1:260:4 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:260:1:260:8 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:262:1:262:16 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:262:1:262:16 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:262:6:262:16 | "top-level" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:262:7:262:15 | top-level | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:264:1:266:3 | singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:264:5:264:14 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:265:5:265:22 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:265:5:265:22 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:265:10:265:22 | "singleton_g" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:265:11:265:21 | singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:268:1:268:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:268:1:268:22 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:269:1:269:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:270:1:270:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:270:1:270:19 | call to call_singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:271:1:271:2 | c2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:271:1:271:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:272:1:272:2 | c3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:272:1:272:19 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:272:6:272:15 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:272:6:272:19 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:273:1:273:2 | c3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:273:1:273:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:275:1:283:3 | create | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:275:12:275:15 | type | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:275:12:275:15 | type | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:276:5:276:8 | type | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:276:5:276:12 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:276:5:276:21 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:278:5:280:7 | singleton_h | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:278:9:278:12 | type | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:279:9:279:26 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:279:9:279:26 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:279:14:279:26 | "singleton_h" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:279:15:279:25 | singleton_h | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:282:5:282:8 | type | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:285:1:285:17 | call to create | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:285:1:285:17 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:285:8:285:17 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:286:1:286:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:286:1:286:22 | call to singleton_h | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:288:1:288:1 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:288:1:288:14 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:288:5:288:14 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:290:1:294:3 | class << ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:290:10:290:10 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:291:5:293:7 | singleton_i | calls.rb:290:1:294:3 | class << ... |
+| calls.rb:292:9:292:26 | call to puts | calls.rb:290:1:294:3 | class << ... |
+| calls.rb:292:9:292:26 | self | calls.rb:290:1:294:3 | class << ... |
+| calls.rb:292:14:292:26 | "singleton_i" | calls.rb:290:1:294:3 | class << ... |
+| calls.rb:292:15:292:25 | singleton_i | calls.rb:290:1:294:3 | class << ... |
+| calls.rb:296:1:296:1 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:296:1:296:13 | call to singleton_i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:297:1:297:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:297:1:297:22 | call to singleton_i | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:299:1:303:3 | class << ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:299:10:299:19 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:300:5:302:7 | singleton_j | calls.rb:299:1:303:3 | class << ... |
+| calls.rb:301:9:301:26 | call to puts | calls.rb:299:1:303:3 | class << ... |
+| calls.rb:301:9:301:26 | self | calls.rb:299:1:303:3 | class << ... |
+| calls.rb:301:14:301:26 | "singleton_j" | calls.rb:299:1:303:3 | class << ... |
+| calls.rb:301:15:301:25 | singleton_j | calls.rb:299:1:303:3 | class << ... |
+| calls.rb:305:1:305:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:305:1:305:22 | call to singleton_j | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:307:1:318:3 | SelfNew | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:308:5:311:7 | instance | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:309:9:309:31 | call to puts | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:309:9:309:31 | self | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:309:14:309:31 | "SelfNew#instance" | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:309:15:309:30 | SelfNew#instance | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:310:9:310:11 | call to new | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:310:9:310:11 | self | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:310:9:310:20 | call to instance | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:313:5:315:7 | singleton | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:313:9:313:12 | self | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:314:9:314:11 | call to new | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:314:9:314:11 | self | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:314:9:314:20 | call to instance | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:317:5:317:7 | call to new | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:317:5:317:7 | self | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:317:5:317:16 | call to instance | calls.rb:307:1:318:3 | SelfNew |
+| calls.rb:320:1:320:7 | SelfNew | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:320:1:320:17 | call to singleton | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:322:1:326:3 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:323:5:325:7 | instance | calls.rb:322:1:326:3 | C1 |
+| calls.rb:324:9:324:26 | call to puts | calls.rb:322:1:326:3 | C1 |
+| calls.rb:324:9:324:26 | self | calls.rb:322:1:326:3 | C1 |
+| calls.rb:324:14:324:26 | "C1#instance" | calls.rb:322:1:326:3 | C1 |
+| calls.rb:324:15:324:25 | C1#instance | calls.rb:322:1:326:3 | C1 |
+| calls.rb:328:1:332:3 | C2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:328:12:328:13 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:329:5:331:7 | instance | calls.rb:328:1:332:3 | C2 |
+| calls.rb:330:9:330:26 | call to puts | calls.rb:328:1:332:3 | C2 |
+| calls.rb:330:9:330:26 | self | calls.rb:328:1:332:3 | C2 |
+| calls.rb:330:14:330:26 | "C2#instance" | calls.rb:328:1:332:3 | C2 |
+| calls.rb:330:15:330:25 | C2#instance | calls.rb:328:1:332:3 | C2 |
+| calls.rb:334:1:338:3 | C3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:334:12:334:13 | C2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:335:5:337:7 | instance | calls.rb:334:1:338:3 | C3 |
+| calls.rb:336:9:336:26 | call to puts | calls.rb:334:1:338:3 | C3 |
+| calls.rb:336:9:336:26 | self | calls.rb:334:1:338:3 | C3 |
+| calls.rb:336:14:336:26 | "C3#instance" | calls.rb:334:1:338:3 | C3 |
+| calls.rb:336:15:336:25 | C3#instance | calls.rb:334:1:338:3 | C3 |
+| calls.rb:340:1:356:3 | pattern_dispatch | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:340:22:340:22 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:340:22:340:22 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:341:5:349:7 | case ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:341:10:341:10 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:342:5:343:18 | when ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:342:10:342:11 | C3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:342:12:343:18 | then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:343:9:343:9 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:343:9:343:18 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:344:5:345:18 | when ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:344:10:344:11 | C2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:344:12:345:18 | then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:345:9:345:9 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:345:9:345:18 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:346:5:347:18 | when ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:346:10:346:11 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:346:12:347:18 | then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:347:9:347:9 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:347:9:347:18 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:348:5:348:8 | else ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:351:5:355:7 | case ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:351:10:351:10 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:352:9:352:29 | in ... then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:352:12:352:13 | C3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:352:15:352:29 | then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:352:20:352:20 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:352:20:352:29 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:353:9:353:36 | in ... then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:353:12:353:13 | C2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:353:12:353:19 | ... => ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:353:18:353:19 | c2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:353:21:353:36 | then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:353:26:353:27 | c2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:353:26:353:36 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:354:9:354:36 | in ... then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:354:12:354:13 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:354:12:354:19 | ... => ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:354:18:354:19 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:354:21:354:36 | then ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:354:26:354:27 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:354:26:354:36 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:358:1:358:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:358:1:358:11 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:358:6:358:7 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:358:6:358:11 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:359:1:359:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:359:1:359:11 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:360:1:360:25 | call to pattern_dispatch | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:360:1:360:25 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:360:18:360:25 | ( ... ) | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:360:19:360:20 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:360:19:360:24 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:361:1:361:25 | call to pattern_dispatch | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:361:1:361:25 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:361:18:361:25 | ( ... ) | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:361:19:361:20 | C2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:361:19:361:24 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:362:1:362:25 | call to pattern_dispatch | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:362:1:362:25 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:362:18:362:25 | ( ... ) | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:362:19:362:20 | C3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:362:19:362:24 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:364:1:368:3 | add_singleton | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:364:19:364:19 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:364:19:364:19 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:365:5:367:7 | instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:365:9:365:9 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:366:9:366:28 | call to puts | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:366:9:366:28 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:366:14:366:28 | "instance_on x" | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:366:15:366:27 | instance_on x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:370:1:370:2 | c3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:370:1:370:11 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:370:6:370:7 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:370:6:370:11 | call to new | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:371:1:371:16 | call to add_singleton | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:371:1:371:16 | self | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:371:15:371:16 | c3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:372:1:372:2 | c3 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:372:1:372:11 | call to instance | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:375:5:383:7 | class << ... | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:375:14:375:17 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:376:9:378:11 | singleton1 | calls.rb:375:5:383:7 | class << ... |
+| calls.rb:377:13:377:48 | call to puts | calls.rb:375:5:383:7 | class << ... |
+| calls.rb:377:13:377:48 | self | calls.rb:375:5:383:7 | class << ... |
+| calls.rb:377:18:377:48 | "SingletonOverride1#singleton1" | calls.rb:375:5:383:7 | class << ... |
+| calls.rb:377:19:377:47 | SingletonOverride1#singleton1 | calls.rb:375:5:383:7 | class << ... |
+| calls.rb:380:9:382:11 | call_singleton1 | calls.rb:375:5:383:7 | class << ... |
+| calls.rb:381:13:381:22 | call to singleton1 | calls.rb:375:5:383:7 | class << ... |
+| calls.rb:381:13:381:22 | self | calls.rb:375:5:383:7 | class << ... |
+| calls.rb:385:5:387:7 | singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:385:9:385:12 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:386:9:386:44 | call to puts | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:386:9:386:44 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:386:14:386:44 | "SingletonOverride1#singleton2" | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:386:15:386:43 | SingletonOverride1#singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:389:5:391:7 | call_singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:389:9:389:12 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:390:9:390:18 | call to singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:390:9:390:18 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:393:5:393:14 | call to singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:393:5:393:14 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:396:1:396:18 | SingletonOverride1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:397:1:397:18 | SingletonOverride1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:399:28:399:45 | SingletonOverride1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:400:5:404:7 | class << ... | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:400:14:400:17 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:401:9:403:11 | singleton1 | calls.rb:400:5:404:7 | class << ... |
+| calls.rb:402:13:402:48 | call to puts | calls.rb:400:5:404:7 | class << ... |
+| calls.rb:402:13:402:48 | self | calls.rb:400:5:404:7 | class << ... |
+| calls.rb:402:18:402:48 | "SingletonOverride2#singleton1" | calls.rb:400:5:404:7 | class << ... |
+| calls.rb:402:19:402:47 | SingletonOverride2#singleton1 | calls.rb:400:5:404:7 | class << ... |
+| calls.rb:406:5:408:7 | singleton2 | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:406:9:406:12 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:407:9:407:44 | call to puts | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:407:9:407:44 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:407:14:407:44 | "SingletonOverride2#singleton2" | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:407:15:407:43 | SingletonOverride2#singleton2 | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:411:1:411:18 | SingletonOverride2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:411:1:411:34 | call to call_singleton1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:412:1:412:18 | SingletonOverride2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:412:1:412:34 | call to call_singleton2 | calls.rb:1:1:412:35 | calls.rb |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:22:3 | hello.rb |
 | hello.rb:2:5:4:7 | hello | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:3:9:3:22 | return | hello.rb:1:1:8:3 | EnglishWords |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -1,18 +1,22 @@
 getModule
-| calls.rb:15:1:24:3 | M |
-| calls.rb:29:1:44:3 | C |
-| calls.rb:51:1:55:3 | D |
-| calls.rb:77:1:80:3 | Integer |
-| calls.rb:82:1:84:3 | String |
-| calls.rb:86:1:88:3 | Kernel |
-| calls.rb:90:1:95:3 | Module |
-| calls.rb:97:1:100:3 | Object |
-| calls.rb:102:1:104:3 | Hash |
-| calls.rb:106:1:117:3 | Array |
-| calls.rb:144:1:148:3 | S |
-| calls.rb:150:1:153:3 | A |
-| calls.rb:155:1:158:3 | B |
-| calls.rb:169:1:184:3 | Singletons |
+| calls.rb:21:1:30:3 | M |
+| calls.rb:35:1:50:3 | C |
+| calls.rb:57:1:61:3 | D |
+| calls.rb:83:1:86:3 | Integer |
+| calls.rb:88:1:90:3 | String |
+| calls.rb:92:1:95:3 | Kernel |
+| calls.rb:97:1:102:3 | Module |
+| calls.rb:104:1:107:3 | Object |
+| calls.rb:109:1:112:3 | Hash |
+| calls.rb:114:1:127:3 | Array |
+| calls.rb:154:1:158:3 | S |
+| calls.rb:160:1:163:3 | A |
+| calls.rb:165:1:168:3 | B |
+| calls.rb:179:1:215:3 | Singletons |
+| calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:313:1:317:3 | C1 |
+| calls.rb:319:1:323:3 | C2 |
+| calls.rb:325:1:329:3 | C3 |
 | file://:0:0:0:0 | BasicObject |
 | file://:0:0:0:0 | Class |
 | file://:0:0:0:0 | Complex |
@@ -62,26 +66,30 @@ getModule
 | private.rb:1:1:29:3 | E |
 | private.rb:42:1:60:3 | F |
 getADeclaration
-| calls.rb:15:1:24:3 | M | calls.rb:15:1:24:3 | M |
-| calls.rb:29:1:44:3 | C | calls.rb:29:1:44:3 | C |
-| calls.rb:51:1:55:3 | D | calls.rb:51:1:55:3 | D |
-| calls.rb:77:1:80:3 | Integer | calls.rb:77:1:80:3 | Integer |
-| calls.rb:82:1:84:3 | String | calls.rb:82:1:84:3 | String |
-| calls.rb:86:1:88:3 | Kernel | calls.rb:86:1:88:3 | Kernel |
-| calls.rb:90:1:95:3 | Module | calls.rb:90:1:95:3 | Module |
-| calls.rb:97:1:100:3 | Object | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:97:1:100:3 | Object | calls.rb:97:1:100:3 | Object |
-| calls.rb:97:1:100:3 | Object | hello.rb:1:1:22:3 | hello.rb |
-| calls.rb:97:1:100:3 | Object | modules.rb:1:1:129:4 | modules.rb |
-| calls.rb:97:1:100:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
-| calls.rb:97:1:100:3 | Object | private.rb:1:1:60:3 | private.rb |
-| calls.rb:102:1:104:3 | Hash | calls.rb:102:1:104:3 | Hash |
-| calls.rb:106:1:117:3 | Array | calls.rb:106:1:117:3 | Array |
-| calls.rb:144:1:148:3 | S | calls.rb:144:1:148:3 | S |
-| calls.rb:150:1:153:3 | A | calls.rb:150:1:153:3 | A |
-| calls.rb:150:1:153:3 | A | modules_rec.rb:7:1:9:3 | A |
-| calls.rb:155:1:158:3 | B | calls.rb:155:1:158:3 | B |
-| calls.rb:169:1:184:3 | Singletons | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:21:1:30:3 | M | calls.rb:21:1:30:3 | M |
+| calls.rb:35:1:50:3 | C | calls.rb:35:1:50:3 | C |
+| calls.rb:57:1:61:3 | D | calls.rb:57:1:61:3 | D |
+| calls.rb:83:1:86:3 | Integer | calls.rb:83:1:86:3 | Integer |
+| calls.rb:88:1:90:3 | String | calls.rb:88:1:90:3 | String |
+| calls.rb:92:1:95:3 | Kernel | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:97:1:102:3 | Module | calls.rb:97:1:102:3 | Module |
+| calls.rb:104:1:107:3 | Object | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:104:1:107:3 | Object | calls.rb:104:1:107:3 | Object |
+| calls.rb:104:1:107:3 | Object | hello.rb:1:1:22:3 | hello.rb |
+| calls.rb:104:1:107:3 | Object | modules.rb:1:1:129:4 | modules.rb |
+| calls.rb:104:1:107:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| calls.rb:104:1:107:3 | Object | private.rb:1:1:60:3 | private.rb |
+| calls.rb:109:1:112:3 | Hash | calls.rb:109:1:112:3 | Hash |
+| calls.rb:114:1:127:3 | Array | calls.rb:114:1:127:3 | Array |
+| calls.rb:154:1:158:3 | S | calls.rb:154:1:158:3 | S |
+| calls.rb:160:1:163:3 | A | calls.rb:160:1:163:3 | A |
+| calls.rb:160:1:163:3 | A | modules_rec.rb:7:1:9:3 | A |
+| calls.rb:165:1:168:3 | B | calls.rb:165:1:168:3 | B |
+| calls.rb:179:1:215:3 | Singletons | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:299:1:309:3 | SelfNew | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:313:1:317:3 | C1 | calls.rb:313:1:317:3 | C1 |
+| calls.rb:319:1:323:3 | C2 | calls.rb:319:1:323:3 | C2 |
+| calls.rb:325:1:329:3 | C3 | calls.rb:325:1:329:3 | C3 |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
@@ -123,71 +131,101 @@ getADeclaration
 | private.rb:1:1:29:3 | E | private.rb:1:1:29:3 | E |
 | private.rb:42:1:60:3 | F | private.rb:42:1:60:3 | F |
 getSuperClass
-| calls.rb:29:1:44:3 | C | calls.rb:97:1:100:3 | Object |
-| calls.rb:51:1:55:3 | D | calls.rb:29:1:44:3 | C |
-| calls.rb:77:1:80:3 | Integer | file://:0:0:0:0 | Numeric |
-| calls.rb:82:1:84:3 | String | calls.rb:97:1:100:3 | Object |
-| calls.rb:90:1:95:3 | Module | calls.rb:97:1:100:3 | Object |
-| calls.rb:97:1:100:3 | Object | file://:0:0:0:0 | BasicObject |
-| calls.rb:102:1:104:3 | Hash | calls.rb:97:1:100:3 | Object |
-| calls.rb:106:1:117:3 | Array | calls.rb:97:1:100:3 | Object |
-| calls.rb:144:1:148:3 | S | calls.rb:97:1:100:3 | Object |
-| calls.rb:150:1:153:3 | A | calls.rb:144:1:148:3 | S |
-| calls.rb:150:1:153:3 | A | calls.rb:155:1:158:3 | B |
-| calls.rb:155:1:158:3 | B | calls.rb:144:1:148:3 | S |
-| calls.rb:169:1:184:3 | Singletons | calls.rb:97:1:100:3 | Object |
-| file://:0:0:0:0 | Class | calls.rb:90:1:95:3 | Module |
+| calls.rb:35:1:50:3 | C | calls.rb:104:1:107:3 | Object |
+| calls.rb:57:1:61:3 | D | calls.rb:35:1:50:3 | C |
+| calls.rb:83:1:86:3 | Integer | file://:0:0:0:0 | Numeric |
+| calls.rb:88:1:90:3 | String | calls.rb:104:1:107:3 | Object |
+| calls.rb:97:1:102:3 | Module | calls.rb:104:1:107:3 | Object |
+| calls.rb:104:1:107:3 | Object | file://:0:0:0:0 | BasicObject |
+| calls.rb:109:1:112:3 | Hash | calls.rb:104:1:107:3 | Object |
+| calls.rb:114:1:127:3 | Array | calls.rb:104:1:107:3 | Object |
+| calls.rb:154:1:158:3 | S | calls.rb:104:1:107:3 | Object |
+| calls.rb:160:1:163:3 | A | calls.rb:154:1:158:3 | S |
+| calls.rb:160:1:163:3 | A | calls.rb:165:1:168:3 | B |
+| calls.rb:165:1:168:3 | B | calls.rb:154:1:158:3 | S |
+| calls.rb:179:1:215:3 | Singletons | calls.rb:104:1:107:3 | Object |
+| calls.rb:299:1:309:3 | SelfNew | calls.rb:104:1:107:3 | Object |
+| calls.rb:313:1:317:3 | C1 | calls.rb:104:1:107:3 | Object |
+| calls.rb:319:1:323:3 | C2 | calls.rb:313:1:317:3 | C1 |
+| calls.rb:325:1:329:3 | C3 | calls.rb:319:1:323:3 | C2 |
+| file://:0:0:0:0 | Class | calls.rb:97:1:102:3 | Module |
 | file://:0:0:0:0 | Complex | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | FalseClass | calls.rb:97:1:100:3 | Object |
+| file://:0:0:0:0 | FalseClass | calls.rb:104:1:107:3 | Object |
 | file://:0:0:0:0 | Float | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | NilClass | calls.rb:97:1:100:3 | Object |
-| file://:0:0:0:0 | Numeric | calls.rb:97:1:100:3 | Object |
+| file://:0:0:0:0 | NilClass | calls.rb:104:1:107:3 | Object |
+| file://:0:0:0:0 | Numeric | calls.rb:104:1:107:3 | Object |
 | file://:0:0:0:0 | Rational | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | TrueClass | calls.rb:97:1:100:3 | Object |
-| hello.rb:11:1:16:3 | Greeting | calls.rb:97:1:100:3 | Object |
+| file://:0:0:0:0 | TrueClass | calls.rb:104:1:107:3 | Object |
+| hello.rb:11:1:16:3 | Greeting | calls.rb:104:1:107:3 | Object |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:11:1:16:3 | Greeting |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:97:1:100:3 | Object |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:97:1:100:3 | Object |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:97:1:100:3 | Object |
-| modules.rb:37:1:46:3 | Bar | calls.rb:97:1:100:3 | Object |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | calls.rb:97:1:100:3 | Object |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | calls.rb:97:1:100:3 | Object |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | calls.rb:97:1:100:3 | Object |
-| modules.rb:112:1:113:3 | YY | calls.rb:97:1:100:3 | Object |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:104:1:107:3 | Object |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:104:1:107:3 | Object |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:104:1:107:3 | Object |
+| modules.rb:37:1:46:3 | Bar | calls.rb:104:1:107:3 | Object |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | calls.rb:104:1:107:3 | Object |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | calls.rb:104:1:107:3 | Object |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | calls.rb:104:1:107:3 | Object |
+| modules.rb:112:1:113:3 | YY | calls.rb:104:1:107:3 | Object |
 | modules.rb:116:7:117:9 | XX::YY | modules.rb:112:1:113:3 | YY |
-| modules_rec.rb:1:1:2:3 | B::A | calls.rb:97:1:100:3 | Object |
-| modules_rec.rb:4:1:5:3 | A::B | calls.rb:97:1:100:3 | Object |
-| private.rb:1:1:29:3 | E | calls.rb:97:1:100:3 | Object |
+| modules_rec.rb:1:1:2:3 | B::A | calls.rb:104:1:107:3 | Object |
+| modules_rec.rb:4:1:5:3 | A::B | calls.rb:104:1:107:3 | Object |
+| private.rb:1:1:29:3 | E | calls.rb:104:1:107:3 | Object |
 getAPrependedModule
-| calls.rb:97:1:100:3 | Object | calls.rb:150:1:153:3 | A |
-| calls.rb:150:1:153:3 | A | modules_rec.rb:4:1:5:3 | A::B |
+| calls.rb:104:1:107:3 | Object | calls.rb:160:1:163:3 | A |
+| calls.rb:160:1:163:3 | A | modules_rec.rb:4:1:5:3 | A::B |
 | modules.rb:101:1:105:3 | PrependTest | modules.rb:63:1:81:3 | Test |
 getAnIncludedModule
-| calls.rb:29:1:44:3 | C | calls.rb:15:1:24:3 | M |
-| calls.rb:97:1:100:3 | Object | calls.rb:86:1:88:3 | Kernel |
+| calls.rb:35:1:50:3 | C | calls.rb:21:1:30:3 | M |
+| calls.rb:104:1:107:3 | Object | calls.rb:92:1:95:3 | Kernel |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:1:1:8:3 | EnglishWords |
 | modules.rb:88:1:93:3 | IncludeTest | modules.rb:63:1:81:3 | Test |
 | modules.rb:95:1:99:3 | IncludeTest2 | modules.rb:63:1:81:3 | Test |
 resolveConstantReadAccess
-| calls.rb:26:1:26:1 | M | M |
-| calls.rb:27:1:27:1 | M | M |
-| calls.rb:30:13:30:13 | M | M |
-| calls.rb:46:5:46:5 | C | C |
-| calls.rb:51:11:51:11 | C | C |
-| calls.rb:57:5:57:5 | D | D |
-| calls.rb:72:11:72:14 | Hash | Hash |
-| calls.rb:97:16:97:21 | Module | Module |
-| calls.rb:98:13:98:18 | Kernel | Kernel |
-| calls.rb:129:1:129:13 | Array | Array |
-| calls.rb:131:1:131:7 | Array | Array |
-| calls.rb:133:1:133:7 | Array | Array |
-| calls.rb:135:1:135:8 | Array | Array |
-| calls.rb:150:11:150:11 | S | S |
-| calls.rb:155:11:155:11 | S | S |
-| calls.rb:160:1:160:1 | S | S |
-| calls.rb:161:1:161:1 | A | A |
-| calls.rb:162:1:162:1 | B | B |
-| calls.rb:186:1:186:10 | Singletons | Singletons |
+| calls.rb:32:1:32:1 | M | M |
+| calls.rb:33:1:33:1 | M | M |
+| calls.rb:36:13:36:13 | M | M |
+| calls.rb:52:5:52:5 | C | C |
+| calls.rb:57:11:57:11 | C | C |
+| calls.rb:63:5:63:5 | D | D |
+| calls.rb:78:11:78:14 | Hash | Hash |
+| calls.rb:104:16:104:21 | Module | Module |
+| calls.rb:105:13:105:18 | Kernel | Kernel |
+| calls.rb:139:1:139:13 | Array | Array |
+| calls.rb:141:1:141:7 | Array | Array |
+| calls.rb:143:1:143:7 | Array | Array |
+| calls.rb:145:1:145:8 | Array | Array |
+| calls.rb:160:11:160:11 | S | S |
+| calls.rb:165:11:165:11 | S | S |
+| calls.rb:170:1:170:1 | S | S |
+| calls.rb:171:1:171:1 | A | A |
+| calls.rb:172:1:172:1 | B | B |
+| calls.rb:217:1:217:10 | Singletons | Singletons |
+| calls.rb:218:1:218:10 | Singletons | Singletons |
+| calls.rb:220:6:220:15 | Singletons | Singletons |
+| calls.rb:248:6:248:15 | Singletons | Singletons |
+| calls.rb:256:5:256:14 | Singletons | Singletons |
+| calls.rb:260:1:260:10 | Singletons | Singletons |
+| calls.rb:264:6:264:15 | Singletons | Singletons |
+| calls.rb:277:8:277:17 | Singletons | Singletons |
+| calls.rb:278:1:278:10 | Singletons | Singletons |
+| calls.rb:280:5:280:14 | Singletons | Singletons |
+| calls.rb:289:1:289:10 | Singletons | Singletons |
+| calls.rb:291:10:291:19 | Singletons | Singletons |
+| calls.rb:297:1:297:10 | Singletons | Singletons |
+| calls.rb:311:1:311:7 | SelfNew | SelfNew |
+| calls.rb:319:12:319:13 | C1 | C1 |
+| calls.rb:325:12:325:13 | C2 | C2 |
+| calls.rb:333:10:333:11 | C3 | C3 |
+| calls.rb:335:10:335:11 | C2 | C2 |
+| calls.rb:337:10:337:11 | C1 | C1 |
+| calls.rb:343:12:343:13 | C3 | C3 |
+| calls.rb:344:12:344:13 | C2 | C2 |
+| calls.rb:345:12:345:13 | C1 | C1 |
+| calls.rb:349:6:349:7 | C1 | C1 |
+| calls.rb:351:19:351:20 | C1 | C1 |
+| calls.rb:352:19:352:20 | C2 | C2 |
+| calls.rb:353:19:353:20 | C3 | C3 |
+| calls.rb:361:6:361:7 | C1 | C1 |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
 | modules.rb:48:8:48:10 | Foo | Foo |
@@ -220,20 +258,24 @@ resolveConstantReadAccess
 | private.rb:37:1:37:1 | E | E |
 | private.rb:38:1:38:1 | E | E |
 resolveConstantWriteAccess
-| calls.rb:15:1:24:3 | M | M |
-| calls.rb:29:1:44:3 | C | C |
-| calls.rb:51:1:55:3 | D | D |
-| calls.rb:77:1:80:3 | Integer | Integer |
-| calls.rb:82:1:84:3 | String | String |
-| calls.rb:86:1:88:3 | Kernel | Kernel |
-| calls.rb:90:1:95:3 | Module | Module |
-| calls.rb:97:1:100:3 | Object | Object |
-| calls.rb:102:1:104:3 | Hash | Hash |
-| calls.rb:106:1:117:3 | Array | Array |
-| calls.rb:144:1:148:3 | S | S |
-| calls.rb:150:1:153:3 | A | A |
-| calls.rb:155:1:158:3 | B | B |
-| calls.rb:169:1:184:3 | Singletons | Singletons |
+| calls.rb:21:1:30:3 | M | M |
+| calls.rb:35:1:50:3 | C | C |
+| calls.rb:57:1:61:3 | D | D |
+| calls.rb:83:1:86:3 | Integer | Integer |
+| calls.rb:88:1:90:3 | String | String |
+| calls.rb:92:1:95:3 | Kernel | Kernel |
+| calls.rb:97:1:102:3 | Module | Module |
+| calls.rb:104:1:107:3 | Object | Object |
+| calls.rb:109:1:112:3 | Hash | Hash |
+| calls.rb:114:1:127:3 | Array | Array |
+| calls.rb:154:1:158:3 | S | S |
+| calls.rb:160:1:163:3 | A | A |
+| calls.rb:165:1:168:3 | B | B |
+| calls.rb:179:1:215:3 | Singletons | Singletons |
+| calls.rb:299:1:309:3 | SelfNew | SelfNew |
+| calls.rb:313:1:317:3 | C1 | C1 |
+| calls.rb:319:1:323:3 | C2 | C2 |
+| calls.rb:325:1:329:3 | C3 | C3 |
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |
@@ -286,300 +328,607 @@ resolveConstantWriteAccess
 | private.rb:1:1:29:3 | E | E |
 | private.rb:42:1:60:3 | F | F |
 enclosingModule
-| calls.rb:1:1:3:3 | foo | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:2:5:2:14 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:2:11:2:13 | foo | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:5:1:5:3 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:7:1:9:3 | bar | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:7:5:7:8 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:8:5:8:14 | call to puts | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:8:5:8:14 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:8:10:8:14 | "bar" | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:8:11:8:13 | bar | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:11:1:11:4 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:13:1:13:4 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:13:1:13:8 | call to foo | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:15:1:24:3 | M | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:16:5:16:23 | instance_m | calls.rb:15:1:24:3 | M |
-| calls.rb:17:5:17:29 | singleton_m | calls.rb:15:1:24:3 | M |
-| calls.rb:17:9:17:12 | self | calls.rb:15:1:24:3 | M |
-| calls.rb:19:5:19:14 | call to instance_m | calls.rb:15:1:24:3 | M |
-| calls.rb:19:5:19:14 | self | calls.rb:15:1:24:3 | M |
-| calls.rb:20:5:20:8 | self | calls.rb:15:1:24:3 | M |
-| calls.rb:20:5:20:19 | call to instance_m | calls.rb:15:1:24:3 | M |
-| calls.rb:22:5:22:15 | call to singleton_m | calls.rb:15:1:24:3 | M |
-| calls.rb:22:5:22:15 | self | calls.rb:15:1:24:3 | M |
-| calls.rb:23:5:23:8 | self | calls.rb:15:1:24:3 | M |
-| calls.rb:23:5:23:20 | call to singleton_m | calls.rb:15:1:24:3 | M |
-| calls.rb:26:1:26:1 | M | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:26:1:26:12 | call to instance_m | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:27:1:27:1 | M | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:27:1:27:13 | call to singleton_m | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:29:1:44:3 | C | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:30:5:30:13 | call to include | calls.rb:29:1:44:3 | C |
-| calls.rb:30:5:30:13 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:30:13:30:13 | M | calls.rb:29:1:44:3 | C |
-| calls.rb:31:5:31:14 | call to instance_m | calls.rb:29:1:44:3 | C |
-| calls.rb:31:5:31:14 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:32:5:32:8 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:32:5:32:19 | call to instance_m | calls.rb:29:1:44:3 | C |
-| calls.rb:34:5:34:15 | call to singleton_m | calls.rb:29:1:44:3 | C |
-| calls.rb:34:5:34:15 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:35:5:35:8 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:35:5:35:20 | call to singleton_m | calls.rb:29:1:44:3 | C |
-| calls.rb:37:5:43:7 | baz | calls.rb:29:1:44:3 | C |
-| calls.rb:38:9:38:18 | call to instance_m | calls.rb:29:1:44:3 | C |
-| calls.rb:38:9:38:18 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:39:9:39:12 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:39:9:39:23 | call to instance_m | calls.rb:29:1:44:3 | C |
-| calls.rb:41:9:41:19 | call to singleton_m | calls.rb:29:1:44:3 | C |
-| calls.rb:41:9:41:19 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:42:9:42:12 | self | calls.rb:29:1:44:3 | C |
-| calls.rb:42:9:42:24 | call to singleton_m | calls.rb:29:1:44:3 | C |
-| calls.rb:46:1:46:1 | c | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:46:1:46:9 | ... = ... | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:46:5:46:5 | C | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:46:5:46:9 | call to new | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:47:1:47:1 | c | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:47:1:47:5 | call to baz | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:48:1:48:1 | c | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:48:1:48:13 | call to singleton_m | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:49:1:49:1 | c | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:49:1:49:12 | call to instance_m | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:51:1:55:3 | D | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:51:11:51:11 | C | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:52:5:54:7 | baz | calls.rb:51:1:55:3 | D |
-| calls.rb:53:9:53:13 | call to super | calls.rb:51:1:55:3 | D |
-| calls.rb:57:1:57:1 | d | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:57:1:57:9 | ... = ... | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:57:5:57:5 | D | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:57:5:57:9 | call to new | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:58:1:58:1 | d | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:58:1:58:5 | call to baz | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:59:1:59:1 | d | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:59:1:59:13 | call to singleton_m | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:60:1:60:1 | d | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:60:1:60:12 | call to instance_m | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:62:1:65:3 | optional_arg | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:62:18:62:18 | a | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:62:18:62:18 | a | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:62:22:62:22 | 4 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:62:25:62:25 | b | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:62:25:62:25 | b | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:62:28:62:28 | 5 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:63:5:63:5 | a | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:63:5:63:16 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:64:5:64:5 | b | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:64:5:64:16 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:67:1:69:3 | call_block | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:68:5:68:11 | yield ... | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:68:11:68:11 | 1 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:71:1:75:3 | foo | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:72:5:72:7 | var | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:72:5:72:18 | ... = ... | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:72:11:72:14 | Hash | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:72:11:72:18 | call to new | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:73:5:73:7 | var | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:73:5:73:10 | ...[...] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:73:9:73:9 | 1 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:74:5:74:29 | call to call_block | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:74:5:74:29 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:74:16:74:29 | { ... } | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:74:19:74:19 | x | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:74:19:74:19 | x | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:74:22:74:24 | var | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:74:22:74:27 | ...[...] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:74:26:74:26 | x | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:77:1:80:3 | Integer | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:78:5:78:23 | bit_length | calls.rb:77:1:80:3 | Integer |
-| calls.rb:79:5:79:16 | abs | calls.rb:77:1:80:3 | Integer |
-| calls.rb:82:1:84:3 | String | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:83:5:83:23 | capitalize | calls.rb:82:1:84:3 | String |
-| calls.rb:86:1:88:3 | Kernel | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:87:5:87:17 | puts | calls.rb:86:1:88:3 | Kernel |
-| calls.rb:90:1:95:3 | Module | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:91:5:91:24 | module_eval | calls.rb:90:1:95:3 | Module |
-| calls.rb:92:5:92:20 | include | calls.rb:90:1:95:3 | Module |
-| calls.rb:93:5:93:20 | prepend | calls.rb:90:1:95:3 | Module |
-| calls.rb:94:5:94:20 | private | calls.rb:90:1:95:3 | Module |
-| calls.rb:97:1:100:3 | Object | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:97:16:97:21 | Module | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:98:5:98:18 | call to include | calls.rb:97:1:100:3 | Object |
-| calls.rb:98:5:98:18 | self | calls.rb:97:1:100:3 | Object |
-| calls.rb:98:13:98:18 | Kernel | calls.rb:97:1:100:3 | Object |
-| calls.rb:99:5:99:16 | new | calls.rb:97:1:100:3 | Object |
-| calls.rb:102:1:104:3 | Hash | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:103:5:103:15 | [] | calls.rb:102:1:104:3 | Hash |
-| calls.rb:106:1:117:3 | Array | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:107:3:107:13 | [] | calls.rb:106:1:117:3 | Array |
-| calls.rb:108:3:108:17 | length | calls.rb:106:1:117:3 | Array |
-| calls.rb:110:3:116:5 | foreach | calls.rb:106:1:117:3 | Array |
-| calls.rb:110:15:110:19 | &body | calls.rb:106:1:117:3 | Array |
-| calls.rb:110:16:110:19 | body | calls.rb:106:1:117:3 | Array |
-| calls.rb:111:5:111:5 | x | calls.rb:106:1:117:3 | Array |
-| calls.rb:111:5:111:9 | ... = ... | calls.rb:106:1:117:3 | Array |
-| calls.rb:111:9:111:9 | 0 | calls.rb:106:1:117:3 | Array |
-| calls.rb:112:5:115:7 | while ... | calls.rb:106:1:117:3 | Array |
-| calls.rb:112:11:112:11 | x | calls.rb:106:1:117:3 | Array |
-| calls.rb:112:11:112:25 | ... < ... | calls.rb:106:1:117:3 | Array |
-| calls.rb:112:15:112:18 | self | calls.rb:106:1:117:3 | Array |
-| calls.rb:112:15:112:25 | call to length | calls.rb:106:1:117:3 | Array |
-| calls.rb:112:26:115:7 | do ... | calls.rb:106:1:117:3 | Array |
-| calls.rb:113:9:113:24 | yield ... | calls.rb:106:1:117:3 | Array |
-| calls.rb:113:15:113:15 | x | calls.rb:106:1:117:3 | Array |
-| calls.rb:113:18:113:21 | self | calls.rb:106:1:117:3 | Array |
-| calls.rb:113:18:113:24 | ...[...] | calls.rb:106:1:117:3 | Array |
-| calls.rb:113:23:113:23 | x | calls.rb:106:1:117:3 | Array |
-| calls.rb:114:9:114:9 | x | calls.rb:106:1:117:3 | Array |
-| calls.rb:114:9:114:9 | x | calls.rb:106:1:117:3 | Array |
-| calls.rb:114:9:114:14 | ... += ... | calls.rb:106:1:117:3 | Array |
-| calls.rb:114:9:114:14 | ... = ... | calls.rb:106:1:117:3 | Array |
-| calls.rb:114:11:114:12 | ... + ... | calls.rb:106:1:117:3 | Array |
-| calls.rb:114:14:114:14 | 1 | calls.rb:106:1:117:3 | Array |
-| calls.rb:119:1:121:3 | funny | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:120:5:120:20 | yield ... | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:120:11:120:20 | "prefix: " | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:120:12:120:19 | prefix:  | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:1:123:30 | call to funny | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:1:123:30 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:7:123:30 | { ... } | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:10:123:10 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:10:123:10 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:13:123:29 | call to puts | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:13:123:29 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:18:123:18 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:123:18:123:29 | call to capitalize | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:125:1:125:3 | "a" | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:125:1:125:14 | call to capitalize | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:125:2:125:2 | a | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:126:1:126:1 | 1 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:126:1:126:12 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:127:1:127:1 | 1 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:127:1:127:5 | call to abs | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:1:129:13 | Array | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:1:129:13 | [...] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:1:129:13 | call to [] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:1:129:62 | call to foreach | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:2:129:4 | "a" | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:3:129:3 | a | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:6:129:8 | "b" | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:7:129:7 | b | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:10:129:12 | "c" | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:11:129:11 | c | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:23:129:62 | { ... } | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:26:129:26 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:26:129:26 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:29:129:29 | v | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:29:129:29 | v | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:32:129:61 | call to puts | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:32:129:61 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:37:129:61 | "#{...} -> #{...}" | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:38:129:41 | #{...} | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:40:129:40 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:42:129:45 |  ->  | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:46:129:60 | #{...} | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:48:129:48 | v | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:129:48:129:59 | call to capitalize | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:1:131:7 | Array | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:1:131:7 | [...] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:1:131:7 | call to [] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:1:131:35 | call to foreach | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:2:131:2 | 1 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:4:131:4 | 2 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:6:131:6 | 3 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:17:131:35 | { ... } | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:20:131:20 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:20:131:20 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:23:131:23 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:131:23:131:34 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:1:133:7 | Array | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:1:133:7 | [...] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:1:133:7 | call to [] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:1:133:40 | call to foreach | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:2:133:2 | 1 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:4:133:4 | 2 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:6:133:6 | 3 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:17:133:40 | { ... } | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:20:133:20 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:20:133:20 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:23:133:39 | call to puts | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:23:133:39 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:28:133:28 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:133:28:133:39 | call to capitalize | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:1:135:8 | Array | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:1:135:8 | [...] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:1:135:8 | call to [] | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:1:135:37 | call to foreach | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:2:135:2 | 1 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:4:135:5 | - ... | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:5:135:5 | 2 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:7:135:7 | 3 | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:18:135:37 | { ... } | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:21:135:21 | _ | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:21:135:21 | _ | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:24:135:24 | v | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:24:135:24 | v | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:27:135:36 | call to puts | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:27:135:36 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:32:135:32 | v | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:135:32:135:36 | call to abs | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:137:1:139:3 | indirect | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:137:14:137:15 | &b | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:137:15:137:15 | b | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:138:5:138:17 | call to call_block | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:138:5:138:17 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:138:16:138:17 | &... | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:138:17:138:17 | b | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:141:1:141:28 | call to indirect | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:141:1:141:28 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:141:10:141:28 | { ... } | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:141:13:141:13 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:141:13:141:13 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:141:16:141:16 | i | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:141:16:141:27 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:144:1:148:3 | S | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:145:5:147:7 | s_method | calls.rb:144:1:148:3 | S |
-| calls.rb:146:9:146:12 | self | calls.rb:144:1:148:3 | S |
-| calls.rb:146:9:146:17 | call to to_s | calls.rb:144:1:148:3 | S |
-| calls.rb:150:1:153:3 | A | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:150:11:150:11 | S | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:151:5:152:7 | to_s | calls.rb:150:1:153:3 | A |
-| calls.rb:155:1:158:3 | B | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:155:11:155:11 | S | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:156:5:157:7 | to_s | calls.rb:155:1:158:3 | B |
-| calls.rb:160:1:160:1 | S | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:160:1:160:5 | call to new | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:160:1:160:14 | call to s_method | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:161:1:161:1 | A | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:161:1:161:5 | call to new | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:161:1:161:14 | call to s_method | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:162:1:162:1 | B | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:162:1:162:5 | call to new | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:162:1:162:14 | call to s_method | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:164:1:165:3 | private_on_main | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:167:1:167:15 | call to private_on_main | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:167:1:167:15 | self | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:169:1:184:3 | Singletons | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:170:5:172:7 | singleton_a | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:170:9:170:12 | self | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:171:9:171:12 | self | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:171:9:171:24 | call to singleton_b | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:174:5:176:7 | singleton_b | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:174:9:174:12 | self | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:175:9:175:12 | self | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:175:9:175:24 | call to singleton_c | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:178:5:179:7 | singleton_c | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:178:9:178:12 | self | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:181:5:183:7 | singleton_d | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:181:9:181:12 | self | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:182:9:182:12 | self | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:182:9:182:24 | call to singleton_a | calls.rb:169:1:184:3 | Singletons |
-| calls.rb:186:1:186:10 | Singletons | calls.rb:1:1:186:22 | calls.rb |
-| calls.rb:186:1:186:22 | call to singleton_a | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:1:1:3:3 | foo | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:5:1:5:3 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:7:1:9:3 | bar | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:7:5:7:8 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:8:5:8:15 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:11:1:11:4 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:13:1:15:3 | bar | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:13:5:13:8 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:14:5:14:15 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:17:1:17:4 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:19:1:19:4 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:21:1:30:3 | M | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:22:5:22:23 | instance_m | calls.rb:21:1:30:3 | M |
+| calls.rb:23:5:23:29 | singleton_m | calls.rb:21:1:30:3 | M |
+| calls.rb:23:9:23:12 | self | calls.rb:21:1:30:3 | M |
+| calls.rb:25:5:25:14 | call to instance_m | calls.rb:21:1:30:3 | M |
+| calls.rb:25:5:25:14 | self | calls.rb:21:1:30:3 | M |
+| calls.rb:26:5:26:8 | self | calls.rb:21:1:30:3 | M |
+| calls.rb:26:5:26:19 | call to instance_m | calls.rb:21:1:30:3 | M |
+| calls.rb:28:5:28:15 | call to singleton_m | calls.rb:21:1:30:3 | M |
+| calls.rb:28:5:28:15 | self | calls.rb:21:1:30:3 | M |
+| calls.rb:29:5:29:8 | self | calls.rb:21:1:30:3 | M |
+| calls.rb:29:5:29:20 | call to singleton_m | calls.rb:21:1:30:3 | M |
+| calls.rb:32:1:32:1 | M | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:32:1:32:12 | call to instance_m | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:33:1:33:1 | M | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:33:1:33:13 | call to singleton_m | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:35:1:50:3 | C | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:36:5:36:13 | call to include | calls.rb:35:1:50:3 | C |
+| calls.rb:36:5:36:13 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:36:13:36:13 | M | calls.rb:35:1:50:3 | C |
+| calls.rb:37:5:37:14 | call to instance_m | calls.rb:35:1:50:3 | C |
+| calls.rb:37:5:37:14 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:38:5:38:8 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:38:5:38:19 | call to instance_m | calls.rb:35:1:50:3 | C |
+| calls.rb:40:5:40:15 | call to singleton_m | calls.rb:35:1:50:3 | C |
+| calls.rb:40:5:40:15 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:41:5:41:8 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:41:5:41:20 | call to singleton_m | calls.rb:35:1:50:3 | C |
+| calls.rb:43:5:49:7 | baz | calls.rb:35:1:50:3 | C |
+| calls.rb:44:9:44:18 | call to instance_m | calls.rb:35:1:50:3 | C |
+| calls.rb:44:9:44:18 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:45:9:45:12 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:45:9:45:23 | call to instance_m | calls.rb:35:1:50:3 | C |
+| calls.rb:47:9:47:19 | call to singleton_m | calls.rb:35:1:50:3 | C |
+| calls.rb:47:9:47:19 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:48:9:48:12 | self | calls.rb:35:1:50:3 | C |
+| calls.rb:48:9:48:24 | call to singleton_m | calls.rb:35:1:50:3 | C |
+| calls.rb:52:1:52:1 | c | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:52:1:52:9 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:52:5:52:5 | C | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:52:5:52:9 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:53:1:53:1 | c | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:53:1:53:5 | call to baz | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:54:1:54:1 | c | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:54:1:54:13 | call to singleton_m | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:55:1:55:1 | c | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:55:1:55:12 | call to instance_m | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:57:1:61:3 | D | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:57:11:57:11 | C | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:58:5:60:7 | baz | calls.rb:57:1:61:3 | D |
+| calls.rb:59:9:59:13 | call to super | calls.rb:57:1:61:3 | D |
+| calls.rb:63:1:63:1 | d | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:63:1:63:9 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:63:5:63:5 | D | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:63:5:63:9 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:64:1:64:1 | d | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:64:1:64:5 | call to baz | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:65:1:65:1 | d | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:65:1:65:13 | call to singleton_m | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:66:1:66:1 | d | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:66:1:66:12 | call to instance_m | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:68:1:71:3 | optional_arg | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:68:18:68:18 | a | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:68:18:68:18 | a | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:68:22:68:22 | 4 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:68:25:68:25 | b | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:68:25:68:25 | b | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:68:28:68:28 | 5 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:69:5:69:5 | a | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:69:5:69:16 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:70:5:70:5 | b | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:70:5:70:16 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:73:1:75:3 | call_block | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:74:5:74:11 | yield ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:74:11:74:11 | 1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:77:1:81:3 | foo | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:78:5:78:7 | var | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:78:5:78:18 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:78:11:78:14 | Hash | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:78:11:78:18 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:79:5:79:7 | var | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:79:5:79:10 | ...[...] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:79:9:79:9 | 1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:80:5:80:29 | call to call_block | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:80:5:80:29 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:80:16:80:29 | { ... } | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:80:19:80:19 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:80:19:80:19 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:80:22:80:24 | var | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:80:22:80:27 | ...[...] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:80:26:80:26 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:83:1:86:3 | Integer | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:84:5:84:23 | bit_length | calls.rb:83:1:86:3 | Integer |
+| calls.rb:85:5:85:16 | abs | calls.rb:83:1:86:3 | Integer |
+| calls.rb:88:1:90:3 | String | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:89:5:89:23 | capitalize | calls.rb:88:1:90:3 | String |
+| calls.rb:92:1:95:3 | Kernel | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:93:5:93:25 | alias ... | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:93:11:93:19 | :old_puts | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:93:11:93:19 | old_puts | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:93:21:93:25 | :puts | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:93:21:93:25 | puts | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:94:5:94:30 | puts | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:94:14:94:14 | x | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:94:14:94:14 | x | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:94:17:94:26 | call to old_puts | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:94:17:94:26 | self | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:94:26:94:26 | x | calls.rb:92:1:95:3 | Kernel |
+| calls.rb:97:1:102:3 | Module | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:98:5:98:24 | module_eval | calls.rb:97:1:102:3 | Module |
+| calls.rb:99:5:99:20 | include | calls.rb:97:1:102:3 | Module |
+| calls.rb:100:5:100:20 | prepend | calls.rb:97:1:102:3 | Module |
+| calls.rb:101:5:101:20 | private | calls.rb:97:1:102:3 | Module |
+| calls.rb:104:1:107:3 | Object | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:104:16:104:21 | Module | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:105:5:105:18 | call to include | calls.rb:104:1:107:3 | Object |
+| calls.rb:105:5:105:18 | self | calls.rb:104:1:107:3 | Object |
+| calls.rb:105:13:105:18 | Kernel | calls.rb:104:1:107:3 | Object |
+| calls.rb:106:5:106:16 | new | calls.rb:104:1:107:3 | Object |
+| calls.rb:109:1:112:3 | Hash | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:110:5:110:25 | alias ... | calls.rb:109:1:112:3 | Hash |
+| calls.rb:110:11:110:21 | :old_lookup | calls.rb:109:1:112:3 | Hash |
+| calls.rb:110:11:110:21 | old_lookup | calls.rb:109:1:112:3 | Hash |
+| calls.rb:110:23:110:25 | :[] | calls.rb:109:1:112:3 | Hash |
+| calls.rb:110:23:110:25 | [] | calls.rb:109:1:112:3 | Hash |
+| calls.rb:111:5:111:31 | [] | calls.rb:109:1:112:3 | Hash |
+| calls.rb:111:12:111:12 | x | calls.rb:109:1:112:3 | Hash |
+| calls.rb:111:12:111:12 | x | calls.rb:109:1:112:3 | Hash |
+| calls.rb:111:15:111:27 | call to old_lookup | calls.rb:109:1:112:3 | Hash |
+| calls.rb:111:15:111:27 | self | calls.rb:109:1:112:3 | Hash |
+| calls.rb:111:26:111:26 | x | calls.rb:109:1:112:3 | Hash |
+| calls.rb:114:1:127:3 | Array | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:115:3:115:23 | alias ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:115:9:115:19 | :old_lookup | calls.rb:114:1:127:3 | Array |
+| calls.rb:115:9:115:19 | old_lookup | calls.rb:114:1:127:3 | Array |
+| calls.rb:115:21:115:23 | :[] | calls.rb:114:1:127:3 | Array |
+| calls.rb:115:21:115:23 | [] | calls.rb:114:1:127:3 | Array |
+| calls.rb:116:3:116:29 | [] | calls.rb:114:1:127:3 | Array |
+| calls.rb:116:10:116:10 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:116:10:116:10 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:116:13:116:25 | call to old_lookup | calls.rb:114:1:127:3 | Array |
+| calls.rb:116:13:116:25 | self | calls.rb:114:1:127:3 | Array |
+| calls.rb:116:24:116:24 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:118:3:118:17 | length | calls.rb:114:1:127:3 | Array |
+| calls.rb:120:3:126:5 | foreach | calls.rb:114:1:127:3 | Array |
+| calls.rb:120:15:120:19 | &body | calls.rb:114:1:127:3 | Array |
+| calls.rb:120:16:120:19 | body | calls.rb:114:1:127:3 | Array |
+| calls.rb:121:5:121:5 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:121:5:121:9 | ... = ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:121:9:121:9 | 0 | calls.rb:114:1:127:3 | Array |
+| calls.rb:122:5:125:7 | while ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:122:11:122:11 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:122:11:122:25 | ... < ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:122:15:122:18 | self | calls.rb:114:1:127:3 | Array |
+| calls.rb:122:15:122:25 | call to length | calls.rb:114:1:127:3 | Array |
+| calls.rb:122:26:125:7 | do ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:123:9:123:24 | yield ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:123:15:123:15 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:123:18:123:21 | self | calls.rb:114:1:127:3 | Array |
+| calls.rb:123:18:123:24 | ...[...] | calls.rb:114:1:127:3 | Array |
+| calls.rb:123:23:123:23 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:124:9:124:9 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:124:9:124:9 | x | calls.rb:114:1:127:3 | Array |
+| calls.rb:124:9:124:14 | ... += ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:124:9:124:14 | ... = ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:124:11:124:12 | ... + ... | calls.rb:114:1:127:3 | Array |
+| calls.rb:124:14:124:14 | 1 | calls.rb:114:1:127:3 | Array |
+| calls.rb:129:1:131:3 | funny | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:130:5:130:20 | yield ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:130:11:130:20 | "prefix: " | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:130:12:130:19 | prefix:  | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:1:133:30 | call to funny | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:1:133:30 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:7:133:30 | { ... } | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:10:133:10 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:10:133:10 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:13:133:29 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:13:133:29 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:18:133:18 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:133:18:133:29 | call to capitalize | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:135:1:135:3 | "a" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:135:1:135:14 | call to capitalize | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:135:2:135:2 | a | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:136:1:136:1 | 1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:136:1:136:12 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:137:1:137:1 | 1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:137:1:137:5 | call to abs | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:1:139:13 | Array | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:1:139:13 | [...] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:1:139:13 | call to [] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:1:139:62 | call to foreach | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:2:139:4 | "a" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:3:139:3 | a | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:6:139:8 | "b" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:7:139:7 | b | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:10:139:12 | "c" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:11:139:11 | c | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:23:139:62 | { ... } | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:26:139:26 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:26:139:26 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:29:139:29 | v | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:29:139:29 | v | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:32:139:61 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:32:139:61 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:37:139:61 | "#{...} -> #{...}" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:38:139:41 | #{...} | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:40:139:40 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:42:139:45 |  ->  | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:46:139:60 | #{...} | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:48:139:48 | v | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:139:48:139:59 | call to capitalize | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:1:141:7 | Array | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:1:141:7 | [...] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:1:141:7 | call to [] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:1:141:35 | call to foreach | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:2:141:2 | 1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:4:141:4 | 2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:6:141:6 | 3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:17:141:35 | { ... } | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:20:141:20 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:20:141:20 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:23:141:23 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:141:23:141:34 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:1:143:7 | Array | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:1:143:7 | [...] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:1:143:7 | call to [] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:1:143:40 | call to foreach | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:2:143:2 | 1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:4:143:4 | 2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:6:143:6 | 3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:17:143:40 | { ... } | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:20:143:20 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:20:143:20 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:23:143:39 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:23:143:39 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:28:143:28 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:143:28:143:39 | call to capitalize | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:1:145:8 | Array | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:1:145:8 | [...] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:1:145:8 | call to [] | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:1:145:37 | call to foreach | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:2:145:2 | 1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:4:145:5 | - ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:5:145:5 | 2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:7:145:7 | 3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:18:145:37 | { ... } | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:21:145:21 | _ | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:21:145:21 | _ | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:24:145:24 | v | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:24:145:24 | v | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:27:145:36 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:27:145:36 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:32:145:32 | v | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:145:32:145:36 | call to abs | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:147:1:149:3 | indirect | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:147:14:147:15 | &b | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:147:15:147:15 | b | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:148:5:148:17 | call to call_block | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:148:5:148:17 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:148:16:148:17 | &... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:148:17:148:17 | b | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:151:1:151:28 | call to indirect | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:151:1:151:28 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:151:10:151:28 | { ... } | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:151:13:151:13 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:151:13:151:13 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:151:16:151:16 | i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:151:16:151:27 | call to bit_length | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:154:1:158:3 | S | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:155:5:157:7 | s_method | calls.rb:154:1:158:3 | S |
+| calls.rb:156:9:156:12 | self | calls.rb:154:1:158:3 | S |
+| calls.rb:156:9:156:17 | call to to_s | calls.rb:154:1:158:3 | S |
+| calls.rb:160:1:163:3 | A | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:160:11:160:11 | S | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:161:5:162:7 | to_s | calls.rb:160:1:163:3 | A |
+| calls.rb:165:1:168:3 | B | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:165:11:165:11 | S | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:166:5:167:7 | to_s | calls.rb:165:1:168:3 | B |
+| calls.rb:170:1:170:1 | S | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:170:1:170:5 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:170:1:170:14 | call to s_method | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:171:1:171:1 | A | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:171:1:171:5 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:171:1:171:14 | call to s_method | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:172:1:172:1 | B | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:172:1:172:5 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:172:1:172:14 | call to s_method | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:174:1:175:3 | private_on_main | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:177:1:177:15 | call to private_on_main | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:177:1:177:15 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:179:1:215:3 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:180:5:183:7 | singleton_a | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:180:9:180:12 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:181:9:181:26 | call to puts | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:181:9:181:26 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:181:14:181:26 | "singleton_a" | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:181:15:181:25 | singleton_a | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:182:9:182:12 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:182:9:182:24 | call to singleton_b | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:185:5:188:7 | singleton_b | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:185:9:185:12 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:186:9:186:26 | call to puts | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:186:9:186:26 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:186:14:186:26 | "singleton_b" | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:186:15:186:25 | singleton_b | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:187:9:187:12 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:187:9:187:24 | call to singleton_c | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:190:5:192:7 | singleton_c | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:190:9:190:12 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:191:9:191:26 | call to puts | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:191:9:191:26 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:191:14:191:26 | "singleton_c" | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:191:15:191:25 | singleton_c | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:194:5:197:7 | singleton_d | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:194:9:194:12 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:195:9:195:26 | call to puts | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:195:9:195:26 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:195:14:195:26 | "singleton_d" | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:195:15:195:25 | singleton_d | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:196:9:196:12 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:196:9:196:24 | call to singleton_a | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:199:5:204:7 | instance | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:200:9:202:11 | singleton_e | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:200:13:200:16 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:201:13:201:30 | call to puts | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:201:13:201:30 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:201:18:201:30 | "singleton_e" | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:201:19:201:29 | singleton_e | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:203:9:203:19 | call to singleton_e | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:203:9:203:19 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:206:5:210:7 | class << ... | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:206:14:206:17 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:207:9:209:11 | singleton_f | calls.rb:206:5:210:7 | class << ... |
+| calls.rb:208:13:208:30 | call to puts | calls.rb:206:5:210:7 | class << ... |
+| calls.rb:208:13:208:30 | self | calls.rb:206:5:210:7 | class << ... |
+| calls.rb:208:18:208:30 | "singleton_f" | calls.rb:206:5:210:7 | class << ... |
+| calls.rb:208:19:208:29 | singleton_f | calls.rb:206:5:210:7 | class << ... |
+| calls.rb:212:5:214:7 | call_singleton_g | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:213:9:213:12 | self | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:213:9:213:24 | call to singleton_g | calls.rb:179:1:215:3 | Singletons |
+| calls.rb:217:1:217:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:217:1:217:22 | call to singleton_a | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:218:1:218:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:218:1:218:22 | call to singleton_f | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:220:1:220:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:220:1:220:19 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:220:6:220:15 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:220:6:220:19 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:222:1:222:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:222:1:222:11 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:223:1:223:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:223:1:223:14 | call to singleton_e | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:225:1:227:3 | singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:225:5:225:6 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:226:5:226:24 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:226:5:226:24 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:226:10:226:24 | "singleton_g_1" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:226:11:226:23 | singleton_g_1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:229:1:229:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:229:1:229:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:230:1:230:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:230:1:230:19 | call to call_singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:232:1:234:3 | singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:232:5:232:6 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:233:5:233:24 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:233:5:233:24 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:233:10:233:24 | "singleton_g_2" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:233:11:233:23 | singleton_g_2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:236:1:236:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:236:1:236:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:237:1:237:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:237:1:237:19 | call to call_singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:239:1:243:3 | class << ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:239:10:239:11 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:240:5:242:7 | singleton_g | calls.rb:239:1:243:3 | class << ... |
+| calls.rb:241:9:241:28 | call to puts | calls.rb:239:1:243:3 | class << ... |
+| calls.rb:241:9:241:28 | self | calls.rb:239:1:243:3 | class << ... |
+| calls.rb:241:14:241:28 | "singleton_g_3" | calls.rb:239:1:243:3 | class << ... |
+| calls.rb:241:15:241:27 | singleton_g_3 | calls.rb:239:1:243:3 | class << ... |
+| calls.rb:245:1:245:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:245:1:245:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:246:1:246:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:246:1:246:19 | call to call_singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:248:1:248:2 | c2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:248:1:248:19 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:248:6:248:15 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:248:6:248:19 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:249:1:249:2 | c2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:249:1:249:14 | call to singleton_e | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:250:1:250:2 | c2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:250:1:250:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:252:1:252:4 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:252:1:252:8 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:254:1:254:16 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:254:1:254:16 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:254:6:254:16 | "top-level" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:254:7:254:15 | top-level | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:256:1:258:3 | singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:256:5:256:14 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:257:5:257:22 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:257:5:257:22 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:257:10:257:22 | "singleton_g" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:257:11:257:21 | singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:260:1:260:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:260:1:260:22 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:261:1:261:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:262:1:262:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:262:1:262:19 | call to call_singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:263:1:263:2 | c2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:263:1:263:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:264:1:264:2 | c3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:264:1:264:19 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:264:6:264:15 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:264:6:264:19 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:265:1:265:2 | c3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:265:1:265:14 | call to singleton_g | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:267:1:275:3 | create | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:267:12:267:15 | type | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:267:12:267:15 | type | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:268:5:268:8 | type | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:268:5:268:12 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:268:5:268:21 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:270:5:272:7 | singleton_h | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:270:9:270:12 | type | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:271:9:271:26 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:271:9:271:26 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:271:14:271:26 | "singleton_h" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:271:15:271:25 | singleton_h | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:274:5:274:8 | type | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:274:5:274:20 | call to singleton_h | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:277:1:277:17 | call to create | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:277:1:277:17 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:277:8:277:17 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:278:1:278:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:278:1:278:22 | call to singleton_h | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:280:1:280:1 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:280:1:280:14 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:280:5:280:14 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:282:1:286:3 | class << ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:282:10:282:10 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:283:5:285:7 | singleton_i | calls.rb:282:1:286:3 | class << ... |
+| calls.rb:284:9:284:26 | call to puts | calls.rb:282:1:286:3 | class << ... |
+| calls.rb:284:9:284:26 | self | calls.rb:282:1:286:3 | class << ... |
+| calls.rb:284:14:284:26 | "singleton_i" | calls.rb:282:1:286:3 | class << ... |
+| calls.rb:284:15:284:25 | singleton_i | calls.rb:282:1:286:3 | class << ... |
+| calls.rb:288:1:288:1 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:288:1:288:13 | call to singleton_i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:289:1:289:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:289:1:289:22 | call to singleton_i | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:291:1:295:3 | class << ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:291:10:291:19 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:292:5:294:7 | singleton_j | calls.rb:291:1:295:3 | class << ... |
+| calls.rb:293:9:293:26 | call to puts | calls.rb:291:1:295:3 | class << ... |
+| calls.rb:293:9:293:26 | self | calls.rb:291:1:295:3 | class << ... |
+| calls.rb:293:14:293:26 | "singleton_j" | calls.rb:291:1:295:3 | class << ... |
+| calls.rb:293:15:293:25 | singleton_j | calls.rb:291:1:295:3 | class << ... |
+| calls.rb:297:1:297:10 | Singletons | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:297:1:297:22 | call to singleton_j | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:299:1:309:3 | SelfNew | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:300:5:302:7 | instance | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:301:9:301:31 | call to puts | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:301:9:301:31 | self | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:301:14:301:31 | "SelfNew#instance" | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:301:15:301:30 | SelfNew#instance | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:304:5:306:7 | singleton | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:304:9:304:12 | self | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:305:9:305:11 | call to new | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:305:9:305:11 | self | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:305:9:305:20 | call to instance | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:308:5:308:7 | call to new | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:308:5:308:7 | self | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:308:5:308:16 | call to instance | calls.rb:299:1:309:3 | SelfNew |
+| calls.rb:311:1:311:7 | SelfNew | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:311:1:311:17 | call to singleton | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:313:1:317:3 | C1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:314:5:316:7 | instance | calls.rb:313:1:317:3 | C1 |
+| calls.rb:315:9:315:26 | call to puts | calls.rb:313:1:317:3 | C1 |
+| calls.rb:315:9:315:26 | self | calls.rb:313:1:317:3 | C1 |
+| calls.rb:315:14:315:26 | "C1#instance" | calls.rb:313:1:317:3 | C1 |
+| calls.rb:315:15:315:25 | C1#instance | calls.rb:313:1:317:3 | C1 |
+| calls.rb:319:1:323:3 | C2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:319:12:319:13 | C1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:320:5:322:7 | instance | calls.rb:319:1:323:3 | C2 |
+| calls.rb:321:9:321:26 | call to puts | calls.rb:319:1:323:3 | C2 |
+| calls.rb:321:9:321:26 | self | calls.rb:319:1:323:3 | C2 |
+| calls.rb:321:14:321:26 | "C2#instance" | calls.rb:319:1:323:3 | C2 |
+| calls.rb:321:15:321:25 | C2#instance | calls.rb:319:1:323:3 | C2 |
+| calls.rb:325:1:329:3 | C3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:325:12:325:13 | C2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:326:5:328:7 | instance | calls.rb:325:1:329:3 | C3 |
+| calls.rb:327:9:327:26 | call to puts | calls.rb:325:1:329:3 | C3 |
+| calls.rb:327:9:327:26 | self | calls.rb:325:1:329:3 | C3 |
+| calls.rb:327:14:327:26 | "C3#instance" | calls.rb:325:1:329:3 | C3 |
+| calls.rb:327:15:327:25 | C3#instance | calls.rb:325:1:329:3 | C3 |
+| calls.rb:331:1:347:3 | pattern_dispatch | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:331:22:331:22 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:331:22:331:22 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:332:5:340:7 | case ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:332:10:332:10 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:333:5:334:18 | when ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:333:10:333:11 | C3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:333:12:334:18 | then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:334:9:334:9 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:334:9:334:18 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:335:5:336:18 | when ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:335:10:335:11 | C2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:335:12:336:18 | then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:336:9:336:9 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:336:9:336:18 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:337:5:338:18 | when ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:337:10:337:11 | C1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:337:12:338:18 | then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:338:9:338:9 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:338:9:338:18 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:339:5:339:8 | else ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:342:5:346:7 | case ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:342:10:342:10 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:343:9:343:29 | in ... then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:343:12:343:13 | C3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:343:15:343:29 | then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:343:20:343:20 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:343:20:343:29 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:344:9:344:36 | in ... then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:344:12:344:13 | C2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:344:12:344:19 | ... => ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:344:18:344:19 | c2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:344:21:344:36 | then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:344:26:344:27 | c2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:344:26:344:36 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:345:9:345:36 | in ... then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:345:12:345:13 | C1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:345:12:345:19 | ... => ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:345:18:345:19 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:345:21:345:36 | then ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:345:26:345:27 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:345:26:345:36 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:349:1:349:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:349:1:349:11 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:349:6:349:7 | C1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:349:6:349:11 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:350:1:350:2 | c1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:350:1:350:11 | call to instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:351:1:351:25 | call to pattern_dispatch | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:351:1:351:25 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:351:18:351:25 | ( ... ) | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:351:19:351:20 | C1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:351:19:351:24 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:352:1:352:25 | call to pattern_dispatch | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:352:1:352:25 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:352:18:352:25 | ( ... ) | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:352:19:352:20 | C2 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:352:19:352:24 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:353:1:353:25 | call to pattern_dispatch | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:353:1:353:25 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:353:18:353:25 | ( ... ) | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:353:19:353:20 | C3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:353:19:353:24 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:355:1:359:3 | add_singleton | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:355:19:355:19 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:355:19:355:19 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:356:5:358:7 | instance | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:356:9:356:9 | x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:357:9:357:28 | call to puts | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:357:9:357:28 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:357:14:357:28 | "instance_on x" | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:357:15:357:27 | instance_on x | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:361:1:361:2 | c3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:361:1:361:11 | ... = ... | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:361:6:361:7 | C1 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:361:6:361:11 | call to new | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:362:1:362:16 | call to add_singleton | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:362:1:362:16 | self | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:362:15:362:16 | c3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:363:1:363:2 | c3 | calls.rb:1:1:363:11 | calls.rb |
+| calls.rb:363:1:363:11 | call to instance | calls.rb:1:1:363:11 | calls.rb |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:22:3 | hello.rb |
 | hello.rb:2:5:4:7 | hello | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:3:9:3:22 | return | hello.rb:1:1:8:3 | EnglishWords |

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -31,56 +31,62 @@
 calls.rb:
 #   21| M
 
-#   39| C
+#   43| C
 #-----|  -> Object
 
-#   61| D
+#   65| D
 #-----|  -> C
 
-#   87| Integer
+#   91| Integer
 #-----|  -> Numeric
 
-#   92| String
+#   96| String
 #-----|  -> Object
 
-#   96| Kernel
+#  100| Kernel
 
-#  101| Module
+#  105| Module
 #-----|  -> Object
 
-#  108| Object
+#  112| Object
 #-----|  -> BasicObject
 
-#  113| Hash
+#  117| Hash
 #-----|  -> Object
 
-#  118| Array
+#  122| Array
 #-----|  -> Object
 
-#  158| S
+#  162| S
 #-----|  -> Object
 
-#  164| A
+#  168| A
 #-----|  -> B
 #-----|  -> S
 
-#  169| B
+#  173| B
 #-----|  -> S
 
-#  183| Singletons
+#  187| Singletons
 #-----|  -> Object
 
-#  303| SelfNew
+#  307| SelfNew
 #-----|  -> Object
 
-#  317| C1
+#  322| C1
 #-----|  -> Object
 
-#  323| C2
+#  328| C2
 #-----|  -> C1
 
-#  329| C3
+#  334| C3
 #-----|  -> C2
+
+#  374| SingletonOverride1
+#-----|  -> Object
+
+#  399| SingletonOverride2
+#-----|  -> SingletonOverride1
 
 hello.rb:
 #    1| EnglishWords

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -31,55 +31,55 @@
 calls.rb:
 #   21| M
 
-#   35| C
+#   39| C
 #-----|  -> Object
 
-#   57| D
+#   61| D
 #-----|  -> C
 
-#   83| Integer
+#   87| Integer
 #-----|  -> Numeric
 
-#   88| String
+#   92| String
 #-----|  -> Object
 
-#   92| Kernel
+#   96| Kernel
 
-#   97| Module
+#  101| Module
 #-----|  -> Object
 
-#  104| Object
+#  108| Object
 #-----|  -> BasicObject
 
-#  109| Hash
+#  113| Hash
 #-----|  -> Object
 
-#  114| Array
+#  118| Array
 #-----|  -> Object
 
-#  154| S
+#  158| S
 #-----|  -> Object
 
-#  160| A
+#  164| A
 #-----|  -> B
 #-----|  -> S
 
-#  165| B
+#  169| B
 #-----|  -> S
 
-#  179| Singletons
+#  183| Singletons
 #-----|  -> Object
 
-#  299| SelfNew
+#  303| SelfNew
 #-----|  -> Object
 
-#  313| C1
+#  317| C1
 #-----|  -> Object
 
-#  319| C2
+#  323| C2
 #-----|  -> C1
 
-#  325| C3
+#  329| C3
 #-----|  -> C2
 
 hello.rb:

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -29,46 +29,58 @@
 #-----|  -> Object
 
 calls.rb:
-#   15| M
+#   21| M
 
-#   29| C
+#   35| C
 #-----|  -> Object
 
-#   51| D
+#   57| D
 #-----|  -> C
 
-#   77| Integer
+#   83| Integer
 #-----|  -> Numeric
 
-#   82| String
+#   88| String
 #-----|  -> Object
 
-#   86| Kernel
+#   92| Kernel
 
-#   90| Module
+#   97| Module
 #-----|  -> Object
 
-#   97| Object
+#  104| Object
 #-----|  -> BasicObject
 
-#  102| Hash
+#  109| Hash
 #-----|  -> Object
 
-#  106| Array
+#  114| Array
 #-----|  -> Object
 
-#  144| S
+#  154| S
 #-----|  -> Object
 
-#  150| A
+#  160| A
 #-----|  -> B
 #-----|  -> S
 
-#  155| B
+#  165| B
 #-----|  -> S
 
-#  169| Singletons
+#  179| Singletons
 #-----|  -> Object
+
+#  299| SelfNew
+#-----|  -> Object
+
+#  313| C1
+#-----|  -> Object
+
+#  319| C2
+#-----|  -> C1
+
+#  325| C3
+#-----|  -> C2
 
 hello.rb:
 #    1| EnglishWords


### PR DESCRIPTION
This PR rewrites the call graph computation in the following ways:
1. Remove temporary fix for `require` and `require_relative` methods.
2. No longer resolve instance methods based on flow through `self` (closed-world assumption); instead rely on the type hierarchy, and allow dispatch to any overrides (open-world assumption), as long as the type is not known exactly (such as when constructed with `new`).
3. Improve precision for singleton methods defined on objects, such as `def x.foo; end`, by taking overriding redefinitions into account:
```rb
def x.foo; end
def x.foo; end
x.foo # now only resolves to the latter definition
```
5. Add missing call targets for singleton methods defined on parameters (including `self`):
```rb
def add_singleton x
  def x.singleton; end
end
add_singleton y
y.singleton # now has a call target
```
7. Add missing call targets for instance methods on objects referenced by variables introduced via pattern matching:
```rb
case object
  in C => c then c.foo # resolves in the same was as a call to `foo` inside `C`
end
```
9. Take type information  into account for objects that are being type checked:
```rb
case object
  when C then object.foo # resolves in the same was as a call to `foo` inside `C`
end
```

Commit-by-commit review is encouraged.

I spot checked some of the missing results on `opal/opal`, and they look like false positives to me. We were previously generating a lot of flow through [this](https://github.com/ruby/mspec/blob/098b3200ac8925a0285c6ccc29089e1e19908a07/lib/mspec/utils/format.rb#L9) call (included as a sub-module), which now has only 1 call target instead of 42, due to the change 2 above.