### PR TITLE
Go: Remove the legacy tracer configuration files.

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -14,7 +14,7 @@ CODEQL_PLATFORM = osx64
 endif
 endif
 
-CODEQL_TOOLS = $(addprefix codeql-tools/,autobuild.cmd autobuild.sh pre-finalize.cmd pre-finalize.sh index.cmd index.sh linux64 osx64 win64 tracing-config.lua)
+CODEQL_TOOLS = $(addprefix codeql-tools/,autobuild.cmd autobuild.sh pre-finalize.cmd pre-finalize.sh index.cmd index.sh tracing-config.lua)
 
 EXTRACTOR_PACK_OUT = build/codeql-extractor-go
 

--- a/go/codeql-tools/linux64/compiler-tracing.spec
+++ b/go/codeql-tools/linux64/compiler-tracing.spec
@@ -1,7 +1,0 @@
-**/go-autobuilder:
-  order compiler
-  trace no
-**/go:
-  invoke ${config_dir}/go-extractor
-  prepend --mimic
-  prepend "${compiler}"

--- a/go/codeql-tools/osx64/compiler-tracing.spec
+++ b/go/codeql-tools/osx64/compiler-tracing.spec
@@ -1,7 +1,0 @@
-**/go-autobuilder:
-  order compiler
-  trace no
-**/go:
-  invoke ${config_dir}/go-extractor
-  prepend --mimic
-  prepend "${compiler}"

--- a/go/codeql-tools/win64/compiler-tracing.spec
+++ b/go/codeql-tools/win64/compiler-tracing.spec
@@ -1,7 +1,0 @@
-**/go-autobuilder.exe:
-  order compiler
-  trace no
-**/go.exe:
-  invoke ${config_dir}/go-extractor.exe
-  prepend --mimic
-  prepend "${compiler}"


### PR DESCRIPTION
These are not needed anymore, and from 2.11.0 on we will not ship a CLI that can read these files.