### PR TITLE
Python: `getStarArg` gives first `*args` argument

### DIFF
--- a/python/ql/lib/change-notes/2022-09-12-getStarArg-first.md
+++ b/python/ql/lib/change-notes/2022-09-12-getStarArg-first.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* `getStarArg` member-predicate on `Call` and `CallNode` has been changed for calls that have multiple `*args` arguments (for example `func(42, *my_args, *other_args)`): Instead of producing no results, it will always have a result for the _first_ such `*args` argument.

--- a/python/ql/lib/semmle/python/Exprs.qll
+++ b/python/ql/lib/semmle/python/Exprs.qll
@@ -245,10 +245,12 @@ class Call extends Call_ {
     result = count(Expr arg | arg = this.getAPositionalArg() and not arg instanceof Starred)
   }
 
-  /** Gets the tuple (*) argument of this call, provided there is exactly one. */
+  /** Gets the first tuple (*) argument of this call, if any. */
   Expr getStarArg() {
-    count(this.getStarargs()) < 2 and
-    result = this.getStarargs()
+    exists(int firstStarArgIndex |
+      firstStarArgIndex = min(int i | this.getPositionalArg(i) instanceof Starred | i) and
+      result = this.getPositionalArg(firstStarArgIndex).(Starred).getValue()
+    )
   }
 }
 

--- a/python/ql/lib/semmle/python/Flow.qll
+++ b/python/ql/lib/semmle/python/Flow.qll
@@ -406,7 +406,7 @@ class CallNode extends ControlFlowNode {
     exists(FunctionExpr func | this.getNode() = func.getADecoratorCall())
   }
 
-  /** Gets the tuple (*) argument of this call, provided there is exactly one. */
+  /** Gets the first tuple (*) argument of this call, if any. */
   ControlFlowNode getStarArg() {
     result.getNode() = this.getNode().getStarArg() and
     result.getBasicBlock().dominates(this.getBasicBlock())


### PR DESCRIPTION
Besides my intended use in the new call-graph PR, these member-predicates only seems to be used in this part of points-to:
https://github.com/github/codeql/blob/2436b060f1a330b02f333bf99d716bff1f02f0da/python/ql/lib/semmle/python/pointsto/PointsTo.qll#L1142-L1167

I couldn't see any reason that we should give up altogether if there are multiple `*args` arguments. Including the first one looks like a win to me!