### PR TITLE
JS: find a main module in more cases

### DIFF
--- a/javascript/ql/lib/semmle/javascript/NodeModuleResolutionImpl.qll
+++ b/javascript/ql/lib/semmle/javascript/NodeModuleResolutionImpl.qll
@@ -90,21 +90,18 @@ bindingset[name]
 private string getStem(string name) { result = name.regexpCapture("(.+?)(?:\\.([^.]+))?", 1) }
 
 /**
- * Gets the main module described by `pkg` with the given `priority`.
+ * Gets a file that a main module from `pkg` exported as `mainPath` with the given `priority`.
+ * `mainPath` is "." if it's the main module of the package.
  */
-File resolveMainModule(PackageJson pkg, int priority) {
-  exists(PathExpr main, int subPriority, string mainPath |
-    main = MainModulePath::of(pkg, mainPath) and
-    if mainPath = "." then subPriority = priority else priority = subPriority + 1000
-  |
-    result = main.resolve() and subPriority = 0
+private File resolveMainPath(PackageJson pkg, string mainPath, int priority) {
+  exists(PathExpr main | main = MainModulePath::of(pkg, mainPath) |
+    result = main.resolve() and priority = 0
     or
-    result = tryExtensions(main.resolve(), "index", subPriority)
+    result = tryExtensions(main.resolve(), "index", priority)
     or
     not main.resolve() instanceof File and
     exists(int n | n = main.getNumComponent() |
-      result =
-        tryExtensions(main.resolveUpTo(n - 1), getStem(main.getComponent(n - 1)), subPriority)
+      result = tryExtensions(main.resolveUpTo(n - 1), getStem(main.getComponent(n - 1)), priority)
     )
     or
     // assuming the files get moved from one dir to another during compilation:
@@ -114,8 +111,18 @@ File resolveMainModule(PackageJson pkg, int priority) {
       // is in one folder below the package.json, and has the right basename
       result =
         tryExtensions(subFolder, getStem(main.getComponent(main.getNumComponent() - 1)),
-          subPriority - 999)
+          priority - 999) // very high priority, to make sure everything else is tried first
     )
+  )
+}
+
+/**
+ * Gets the main module described by `pkg` with the given `priority`.
+ */
+File resolveMainModule(PackageJson pkg, int priority) {
+  exists(int subPriority, string mainPath |
+    result = resolveMainPath(pkg, mainPath, subPriority) and
+    if mainPath = "." then subPriority = priority else priority = subPriority + 1000
   )
   or
   exists(Folder folder, Folder child |

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/UnsafeHtmlConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/UnsafeHtmlConstruction.expected
@@ -8,6 +8,14 @@ nodes
 | jquery-plugin.js:12:31:12:41 | options.foo |
 | jquery-plugin.js:14:31:14:35 | stuff |
 | jquery-plugin.js:14:31:14:35 | stuff |
+| lib2/index.ts:1:28:1:28 | s |
+| lib2/index.ts:1:28:1:28 | s |
+| lib2/index.ts:2:29:2:29 | s |
+| lib2/index.ts:2:29:2:29 | s |
+| lib/src/MyNode.ts:1:28:1:28 | s |
+| lib/src/MyNode.ts:1:28:1:28 | s |
+| lib/src/MyNode.ts:2:29:2:29 | s |
+| lib/src/MyNode.ts:2:29:2:29 | s |
 | main.js:1:55:1:55 | s |
 | main.js:1:55:1:55 | s |
 | main.js:2:29:2:29 | s |
@@ -96,6 +104,14 @@ edges
 | jquery-plugin.js:11:34:11:40 | options | jquery-plugin.js:12:31:12:37 | options |
 | jquery-plugin.js:12:31:12:37 | options | jquery-plugin.js:12:31:12:41 | options.foo |
 | jquery-plugin.js:12:31:12:37 | options | jquery-plugin.js:12:31:12:41 | options.foo |
+| lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s |
+| lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s |
+| lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s |
+| lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s |
+| lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s |
+| lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s |
+| lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s |
+| lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s |
 | main.js:1:55:1:55 | s | main.js:2:29:2:29 | s |
 | main.js:1:55:1:55 | s | main.js:2:29:2:29 | s |
 | main.js:1:55:1:55 | s | main.js:2:29:2:29 | s |
@@ -183,6 +199,8 @@ edges
 #select
 | jquery-plugin.js:12:31:12:41 | options.foo | jquery-plugin.js:11:34:11:40 | options | jquery-plugin.js:12:31:12:41 | options.foo | $@ based on $@ might later cause $@. | jquery-plugin.js:12:31:12:41 | options.foo | HTML construction | jquery-plugin.js:11:34:11:40 | options | library input | jquery-plugin.js:12:20:12:53 | "<span> ... /span>" | cross-site scripting |
 | jquery-plugin.js:14:31:14:35 | stuff | jquery-plugin.js:11:27:11:31 | stuff | jquery-plugin.js:14:31:14:35 | stuff | $@ based on $@ might later cause $@. | jquery-plugin.js:14:31:14:35 | stuff | HTML construction | jquery-plugin.js:11:27:11:31 | stuff | library input | jquery-plugin.js:14:20:14:47 | "<span> ... /span>" | cross-site scripting |
+| lib2/index.ts:2:29:2:29 | s | lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s | $@ based on $@ might later cause $@. | lib2/index.ts:2:29:2:29 | s | HTML construction | lib2/index.ts:1:28:1:28 | s | library input | lib2/index.ts:3:49:3:52 | html | cross-site scripting |
+| lib/src/MyNode.ts:2:29:2:29 | s | lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s | $@ based on $@ might later cause $@. | lib/src/MyNode.ts:2:29:2:29 | s | HTML construction | lib/src/MyNode.ts:1:28:1:28 | s | library input | lib/src/MyNode.ts:3:49:3:52 | html | cross-site scripting |
 | main.js:2:29:2:29 | s | main.js:1:55:1:55 | s | main.js:2:29:2:29 | s | $@ based on $@ might later cause $@. | main.js:2:29:2:29 | s | HTML construction | main.js:1:55:1:55 | s | library input | main.js:3:49:3:52 | html | cross-site scripting |
 | main.js:7:49:7:49 | s | main.js:6:49:6:49 | s | main.js:7:49:7:49 | s | $@ based on $@ might later cause $@. | main.js:7:49:7:49 | s | XML parsing | main.js:6:49:6:49 | s | library input | main.js:8:48:8:66 | doc.documentElement | cross-site scripting |
 | main.js:12:49:12:49 | s | main.js:11:60:11:60 | s | main.js:12:49:12:49 | s | $@ based on $@ might later cause $@. | main.js:12:49:12:49 | s | XML parsing | main.js:11:60:11:60 | s | library input | main.js:16:21:16:35 | xml.cloneNode() | cross-site scripting |

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib/package.json
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "my-unsafe-library",
+    "main": "./index.js",
+    "exports": {
+        "./MyNode": {
+            "require": "./lib/MyNode.cjs",
+            "import": "./lib/MyNode.mjs"
+        }
+    }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib/src/MyNode.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib/src/MyNode.ts
@@ -1,0 +1,4 @@
+export function trivialXss(s: string) {
+    const html = "<span>" + s + "</span>"; // NOT OK
+    document.querySelector("#html").innerHTML = html;
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/index.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/index.ts
@@ -1,0 +1,4 @@
+export function trivialXss(s: string) {
+    const html = "<span>" + s + "</span>"; // NOT OK - this file is recognized as a main file.
+    document.querySelector("#html").innerHTML = html;
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/package.json
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "my-unsafe-library",
+    "main": "./foobar.js",
+    "exports": {
+        "./MyNode": {
+            "require": "./lib/MyNode.cjs",
+            "import": "./lib/MyNode.mjs"
+        }
+    }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/src/MyNode.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/src/MyNode.ts
@@ -1,0 +1,4 @@
+export function trivialXss(s: string) {
+    const html = "<span>" + s + "</span>"; // OK - this file is not recognized as a main file.
+    document.querySelector("#html").innerHTML = html;
+}


### PR DESCRIPTION
Gets a TP/TN for CVE-2022-36036.  

Recognizes files that aren't exported under the "." path as a "main module", if we can't find anything else.  

Also looks in all subfolders if we can't directly find the file.  
The basename must match, and both the file and the path are equally deep (and exactly one level down).   
This handles if e.g. Rollup moves the compiled files from one folder to another (e.g. `lib` or `dist`).  

---- 

[Evaluation looks OK. ](https://github.com/github/codeql-dca-main/blob/data/erik-krogh/moreMains__nightly-old__code-scanning__1/reports) 
There are 2 new resolved imports. One is an FP, but that's due to us not extracting the file that is supposed to be imported (I'll check that later).  
There are a bunch of new library-inputs, they seem reasonable.  
The new alerts also look reasonable.  
