### PR TITLE
Ruby: Fix bad join-order in DB upgrade script

### DIFF
--- a/ruby/ql/lib/upgrades/4ba51641799d2aaa315c7323931e2dd2a94c9f9d/locations_default.ql
+++ b/ruby/ql/lib/upgrades/4ba51641799d2aaa315c7323931e2dd2a94c9f9d/locations_default.ql
@@ -58,11 +58,11 @@ where
     ruby_ast_node_info(node, _, _, loc) and
     exists(Location first |
       body_statement(node, 0, first) and
-      locations_default(first, file, start_line, start_column, _, _)
+      locations_default(first, pragma[only_bind_into](file), start_line, start_column, _, _)
     ) and
     exists(Location last |
       last = max(Location l, int i | body_statement(node, i, l) | l order by i) and
-      locations_default(last, file, _, _, end_line, end_column)
+      locations_default(last, pragma[only_bind_into](file), _, _, end_line, end_column)
     )
   )
 select loc, file, start_line, start_column, end_line, end_column


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate #select#query#ffffff@3e1dedi5 with tuple counts:
          30411461   ~0%    {6} r1 = locations_default AND NOT #select#query#ffffff#antijoin_rhs(Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5)

          30840645   ~4%    {2} r2 = SCAN #select#query#ffff OUTPUT In.0, In.3
            515559   ~1%    {3} r3 = JOIN r2 WITH #select#query#ffffff#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1
            515559   ~0%    {5} r4 = JOIN r3 WITH locations_default ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Rhs.4, Rhs.5
        2397708060   ~0%    {9} r5 = JOIN r4 WITH locations_default_1023#join_rhs ON FIRST 1 OUTPUT Lhs.1, 0, Rhs.1, Lhs.2, Lhs.0, Lhs.3, Lhs.4, Rhs.2, Rhs.3
            515559   ~4%    {6} r6 = JOIN r5 WITH query#f0820431::body_statement#3#bff ON FIRST 3 OUTPUT Lhs.3, Lhs.4, Lhs.7, Lhs.8, Lhs.5, Lhs.6

          30927020   ~0%    {6} r7 = r1 UNION r6
                            return
```

After
```
Evaluated relational algebra for predicate #select#query#ffffff@8810e071 with tuple counts:
        30411461   ~0%    {6} r1 = #select#query#ffffff#shared AND NOT #select#query#ffffff#antijoin_rhs(Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5)

        30840645   ~4%    {2} r2 = SCAN #select#query#ffff OUTPUT In.0, In.3
          515559   ~1%    {3} r3 = JOIN r2 WITH #select#query#ffffff#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1
          515559   ~0%    {6} r4 = JOIN r3 WITH locations_default ON FIRST 1 OUTPUT Lhs.1, 0, Lhs.2, Rhs.1, Rhs.4, Rhs.5
          515559   ~0%    {5} r5 = JOIN r4 WITH query#f0820431::body_statement#3#bff ON FIRST 2 OUTPUT Rhs.2, Lhs.3, Lhs.2, Lhs.4, Lhs.5
          515559   ~0%    {6} r6 = JOIN r5 WITH locations_default ON FIRST 2 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.2, Rhs.3
          515559   ~4%    {6} r7 = JOIN r6 WITH files ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.4, Lhs.5, Lhs.2, Lhs.3

        30927020   ~0%    {6} r8 = r1 UNION r7
                          return r8
```