### PR TITLE
remove several upper-case `NamedExpression` variable names

### DIFF
--- a/cpp/ql/src/Architecture/General Class-Level Information/InheritanceDepthDistribution.ql
+++ b/cpp/ql/src/Architecture/General Class-Level Information/InheritanceDepthDistribution.ql
@@ -16,5 +16,5 @@ predicate hasInheritanceDepth(Class c, int d) {
 
 from int depth
 where hasInheritanceDepth(_, depth)
-select depth as InheritanceDepth, count(Class c | hasInheritanceDepth(c, depth)) as NumberOfClasses
-  order by InheritanceDepth
+select depth as inheritanceDepth, count(Class c | hasInheritanceDepth(c, depth)) as numberOfClasses
+  order by inheritanceDepth

--- a/cpp/ql/src/Architecture/General Top-Level Information/GeneralStatistics.ql
+++ b/cpp/ql/src/Architecture/General Top-Level Information/GeneralStatistics.ql
@@ -51,4 +51,4 @@ where
         100 * sum(Class c | c.fromSource() | c.getMetrics().getEfferentSourceCoupling()) /
           sum(Class c | c.fromSource() | c.getMetrics().getEfferentCoupling())
       ).toString() + "%"
-select l as Title, n as Value
+select l as title, n as value

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyDependencies.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyDependencies.ql
@@ -16,4 +16,4 @@ where
   t.fromSource() and
   n = t.getMetrics().getEfferentSourceCoupling() and
   n > 10
-select t as Class, "This class has too many dependencies (" + n.toString() + ")"
+select t as class_, "This class has too many dependencies (" + n.toString() + ")"

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ComplexFunctions.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ComplexFunctions.ql
@@ -17,4 +17,4 @@ where
   n = f.getMetrics().getNumberOfCalls() and
   n > 99 and
   not f.isMultiplyDefined()
-select f as Function, "This function makes too many calls (" + n.toString() + ")"
+select f as function, "This function makes too many calls (" + n.toString() + ")"

--- a/cpp/ql/src/Metrics/Namespaces/AbstractNamespaces.ql
+++ b/cpp/ql/src/Metrics/Namespaces/AbstractNamespaces.ql
@@ -14,4 +14,4 @@ where
   n.fromSource() and
   c = n.getMetrics().getAbstractness() and
   c > 0.2
-select n as Namespace, c as Abstractness order by Abstractness desc
+select n as namespace, c as abstractness order by abstractness desc

--- a/cpp/ql/src/Metrics/Namespaces/ConcreteNamespaces.ql
+++ b/cpp/ql/src/Metrics/Namespaces/ConcreteNamespaces.ql
@@ -13,4 +13,4 @@ where
   n.fromSource() and
   c = n.getMetrics().getAbstractness() and
   c = 0
-select n as Namespace, c as Abstractness order by Abstractness desc
+select n as namespace, c as abstractness order by abstractness desc

--- a/cpp/ql/src/Metrics/Namespaces/HighAfferentCouplingNamespaces.ql
+++ b/cpp/ql/src/Metrics/Namespaces/HighAfferentCouplingNamespaces.ql
@@ -15,4 +15,4 @@ where
   n.fromSource() and
   c = n.getMetrics().getAfferentCoupling() and
   c > 20
-select n as Namespace, c as AfferentCoupling order by AfferentCoupling desc
+select n as namespace, c as afferentCoupling order by afferentCoupling desc

--- a/cpp/ql/src/Metrics/Namespaces/HighDistanceFromMainLineNamespaces.ql
+++ b/cpp/ql/src/Metrics/Namespaces/HighDistanceFromMainLineNamespaces.ql
@@ -15,4 +15,4 @@ where
   n.fromSource() and
   c = n.getMetrics().getDistanceFromMain() and
   c > 0.7
-select n as Namespace, c as DistanceFromMainline order by DistanceFromMainline desc
+select n as namespace, c as distanceFromMainline order by distanceFromMainline desc

--- a/cpp/ql/src/Metrics/Namespaces/HighEfferentCouplingNamespaces.ql
+++ b/cpp/ql/src/Metrics/Namespaces/HighEfferentCouplingNamespaces.ql
@@ -15,4 +15,4 @@ where
   n.fromSource() and
   c = n.getMetrics().getEfferentCoupling() and
   c > 20
-select n as Namespace, c as EfferentCoupling order by EfferentCoupling desc
+select n as namespace, c as efferentCoupling order by efferentCoupling desc

--- a/cpp/ql/src/Metrics/Namespaces/StableNamespaces.ql
+++ b/cpp/ql/src/Metrics/Namespaces/StableNamespaces.ql
@@ -14,4 +14,4 @@ where
   n.fromSource() and
   c = n.getMetrics().getInstability() and
   c < 0.2
-select n as Namespace, c as Instability order by Instability desc
+select n as namespace, c as instability order by instability desc

--- a/cpp/ql/src/Metrics/Namespaces/UnstableNamespaces.ql
+++ b/cpp/ql/src/Metrics/Namespaces/UnstableNamespaces.ql
@@ -14,4 +14,4 @@ where
   n.fromSource() and
   c = n.getMetrics().getInstability() and
   c > 0.8
-select n as Package, c as Instability order by Instability desc
+select n as package, c as instability order by instability desc


### PR DESCRIPTION
The previous problem (https://github.com/github/codeql/pull/10417) was apparently just hiding more.