### PR TITLE
Ruby: Adjust the scope of singleton class targets

### DIFF
--- a/ruby/ql/lib/codeql/ruby/AST.qll
+++ b/ruby/ql/lib/codeql/ruby/AST.qll
@@ -60,10 +60,10 @@ class AstNode extends TAstNode {
   final string getPrimaryQlClasses() { result = concat(this.getAPrimaryQlClass(), ",") }
 
   /** Gets the enclosing module, if any. */
-  ModuleBase getEnclosingModule() { result = getEnclosingModule(scopeOfInclSynth(this)) }
+  final ModuleBase getEnclosingModule() { result = getEnclosingModule(scopeOfInclSynth(this)) }
 
   /** Gets the enclosing method, if any. */
-  MethodBase getEnclosingMethod() { result = getEnclosingMethod(scopeOfInclSynth(this)) }
+  final MethodBase getEnclosingMethod() { result = getEnclosingMethod(scopeOfInclSynth(this)) }
 
   /** Gets a textual representation of this node. */
   cached

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Scope.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Scope.qll
@@ -128,7 +128,7 @@ private AstNode specialParentOfInclSynth(AstNode n) {
   n =
     [
       result.(Namespace).getScopeExpr(), result.(ClassDeclaration).getSuperclassExpr(),
-      result.(SingletonMethod).getObject()
+      result.(SingletonMethod).getObject(), result.(SingletonClass).getValue()
     ]
 }
 

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -155,7 +155,7 @@ modules.rb:
 #  116| XX::YY
 #-----| super -> YY
 
-#  120| Test::Foo1::Bar::Baz
+#  123| Test::Foo1::Bar::Baz
 
 modules_rec.rb:
 #    1| B::A

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -79,6 +79,7 @@ getTarget
 | modules.rb:90:24:90:36 | call to prepend | calls.rb:93:5:93:20 | prepend |
 | modules.rb:96:3:96:14 | call to include | calls.rb:92:5:92:20 | include |
 | modules.rb:102:3:102:16 | call to prepend | calls.rb:93:5:93:20 | prepend |
+| modules.rb:126:6:126:11 | call to new | calls.rb:99:5:99:16 | new |
 | modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:93:5:93:20 | prepend |
 | private.rb:2:3:3:5 | call to private | calls.rb:94:5:94:20 | private |
 | private.rb:10:3:10:19 | call to private | calls.rb:94:5:94:20 | private |

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -272,3 +272,107 @@ lookupMethod
 | private.rb:42:1:60:3 | F | private3 | private.rb:55:3:56:5 | private3 |
 | private.rb:42:1:60:3 | F | private4 | private.rb:58:3:59:5 | private4 |
 | private.rb:42:1:60:3 | F | public | private.rb:46:3:47:5 | public |
+enclosingMethod
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:3:3 | foo |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:3:3 | foo |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:3:3 | foo |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:8:5:8:14 | call to puts | calls.rb:7:1:9:3 | bar |
+| calls.rb:8:5:8:14 | self | calls.rb:7:1:9:3 | bar |
+| calls.rb:8:10:8:14 | "bar" | calls.rb:7:1:9:3 | bar |
+| calls.rb:8:11:8:13 | bar | calls.rb:7:1:9:3 | bar |
+| calls.rb:38:9:38:18 | call to instance_m | calls.rb:37:5:43:7 | baz |
+| calls.rb:38:9:38:18 | self | calls.rb:37:5:43:7 | baz |
+| calls.rb:39:9:39:12 | self | calls.rb:37:5:43:7 | baz |
+| calls.rb:39:9:39:23 | call to instance_m | calls.rb:37:5:43:7 | baz |
+| calls.rb:41:9:41:19 | call to singleton_m | calls.rb:37:5:43:7 | baz |
+| calls.rb:41:9:41:19 | self | calls.rb:37:5:43:7 | baz |
+| calls.rb:42:9:42:12 | self | calls.rb:37:5:43:7 | baz |
+| calls.rb:42:9:42:24 | call to singleton_m | calls.rb:37:5:43:7 | baz |
+| calls.rb:53:9:53:13 | call to super | calls.rb:52:5:54:7 | baz |
+| calls.rb:62:18:62:18 | a | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:62:18:62:18 | a | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:62:22:62:22 | 4 | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:62:25:62:25 | b | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:62:25:62:25 | b | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:62:28:62:28 | 5 | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:63:5:63:5 | a | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:63:5:63:16 | call to bit_length | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:64:5:64:5 | b | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:64:5:64:16 | call to bit_length | calls.rb:62:1:65:3 | optional_arg |
+| calls.rb:68:5:68:11 | yield ... | calls.rb:67:1:69:3 | call_block |
+| calls.rb:68:11:68:11 | 1 | calls.rb:67:1:69:3 | call_block |
+| calls.rb:72:5:72:7 | var | calls.rb:71:1:75:3 | foo |
+| calls.rb:72:5:72:18 | ... = ... | calls.rb:71:1:75:3 | foo |
+| calls.rb:72:11:72:14 | Hash | calls.rb:71:1:75:3 | foo |
+| calls.rb:72:11:72:18 | call to new | calls.rb:71:1:75:3 | foo |
+| calls.rb:73:5:73:7 | var | calls.rb:71:1:75:3 | foo |
+| calls.rb:73:5:73:10 | ...[...] | calls.rb:71:1:75:3 | foo |
+| calls.rb:73:9:73:9 | 1 | calls.rb:71:1:75:3 | foo |
+| calls.rb:74:5:74:29 | call to call_block | calls.rb:71:1:75:3 | foo |
+| calls.rb:74:5:74:29 | self | calls.rb:71:1:75:3 | foo |
+| calls.rb:74:16:74:29 | { ... } | calls.rb:71:1:75:3 | foo |
+| calls.rb:74:19:74:19 | x | calls.rb:71:1:75:3 | foo |
+| calls.rb:74:19:74:19 | x | calls.rb:71:1:75:3 | foo |
+| calls.rb:74:22:74:24 | var | calls.rb:71:1:75:3 | foo |
+| calls.rb:74:22:74:27 | ...[...] | calls.rb:71:1:75:3 | foo |
+| calls.rb:74:26:74:26 | x | calls.rb:71:1:75:3 | foo |
+| calls.rb:110:15:110:19 | &body | calls.rb:110:3:116:5 | foreach |
+| calls.rb:110:16:110:19 | body | calls.rb:110:3:116:5 | foreach |
+| calls.rb:111:5:111:5 | x | calls.rb:110:3:116:5 | foreach |
+| calls.rb:111:5:111:9 | ... = ... | calls.rb:110:3:116:5 | foreach |
+| calls.rb:111:9:111:9 | 0 | calls.rb:110:3:116:5 | foreach |
+| calls.rb:112:5:115:7 | while ... | calls.rb:110:3:116:5 | foreach |
+| calls.rb:112:11:112:11 | x | calls.rb:110:3:116:5 | foreach |
+| calls.rb:112:11:112:25 | ... < ... | calls.rb:110:3:116:5 | foreach |
+| calls.rb:112:15:112:18 | self | calls.rb:110:3:116:5 | foreach |
+| calls.rb:112:15:112:25 | call to length | calls.rb:110:3:116:5 | foreach |
+| calls.rb:112:26:115:7 | do ... | calls.rb:110:3:116:5 | foreach |
+| calls.rb:113:9:113:24 | yield ... | calls.rb:110:3:116:5 | foreach |
+| calls.rb:113:15:113:15 | x | calls.rb:110:3:116:5 | foreach |
+| calls.rb:113:18:113:21 | self | calls.rb:110:3:116:5 | foreach |
+| calls.rb:113:18:113:24 | ...[...] | calls.rb:110:3:116:5 | foreach |
+| calls.rb:113:23:113:23 | x | calls.rb:110:3:116:5 | foreach |
+| calls.rb:114:9:114:9 | x | calls.rb:110:3:116:5 | foreach |
+| calls.rb:114:9:114:9 | x | calls.rb:110:3:116:5 | foreach |
+| calls.rb:114:9:114:14 | ... += ... | calls.rb:110:3:116:5 | foreach |
+| calls.rb:114:9:114:14 | ... = ... | calls.rb:110:3:116:5 | foreach |
+| calls.rb:114:11:114:12 | ... + ... | calls.rb:110:3:116:5 | foreach |
+| calls.rb:114:14:114:14 | 1 | calls.rb:110:3:116:5 | foreach |
+| calls.rb:120:5:120:20 | yield ... | calls.rb:119:1:121:3 | funny |
+| calls.rb:120:11:120:20 | "prefix: " | calls.rb:119:1:121:3 | funny |
+| calls.rb:120:12:120:19 | prefix:  | calls.rb:119:1:121:3 | funny |
+| calls.rb:137:14:137:15 | &b | calls.rb:137:1:139:3 | indirect |
+| calls.rb:137:15:137:15 | b | calls.rb:137:1:139:3 | indirect |
+| calls.rb:138:5:138:17 | call to call_block | calls.rb:137:1:139:3 | indirect |
+| calls.rb:138:5:138:17 | self | calls.rb:137:1:139:3 | indirect |
+| calls.rb:138:16:138:17 | &... | calls.rb:137:1:139:3 | indirect |
+| calls.rb:138:17:138:17 | b | calls.rb:137:1:139:3 | indirect |
+| calls.rb:146:9:146:12 | self | calls.rb:145:5:147:7 | s_method |
+| calls.rb:146:9:146:17 | call to to_s | calls.rb:145:5:147:7 | s_method |
+| calls.rb:171:9:171:12 | self | calls.rb:170:5:172:7 | singleton_a |
+| calls.rb:171:9:171:24 | call to singleton_b | calls.rb:170:5:172:7 | singleton_a |
+| calls.rb:175:9:175:12 | self | calls.rb:174:5:176:7 | singleton_b |
+| calls.rb:175:9:175:24 | call to singleton_c | calls.rb:174:5:176:7 | singleton_b |
+| calls.rb:182:9:182:12 | self | calls.rb:181:5:183:7 | singleton_d |
+| calls.rb:182:9:182:24 | call to singleton_a | calls.rb:181:5:183:7 | singleton_d |
+| hello.rb:3:9:3:22 | return | hello.rb:2:5:4:7 | hello |
+| hello.rb:3:16:3:22 | "hello" | hello.rb:2:5:4:7 | hello |
+| hello.rb:3:17:3:21 | hello | hello.rb:2:5:4:7 | hello |
+| hello.rb:6:9:6:22 | return | hello.rb:5:5:7:7 | world |
+| hello.rb:6:16:6:22 | "world" | hello.rb:5:5:7:7 | world |
+| hello.rb:6:17:6:21 | world | hello.rb:5:5:7:7 | world |
+| hello.rb:14:9:14:20 | return | hello.rb:13:5:15:7 | message |
+| hello.rb:14:16:14:20 | call to hello | hello.rb:13:5:15:7 | message |
+| hello.rb:14:16:14:20 | self | hello.rb:13:5:15:7 | message |
+| hello.rb:20:9:20:40 | return | hello.rb:19:5:21:7 | message |
+| hello.rb:20:16:20:20 | call to super | hello.rb:19:5:21:7 | message |
+| hello.rb:20:16:20:26 | ... + ... | hello.rb:19:5:21:7 | message |
+| hello.rb:20:16:20:34 | ... + ... | hello.rb:19:5:21:7 | message |
+| hello.rb:20:16:20:40 | ... + ... | hello.rb:19:5:21:7 | message |
+| hello.rb:20:24:20:26 | " " | hello.rb:19:5:21:7 | message |
+| hello.rb:20:25:20:25 |   | hello.rb:19:5:21:7 | message |
+| hello.rb:20:30:20:34 | call to world | hello.rb:19:5:21:7 | message |
+| hello.rb:20:30:20:34 | self | hello.rb:19:5:21:7 | message |
+| hello.rb:20:38:20:40 | "!" | hello.rb:19:5:21:7 | message |
+| hello.rb:20:39:20:39 | ! | hello.rb:19:5:21:7 | message |

--- a/ruby/ql/test/library-tests/modules/methods.ql
+++ b/ruby/ql/test/library-tests/modules/methods.ql
@@ -6,3 +6,5 @@ query MethodBase getMethod(Module m, string name) {
 }
 
 query MethodBase lookupMethod(Module m, string name) { result = M::lookupMethod(m, name) }
+
+query predicate enclosingMethod(AstNode n, MethodBase m) { m = n.getEnclosingMethod() }

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -54,9 +54,9 @@ getModule
 | modules.rb:107:1:110:3 | MM |
 | modules.rb:108:3:109:5 | MM::MM |
 | modules.rb:112:1:113:3 | YY |
-| modules.rb:115:1:118:3 | XX |
+| modules.rb:115:1:121:3 | XX |
 | modules.rb:116:7:117:9 | XX::YY |
-| modules.rb:120:1:121:3 | Test::Foo1::Bar::Baz |
+| modules.rb:123:1:124:3 | Test::Foo1::Bar::Baz |
 | modules_rec.rb:1:1:2:3 | B::A |
 | modules_rec.rb:4:1:5:3 | A::B |
 | private.rb:1:1:29:3 | E |
@@ -72,7 +72,7 @@ getADeclaration
 | calls.rb:97:1:100:3 | Object | calls.rb:1:1:186:22 | calls.rb |
 | calls.rb:97:1:100:3 | Object | calls.rb:97:1:100:3 | Object |
 | calls.rb:97:1:100:3 | Object | hello.rb:1:1:22:3 | hello.rb |
-| calls.rb:97:1:100:3 | Object | modules.rb:1:1:121:4 | modules.rb |
+| calls.rb:97:1:100:3 | Object | modules.rb:1:1:129:4 | modules.rb |
 | calls.rb:97:1:100:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
 | calls.rb:97:1:100:3 | Object | private.rb:1:1:60:3 | private.rb |
 | calls.rb:102:1:104:3 | Hash | calls.rb:102:1:104:3 | Hash |
@@ -115,9 +115,9 @@ getADeclaration
 | modules.rb:107:1:110:3 | MM | modules.rb:107:1:110:3 | MM |
 | modules.rb:108:3:109:5 | MM::MM | modules.rb:108:3:109:5 | MM |
 | modules.rb:112:1:113:3 | YY | modules.rb:112:1:113:3 | YY |
-| modules.rb:115:1:118:3 | XX | modules.rb:115:1:118:3 | XX |
+| modules.rb:115:1:121:3 | XX | modules.rb:115:1:121:3 | XX |
 | modules.rb:116:7:117:9 | XX::YY | modules.rb:116:7:117:9 | YY |
-| modules.rb:120:1:121:3 | Test::Foo1::Bar::Baz | modules.rb:120:1:121:3 | Baz |
+| modules.rb:123:1:124:3 | Test::Foo1::Bar::Baz | modules.rb:123:1:124:3 | Baz |
 | modules_rec.rb:1:1:2:3 | B::A | modules_rec.rb:1:1:2:3 | A |
 | modules_rec.rb:4:1:5:3 | A::B | modules_rec.rb:4:1:5:3 | B |
 | private.rb:1:1:29:3 | E | private.rb:1:1:29:3 | E |
@@ -205,9 +205,10 @@ resolveConstantReadAccess
 | modules.rb:103:10:103:13 | Foo2 | Test::Foo2 |
 | modules.rb:108:10:108:11 | MM | MM |
 | modules.rb:116:18:116:19 | YY | YY |
-| modules.rb:120:8:120:11 | Test | Test |
-| modules.rb:120:8:120:17 | Foo1 | Test::Foo1 |
-| modules.rb:120:8:120:22 | Bar | Test::Foo1::Bar |
+| modules.rb:123:8:123:11 | Test | Test |
+| modules.rb:123:8:123:17 | Foo1 | Test::Foo1 |
+| modules.rb:123:8:123:22 | Bar | Test::Foo1::Bar |
+| modules.rb:126:6:126:7 | XX | XX |
 | modules_rec.rb:1:7:1:7 | B | B |
 | modules_rec.rb:4:7:4:7 | A | A |
 | modules_rec.rb:7:11:7:11 | B | B |
@@ -276,11 +277,519 @@ resolveConstantWriteAccess
 | modules.rb:108:3:109:5 | MM | MM::MM |
 | modules.rb:108:3:109:5 | MM | MM::MM::MM |
 | modules.rb:112:1:113:3 | YY | YY |
-| modules.rb:115:1:118:3 | XX | XX |
+| modules.rb:115:1:121:3 | XX | XX |
 | modules.rb:116:7:117:9 | YY | XX::YY |
-| modules.rb:120:1:121:3 | Baz | Test::Foo1::Bar::Baz |
+| modules.rb:123:1:124:3 | Baz | Test::Foo1::Bar::Baz |
 | modules_rec.rb:1:1:2:3 | A | B::A |
 | modules_rec.rb:4:1:5:3 | B | A::B |
 | modules_rec.rb:7:1:9:3 | A | A |
 | private.rb:1:1:29:3 | E | E |
 | private.rb:42:1:60:3 | F | F |
+enclosingModule
+| calls.rb:1:1:3:3 | foo | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:5:1:5:3 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:7:1:9:3 | bar | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:7:5:7:8 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:8:5:8:14 | call to puts | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:8:5:8:14 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:8:10:8:14 | "bar" | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:8:11:8:13 | bar | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:11:1:11:4 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:13:1:13:4 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:13:1:13:8 | call to foo | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:15:1:24:3 | M | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:16:5:16:23 | instance_m | calls.rb:15:1:24:3 | M |
+| calls.rb:17:5:17:29 | singleton_m | calls.rb:15:1:24:3 | M |
+| calls.rb:17:9:17:12 | self | calls.rb:15:1:24:3 | M |
+| calls.rb:19:5:19:14 | call to instance_m | calls.rb:15:1:24:3 | M |
+| calls.rb:19:5:19:14 | self | calls.rb:15:1:24:3 | M |
+| calls.rb:20:5:20:8 | self | calls.rb:15:1:24:3 | M |
+| calls.rb:20:5:20:19 | call to instance_m | calls.rb:15:1:24:3 | M |
+| calls.rb:22:5:22:15 | call to singleton_m | calls.rb:15:1:24:3 | M |
+| calls.rb:22:5:22:15 | self | calls.rb:15:1:24:3 | M |
+| calls.rb:23:5:23:8 | self | calls.rb:15:1:24:3 | M |
+| calls.rb:23:5:23:20 | call to singleton_m | calls.rb:15:1:24:3 | M |
+| calls.rb:26:1:26:1 | M | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:26:1:26:12 | call to instance_m | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:27:1:27:1 | M | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:27:1:27:13 | call to singleton_m | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:29:1:44:3 | C | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:30:5:30:13 | call to include | calls.rb:29:1:44:3 | C |
+| calls.rb:30:5:30:13 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:30:13:30:13 | M | calls.rb:29:1:44:3 | C |
+| calls.rb:31:5:31:14 | call to instance_m | calls.rb:29:1:44:3 | C |
+| calls.rb:31:5:31:14 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:32:5:32:8 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:32:5:32:19 | call to instance_m | calls.rb:29:1:44:3 | C |
+| calls.rb:34:5:34:15 | call to singleton_m | calls.rb:29:1:44:3 | C |
+| calls.rb:34:5:34:15 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:35:5:35:8 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:35:5:35:20 | call to singleton_m | calls.rb:29:1:44:3 | C |
+| calls.rb:37:5:43:7 | baz | calls.rb:29:1:44:3 | C |
+| calls.rb:38:9:38:18 | call to instance_m | calls.rb:29:1:44:3 | C |
+| calls.rb:38:9:38:18 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:39:9:39:12 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:39:9:39:23 | call to instance_m | calls.rb:29:1:44:3 | C |
+| calls.rb:41:9:41:19 | call to singleton_m | calls.rb:29:1:44:3 | C |
+| calls.rb:41:9:41:19 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:42:9:42:12 | self | calls.rb:29:1:44:3 | C |
+| calls.rb:42:9:42:24 | call to singleton_m | calls.rb:29:1:44:3 | C |
+| calls.rb:46:1:46:1 | c | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:46:1:46:9 | ... = ... | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:46:5:46:5 | C | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:46:5:46:9 | call to new | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:47:1:47:1 | c | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:47:1:47:5 | call to baz | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:48:1:48:1 | c | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:48:1:48:13 | call to singleton_m | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:49:1:49:1 | c | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:49:1:49:12 | call to instance_m | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:51:1:55:3 | D | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:51:11:51:11 | C | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:52:5:54:7 | baz | calls.rb:51:1:55:3 | D |
+| calls.rb:53:9:53:13 | call to super | calls.rb:51:1:55:3 | D |
+| calls.rb:57:1:57:1 | d | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:57:1:57:9 | ... = ... | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:57:5:57:5 | D | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:57:5:57:9 | call to new | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:58:1:58:1 | d | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:58:1:58:5 | call to baz | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:59:1:59:1 | d | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:59:1:59:13 | call to singleton_m | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:60:1:60:1 | d | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:60:1:60:12 | call to instance_m | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:62:1:65:3 | optional_arg | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:62:18:62:18 | a | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:62:18:62:18 | a | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:62:22:62:22 | 4 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:62:25:62:25 | b | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:62:25:62:25 | b | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:62:28:62:28 | 5 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:63:5:63:5 | a | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:63:5:63:16 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:64:5:64:5 | b | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:64:5:64:16 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:67:1:69:3 | call_block | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:68:5:68:11 | yield ... | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:68:11:68:11 | 1 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:71:1:75:3 | foo | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:72:5:72:7 | var | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:72:5:72:18 | ... = ... | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:72:11:72:14 | Hash | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:72:11:72:18 | call to new | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:73:5:73:7 | var | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:73:5:73:10 | ...[...] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:73:9:73:9 | 1 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:74:5:74:29 | call to call_block | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:74:5:74:29 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:74:16:74:29 | { ... } | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:74:19:74:19 | x | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:74:19:74:19 | x | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:74:22:74:24 | var | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:74:22:74:27 | ...[...] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:74:26:74:26 | x | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:77:1:80:3 | Integer | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:78:5:78:23 | bit_length | calls.rb:77:1:80:3 | Integer |
+| calls.rb:79:5:79:16 | abs | calls.rb:77:1:80:3 | Integer |
+| calls.rb:82:1:84:3 | String | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:83:5:83:23 | capitalize | calls.rb:82:1:84:3 | String |
+| calls.rb:86:1:88:3 | Kernel | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:87:5:87:17 | puts | calls.rb:86:1:88:3 | Kernel |
+| calls.rb:90:1:95:3 | Module | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:91:5:91:24 | module_eval | calls.rb:90:1:95:3 | Module |
+| calls.rb:92:5:92:20 | include | calls.rb:90:1:95:3 | Module |
+| calls.rb:93:5:93:20 | prepend | calls.rb:90:1:95:3 | Module |
+| calls.rb:94:5:94:20 | private | calls.rb:90:1:95:3 | Module |
+| calls.rb:97:1:100:3 | Object | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:97:16:97:21 | Module | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:98:5:98:18 | call to include | calls.rb:97:1:100:3 | Object |
+| calls.rb:98:5:98:18 | self | calls.rb:97:1:100:3 | Object |
+| calls.rb:98:13:98:18 | Kernel | calls.rb:97:1:100:3 | Object |
+| calls.rb:99:5:99:16 | new | calls.rb:97:1:100:3 | Object |
+| calls.rb:102:1:104:3 | Hash | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:103:5:103:15 | [] | calls.rb:102:1:104:3 | Hash |
+| calls.rb:106:1:117:3 | Array | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:107:3:107:13 | [] | calls.rb:106:1:117:3 | Array |
+| calls.rb:108:3:108:17 | length | calls.rb:106:1:117:3 | Array |
+| calls.rb:110:3:116:5 | foreach | calls.rb:106:1:117:3 | Array |
+| calls.rb:110:15:110:19 | &body | calls.rb:106:1:117:3 | Array |
+| calls.rb:110:16:110:19 | body | calls.rb:106:1:117:3 | Array |
+| calls.rb:111:5:111:5 | x | calls.rb:106:1:117:3 | Array |
+| calls.rb:111:5:111:9 | ... = ... | calls.rb:106:1:117:3 | Array |
+| calls.rb:111:9:111:9 | 0 | calls.rb:106:1:117:3 | Array |
+| calls.rb:112:5:115:7 | while ... | calls.rb:106:1:117:3 | Array |
+| calls.rb:112:11:112:11 | x | calls.rb:106:1:117:3 | Array |
+| calls.rb:112:11:112:25 | ... < ... | calls.rb:106:1:117:3 | Array |
+| calls.rb:112:15:112:18 | self | calls.rb:106:1:117:3 | Array |
+| calls.rb:112:15:112:25 | call to length | calls.rb:106:1:117:3 | Array |
+| calls.rb:112:26:115:7 | do ... | calls.rb:106:1:117:3 | Array |
+| calls.rb:113:9:113:24 | yield ... | calls.rb:106:1:117:3 | Array |
+| calls.rb:113:15:113:15 | x | calls.rb:106:1:117:3 | Array |
+| calls.rb:113:18:113:21 | self | calls.rb:106:1:117:3 | Array |
+| calls.rb:113:18:113:24 | ...[...] | calls.rb:106:1:117:3 | Array |
+| calls.rb:113:23:113:23 | x | calls.rb:106:1:117:3 | Array |
+| calls.rb:114:9:114:9 | x | calls.rb:106:1:117:3 | Array |
+| calls.rb:114:9:114:9 | x | calls.rb:106:1:117:3 | Array |
+| calls.rb:114:9:114:14 | ... += ... | calls.rb:106:1:117:3 | Array |
+| calls.rb:114:9:114:14 | ... = ... | calls.rb:106:1:117:3 | Array |
+| calls.rb:114:11:114:12 | ... + ... | calls.rb:106:1:117:3 | Array |
+| calls.rb:114:14:114:14 | 1 | calls.rb:106:1:117:3 | Array |
+| calls.rb:119:1:121:3 | funny | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:120:5:120:20 | yield ... | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:120:11:120:20 | "prefix: " | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:120:12:120:19 | prefix:  | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:1:123:30 | call to funny | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:1:123:30 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:7:123:30 | { ... } | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:10:123:10 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:10:123:10 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:13:123:29 | call to puts | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:13:123:29 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:18:123:18 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:123:18:123:29 | call to capitalize | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:125:1:125:3 | "a" | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:125:1:125:14 | call to capitalize | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:125:2:125:2 | a | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:126:1:126:1 | 1 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:126:1:126:12 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:127:1:127:1 | 1 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:127:1:127:5 | call to abs | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:1:129:13 | Array | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:1:129:13 | [...] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:1:129:13 | call to [] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:1:129:62 | call to foreach | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:2:129:4 | "a" | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:3:129:3 | a | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:6:129:8 | "b" | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:7:129:7 | b | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:10:129:12 | "c" | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:11:129:11 | c | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:23:129:62 | { ... } | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:26:129:26 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:26:129:26 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:29:129:29 | v | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:29:129:29 | v | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:32:129:61 | call to puts | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:32:129:61 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:37:129:61 | "#{...} -> #{...}" | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:38:129:41 | #{...} | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:40:129:40 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:42:129:45 |  ->  | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:46:129:60 | #{...} | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:48:129:48 | v | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:129:48:129:59 | call to capitalize | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:1:131:7 | Array | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:1:131:7 | [...] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:1:131:7 | call to [] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:1:131:35 | call to foreach | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:2:131:2 | 1 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:4:131:4 | 2 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:6:131:6 | 3 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:17:131:35 | { ... } | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:20:131:20 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:20:131:20 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:23:131:23 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:131:23:131:34 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:1:133:7 | Array | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:1:133:7 | [...] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:1:133:7 | call to [] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:1:133:40 | call to foreach | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:2:133:2 | 1 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:4:133:4 | 2 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:6:133:6 | 3 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:17:133:40 | { ... } | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:20:133:20 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:20:133:20 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:23:133:39 | call to puts | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:23:133:39 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:28:133:28 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:133:28:133:39 | call to capitalize | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:1:135:8 | Array | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:1:135:8 | [...] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:1:135:8 | call to [] | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:1:135:37 | call to foreach | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:2:135:2 | 1 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:4:135:5 | - ... | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:5:135:5 | 2 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:7:135:7 | 3 | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:18:135:37 | { ... } | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:21:135:21 | _ | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:21:135:21 | _ | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:24:135:24 | v | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:24:135:24 | v | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:27:135:36 | call to puts | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:27:135:36 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:32:135:32 | v | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:135:32:135:36 | call to abs | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:137:1:139:3 | indirect | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:137:14:137:15 | &b | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:137:15:137:15 | b | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:138:5:138:17 | call to call_block | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:138:5:138:17 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:138:16:138:17 | &... | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:138:17:138:17 | b | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:141:1:141:28 | call to indirect | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:141:1:141:28 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:141:10:141:28 | { ... } | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:141:13:141:13 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:141:13:141:13 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:141:16:141:16 | i | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:141:16:141:27 | call to bit_length | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:144:1:148:3 | S | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:145:5:147:7 | s_method | calls.rb:144:1:148:3 | S |
+| calls.rb:146:9:146:12 | self | calls.rb:144:1:148:3 | S |
+| calls.rb:146:9:146:17 | call to to_s | calls.rb:144:1:148:3 | S |
+| calls.rb:150:1:153:3 | A | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:150:11:150:11 | S | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:151:5:152:7 | to_s | calls.rb:150:1:153:3 | A |
+| calls.rb:155:1:158:3 | B | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:155:11:155:11 | S | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:156:5:157:7 | to_s | calls.rb:155:1:158:3 | B |
+| calls.rb:160:1:160:1 | S | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:160:1:160:5 | call to new | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:160:1:160:14 | call to s_method | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:161:1:161:1 | A | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:161:1:161:5 | call to new | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:161:1:161:14 | call to s_method | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:162:1:162:1 | B | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:162:1:162:5 | call to new | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:162:1:162:14 | call to s_method | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:164:1:165:3 | private_on_main | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:167:1:167:15 | call to private_on_main | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:167:1:167:15 | self | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:169:1:184:3 | Singletons | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:170:5:172:7 | singleton_a | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:170:9:170:12 | self | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:171:9:171:12 | self | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:171:9:171:24 | call to singleton_b | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:174:5:176:7 | singleton_b | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:174:9:174:12 | self | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:175:9:175:12 | self | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:175:9:175:24 | call to singleton_c | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:178:5:179:7 | singleton_c | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:178:9:178:12 | self | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:181:5:183:7 | singleton_d | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:181:9:181:12 | self | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:182:9:182:12 | self | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:182:9:182:24 | call to singleton_a | calls.rb:169:1:184:3 | Singletons |
+| calls.rb:186:1:186:10 | Singletons | calls.rb:1:1:186:22 | calls.rb |
+| calls.rb:186:1:186:22 | call to singleton_a | calls.rb:1:1:186:22 | calls.rb |
+| hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:22:3 | hello.rb |
+| hello.rb:2:5:4:7 | hello | hello.rb:1:1:8:3 | EnglishWords |
+| hello.rb:3:9:3:22 | return | hello.rb:1:1:8:3 | EnglishWords |
+| hello.rb:3:16:3:22 | "hello" | hello.rb:1:1:8:3 | EnglishWords |
+| hello.rb:3:17:3:21 | hello | hello.rb:1:1:8:3 | EnglishWords |
+| hello.rb:5:5:7:7 | world | hello.rb:1:1:8:3 | EnglishWords |
+| hello.rb:6:9:6:22 | return | hello.rb:1:1:8:3 | EnglishWords |
+| hello.rb:6:16:6:22 | "world" | hello.rb:1:1:8:3 | EnglishWords |
+| hello.rb:6:17:6:21 | world | hello.rb:1:1:8:3 | EnglishWords |
+| hello.rb:11:1:16:3 | Greeting | hello.rb:1:1:22:3 | hello.rb |
+| hello.rb:12:5:12:24 | call to include | hello.rb:11:1:16:3 | Greeting |
+| hello.rb:12:5:12:24 | self | hello.rb:11:1:16:3 | Greeting |
+| hello.rb:12:13:12:24 | EnglishWords | hello.rb:11:1:16:3 | Greeting |
+| hello.rb:13:5:15:7 | message | hello.rb:11:1:16:3 | Greeting |
+| hello.rb:14:9:14:20 | return | hello.rb:11:1:16:3 | Greeting |
+| hello.rb:14:16:14:20 | call to hello | hello.rb:11:1:16:3 | Greeting |
+| hello.rb:14:16:14:20 | self | hello.rb:11:1:16:3 | Greeting |
+| hello.rb:18:1:22:3 | HelloWorld | hello.rb:1:1:22:3 | hello.rb |
+| hello.rb:18:20:18:27 | Greeting | hello.rb:1:1:22:3 | hello.rb |
+| hello.rb:19:5:21:7 | message | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:9:20:40 | return | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:16:20:20 | call to super | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:16:20:26 | ... + ... | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:16:20:34 | ... + ... | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:16:20:40 | ... + ... | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:24:20:26 | " " | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:25:20:25 |   | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:30:20:34 | call to world | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:30:20:34 | self | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:38:20:40 | "!" | hello.rb:18:1:22:3 | HelloWorld |
+| hello.rb:20:39:20:39 | ! | hello.rb:18:1:22:3 | HelloWorld |
+| modules.rb:1:1:2:3 | Empty | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:4:1:24:3 | Foo | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:5:3:14:5 | Bar | modules.rb:4:1:24:3 | Foo |
+| modules.rb:6:5:7:7 | ClassInFooBar | modules.rb:5:3:14:5 | Bar |
+| modules.rb:9:5:10:7 | method_in_foo_bar | modules.rb:5:3:14:5 | Bar |
+| modules.rb:12:5:12:26 | call to puts | modules.rb:5:3:14:5 | Bar |
+| modules.rb:12:5:12:26 | self | modules.rb:5:3:14:5 | Bar |
+| modules.rb:12:10:12:26 | "module Foo::Bar" | modules.rb:5:3:14:5 | Bar |
+| modules.rb:12:11:12:25 | module Foo::Bar | modules.rb:5:3:14:5 | Bar |
+| modules.rb:13:5:13:15 | $global_var | modules.rb:5:3:14:5 | Bar |
+| modules.rb:13:5:13:19 | ... = ... | modules.rb:5:3:14:5 | Bar |
+| modules.rb:13:19:13:19 | 0 | modules.rb:5:3:14:5 | Bar |
+| modules.rb:16:3:17:5 | method_in_foo | modules.rb:4:1:24:3 | Foo |
+| modules.rb:19:3:20:5 | ClassInFoo | modules.rb:4:1:24:3 | Foo |
+| modules.rb:22:3:22:19 | call to puts | modules.rb:4:1:24:3 | Foo |
+| modules.rb:22:3:22:19 | self | modules.rb:4:1:24:3 | Foo |
+| modules.rb:22:8:22:19 | "module Foo" | modules.rb:4:1:24:3 | Foo |
+| modules.rb:22:9:22:18 | module Foo | modules.rb:4:1:24:3 | Foo |
+| modules.rb:23:3:23:13 | $global_var | modules.rb:4:1:24:3 | Foo |
+| modules.rb:23:3:23:17 | ... = ... | modules.rb:4:1:24:3 | Foo |
+| modules.rb:23:17:23:17 | 1 | modules.rb:4:1:24:3 | Foo |
+| modules.rb:26:1:35:3 | Foo | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:27:3:28:5 | method_in_another_definition_of_foo | modules.rb:26:1:35:3 | Foo |
+| modules.rb:30:3:31:5 | ClassInAnotherDefinitionOfFoo | modules.rb:26:1:35:3 | Foo |
+| modules.rb:33:3:33:25 | call to puts | modules.rb:26:1:35:3 | Foo |
+| modules.rb:33:3:33:25 | self | modules.rb:26:1:35:3 | Foo |
+| modules.rb:33:8:33:25 | "module Foo again" | modules.rb:26:1:35:3 | Foo |
+| modules.rb:33:9:33:24 | module Foo again | modules.rb:26:1:35:3 | Foo |
+| modules.rb:34:3:34:13 | $global_var | modules.rb:26:1:35:3 | Foo |
+| modules.rb:34:3:34:17 | ... = ... | modules.rb:26:1:35:3 | Foo |
+| modules.rb:34:17:34:17 | 2 | modules.rb:26:1:35:3 | Foo |
+| modules.rb:37:1:46:3 | Bar | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:38:3:39:5 | method_a | modules.rb:37:1:46:3 | Bar |
+| modules.rb:41:3:42:5 | method_b | modules.rb:37:1:46:3 | Bar |
+| modules.rb:44:3:44:19 | call to puts | modules.rb:37:1:46:3 | Bar |
+| modules.rb:44:3:44:19 | self | modules.rb:37:1:46:3 | Bar |
+| modules.rb:44:8:44:19 | "module Bar" | modules.rb:37:1:46:3 | Bar |
+| modules.rb:44:9:44:18 | module Bar | modules.rb:37:1:46:3 | Bar |
+| modules.rb:45:3:45:13 | $global_var | modules.rb:37:1:46:3 | Bar |
+| modules.rb:45:3:45:17 | ... = ... | modules.rb:37:1:46:3 | Bar |
+| modules.rb:45:17:45:17 | 3 | modules.rb:37:1:46:3 | Bar |
+| modules.rb:48:1:57:3 | Bar | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:48:8:48:10 | Foo | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:49:3:50:5 | ClassInAnotherDefinitionOfFooBar | modules.rb:48:1:57:3 | Bar |
+| modules.rb:52:3:53:5 | method_in_another_definition_of_foo_bar | modules.rb:48:1:57:3 | Bar |
+| modules.rb:55:3:55:30 | call to puts | modules.rb:48:1:57:3 | Bar |
+| modules.rb:55:3:55:30 | self | modules.rb:48:1:57:3 | Bar |
+| modules.rb:55:8:55:30 | "module Foo::Bar again" | modules.rb:48:1:57:3 | Bar |
+| modules.rb:55:9:55:29 | module Foo::Bar again | modules.rb:48:1:57:3 | Bar |
+| modules.rb:56:3:56:13 | $global_var | modules.rb:48:1:57:3 | Bar |
+| modules.rb:56:3:56:17 | ... = ... | modules.rb:48:1:57:3 | Bar |
+| modules.rb:56:17:56:17 | 4 | modules.rb:48:1:57:3 | Bar |
+| modules.rb:60:1:61:3 | MyModuleInGlobalScope | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:63:1:81:3 | Test | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:65:3:68:5 | Foo1 | modules.rb:63:1:81:3 | Test |
+| modules.rb:66:5:67:7 | Bar | modules.rb:65:3:68:5 | Foo1 |
+| modules.rb:66:11:66:14 | Foo1 | modules.rb:65:3:68:5 | Foo1 |
+| modules.rb:70:3:74:5 | Foo2 | modules.rb:63:1:81:3 | Test |
+| modules.rb:71:5:71:19 | Foo2 | modules.rb:70:3:74:5 | Foo2 |
+| modules.rb:72:5:73:7 | Bar | modules.rb:70:3:74:5 | Foo2 |
+| modules.rb:72:11:72:14 | Foo2 | modules.rb:70:3:74:5 | Foo2 |
+| modules.rb:76:3:80:5 | Foo3 | modules.rb:63:1:81:3 | Test |
+| modules.rb:77:5:77:8 | Foo3 | modules.rb:76:3:80:5 | Foo3 |
+| modules.rb:77:5:77:17 | ... = ... | modules.rb:76:3:80:5 | Foo3 |
+| modules.rb:77:12:77:17 | Object | modules.rb:76:3:80:5 | Foo3 |
+| modules.rb:78:5:79:7 | Bar | modules.rb:76:3:80:5 | Foo3 |
+| modules.rb:78:11:78:14 | Foo3 | modules.rb:76:3:80:5 | Foo3 |
+| modules.rb:83:1:86:3 | Other | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:84:3:85:5 | Foo1 | modules.rb:83:1:86:3 | Other |
+| modules.rb:88:1:93:3 | IncludeTest | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:89:3:89:16 | call to include | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:89:3:89:16 | self | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:89:11:89:16 | Test | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:90:3:90:8 | Object | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:90:3:90:38 | call to module_eval | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:90:22:90:38 | { ... } | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:90:24:90:36 | call to prepend | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:90:24:90:36 | self | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:90:32:90:36 | Other | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:91:3:92:5 | Y | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:91:10:91:13 | Foo1 | modules.rb:88:1:93:3 | IncludeTest |
+| modules.rb:95:1:99:3 | IncludeTest2 | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:96:3:96:14 | call to include | modules.rb:95:1:99:3 | IncludeTest2 |
+| modules.rb:96:3:96:14 | self | modules.rb:95:1:99:3 | IncludeTest2 |
+| modules.rb:96:11:96:14 | Test | modules.rb:95:1:99:3 | IncludeTest2 |
+| modules.rb:97:3:98:5 | Z | modules.rb:95:1:99:3 | IncludeTest2 |
+| modules.rb:97:10:97:13 | Foo1 | modules.rb:95:1:99:3 | IncludeTest2 |
+| modules.rb:101:1:105:3 | PrependTest | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:102:3:102:16 | call to prepend | modules.rb:101:1:105:3 | PrependTest |
+| modules.rb:102:3:102:16 | self | modules.rb:101:1:105:3 | PrependTest |
+| modules.rb:102:11:102:16 | Test | modules.rb:101:1:105:3 | PrependTest |
+| modules.rb:103:3:104:5 | Y | modules.rb:101:1:105:3 | PrependTest |
+| modules.rb:103:10:103:13 | Foo2 | modules.rb:101:1:105:3 | PrependTest |
+| modules.rb:107:1:110:3 | MM | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:108:3:109:5 | MM | modules.rb:107:1:110:3 | MM |
+| modules.rb:108:10:108:11 | MM | modules.rb:107:1:110:3 | MM |
+| modules.rb:112:1:113:3 | YY | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:115:1:121:3 | XX | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:116:7:117:9 | YY | modules.rb:115:1:121:3 | XX |
+| modules.rb:116:18:116:19 | YY | modules.rb:115:1:121:3 | XX |
+| modules.rb:119:7:120:9 | class << ... | modules.rb:115:1:121:3 | XX |
+| modules.rb:119:16:119:19 | self | modules.rb:119:7:120:9 | class << ... |
+| modules.rb:123:1:124:3 | Baz | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:123:8:123:11 | Test | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:123:8:123:17 | Foo1 | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:123:8:123:22 | Bar | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:126:1:126:2 | xx | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:126:1:126:11 | ... = ... | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:126:6:126:7 | XX | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:126:6:126:11 | call to new | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:128:1:129:3 | class << ... | modules.rb:1:1:129:4 | modules.rb |
+| modules.rb:128:10:128:11 | xx | modules.rb:128:1:129:3 | class << ... |
+| modules_rec.rb:1:1:2:3 | A | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| modules_rec.rb:1:7:1:7 | B | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| modules_rec.rb:4:1:5:3 | B | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| modules_rec.rb:4:7:4:7 | A | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| modules_rec.rb:7:1:9:3 | A | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| modules_rec.rb:7:11:7:11 | B | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| modules_rec.rb:8:3:8:11 | call to prepend | modules_rec.rb:7:1:9:3 | A |
+| modules_rec.rb:8:3:8:11 | self | modules_rec.rb:7:1:9:3 | A |
+| modules_rec.rb:8:11:8:11 | B | modules_rec.rb:7:1:9:3 | A |
+| modules_rec.rb:11:1:11:9 | call to prepend | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| modules_rec.rb:11:1:11:9 | self | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| modules_rec.rb:11:9:11:9 | A | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| private.rb:1:1:29:3 | E | private.rb:1:1:60:3 | private.rb |
+| private.rb:2:3:3:5 | call to private | private.rb:1:1:29:3 | E |
+| private.rb:2:3:3:5 | self | private.rb:1:1:29:3 | E |
+| private.rb:2:11:3:5 | private1 | private.rb:1:1:29:3 | E |
+| private.rb:5:3:6:5 | public | private.rb:1:1:29:3 | E |
+| private.rb:8:3:9:5 | private2 | private.rb:1:1:29:3 | E |
+| private.rb:10:3:10:19 | call to private | private.rb:1:1:29:3 | E |
+| private.rb:10:3:10:19 | self | private.rb:1:1:29:3 | E |
+| private.rb:10:11:10:19 | :private2 | private.rb:1:1:29:3 | E |
+| private.rb:10:11:10:19 | private2 | private.rb:1:1:29:3 | E |
+| private.rb:12:3:12:9 | call to private | private.rb:1:1:29:3 | E |
+| private.rb:12:3:12:9 | self | private.rb:1:1:29:3 | E |
+| private.rb:14:3:15:5 | private3 | private.rb:1:1:29:3 | E |
+| private.rb:17:3:18:5 | private4 | private.rb:1:1:29:3 | E |
+| private.rb:20:3:21:5 | public2 | private.rb:1:1:29:3 | E |
+| private.rb:20:7:20:10 | self | private.rb:1:1:29:3 | E |
+| private.rb:23:3:24:5 | call to private_class_method | private.rb:1:1:29:3 | E |
+| private.rb:23:3:24:5 | self | private.rb:1:1:29:3 | E |
+| private.rb:23:24:24:5 | private5 | private.rb:1:1:29:3 | E |
+| private.rb:23:28:23:31 | self | private.rb:1:1:29:3 | E |
+| private.rb:26:3:27:5 | private6 | private.rb:1:1:29:3 | E |
+| private.rb:26:7:26:10 | self | private.rb:1:1:29:3 | E |
+| private.rb:28:3:28:32 | call to private_class_method | private.rb:1:1:29:3 | E |
+| private.rb:28:3:28:32 | self | private.rb:1:1:29:3 | E |
+| private.rb:28:24:28:32 | :private6 | private.rb:1:1:29:3 | E |
+| private.rb:28:24:28:32 | private6 | private.rb:1:1:29:3 | E |
+| private.rb:31:1:32:3 | private_on_main | private.rb:1:1:60:3 | private.rb |
+| private.rb:34:1:34:1 | E | private.rb:1:1:60:3 | private.rb |
+| private.rb:34:1:34:5 | call to new | private.rb:1:1:60:3 | private.rb |
+| private.rb:34:1:34:14 | call to private1 | private.rb:1:1:60:3 | private.rb |
+| private.rb:35:1:35:1 | E | private.rb:1:1:60:3 | private.rb |
+| private.rb:35:1:35:5 | call to new | private.rb:1:1:60:3 | private.rb |
+| private.rb:35:1:35:14 | call to private2 | private.rb:1:1:60:3 | private.rb |
+| private.rb:36:1:36:1 | E | private.rb:1:1:60:3 | private.rb |
+| private.rb:36:1:36:5 | call to new | private.rb:1:1:60:3 | private.rb |
+| private.rb:36:1:36:14 | call to private3 | private.rb:1:1:60:3 | private.rb |
+| private.rb:37:1:37:1 | E | private.rb:1:1:60:3 | private.rb |
+| private.rb:37:1:37:5 | call to new | private.rb:1:1:60:3 | private.rb |
+| private.rb:37:1:37:14 | call to private4 | private.rb:1:1:60:3 | private.rb |
+| private.rb:38:1:38:1 | E | private.rb:1:1:60:3 | private.rb |
+| private.rb:38:1:38:5 | call to new | private.rb:1:1:60:3 | private.rb |
+| private.rb:38:1:38:12 | call to public | private.rb:1:1:60:3 | private.rb |
+| private.rb:40:1:40:15 | call to private_on_main | private.rb:1:1:60:3 | private.rb |
+| private.rb:40:1:40:15 | self | private.rb:1:1:60:3 | private.rb |
+| private.rb:42:1:60:3 | F | private.rb:1:1:60:3 | private.rb |
+| private.rb:43:3:44:5 | call to private | private.rb:42:1:60:3 | F |
+| private.rb:43:3:44:5 | self | private.rb:42:1:60:3 | F |
+| private.rb:43:11:44:5 | private1 | private.rb:42:1:60:3 | F |
+| private.rb:46:3:47:5 | public | private.rb:42:1:60:3 | F |
+| private.rb:49:3:50:5 | private2 | private.rb:42:1:60:3 | F |
+| private.rb:51:3:51:19 | call to private | private.rb:42:1:60:3 | F |
+| private.rb:51:3:51:19 | self | private.rb:42:1:60:3 | F |
+| private.rb:51:11:51:19 | :private2 | private.rb:42:1:60:3 | F |
+| private.rb:51:11:51:19 | private2 | private.rb:42:1:60:3 | F |
+| private.rb:53:3:53:9 | call to private | private.rb:42:1:60:3 | F |
+| private.rb:53:3:53:9 | self | private.rb:42:1:60:3 | F |
+| private.rb:55:3:56:5 | private3 | private.rb:42:1:60:3 | F |
+| private.rb:58:3:59:5 | private4 | private.rb:42:1:60:3 | F |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -712,7 +712,7 @@ enclosingModule
 | modules.rb:116:7:117:9 | YY | modules.rb:115:1:121:3 | XX |
 | modules.rb:116:18:116:19 | YY | modules.rb:115:1:121:3 | XX |
 | modules.rb:119:7:120:9 | class << ... | modules.rb:115:1:121:3 | XX |
-| modules.rb:119:16:119:19 | self | modules.rb:119:7:120:9 | class << ... |
+| modules.rb:119:16:119:19 | self | modules.rb:115:1:121:3 | XX |
 | modules.rb:123:1:124:3 | Baz | modules.rb:1:1:129:4 | modules.rb |
 | modules.rb:123:8:123:11 | Test | modules.rb:1:1:129:4 | modules.rb |
 | modules.rb:123:8:123:17 | Foo1 | modules.rb:1:1:129:4 | modules.rb |
@@ -722,7 +722,7 @@ enclosingModule
 | modules.rb:126:6:126:7 | XX | modules.rb:1:1:129:4 | modules.rb |
 | modules.rb:126:6:126:11 | call to new | modules.rb:1:1:129:4 | modules.rb |
 | modules.rb:128:1:129:3 | class << ... | modules.rb:1:1:129:4 | modules.rb |
-| modules.rb:128:10:128:11 | xx | modules.rb:128:1:129:3 | class << ... |
+| modules.rb:128:10:128:11 | xx | modules.rb:1:1:129:4 | modules.rb |
 | modules_rec.rb:1:1:2:3 | A | modules_rec.rb:1:1:11:26 | modules_rec.rb |
 | modules_rec.rb:1:7:1:7 | B | modules_rec.rb:1:1:11:26 | modules_rec.rb |
 | modules_rec.rb:4:1:5:3 | B | modules_rec.rb:1:1:11:26 | modules_rec.rb |

--- a/ruby/ql/test/library-tests/modules/modules.ql
+++ b/ruby/ql/test/library-tests/modules/modules.ql
@@ -18,3 +18,5 @@ query predicate resolveConstantReadAccess(ConstantReadAccess a, string s) {
 query predicate resolveConstantWriteAccess(ConstantWriteAccess c, string s) {
   s = Internal::resolveConstantWriteAccess(c)
 }
+
+query predicate enclosingModule(AstNode n, ModuleBase m) { m = n.getEnclosingModule() }

--- a/ruby/ql/test/library-tests/modules/modules.rb
+++ b/ruby/ql/test/library-tests/modules/modules.rb
@@ -115,7 +115,15 @@ end
 module XX
       class YY < YY
       end
+
+      class << self
+      end
 end
 
 module Test::Foo1::Bar::Baz
+end
+
+xx = XX.new
+
+class << xx
 end

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -147,7 +147,7 @@ modules.rb:
 #  116| XX::YY
 #-----|  -> YY
 
-#  120| Test::Foo1::Bar::Baz
+#  123| Test::Foo1::Bar::Baz
 
 modules_rec.rb:
 #    1| B::A


### PR DESCRIPTION
In

```rb
class << x
  ...
end
```

the scope of `x` is not the singleton class itself, but rather the outer scope.