### PR TITLE
JS: Fix FP in js/regexp/always-matches

### DIFF
--- a/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql
+++ b/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql
@@ -118,6 +118,6 @@ where
     call instanceof RegExpSearchCall and
     not term.getAChild*() instanceof RegExpDollar and
     message =
-      "This regular expression always the matches at index 0 when used $@, as it matches the empty substring."
+      "This regular expression always matches at index 0 when used $@, as it matches the empty substring."
   )
 select term, message, call, "here"

--- a/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql
+++ b/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql
@@ -54,6 +54,8 @@ predicate isUniversalRegExp(RegExpTerm term) {
     or
     child.(RegExpCharacterClass).isUniversalClass()
   )
+  or
+  term.(RegExpSequence).getNumChild() = 0
 }
 
 /**

--- a/javascript/ql/src/change-notes/2022-09-13-regexp-always-matches-fp.md
+++ b/javascript/ql/src/change-notes/2022-09-13-regexp-always-matches-fp.md
@@ -1,0 +1,6 @@
+---
+category: minorAnalysis
+---
+
+- The `js/regexp/always-matches` query will no longer report an empty regular expression as always
+  matching, as this is often the intended behavior.

--- a/javascript/ql/test/query-tests/RegExp/RegExpAlwaysMatches/RegExpAlwaysMatches.expected
+++ b/javascript/ql/test/query-tests/RegExp/RegExpAlwaysMatches/RegExpAlwaysMatches.expected
@@ -5,4 +5,3 @@
 | tst.js:34:21:34:26 | (baz)? | This regular expression always matches when used in a test $@, as it can match an empty substring. | tst.js:34:10:34:35 | /^foo\|b ... test(x) | here |
 | tst.js:58:20:58:25 | [a-z]* | This regular expression always the matches at index 0 when used $@, as it matches the empty substring. | tst.js:58:10:58:27 | x.search(/[a-z]*/) | here |
 | tst.js:70:20:70:26 | ^(foo)? | This regular expression always the matches at index 0 when used $@, as it matches the empty substring. | tst.js:70:10:70:28 | x.search(/^(foo)?/) | here |
-| tst.js:86:22:86:21 |  | This regular expression always matches when used in a test $@, as it can match an empty substring. | tst.js:86:10:86:31 | new Reg ... test(x) | here |

--- a/javascript/ql/test/query-tests/RegExp/RegExpAlwaysMatches/RegExpAlwaysMatches.expected
+++ b/javascript/ql/test/query-tests/RegExp/RegExpAlwaysMatches/RegExpAlwaysMatches.expected
@@ -3,5 +3,5 @@
 | tst.js:22:11:22:34 | ^(?:https?:\|ftp:\|file:)? | This regular expression always matches when used in a test $@, as it can match an empty substring. | tst.js:22:10:22:43 | /^(?:ht ... test(x) | here |
 | tst.js:30:11:30:20 | (foo\|bar)? | This regular expression always matches when used in a test $@, as it can match an empty substring. | tst.js:30:10:30:29 | /(foo\|bar)?/.test(x) | here |
 | tst.js:34:21:34:26 | (baz)? | This regular expression always matches when used in a test $@, as it can match an empty substring. | tst.js:34:10:34:35 | /^foo\|b ... test(x) | here |
-| tst.js:58:20:58:25 | [a-z]* | This regular expression always the matches at index 0 when used $@, as it matches the empty substring. | tst.js:58:10:58:27 | x.search(/[a-z]*/) | here |
-| tst.js:70:20:70:26 | ^(foo)? | This regular expression always the matches at index 0 when used $@, as it matches the empty substring. | tst.js:70:10:70:28 | x.search(/^(foo)?/) | here |
+| tst.js:58:20:58:25 | [a-z]* | This regular expression always matches at index 0 when used $@, as it matches the empty substring. | tst.js:58:10:58:27 | x.search(/[a-z]*/) | here |
+| tst.js:70:20:70:26 | ^(foo)? | This regular expression always matches at index 0 when used $@, as it matches the empty substring. | tst.js:70:10:70:28 | x.search(/^(foo)?/) | here |

--- a/javascript/ql/test/query-tests/RegExp/RegExpAlwaysMatches/tst.js
+++ b/javascript/ql/test/query-tests/RegExp/RegExpAlwaysMatches/tst.js
@@ -83,10 +83,10 @@ function nonWordBoundary(x) {
 }
 
 function emptyRegex(x) {
-  return new RegExp("").test(x); // NOT OK
+  return new RegExp("").test(x); // OK
 }
 
 function parserTest(x) {
   /(\w\s*:\s*[^:}]+|#){|@import[^\n]+(?:url|,)/.test(x); // OK
-  /^((?:a{0,2}|-)|\w\{\d,\d\})+X$/.text(x); // ok 
+  /^((?:a{0,2}|-)|\w\{\d,\d\})+X$/.text(x); // ok
 }


### PR DESCRIPTION
I noticed some FPs in vscode while investigating a timeout.

This query is not currently tagged as a security query, but it's one of those queries that could be security relevant in some contexts, so it's worth maintaining a low FP rate for it.