### PR TITLE
Swift: Fix missing results in swift/cleartext-storage-database

### DIFF
--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -43,24 +43,6 @@ class CoreDataStore extends Stored {
  */
 class RealmStore extends Stored {
   RealmStore() {
-    // `object` arg to `Realm.add` is a sink
-    exists(ClassDecl c, AbstractFunctionDecl f, CallExpr call |
-      c.getName() = "Realm" and
-      c.getAMember() = f and
-      f.getName() = "add(_:update:)" and
-      call.getStaticTarget() = f and
-      call.getArgument(0).getExpr() = this
-    )
-    or
-    // `value` arg to `Realm.create` is a sink
-    exists(ClassDecl c, AbstractFunctionDecl f, CallExpr call |
-      c.getName() = "Realm" and
-      c.getAMember() = f and
-      f.getName() = "create(_:value:update:)" and
-      call.getStaticTarget() = f and
-      call.getArgument(1).getExpr() = this
-    )
-    or
     // any access into a class derived from `RealmSwiftObject` is a sink
     exists(ClassDecl cd |
       cd.getABaseTypeDecl*().getName() = "RealmSwiftObject" and

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -46,10 +46,11 @@ class RealmStore extends Stored {
     // any write into a class derived from `RealmSwiftObject` is a sink. For
     // example in `realmObj.data = sensitive` the post-update node corresponding
     // with `realmObj.data` is a sink.
-    exists(ClassDecl cd |
+    exists(ClassDecl cd, Expr e |
       cd.getABaseTypeDecl*().getName() = "RealmSwiftObject" and
-      this.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getFullyConverted().getType() =
-        cd.getType()
+      this.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr() = e and
+      e.getFullyConverted().getType() = cd.getType() and
+      not e.(DeclRefExpr).getDecl() instanceof SelfParamDecl
     )
   }
 }

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -78,7 +78,7 @@ class CleartextStorageConfig extends TaintTracking::Configuration {
 
   override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
     // flow out from fields of a `RealmSwiftObject` at the sink, for example in
-    // `obj.var = tainted; sink(obj)`.
+    // `realmObj.data = sensitive`.
     isSink(node) and
     exists(ClassDecl cd |
       c.getAReadContent().(DataFlow::Content::FieldContent).getField() = cd.getAMember() and

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -18,12 +18,12 @@ import codeql.swift.dataflow.TaintTracking
 import DataFlow::PathGraph
 
 /**
- * An `Expr` that is stored in a local database.
+ * A `DataFlow::Node` that is something stored in a local database.
  */
 abstract class Stored extends DataFlow::Node { }
 
 /**
- * An `Expr` that is stored with the Core Data library.
+ * A `DataFlow::Node` that is an expression stored with the Core Data library.
  */
 class CoreDataStore extends Stored {
   CoreDataStore() {
@@ -39,16 +39,17 @@ class CoreDataStore extends Stored {
 }
 
 /**
- * An `Expr` that is stored with the Realm database library.
+ * A `DataFlow::Node` that is an expression stored with the Realm database
+ * library.
  */
-class RealmStore extends Stored {
+class RealmStore extends Stored instanceof DataFlow::PostUpdateNode {
   RealmStore() {
     // any write into a class derived from `RealmSwiftObject` is a sink. For
     // example in `realmObj.data = sensitive` the post-update node corresponding
     // with `realmObj.data` is a sink.
     exists(ClassDecl cd, Expr e |
       cd.getABaseTypeDecl*().getName() = "RealmSwiftObject" and
-      this.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr() = e and
+      this.getPreUpdateNode().asExpr() = e and
       e.getFullyConverted().getType() = cd.getType() and
       not e.(DeclRefExpr).getDecl() instanceof SelfParamDecl
     )

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -16,23 +16,17 @@ edges
 | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | value :  |
 | testRealm.swift:34:2:34:2 | [post] a :  | testRealm.swift:34:2:34:2 | a |
 | testRealm.swift:34:2:34:2 | [post] a :  | testRealm.swift:34:2:34:2 | a :  |
-| testRealm.swift:34:2:34:2 | [post] a :  | testRealm.swift:35:12:35:12 | a |
 | testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:34:2:34:2 | a |
 | testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:34:2:34:2 | a :  |
-| testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:35:12:35:12 | a |
 | testRealm.swift:34:2:34:2 | a :  | testRealm.swift:16:6:16:6 | self :  |
-| testRealm.swift:34:2:34:2 | a :  | testRealm.swift:35:12:35:12 | a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a [data] :  |
 | testRealm.swift:42:2:42:2 | [post] c :  | testRealm.swift:42:2:42:2 | c |
 | testRealm.swift:42:2:42:2 | [post] c :  | testRealm.swift:42:2:42:2 | c :  |
-| testRealm.swift:42:2:42:2 | [post] c :  | testRealm.swift:43:47:43:47 | c |
 | testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:42:2:42:2 | c |
 | testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:42:2:42:2 | c :  |
-| testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:43:47:43:47 | c |
 | testRealm.swift:42:2:42:2 | c :  | testRealm.swift:16:6:16:6 | self :  |
-| testRealm.swift:42:2:42:2 | c :  | testRealm.swift:43:47:43:47 | c |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c :  |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c [data] :  |
@@ -91,13 +85,11 @@ nodes
 | testRealm.swift:34:2:34:2 | a | semmle.label | a |
 | testRealm.swift:34:2:34:2 | a :  | semmle.label | a :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | semmle.label | myPassword :  |
-| testRealm.swift:35:12:35:12 | a | semmle.label | a |
 | testRealm.swift:42:2:42:2 | [post] c :  | semmle.label | [post] c :  |
 | testRealm.swift:42:2:42:2 | [post] c [data] :  | semmle.label | [post] c [data] :  |
 | testRealm.swift:42:2:42:2 | c | semmle.label | c |
 | testRealm.swift:42:2:42:2 | c :  | semmle.label | c :  |
 | testRealm.swift:42:11:42:11 | myPassword :  | semmle.label | myPassword :  |
-| testRealm.swift:43:47:43:47 | c | semmle.label | c |
 | testRealm.swift:52:2:52:3 | ...! | semmle.label | ...! |
 | testRealm.swift:52:2:52:3 | ...! :  | semmle.label | ...! :  |
 | testRealm.swift:52:2:52:3 | [post] ...! :  | semmle.label | [post] ...! :  |
@@ -136,9 +128,7 @@ subpaths
 | testCoreData.swift:96:15:96:15 | y | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:92:10:92:10 | passwd :  | passwd |
 | testCoreData.swift:97:15:97:15 | z | testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z | This operation stores 'z' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:93:10:93:10 | passwd :  | passwd |
 | testRealm.swift:34:2:34:2 | a | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
-| testRealm.swift:35:12:35:12 | a | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:35:12:35:12 | a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
 | testRealm.swift:42:2:42:2 | c | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
-| testRealm.swift:43:47:43:47 | c | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:43:47:43:47 | c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
 | testRealm.swift:52:2:52:3 | ...! | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | ...! | This operation stores '...!' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:52:12:52:12 | myPassword :  | myPassword |
 | testRealm.swift:59:2:59:2 | g | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | g | This operation stores 'g' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |
 | testRealm.swift:60:2:60:2 | g | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:60:2:60:2 | g | This operation stores 'g' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -1,7 +1,6 @@
 edges
-| file://:0:0:0:0 | [post] self :  | file://:0:0:0:0 | self |
+| file://:0:0:0:0 | [post] self [data] :  | file://:0:0:0:0 | [post] self |
 | file://:0:0:0:0 | [post] self [data] :  | file://:0:0:0:0 | [post] self :  |
-| file://:0:0:0:0 | [post] self [data] :  | file://:0:0:0:0 | self |
 | file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [data] :  |
 | testCoreData.swift:18:19:18:26 | value :  | testCoreData.swift:19:12:19:12 | value |
 | testCoreData.swift:31:3:31:3 | newValue :  | testCoreData.swift:32:13:32:13 | newValue |
@@ -12,51 +11,27 @@ edges
 | testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:95:15:95:15 | x |
 | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y |
 | testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z |
-| testRealm.swift:16:6:16:6 | self :  | file://:0:0:0:0 | self |
 | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | value :  |
-| testRealm.swift:34:2:34:2 | [post] a :  | testRealm.swift:34:2:34:2 | a |
-| testRealm.swift:34:2:34:2 | [post] a :  | testRealm.swift:34:2:34:2 | a :  |
-| testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:34:2:34:2 | a |
-| testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:34:2:34:2 | a :  |
-| testRealm.swift:34:2:34:2 | a :  | testRealm.swift:16:6:16:6 | self :  |
+| testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:34:2:34:2 | [post] a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
-| testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a :  |
+| testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a [data] :  |
-| testRealm.swift:42:2:42:2 | [post] c :  | testRealm.swift:42:2:42:2 | c |
-| testRealm.swift:42:2:42:2 | [post] c :  | testRealm.swift:42:2:42:2 | c :  |
-| testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:42:2:42:2 | c |
-| testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:42:2:42:2 | c :  |
-| testRealm.swift:42:2:42:2 | c :  | testRealm.swift:16:6:16:6 | self :  |
+| testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:42:2:42:2 | [post] c |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
-| testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c :  |
+| testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c [data] :  |
-| testRealm.swift:52:2:52:3 | ...! :  | testRealm.swift:16:6:16:6 | self :  |
-| testRealm.swift:52:2:52:3 | [post] ...! :  | testRealm.swift:52:2:52:3 | ...! |
-| testRealm.swift:52:2:52:3 | [post] ...! :  | testRealm.swift:52:2:52:3 | ...! :  |
-| testRealm.swift:52:2:52:3 | [post] ...! [data] :  | testRealm.swift:52:2:52:3 | ...! |
-| testRealm.swift:52:2:52:3 | [post] ...! [data] :  | testRealm.swift:52:2:52:3 | ...! :  |
+| testRealm.swift:52:2:52:3 | [post] ...! [data] :  | testRealm.swift:52:2:52:3 | [post] ...! |
 | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
-| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | [post] ...! :  |
+| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | [post] ...! |
 | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | [post] ...! [data] :  |
-| testRealm.swift:59:2:59:2 | [post] g :  | testRealm.swift:59:2:59:2 | g |
-| testRealm.swift:59:2:59:2 | [post] g :  | testRealm.swift:59:2:59:2 | g :  |
-| testRealm.swift:59:2:59:2 | [post] g :  | testRealm.swift:60:2:60:2 | g |
-| testRealm.swift:59:2:59:2 | [post] g :  | testRealm.swift:60:2:60:2 | g :  |
-| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:59:2:59:2 | g |
-| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:59:2:59:2 | g :  |
-| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:60:2:60:2 | g |
-| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:60:2:60:2 | g :  |
-| testRealm.swift:59:2:59:2 | g :  | testRealm.swift:16:6:16:6 | self :  |
-| testRealm.swift:59:2:59:2 | g :  | testRealm.swift:60:2:60:2 | g |
-| testRealm.swift:59:2:59:2 | g :  | testRealm.swift:60:2:60:2 | g :  |
+| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:59:2:59:2 | [post] g |
 | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
-| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | [post] g :  |
+| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | [post] g |
 | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | [post] g [data] :  |
-| testRealm.swift:60:2:60:2 | g :  | testRealm.swift:16:6:16:6 | self :  |
 nodes
+| file://:0:0:0:0 | [post] self | semmle.label | [post] self |
 | file://:0:0:0:0 | [post] self :  | semmle.label | [post] self :  |
 | file://:0:0:0:0 | [post] self [data] :  | semmle.label | [post] self [data] :  |
-| file://:0:0:0:0 | self | semmle.label | self |
 | file://:0:0:0:0 | value :  | semmle.label | value :  |
 | testCoreData.swift:18:19:18:26 | value :  | semmle.label | value :  |
 | testCoreData.swift:19:12:19:12 | value | semmle.label | value |
@@ -78,44 +53,33 @@ nodes
 | testCoreData.swift:95:15:95:15 | x | semmle.label | x |
 | testCoreData.swift:96:15:96:15 | y | semmle.label | y |
 | testCoreData.swift:97:15:97:15 | z | semmle.label | z |
-| testRealm.swift:16:6:16:6 | self :  | semmle.label | self :  |
 | testRealm.swift:16:6:16:6 | value :  | semmle.label | value :  |
-| testRealm.swift:34:2:34:2 | [post] a :  | semmle.label | [post] a :  |
+| testRealm.swift:34:2:34:2 | [post] a | semmle.label | [post] a |
 | testRealm.swift:34:2:34:2 | [post] a [data] :  | semmle.label | [post] a [data] :  |
-| testRealm.swift:34:2:34:2 | a | semmle.label | a |
-| testRealm.swift:34:2:34:2 | a :  | semmle.label | a :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | semmle.label | myPassword :  |
-| testRealm.swift:42:2:42:2 | [post] c :  | semmle.label | [post] c :  |
+| testRealm.swift:42:2:42:2 | [post] c | semmle.label | [post] c |
 | testRealm.swift:42:2:42:2 | [post] c [data] :  | semmle.label | [post] c [data] :  |
-| testRealm.swift:42:2:42:2 | c | semmle.label | c |
-| testRealm.swift:42:2:42:2 | c :  | semmle.label | c :  |
 | testRealm.swift:42:11:42:11 | myPassword :  | semmle.label | myPassword :  |
-| testRealm.swift:52:2:52:3 | ...! | semmle.label | ...! |
-| testRealm.swift:52:2:52:3 | ...! :  | semmle.label | ...! :  |
-| testRealm.swift:52:2:52:3 | [post] ...! :  | semmle.label | [post] ...! :  |
+| testRealm.swift:52:2:52:3 | [post] ...! | semmle.label | [post] ...! |
 | testRealm.swift:52:2:52:3 | [post] ...! [data] :  | semmle.label | [post] ...! [data] :  |
 | testRealm.swift:52:12:52:12 | myPassword :  | semmle.label | myPassword :  |
-| testRealm.swift:59:2:59:2 | [post] g :  | semmle.label | [post] g :  |
+| testRealm.swift:59:2:59:2 | [post] g | semmle.label | [post] g |
 | testRealm.swift:59:2:59:2 | [post] g [data] :  | semmle.label | [post] g [data] :  |
-| testRealm.swift:59:2:59:2 | g | semmle.label | g |
-| testRealm.swift:59:2:59:2 | g :  | semmle.label | g :  |
 | testRealm.swift:59:11:59:11 | myPassword :  | semmle.label | myPassword :  |
-| testRealm.swift:60:2:60:2 | g | semmle.label | g |
-| testRealm.swift:60:2:60:2 | g :  | semmle.label | g :  |
 subpaths
-| testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:34:2:34:2 | [post] a :  |
+| testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:34:2:34:2 | [post] a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:34:2:34:2 | [post] a [data] :  |
-| testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:42:2:42:2 | [post] c :  |
+| testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:42:2:42:2 | [post] c |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:42:2:42:2 | [post] c [data] :  |
-| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:52:2:52:3 | [post] ...! :  |
+| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:52:2:52:3 | [post] ...! |
 | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:52:2:52:3 | [post] ...! [data] :  |
-| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:59:2:59:2 | [post] g :  |
+| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:59:2:59:2 | [post] g |
 | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:59:2:59:2 | [post] g [data] :  |
 #select
-| file://:0:0:0:0 | self | testRealm.swift:34:11:34:11 | myPassword :  | file://:0:0:0:0 | self | This operation stores 'self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
-| file://:0:0:0:0 | self | testRealm.swift:42:11:42:11 | myPassword :  | file://:0:0:0:0 | self | This operation stores 'self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
-| file://:0:0:0:0 | self | testRealm.swift:52:12:52:12 | myPassword :  | file://:0:0:0:0 | self | This operation stores 'self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:52:12:52:12 | myPassword :  | myPassword |
-| file://:0:0:0:0 | self | testRealm.swift:59:11:59:11 | myPassword :  | file://:0:0:0:0 | self | This operation stores 'self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |
+| file://:0:0:0:0 | self | testRealm.swift:34:11:34:11 | myPassword :  | file://:0:0:0:0 | [post] self | This operation stores '[post] self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
+| file://:0:0:0:0 | self | testRealm.swift:42:11:42:11 | myPassword :  | file://:0:0:0:0 | [post] self | This operation stores '[post] self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
+| file://:0:0:0:0 | self | testRealm.swift:52:12:52:12 | myPassword :  | file://:0:0:0:0 | [post] self | This operation stores '[post] self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:52:12:52:12 | myPassword :  | myPassword |
+| file://:0:0:0:0 | self | testRealm.swift:59:11:59:11 | myPassword :  | file://:0:0:0:0 | [post] self | This operation stores '[post] self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |
 | testCoreData.swift:19:12:19:12 | value | testCoreData.swift:61:25:61:25 | password :  | testCoreData.swift:19:12:19:12 | value | This operation stores 'value' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:61:25:61:25 | password :  | password |
 | testCoreData.swift:32:13:32:13 | newValue | testCoreData.swift:64:16:64:16 | password :  | testCoreData.swift:32:13:32:13 | newValue | This operation stores 'newValue' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:64:16:64:16 | password :  | password |
 | testCoreData.swift:48:15:48:15 | password | testCoreData.swift:48:15:48:15 | password | testCoreData.swift:48:15:48:15 | password | This operation stores 'password' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:48:15:48:15 | password | password |
@@ -127,8 +91,7 @@ subpaths
 | testCoreData.swift:95:15:95:15 | x | testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:95:15:95:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:91:10:91:10 | passwd :  | passwd |
 | testCoreData.swift:96:15:96:15 | y | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:92:10:92:10 | passwd :  | passwd |
 | testCoreData.swift:97:15:97:15 | z | testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z | This operation stores 'z' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:93:10:93:10 | passwd :  | passwd |
-| testRealm.swift:34:2:34:2 | a | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
-| testRealm.swift:42:2:42:2 | c | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
-| testRealm.swift:52:2:52:3 | ...! | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | ...! | This operation stores '...!' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:52:12:52:12 | myPassword :  | myPassword |
-| testRealm.swift:59:2:59:2 | g | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | g | This operation stores 'g' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |
-| testRealm.swift:60:2:60:2 | g | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:60:2:60:2 | g | This operation stores 'g' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |
+| testRealm.swift:34:2:34:2 | a | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a | This operation stores '[post] a' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
+| testRealm.swift:42:2:42:2 | c | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c | This operation stores '[post] c' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
+| testRealm.swift:52:2:52:3 | ...! | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | [post] ...! | This operation stores '[post] ...!' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:52:12:52:12 | myPassword :  | myPassword |
+| testRealm.swift:59:2:59:2 | g | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | [post] g | This operation stores '[post] g' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -1,4 +1,7 @@
 edges
+| file://:0:0:0:0 | [post] self :  | file://:0:0:0:0 | self |
+| file://:0:0:0:0 | [post] self [data] :  | file://:0:0:0:0 | [post] self :  |
+| file://:0:0:0:0 | [post] self [data] :  | file://:0:0:0:0 | self |
 | file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [data] :  |
 | testCoreData.swift:18:19:18:26 | value :  | testCoreData.swift:19:12:19:12 | value |
 | testCoreData.swift:31:3:31:3 | newValue :  | testCoreData.swift:32:13:32:13 | newValue |
@@ -9,15 +12,57 @@ edges
 | testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:95:15:95:15 | x |
 | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y |
 | testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z |
+| testRealm.swift:16:6:16:6 | self :  | file://:0:0:0:0 | self |
 | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | value :  |
+| testRealm.swift:34:2:34:2 | [post] a :  | testRealm.swift:34:2:34:2 | a |
+| testRealm.swift:34:2:34:2 | [post] a :  | testRealm.swift:34:2:34:2 | a :  |
+| testRealm.swift:34:2:34:2 | [post] a :  | testRealm.swift:35:12:35:12 | a |
+| testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:34:2:34:2 | a |
+| testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:34:2:34:2 | a :  |
 | testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:35:12:35:12 | a |
+| testRealm.swift:34:2:34:2 | a :  | testRealm.swift:16:6:16:6 | self :  |
+| testRealm.swift:34:2:34:2 | a :  | testRealm.swift:35:12:35:12 | a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
+| testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a [data] :  |
+| testRealm.swift:42:2:42:2 | [post] c :  | testRealm.swift:42:2:42:2 | c |
+| testRealm.swift:42:2:42:2 | [post] c :  | testRealm.swift:42:2:42:2 | c :  |
+| testRealm.swift:42:2:42:2 | [post] c :  | testRealm.swift:43:47:43:47 | c |
+| testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:42:2:42:2 | c |
+| testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:42:2:42:2 | c :  |
 | testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:43:47:43:47 | c |
+| testRealm.swift:42:2:42:2 | c :  | testRealm.swift:16:6:16:6 | self :  |
+| testRealm.swift:42:2:42:2 | c :  | testRealm.swift:43:47:43:47 | c |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
+| testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c :  |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c [data] :  |
+| testRealm.swift:52:2:52:3 | ...! :  | testRealm.swift:16:6:16:6 | self :  |
+| testRealm.swift:52:2:52:3 | [post] ...! :  | testRealm.swift:52:2:52:3 | ...! |
+| testRealm.swift:52:2:52:3 | [post] ...! :  | testRealm.swift:52:2:52:3 | ...! :  |
+| testRealm.swift:52:2:52:3 | [post] ...! [data] :  | testRealm.swift:52:2:52:3 | ...! |
+| testRealm.swift:52:2:52:3 | [post] ...! [data] :  | testRealm.swift:52:2:52:3 | ...! :  |
+| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
+| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | [post] ...! :  |
+| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | [post] ...! [data] :  |
+| testRealm.swift:59:2:59:2 | [post] g :  | testRealm.swift:59:2:59:2 | g |
+| testRealm.swift:59:2:59:2 | [post] g :  | testRealm.swift:59:2:59:2 | g :  |
+| testRealm.swift:59:2:59:2 | [post] g :  | testRealm.swift:60:2:60:2 | g |
+| testRealm.swift:59:2:59:2 | [post] g :  | testRealm.swift:60:2:60:2 | g :  |
+| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:59:2:59:2 | g |
+| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:59:2:59:2 | g :  |
+| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:60:2:60:2 | g |
+| testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:60:2:60:2 | g :  |
+| testRealm.swift:59:2:59:2 | g :  | testRealm.swift:16:6:16:6 | self :  |
+| testRealm.swift:59:2:59:2 | g :  | testRealm.swift:60:2:60:2 | g |
+| testRealm.swift:59:2:59:2 | g :  | testRealm.swift:60:2:60:2 | g :  |
+| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
+| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | [post] g :  |
+| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | [post] g [data] :  |
+| testRealm.swift:60:2:60:2 | g :  | testRealm.swift:16:6:16:6 | self :  |
 nodes
+| file://:0:0:0:0 | [post] self :  | semmle.label | [post] self :  |
 | file://:0:0:0:0 | [post] self [data] :  | semmle.label | [post] self [data] :  |
+| file://:0:0:0:0 | self | semmle.label | self |
 | file://:0:0:0:0 | value :  | semmle.label | value :  |
 | testCoreData.swift:18:19:18:26 | value :  | semmle.label | value :  |
 | testCoreData.swift:19:12:19:12 | value | semmle.label | value |
@@ -39,17 +84,46 @@ nodes
 | testCoreData.swift:95:15:95:15 | x | semmle.label | x |
 | testCoreData.swift:96:15:96:15 | y | semmle.label | y |
 | testCoreData.swift:97:15:97:15 | z | semmle.label | z |
+| testRealm.swift:16:6:16:6 | self :  | semmle.label | self :  |
 | testRealm.swift:16:6:16:6 | value :  | semmle.label | value :  |
+| testRealm.swift:34:2:34:2 | [post] a :  | semmle.label | [post] a :  |
 | testRealm.swift:34:2:34:2 | [post] a [data] :  | semmle.label | [post] a [data] :  |
+| testRealm.swift:34:2:34:2 | a | semmle.label | a |
+| testRealm.swift:34:2:34:2 | a :  | semmle.label | a :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | semmle.label | myPassword :  |
 | testRealm.swift:35:12:35:12 | a | semmle.label | a |
+| testRealm.swift:42:2:42:2 | [post] c :  | semmle.label | [post] c :  |
 | testRealm.swift:42:2:42:2 | [post] c [data] :  | semmle.label | [post] c [data] :  |
+| testRealm.swift:42:2:42:2 | c | semmle.label | c |
+| testRealm.swift:42:2:42:2 | c :  | semmle.label | c :  |
 | testRealm.swift:42:11:42:11 | myPassword :  | semmle.label | myPassword :  |
 | testRealm.swift:43:47:43:47 | c | semmle.label | c |
+| testRealm.swift:52:2:52:3 | ...! | semmle.label | ...! |
+| testRealm.swift:52:2:52:3 | ...! :  | semmle.label | ...! :  |
+| testRealm.swift:52:2:52:3 | [post] ...! :  | semmle.label | [post] ...! :  |
+| testRealm.swift:52:2:52:3 | [post] ...! [data] :  | semmle.label | [post] ...! [data] :  |
+| testRealm.swift:52:12:52:12 | myPassword :  | semmle.label | myPassword :  |
+| testRealm.swift:59:2:59:2 | [post] g :  | semmle.label | [post] g :  |
+| testRealm.swift:59:2:59:2 | [post] g [data] :  | semmle.label | [post] g [data] :  |
+| testRealm.swift:59:2:59:2 | g | semmle.label | g |
+| testRealm.swift:59:2:59:2 | g :  | semmle.label | g :  |
+| testRealm.swift:59:11:59:11 | myPassword :  | semmle.label | myPassword :  |
+| testRealm.swift:60:2:60:2 | g | semmle.label | g |
+| testRealm.swift:60:2:60:2 | g :  | semmle.label | g :  |
 subpaths
+| testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:34:2:34:2 | [post] a :  |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:34:2:34:2 | [post] a [data] :  |
+| testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:42:2:42:2 | [post] c :  |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:42:2:42:2 | [post] c [data] :  |
+| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:52:2:52:3 | [post] ...! :  |
+| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:52:2:52:3 | [post] ...! [data] :  |
+| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:59:2:59:2 | [post] g :  |
+| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:59:2:59:2 | [post] g [data] :  |
 #select
+| file://:0:0:0:0 | self | testRealm.swift:34:11:34:11 | myPassword :  | file://:0:0:0:0 | self | This operation stores 'self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
+| file://:0:0:0:0 | self | testRealm.swift:42:11:42:11 | myPassword :  | file://:0:0:0:0 | self | This operation stores 'self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
+| file://:0:0:0:0 | self | testRealm.swift:52:12:52:12 | myPassword :  | file://:0:0:0:0 | self | This operation stores 'self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:52:12:52:12 | myPassword :  | myPassword |
+| file://:0:0:0:0 | self | testRealm.swift:59:11:59:11 | myPassword :  | file://:0:0:0:0 | self | This operation stores 'self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |
 | testCoreData.swift:19:12:19:12 | value | testCoreData.swift:61:25:61:25 | password :  | testCoreData.swift:19:12:19:12 | value | This operation stores 'value' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:61:25:61:25 | password :  | password |
 | testCoreData.swift:32:13:32:13 | newValue | testCoreData.swift:64:16:64:16 | password :  | testCoreData.swift:32:13:32:13 | newValue | This operation stores 'newValue' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:64:16:64:16 | password :  | password |
 | testCoreData.swift:48:15:48:15 | password | testCoreData.swift:48:15:48:15 | password | testCoreData.swift:48:15:48:15 | password | This operation stores 'password' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:48:15:48:15 | password | password |
@@ -61,5 +135,10 @@ subpaths
 | testCoreData.swift:95:15:95:15 | x | testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:95:15:95:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:91:10:91:10 | passwd :  | passwd |
 | testCoreData.swift:96:15:96:15 | y | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:92:10:92:10 | passwd :  | passwd |
 | testCoreData.swift:97:15:97:15 | z | testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z | This operation stores 'z' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:93:10:93:10 | passwd :  | passwd |
+| testRealm.swift:34:2:34:2 | a | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
 | testRealm.swift:35:12:35:12 | a | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:35:12:35:12 | a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
+| testRealm.swift:42:2:42:2 | c | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
 | testRealm.swift:43:47:43:47 | c | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:43:47:43:47 | c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
+| testRealm.swift:52:2:52:3 | ...! | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | ...! | This operation stores '...!' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:52:12:52:12 | myPassword :  | myPassword |
+| testRealm.swift:59:2:59:2 | g | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | g | This operation stores 'g' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |
+| testRealm.swift:60:2:60:2 | g | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:60:2:60:2 | g | This operation stores 'g' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -1,6 +1,4 @@
 edges
-| file://:0:0:0:0 | [post] self [data] :  | file://:0:0:0:0 | [post] self |
-| file://:0:0:0:0 | [post] self [data] :  | file://:0:0:0:0 | [post] self :  |
 | file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [data] :  |
 | testCoreData.swift:18:19:18:26 | value :  | testCoreData.swift:19:12:19:12 | value |
 | testCoreData.swift:31:3:31:3 | newValue :  | testCoreData.swift:32:13:32:13 | newValue |
@@ -14,23 +12,17 @@ edges
 | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | value :  |
 | testRealm.swift:34:2:34:2 | [post] a [data] :  | testRealm.swift:34:2:34:2 | [post] a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
-| testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:34:2:34:2 | [post] a [data] :  |
 | testRealm.swift:42:2:42:2 | [post] c [data] :  | testRealm.swift:42:2:42:2 | [post] c |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
-| testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:42:2:42:2 | [post] c [data] :  |
 | testRealm.swift:52:2:52:3 | [post] ...! [data] :  | testRealm.swift:52:2:52:3 | [post] ...! |
 | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
-| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | [post] ...! |
 | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:52:2:52:3 | [post] ...! [data] :  |
 | testRealm.swift:59:2:59:2 | [post] g [data] :  | testRealm.swift:59:2:59:2 | [post] g |
 | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  |
-| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | [post] g |
 | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:59:2:59:2 | [post] g [data] :  |
 nodes
-| file://:0:0:0:0 | [post] self | semmle.label | [post] self |
-| file://:0:0:0:0 | [post] self :  | semmle.label | [post] self :  |
 | file://:0:0:0:0 | [post] self [data] :  | semmle.label | [post] self [data] :  |
 | file://:0:0:0:0 | value :  | semmle.label | value :  |
 | testCoreData.swift:18:19:18:26 | value :  | semmle.label | value :  |
@@ -67,19 +59,11 @@ nodes
 | testRealm.swift:59:2:59:2 | [post] g [data] :  | semmle.label | [post] g [data] :  |
 | testRealm.swift:59:11:59:11 | myPassword :  | semmle.label | myPassword :  |
 subpaths
-| testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:34:2:34:2 | [post] a |
 | testRealm.swift:34:11:34:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:34:2:34:2 | [post] a [data] :  |
-| testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:42:2:42:2 | [post] c |
 | testRealm.swift:42:11:42:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:42:2:42:2 | [post] c [data] :  |
-| testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:52:2:52:3 | [post] ...! |
 | testRealm.swift:52:12:52:12 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:52:2:52:3 | [post] ...! [data] :  |
-| testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self :  | testRealm.swift:59:2:59:2 | [post] g |
 | testRealm.swift:59:11:59:11 | myPassword :  | testRealm.swift:16:6:16:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:59:2:59:2 | [post] g [data] :  |
 #select
-| file://:0:0:0:0 | self | testRealm.swift:34:11:34:11 | myPassword :  | file://:0:0:0:0 | [post] self | This operation stores '[post] self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:34:11:34:11 | myPassword :  | myPassword |
-| file://:0:0:0:0 | self | testRealm.swift:42:11:42:11 | myPassword :  | file://:0:0:0:0 | [post] self | This operation stores '[post] self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:42:11:42:11 | myPassword :  | myPassword |
-| file://:0:0:0:0 | self | testRealm.swift:52:12:52:12 | myPassword :  | file://:0:0:0:0 | [post] self | This operation stores '[post] self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:52:12:52:12 | myPassword :  | myPassword |
-| file://:0:0:0:0 | self | testRealm.swift:59:11:59:11 | myPassword :  | file://:0:0:0:0 | [post] self | This operation stores '[post] self' in a database. It may contain unencrypted sensitive data from $@ | testRealm.swift:59:11:59:11 | myPassword :  | myPassword |
 | testCoreData.swift:19:12:19:12 | value | testCoreData.swift:61:25:61:25 | password :  | testCoreData.swift:19:12:19:12 | value | This operation stores 'value' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:61:25:61:25 | password :  | password |
 | testCoreData.swift:32:13:32:13 | newValue | testCoreData.swift:64:16:64:16 | password :  | testCoreData.swift:32:13:32:13 | newValue | This operation stores 'newValue' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:64:16:64:16 | password :  | password |
 | testCoreData.swift:48:15:48:15 | password | testCoreData.swift:48:15:48:15 | password | testCoreData.swift:48:15:48:15 | password | This operation stores 'password' in a database. It may contain unencrypted sensitive data from $@ | testCoreData.swift:48:15:48:15 | password | password |

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -13,6 +13,7 @@
 | testRealm.swift:34:11:34:11 | myPassword | label:myPassword, type:credential |
 | testRealm.swift:42:11:42:11 | myPassword | label:myPassword, type:credential |
 | testRealm.swift:52:12:52:12 | myPassword | label:myPassword, type:credential |
+| testRealm.swift:59:11:59:11 | myPassword | label:myPassword, type:credential |
 | testSend.swift:29:19:29:19 | passwordPlain | label:passwordPlain, type:credential |
 | testSend.swift:33:19:33:19 | passwordPlain | label:passwordPlain, type:credential |
 | testSend.swift:45:13:45:13 | password | label:password, type:credential |

--- a/swift/ql/test/query-tests/Security/CWE-311/testRealm.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testRealm.swift
@@ -31,7 +31,7 @@ func test1(realm : Realm, myPassword : String, myHashedPassword : String) {
 	// add objects (within a transaction) ...
 
 	let a = MyRealmSwiftObject()
-	a.data = myPassword
+	a.data = myPassword // BAD [DUPLICATE]
 	realm.add(a) // BAD
 
 	let b = MyRealmSwiftObject()
@@ -39,7 +39,7 @@ func test1(realm : Realm, myPassword : String, myHashedPassword : String) {
 	realm.add(b) // GOOD (not sensitive)
 
 	let c = MyRealmSwiftObject()
-	c.data = myPassword
+	c.data = myPassword // BAD [DUPLICATE]
 	realm.create(MyRealmSwiftObject.self, value: c) // BAD
 
 	let d = MyRealmSwiftObject()
@@ -49,15 +49,15 @@ func test1(realm : Realm, myPassword : String, myHashedPassword : String) {
 	// retrieve objects ...
 
 	var e = realm.object(ofType: MyRealmSwiftObject.self, forPrimaryKey: "key")
-	e!.data = myPassword // BAD [NOT DETECTED]
+	e!.data = myPassword // BAD
 
 	var f = realm.object(ofType: MyRealmSwiftObject.self, forPrimaryKey: "key")
 	f!.data = myHashedPassword // GOOD (not sensitive)
 
 	let g = MyRealmSwiftObject()
 	g.data = "" // GOOD (not sensitive)
-	g.data = myPassword // BAD [NOT DETECTED]
-	g.data = "" // GOOD (not sensitive)
+	g.data = myPassword // BAD
+	g.data = "" // GOOD (not sensitive) // [FALSE POSITIVE]
 }
 
 // limitation: its possible to configure a Realm DB to be stored encrypted, if this is done correctly

--- a/swift/ql/test/query-tests/Security/CWE-311/testRealm.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testRealm.swift
@@ -31,16 +31,16 @@ func test1(realm : Realm, myPassword : String, myHashedPassword : String) {
 	// add objects (within a transaction) ...
 
 	let a = MyRealmSwiftObject()
-	a.data = myPassword // BAD [DUPLICATE]
-	realm.add(a) // BAD
+	a.data = myPassword // BAD
+	realm.add(a)
 
 	let b = MyRealmSwiftObject()
 	b.data = myHashedPassword
 	realm.add(b) // GOOD (not sensitive)
 
 	let c = MyRealmSwiftObject()
-	c.data = myPassword // BAD [DUPLICATE]
-	realm.create(MyRealmSwiftObject.self, value: c) // BAD
+	c.data = myPassword // BAD
+	realm.create(MyRealmSwiftObject.self, value: c)
 
 	let d = MyRealmSwiftObject()
 	d.data = myHashedPassword

--- a/swift/ql/test/query-tests/Security/CWE-311/testRealm.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testRealm.swift
@@ -53,6 +53,11 @@ func test1(realm : Realm, myPassword : String, myHashedPassword : String) {
 
 	var f = realm.object(ofType: MyRealmSwiftObject.self, forPrimaryKey: "key")
 	f!.data = myHashedPassword // GOOD (not sensitive)
+
+	let g = MyRealmSwiftObject()
+	g.data = "" // GOOD (not sensitive)
+	g.data = myPassword // BAD [NOT DETECTED]
+	g.data = "" // GOOD (not sensitive)
 }
 
 // limitation: its possible to configure a Realm DB to be stored encrypted, if this is done correctly

--- a/swift/ql/test/query-tests/Security/CWE-311/testRealm.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testRealm.swift
@@ -57,7 +57,7 @@ func test1(realm : Realm, myPassword : String, myHashedPassword : String) {
 	let g = MyRealmSwiftObject()
 	g.data = "" // GOOD (not sensitive)
 	g.data = myPassword // BAD
-	g.data = "" // GOOD (not sensitive) // [FALSE POSITIVE]
+	g.data = "" // GOOD (not sensitive)
 }
 
 // limitation: its possible to configure a Realm DB to be stored encrypted, if this is done correctly


### PR DESCRIPTION
Fix missing results in `swift/cleartext-storage-database`.  This is something of a change in philosophy, that any write to a class derived from `RealmSwiftObject` (i.e. something that is to be use with a Realm database) is now considered a sink.  We no longer look for evidence (that we may or may not reliably find) that the `RealmSwiftObject` is truly written to the database, because why would it not be?

