### PR TITLE
C++: Avoid bad standard order in range analysis

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/RangeAnalysis.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/RangeAnalysis.qll
@@ -542,10 +542,30 @@ private predicate unequalIntegralSsa(
 ) {
   exists(SemExpr e, int d1, int d2 |
     unequalFlowStepIntegralSsa(v, pos, e, d1, reason) and
-    bounded(e, b, d2, true, _, _, _) and
-    bounded(e, b, d2, false, _, _, _) and
+    boundedUpper(e, b, d1) and
+    boundedLower(e, b, d2) and
     delta = d2 + d1
   )
+}
+
+/**
+ * Holds if `b + delta` is an upper bound for `e`.
+ *
+ * This predicate only exists to prevent a bad standard order in `unequalIntegralSsa`.
+ */
+pragma[nomagic]
+private predicate boundedUpper(SemExpr e, SemBound b, int delta) {
+  bounded(e, b, delta, true, _, _, _)
+}
+
+/**
+ * Holds if `b + delta` is a lower bound for `e`.
+ *
+ * This predicate only exists to prevent a bad standard order in `unequalIntegralSsa`.
+ */
+pragma[nomagic]
+private predicate boundedLower(SemExpr e, SemBound b, int delta) {
+  bounded(e, b, delta, false, _, _, _)
 }
 
 /** Weakens a delta to lie in the range `[-1..1]`. */


### PR DESCRIPTION
We were getting a bad standard order in `unequalIntegralSsa`:
```ql
Evaluated relational algebra for predicate RangeAnalysis#5b9c51c9::unequalIntegralSsa#5#fffff@b4a4e4wt on iteration 178 running pipeline standard with tuple counts:
146327387   ~0%    {4} r1 = JOIN SemanticType#38838c10::SemUnsignedIntegerType::getByteSize#ff#join_rhs WITH RangeAnalysis#5b9c51c9::bounded#7#fffffff#reorder_3_0_1_2_4_5_6#prev ON FIRST 1 OUTPUT true, Rhs.1, Rhs.2, Rhs.3
        0   ~0%    {3} r2 = JOIN r1 WITH RangeAnalysis#5b9c51c9::bounded#7#fffffff#reorder_3_0_1_2_4_5_6#prev_delta ON FIRST 4 OUTPUT Lhs.1, Lhs.2, Lhs.3
        0   ~0%    {5} r3 = JOIN r2 WITH RangeAnalysis#5b9c51c9::unequalFlowStepIntegralSsa#5#fffff_20134#join_rhs ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Rhs.2, Rhs.4, (Lhs.2 + Rhs.3)
```

And due to the non-linear recursion we can't fix this with `pragma`s. So until we have a proper language feature to control the standard order we have to factor this out into several predicates.

Before:
```
3m22s |   202 |    5s @ 178  | RangeAnalysis#5b9c51c9::unequalIntegralSsa#5#fffff@b4a4e4wt
```

After:
```
487ms |   203 |  31ms @ 3    | RangeAnalysis#5b9c51c9::unequalIntegralSsa#5#fffff@5e7506wn
```