### PR TITLE
C++: Put a warning on the PointsTo library.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/pointsto/PointsTo.qll
+++ b/cpp/ql/lib/semmle/code/cpp/pointsto/PointsTo.qll
@@ -21,7 +21,8 @@
  * equivalence classes are called "points-to sets".
  *
  * WARNING: This library may perform poorly on very large projects.
- * Consider using another library such as ??? instead.
+ * Consider using another library such as `semmle.code.cpp.dataflow.DataFlow`
+ * instead.
  */
 
 import semmle.code.cpp.commons.File

--- a/cpp/ql/lib/semmle/code/cpp/pointsto/PointsTo.qll
+++ b/cpp/ql/lib/semmle/code/cpp/pointsto/PointsTo.qll
@@ -19,6 +19,9 @@
  * `pointstoinfo` predicate determines the transitively implied points-to
  * information by collapsing pointers into equivalence classes. These
  * equivalence classes are called "points-to sets".
+ *
+ * WARNING: This library may perform poorly on very large projects.
+ * Consider using another library such as ??? instead.
  */
 
 import semmle.code.cpp.commons.File


### PR DESCRIPTION
We've wanted to replace the `PointsTo` library for a long time now, as it performs poorly on very large projects.  Unfortunately its still used in quite a few queries* so we can't get rid of it or even formally deprecate it.  But we've had external query developers try to use it, so I feel even just adding a warning to the library somewhere will be worthwhile.
 
`*` - `cpp/file-never-closed` and similar queries; a handful of queries that use `CallGraph.qll`; and a couple of `jsf` rules.  None of these queries are included in the normal query sets, so we actually have quite a lot to gain by modernizing them at some point.