### PR TITLE
JS: don't report every non-ascii range in js/overly-large-range

### DIFF
--- a/java/ql/lib/semmle/code/java/security/OverlyLargeRangeQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/OverlyLargeRangeQuery.qll
@@ -96,7 +96,10 @@ class OverlyWideRange extends RegExpCharacterRange {
       toCodePoint("A") <= high
       or
       // a non-alphanumeric char as part of the range boundaries
-      exists(int bound | bound = [low, high] | not isAlphanumeric(bound.toUnicode()))
+      exists(int bound | bound = [low, high] | not isAlphanumeric(bound.toUnicode())) and
+      // while still being ascii
+      low < 128 and
+      high < 128
     ) and
     // allowlist for known ranges
     not this = allowedWideRanges()

--- a/javascript/ql/lib/semmle/javascript/security/OverlyLargeRangeQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/OverlyLargeRangeQuery.qll
@@ -96,7 +96,10 @@ class OverlyWideRange extends RegExpCharacterRange {
       toCodePoint("A") <= high
       or
       // a non-alphanumeric char as part of the range boundaries
-      exists(int bound | bound = [low, high] | not isAlphanumeric(bound.toUnicode()))
+      exists(int bound | bound = [low, high] | not isAlphanumeric(bound.toUnicode())) and
+      // while still being ascii
+      low < 128 and
+      high < 128
     ) and
     // allowlist for known ranges
     not this = allowedWideRanges()

--- a/javascript/ql/test/query-tests/Security/CWE-020/SuspiciousRegexpRange/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-020/SuspiciousRegexpRange/tst.js
@@ -25,3 +25,6 @@ var numberToLetter = /[7-F]/; // NOT OK
 var overlapsWithClass1 = /[0-9\d]/; // NOT OK
 
 var overlapsWithClass2 = /[\w,.-?:*+]/; // NOT OK
+
+var tst2 = /^([ァ-ヾ]|[ｧ-ﾝﾞﾟ])+$/; // OK
+var tst3 = /[0-9０-９]/; // OK

--- a/python/ql/lib/semmle/python/security/OverlyLargeRangeQuery.qll
+++ b/python/ql/lib/semmle/python/security/OverlyLargeRangeQuery.qll
@@ -96,7 +96,10 @@ class OverlyWideRange extends RegExpCharacterRange {
       toCodePoint("A") <= high
       or
       // a non-alphanumeric char as part of the range boundaries
-      exists(int bound | bound = [low, high] | not isAlphanumeric(bound.toUnicode()))
+      exists(int bound | bound = [low, high] | not isAlphanumeric(bound.toUnicode())) and
+      // while still being ascii
+      low < 128 and
+      high < 128
     ) and
     // allowlist for known ranges
     not this = allowedWideRanges()

--- a/ruby/ql/lib/codeql/ruby/security/OverlyLargeRangeQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/OverlyLargeRangeQuery.qll
@@ -96,7 +96,10 @@ class OverlyWideRange extends RegExpCharacterRange {
       toCodePoint("A") <= high
       or
       // a non-alphanumeric char as part of the range boundaries
-      exists(int bound | bound = [low, high] | not isAlphanumeric(bound.toUnicode()))
+      exists(int bound | bound = [low, high] | not isAlphanumeric(bound.toUnicode())) and
+      // while still being ascii
+      low < 128 and
+      high < 128
     ) and
     // allowlist for known ranges
     not this = allowedWideRanges()


### PR DESCRIPTION
Fixes #10394

[Evaluation (JS) looks good](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-10410-252394__nightly-old__CustomSuite/reports).  
Significantly better performance, and removal of a bunch of ranges that seem to purposely use unicode-chars. 