### PR TITLE
Ruby: Context sensitive instance method resolution

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/Module.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Module.qll
@@ -14,6 +14,9 @@ class Module extends TModule {
   /** Gets the super class of this module, if any. */
   Module getSuperClass() { result = getSuperClass(this) }
 
+  /** Gets a sub class of this module, if any. */
+  Module getASubClass() { this = getSuperClass(result) }
+
   /** Gets a `prepend`ed module. */
   Module getAPrependedModule() { result = getAPrependedModule(this) }
 

--- a/ruby/ql/lib/codeql/ruby/ast/Module.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Module.qll
@@ -14,7 +14,7 @@ class Module extends TModule {
   /** Gets the super class of this module, if any. */
   Module getSuperClass() { result = getSuperClass(this) }
 
-  /** Gets a sub class of this module, if any. */
+  /** Gets an immediate sub class of this module, if any. */
   Module getASubClass() { this = getSuperClass(result) }
 
   /** Gets a `prepend`ed module. */

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,6 +1,4 @@
 failures
-| call_sensitivity.rb:51:10:51:10 | x | Unexpected result: hasValueFlow=12 |
-| call_sensitivity.rb:51:10:51:10 | x | Unexpected result: hasValueFlow=13 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
@@ -52,10 +50,6 @@ edges
 | call_sensitivity.rb:64:11:64:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
 | call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
 | call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
-| call_sensitivity.rb:74:11:74:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:74:11:74:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:75:14:75:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
-| call_sensitivity.rb:75:14:75:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
@@ -119,10 +113,6 @@ nodes
 | call_sensitivity.rb:64:11:64:18 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:65:14:65:22 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:65:14:65:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:74:11:74:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:74:11:74:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:75:14:75:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:75:14:75:22 | call to taint :  | semmle.label | call to taint :  |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint :  | call to taint :  |
@@ -132,5 +122,14 @@ subpaths
 | call_sensitivity.rb:43:32:43:32 | x | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:43:32:43:32 | x | $@ | call_sensitivity.rb:44:26:44:33 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:64:11:64:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:64:11:64:18 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:65:14:65:22 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:74:11:74:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:74:11:74:18 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:75:14:75:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:75:14:75:22 | call to taint :  | call to taint :  |
+mayBenefitFromCallContext
+| call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:59:5:59:16 | call to method1 | call_sensitivity.rb:58:3:60:5 | method3 |
+viableImplInCallContext
+| call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:59:5:59:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:64:1:64:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:74:1:74:19 | call to method2 | call_sensitivity.rb:68:3:70:5 | method1 |
+| call_sensitivity.rb:59:5:59:16 | call to method1 | call_sensitivity.rb:65:1:65:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:59:5:59:16 | call to method1 | call_sensitivity.rb:75:1:75:23 | call to method3 | call_sensitivity.rb:68:3:70:5 | method1 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,4 +1,6 @@
 failures
+| call_sensitivity.rb:51:10:51:10 | x | Unexpected result: hasValueFlow=12 |
+| call_sensitivity.rb:51:10:51:10 | x | Unexpected result: hasValueFlow=13 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
@@ -36,6 +38,24 @@ edges
 | call_sensitivity.rb:43:24:43:24 | x :  | call_sensitivity.rb:43:32:43:32 | x |
 | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:21:27:21:27 | x :  |
 | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:21:27:21:27 | x :  |
+| call_sensitivity.rb:50:15:50:15 | x :  | call_sensitivity.rb:51:10:51:10 | x |
+| call_sensitivity.rb:50:15:50:15 | x :  | call_sensitivity.rb:51:10:51:10 | x |
+| call_sensitivity.rb:54:15:54:15 | x :  | call_sensitivity.rb:55:13:55:13 | x :  |
+| call_sensitivity.rb:54:15:54:15 | x :  | call_sensitivity.rb:55:13:55:13 | x :  |
+| call_sensitivity.rb:55:13:55:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:55:13:55:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:58:18:58:18 | y :  | call_sensitivity.rb:59:15:59:15 | y :  |
+| call_sensitivity.rb:58:18:58:18 | y :  | call_sensitivity.rb:59:15:59:15 | y :  |
+| call_sensitivity.rb:59:15:59:15 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:59:15:59:15 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:64:11:64:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:64:11:64:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
+| call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
+| call_sensitivity.rb:74:11:74:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:74:11:74:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:75:14:75:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
+| call_sensitivity.rb:75:14:75:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
@@ -83,6 +103,26 @@ nodes
 | call_sensitivity.rb:43:32:43:32 | x | semmle.label | x |
 | call_sensitivity.rb:44:26:44:33 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:44:26:44:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:50:15:50:15 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:50:15:50:15 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:51:10:51:10 | x | semmle.label | x |
+| call_sensitivity.rb:51:10:51:10 | x | semmle.label | x |
+| call_sensitivity.rb:54:15:54:15 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:54:15:54:15 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:55:13:55:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:55:13:55:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:58:18:58:18 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:58:18:58:18 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:59:15:59:15 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:59:15:59:15 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:64:11:64:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:64:11:64:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:65:14:65:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:65:14:65:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:74:11:74:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:74:11:74:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:75:14:75:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:75:14:75:22 | call to taint :  | semmle.label | call to taint :  |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint :  | call to taint :  |
@@ -90,3 +130,7 @@ subpaths
 | call_sensitivity.rb:31:27:31:27 | x | call_sensitivity.rb:32:25:32:32 | call to taint :  | call_sensitivity.rb:31:27:31:27 | x | $@ | call_sensitivity.rb:32:25:32:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:40:31:40:31 | x | call_sensitivity.rb:41:25:41:32 | call to taint :  | call_sensitivity.rb:40:31:40:31 | x | $@ | call_sensitivity.rb:41:25:41:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:43:32:43:32 | x | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:43:32:43:32 | x | $@ | call_sensitivity.rb:44:26:44:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:64:11:64:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:64:11:64:18 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:65:14:65:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:74:11:74:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:74:11:74:18 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:75:14:75:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:75:14:75:22 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.ql
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.ql
@@ -6,6 +6,11 @@ import codeql.ruby.AST
 import codeql.ruby.DataFlow
 import TestUtilities.InlineFlowTest
 import DataFlow::PathGraph
+import codeql.ruby.dataflow.internal.DataFlowDispatch as DataFlowDispatch
+
+query predicate mayBenefitFromCallContext = DataFlowDispatch::mayBenefitFromCallContext/2;
+
+query predicate viableImplInCallContext = DataFlowDispatch::viableImplInCallContext/2;
 
 from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultTaintFlowConf conf
 where conf.hasFlowPath(source, sink)

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
@@ -45,3 +45,31 @@ apply_lambda(MY_LAMBDA1, taint(8))
 
 MY_LAMBDA2 = lambda { |x| puts x }
 apply_lambda(MY_LAMBDA2, taint(9))
+
+class A
+  def method1 x
+    sink x # $ hasValueFlow=10 $ hasValueFlow=11
+  end
+
+  def method2 x
+    method1 x
+  end
+
+  def method3(x, y)
+    x.method1(y)
+  end
+end
+
+a = A.new
+a.method2(taint 10)
+a.method3(a, taint(11))
+
+class B < A
+  def method1 x
+    puts x
+  end
+end
+
+b = B.new
+b.method2(taint 12)
+b.method3(b, taint(13))


### PR DESCRIPTION
This PR implements call-sensitive instance method resolution, using [the data-flow library's built-in support](https://github.com/github/codeql/blob/main/docs/ql-libraries/dataflow/dataflow.md#virtual-dispatch-with-call-context).

For example, in
```rb
class A
  def method1 x
    sink x
  end

  def method2 x
    method1 x
  end
end

class B < A
  def method1 x
    non_sink x
  end
end

B.new.method2(taint)
```
we will no longer report flow from `taint` to `sink` (but still to `non_sink`).