### PR TITLE
Add lock files for Swift packs

### DIFF
--- a/swift/ql/lib/qlpack.lock.yml
+++ b/swift/ql/lib/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/swift/ql/src/qlpack.lock.yml
+++ b/swift/ql/src/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0


### PR DESCRIPTION
This fixes some existing CI failures in `main` around unresolved packages. Those failures still shouldn't have happened even without a lock file, but this will fix `main` while I investigate the underlying cause.
