### PR TITLE
Ruby: Inline `getAValueReachableFromSource`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -97,6 +97,7 @@ module API {
      * This is similar to `asSource()` but additionally includes nodes that are transitively reachable by data flow.
      * See `asSource()` for examples.
      */
+    pragma[inline]
     DataFlow::Node getAValueReachableFromSource() {
       exists(DataFlow::LocalSourceNode src | Impl::use(this, src) |
         Impl::trackUseNode(src).flowsTo(result)


### PR DESCRIPTION
Computing this predicate in full can sometimes be expensive, so inline instead (like in JavaScript).