### PR TITLE
Revert "Swift: print a helpful message on macOS ARM"

### DIFF
--- a/swift/rules.bzl
+++ b/swift/rules.bzl
@@ -5,7 +5,11 @@ def _wrap_cc(rule, kwargs):
     _add_args(kwargs, "copts", [
         # Required by LLVM/Swift
         "-fno-rtti",
-    ])
+    ] + select({
+        # temporary, before we do universal merging and have an arm prebuilt package, we make arm build x86
+        "@platforms//os:macos": ["-arch=x86_64"],
+        "//conditions:default": [],
+    }))
     _add_args(kwargs, "features", [
         # temporary, before we do universal merging
         "-universal_binaries",

--- a/swift/tools/prebuilt/BUILD.bazel
+++ b/swift/tools/prebuilt/BUILD.bazel
@@ -1,18 +1,21 @@
 package(default_visibility = ["//swift:__subpackages__"])
 
 #TODO we will be introducing universal binaries at a later stage, when we have both architectures prebuilt for macOS
-# for the moment, we require --cpu=darwin_x86_64 on an ARM macOS
+# for the moment, we make arm build an x86_64 binary
+_arch_override = {
+    "darwin_arm64": "darwin_x86_64",
+}
+
 [
     alias(
         name = name,
-        actual = select(
-            {
-                "@bazel_tools//src/conditions:%s" % arch: "@swift_prebuilt_%s//:%s" % (arch, name)
-                for arch in ("linux", "darwin_x86_64")
-            },
-            no_match_error = "Unsupported platform. Support for the ARM macOS platform is still a todo, " +
-                             "please pass --cpu=darwin_x86_64 for the time being",
-        ),
+        actual = select({
+            "@bazel_tools//src/conditions:%s" % arch: "@swift_prebuilt_%s//:%s" % (
+                _arch_override.get(arch, arch),
+                name,
+            )
+            for arch in ("linux", "darwin_x86_64", "darwin_arm64")
+        }),
     )
     for name in ("swift-llvm-support", "swift-test-sdk")
 ]


### PR DESCRIPTION
Reverts github/codeql#10399

This breaks bumping codeql on the internal repository. Some internal change is required to bring this back.