### PR TITLE
remove upper-case variable name from `HubClasses`

### DIFF
--- a/cpp/ql/src/Architecture/General Class-Level Information/HubClasses.ql
+++ b/cpp/ql/src/Architecture/General Class-Level Information/HubClasses.ql
@@ -12,5 +12,5 @@ import cpp
 
 from Class c
 where c.fromSource()
-select c as Class, c.getMetrics().getAfferentCoupling() as AfferentCoupling,
-  c.getMetrics().getEfferentSourceCoupling() as EfferentCoupling order by AfferentCoupling desc
+select c as Class, c.getMetrics().getAfferentCoupling() as afferentCoupling,
+  c.getMetrics().getEfferentSourceCoupling() as efferentCoupling order by afferentCoupling desc


### PR DESCRIPTION
We are phasing our upper-case variable names: https://github.com/github/codeql-core/issues/2157