### PR TITLE
JS: recognize returning an instance of a class as exporting that class

### DIFF
--- a/javascript/ql/lib/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/lib/semmle/javascript/PackageExports.qll
@@ -52,6 +52,16 @@ private DataFlow::Node getAValueExportedByPackage() {
     not isPrivateMethodDeclaration(result)
   )
   or
+  // module.exports.foo = function () {
+  //   return new Foo(); // <- result
+  // };
+  exists(DataFlow::FunctionNode func, DataFlow::NewNode inst, DataFlow::ClassNode clz |
+    func = getAValueExportedByPackage().getALocalSource() and inst = unique( | | func.getAReturn())
+  |
+    clz.getAnInstanceReference() = inst and
+    result = clz.getAnInstanceMethod()
+  )
+  or
   result = getAValueExportedByPackage().getALocalSource()
   or
   // Nested property reads.

--- a/javascript/ql/lib/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/lib/semmle/javascript/PackageExports.qll
@@ -59,7 +59,7 @@ private DataFlow::Node getAValueExportedByPackage() {
     func = getAValueExportedByPackage().getALocalSource() and inst = unique( | | func.getAReturn())
   |
     clz.getAnInstanceReference() = inst and
-    result = clz.getAnInstanceMethod()
+    result = clz.getAnInstanceMember(_)
   )
   or
   result = getAValueExportedByPackage().getALocalSource()

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
@@ -111,6 +111,12 @@ nodes
 | lib.js:119:13:119:24 | obj[path[0]] |
 | lib.js:119:17:119:20 | path |
 | lib.js:119:17:119:23 | path[0] |
+| lib.js:127:14:127:17 | path |
+| lib.js:127:14:127:17 | path |
+| lib.js:128:9:128:20 | obj[path[0]] |
+| lib.js:128:9:128:20 | obj[path[0]] |
+| lib.js:128:13:128:16 | path |
+| lib.js:128:13:128:19 | path[0] |
 | sublib/sub.js:1:37:1:40 | path |
 | sublib/sub.js:1:37:1:40 | path |
 | sublib/sub.js:2:3:2:14 | obj[path[0]] |
@@ -269,6 +275,11 @@ edges
 | lib.js:119:17:119:20 | path | lib.js:119:17:119:23 | path[0] |
 | lib.js:119:17:119:23 | path[0] | lib.js:119:13:119:24 | obj[path[0]] |
 | lib.js:119:17:119:23 | path[0] | lib.js:119:13:119:24 | obj[path[0]] |
+| lib.js:127:14:127:17 | path | lib.js:128:13:128:16 | path |
+| lib.js:127:14:127:17 | path | lib.js:128:13:128:16 | path |
+| lib.js:128:13:128:16 | path | lib.js:128:13:128:19 | path[0] |
+| lib.js:128:13:128:19 | path[0] | lib.js:128:9:128:20 | obj[path[0]] |
+| lib.js:128:13:128:19 | path[0] | lib.js:128:9:128:20 | obj[path[0]] |
 | sublib/sub.js:1:37:1:40 | path | sublib/sub.js:2:7:2:10 | path |
 | sublib/sub.js:1:37:1:40 | path | sublib/sub.js:2:7:2:10 | path |
 | sublib/sub.js:2:7:2:10 | path | sublib/sub.js:2:7:2:13 | path[0] |
@@ -329,6 +340,7 @@ edges
 | lib.js:87:10:87:14 | proto | lib.js:83:14:83:22 | arguments | lib.js:87:10:87:14 | proto | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:83:14:83:22 | arguments | library input |
 | lib.js:108:3:108:10 | obj[one] | lib.js:104:13:104:21 | arguments | lib.js:108:3:108:10 | obj[one] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:104:13:104:21 | arguments | library input |
 | lib.js:119:13:119:24 | obj[path[0]] | lib.js:118:29:118:32 | path | lib.js:119:13:119:24 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:118:29:118:32 | path | library input |
+| lib.js:128:9:128:20 | obj[path[0]] | lib.js:127:14:127:17 | path | lib.js:128:9:128:20 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:127:14:127:17 | path | library input |
 | sublib/sub.js:2:3:2:14 | obj[path[0]] | sublib/sub.js:1:37:1:40 | path | sublib/sub.js:2:3:2:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | sublib/sub.js:1:37:1:40 | path | library input |
 | tst.js:8:5:8:17 | object[taint] | tst.js:5:24:5:37 | req.query.data | tst.js:8:5:8:17 | object[taint] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |
 | tst.js:9:5:9:17 | object[taint] | tst.js:5:24:5:37 | req.query.data | tst.js:9:5:9:17 | object[taint] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/lib.js
@@ -120,3 +120,18 @@ module.exports.returnsObj = function () {
         }
     }
 }
+
+class MyClass {
+    constructor() {}
+
+    set(obj, path, value) {
+        obj[path[0]][path[1]] = value; // NOT OK
+    }
+
+    static staticSet(obj, path, value) {
+        obj[path[0]][path[1]] = value; // OK - not exported
+    }
+}
+module.exports.returnsMewMyClass = function () {
+    return new MyClass();
+}


### PR DESCRIPTION
Gets a TP/FP for CVE-2020-28471

[Evaluation hints towards a performance regression](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/exportNew__nightly-old__code-scanning/reports).  
Which disappeared when I tried [the same evaluation single-threaded](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/exportNew-single-threaded/reports) 🤷 