### PR TITLE
C++: Create a `ZeroBound` per function

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticBound.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticBound.qll
@@ -15,14 +15,19 @@ class SemBound instanceof Specific::Bound {
   final string toString() { result = super.toString() }
 
   final SemExpr getExpr(int delta) { result = Specific::getBoundExpr(this, delta) }
+
+  final SemCallable getEnclosingCallable() { result = super.getEnclosingCallable() }
 }
 
 /**
  * A bound that is a constant zero.
  */
 class SemZeroBound extends SemBound {
-  SemZeroBound() { Specific::zeroBound(this) }
+  SemZeroBound() { Specific::zeroBound(this, _) }
 }
+
+pragma[nomagic]
+SemZeroBound zeroBound(SemCallable callable) { Specific::zeroBound(result, callable) }
 
 /**
  * A bound that is an SSA definition.

--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticExpr.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticExpr.qll
@@ -5,6 +5,10 @@
 private import Semantic
 private import SemanticExprSpecific::SemanticExprConfig as Specific
 
+class SemCallable instanceof Specific::Callable {
+  final string toString() { result = super.toString() }
+}
+
 /**
  * An language-neutral expression.
  *
@@ -21,6 +25,8 @@ class SemExpr instanceof Specific::Expr {
   SemType getSemType() { result = Specific::getUnknownExprType(this) }
 
   final SemBasicBlock getBasicBlock() { result = Specific::getExprBasicBlock(this) }
+
+  final SemCallable getEnclosingCallable() { result = Specific::getExprEnclosingCallable(this) }
 }
 
 /** An expression with an opcode other than `Unknown`. */

--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticSSA.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticSSA.qll
@@ -37,6 +37,10 @@ class SemSsaReadPosition instanceof Specific::SsaReadPosition {
   final Specific::Location getLocation() { result = super.getLocation() }
 
   final predicate hasReadOfVar(SemSsaVariable var) { Specific::hasReadOfSsaVariable(this, var) }
+
+  final SemCallable getEnclosingCallable() {
+    result = Specific::getSsaReadPositionEnclosingCallable(this)
+  }
 }
 
 class SemSsaReadPositionPhiInputEdge extends SemSsaReadPosition {

--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/ModulusAnalysis.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/ModulusAnalysis.qll
@@ -209,7 +209,8 @@ private predicate ssaModulus(SemSsaVariable v, SemSsaReadPosition pos, SemBound 
     val = remainder(val0 + delta, mod)
   )
   or
-  moduloGuardedRead(v, pos, val, mod) and b instanceof SemZeroBound
+  moduloGuardedRead(v, pos, val, mod) and
+  b = zeroBound(pos.getEnclosingCallable())
 }
 
 /**
@@ -227,7 +228,7 @@ predicate semExprModulus(SemExpr e, SemBound b, int val, int mod) {
     or
     evenlyDivisibleExpr(e, mod) and
     val = 0 and
-    b instanceof SemZeroBound
+    b = zeroBound(e.getEnclosingCallable())
     or
     exists(SemSsaVariable v, SemSsaReadPositionBlock bb |
       ssaModulus(v, bb, b, val, mod) and
@@ -257,9 +258,9 @@ predicate semExprModulus(SemExpr e, SemBound b, int val, int mod) {
       mod != 1 and
       val = remainder(v1 + v2, mod)
     |
-      b = b1 and b2 instanceof SemZeroBound
+      b = b1 and b2 = zeroBound(e.getEnclosingCallable())
       or
-      b = b2 and b1 instanceof SemZeroBound
+      b = b2 and b1 = zeroBound(e.getEnclosingCallable())
     )
     or
     exists(int v1, int v2, int m1, int m2 |

--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/RangeAnalysis.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/RangeAnalysis.qll
@@ -733,7 +733,7 @@ private predicate bounded(
     reason = TSemNoReason()
     or
     baseBound(e, delta, upper) and
-    b instanceof SemZeroBound and
+    b = zeroBound(e.getEnclosingCallable()) and
     fromBackEdge = false and
     origdelta = delta and
     reason = TSemNoReason()


### PR DESCRIPTION
When we call `ZeroBound::getExpr` to get an expression that matches a given bound we eventually reach https://github.com/github/codeql/blob/8b8e74cc9a11f3cb5bedd0aed42ec26de179dc61/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/Bound.qll#L57 which will match _any_ instruction with a constant value of `0`. As @rdmarsh2 noted, this gives a very large tuple explosion.

This PR creates a per-function `ZeroBound` and restricts the expressions returned by `ZeroBound::getExpr` to be only instructions in the same callable as the `ZeroBound`.