### PR TITLE
Python: Allow `CallNode.getArgByName` for keyword args after `**kwargs`

### DIFF
--- a/python/ql/lib/change-notes/2022-09-12-CallNode-getArgByName.md
+++ b/python/ql/lib/change-notes/2022-09-12-CallNode-getArgByName.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Changed `CallNode.getArgByName` such that it has results for keyword arguments given after a dictionary unpacking argument, as the `bar=2` argument in `func(foo=1, **kwargs, bar=2)`.

--- a/python/ql/lib/semmle/python/Flow.qll
+++ b/python/ql/lib/semmle/python/Flow.qll
@@ -376,7 +376,7 @@ class CallNode extends ControlFlowNode {
   ControlFlowNode getArgByName(string name) {
     exists(Call c, Keyword k |
       this.getNode() = c and
-      k = c.getAKeyword() and
+      k = c.getANamedArg() and
       k.getValue() = result.getNode() and
       k.getArg() = name and
       result.getBasicBlock().dominates(this.getBasicBlock())

--- a/python/ql/test/experimental/dataflow/coverage/argumentPassing.py
+++ b/python/ql/test/experimental/dataflow/coverage/argumentPassing.py
@@ -94,7 +94,7 @@ def with_multiple_kw_args(a, b, c):
 def test_multiple_kw_args():
     with_multiple_kw_args(b=arg2, c=arg3, a=arg1)  #$ arg1 arg2 arg3
     with_multiple_kw_args(arg1, *(arg2,), arg3)  #$ arg1 MISSING: arg2 arg3
-    with_multiple_kw_args(arg1, **{"c": arg3}, b=arg2)  #$ arg1 arg3 func=with_multiple_kw_args MISSING: arg2
+    with_multiple_kw_args(arg1, **{"c": arg3}, b=arg2)  #$ arg1 arg2 arg3 func=with_multiple_kw_args MISSING:
     with_multiple_kw_args(**{"b": arg2}, **{"c": arg3}, **{"a": arg1})  #$ arg1 arg2 arg3 func=with_multiple_kw_args
 
 


### PR DESCRIPTION
I was rather surprised when I learned we don't allow this currently. I think this is a minor thing, as it's not a very common pattern to pass your arguments like this, but no reason we shouldn't handle this correctly.

see https://github.com/github/codeql/blob/1c15fc5600c0a566c1938f6a4c84319a6bb0eba3/python/ql/lib/semmle/python/Exprs.qll#L185-L197

We might want to consider deprecating or changing `getKeyword`/`getAKeyword` on the AST `Call` class.