### PR TITLE
C#: Fix join order in InterpretedCallable characteristic predicate.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -504,15 +504,26 @@ class UnboundCallable extends Callable {
   }
 }
 
+pragma[nomagic]
+private predicate callableSpecInfo(Callable c, string namespace, string type, string name) {
+  c.getDeclaringType().hasQualifiedName(namespace, type) and
+  c.getName() = name
+}
+
+pragma[nomagic]
+private predicate subtypeSpecCandidate(Callable c, UnboundValueOrRefType t) {
+  elementSpec(_, _, true, c.getName(), _, _, t)
+}
+
 private class InterpretedCallable extends Callable {
   InterpretedCallable() {
-    exists(UnboundValueOrRefType t, boolean subtypes, string name |
-      elementSpec(_, _, subtypes, name, _, _, t) and
-      this.hasName(name)
-    |
-      this.getDeclaringType() = t
-      or
-      subtypes = true and
+    exists(string namespace, string type, string name |
+      callableSpecInfo(this, namespace, type, name) and
+      elementSpec(namespace, type, _, name, _, _)
+    )
+    or
+    exists(UnboundValueOrRefType t |
+      subtypeSpecCandidate(this, t) and
       this.getDeclaringType() = t.getASubTypeUnbound+()
     )
   }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -511,8 +511,17 @@ private predicate callableSpecInfo(Callable c, string namespace, string type, st
 }
 
 pragma[nomagic]
-private predicate subtypeSpecCandidate(Callable c, UnboundValueOrRefType t) {
-  elementSpec(_, _, true, c.getName(), _, _, t)
+private predicate subtypeSpecCandidate(string name, UnboundValueOrRefType t) {
+  exists(UnboundValueOrRefType t0 |
+    elementSpec(_, _, true, name, _, _, t0) and
+    t = t0.getASubTypeUnbound+()
+  )
+}
+
+pragma[nomagic]
+private predicate callableInfo(Callable c, string name, UnboundValueOrRefType decl) {
+  name = c.getName() and
+  decl = c.getDeclaringType()
 }
 
 private class InterpretedCallable extends Callable {
@@ -522,9 +531,9 @@ private class InterpretedCallable extends Callable {
       elementSpec(namespace, type, _, name, _, _)
     )
     or
-    exists(UnboundValueOrRefType t |
-      subtypeSpecCandidate(this, t) and
-      this.getDeclaringType() = t.getASubTypeUnbound+()
+    exists(string name, UnboundValueOrRefType t |
+      callableInfo(this, name, t) and
+      subtypeSpecCandidate(name, t)
     )
   }
 }


### PR DESCRIPTION
The original solution joined on Callable and elementSpec based on name, which lead to a quite large intermediate relation.
The tuples counts in all the screenshots below are based on the *rappayne_webgoat* database.

The tuple counts for the original solution can be seen here:
<img width="1169" alt="image" src="https://user-images.githubusercontent.com/6472811/190362344-910d3f1b-549b-4858-8642-1873e8406dc5.png">

To improve the join ordering and to keep the intermediate relations as small as possible, we use the following observations
- When we want to use *specific* specs (ie. a spec that directly targets a callable), we would like to join Callable and elementSpec on three columns in one go (namespace, type and name).
- When we want to use specs that are valid for all overrides (subtypes = true), we need project the elementSpec relation (on subtypes = true as this is relatively small subset) and join on Callable name. Afterwards we can inspect the types.

The new predicates and tuples counts can be seen here.
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/6472811/190361251-75bb3280-62d0-4a18-82d2-204795b17cdf.png">
<img width="1151" alt="image" src="https://user-images.githubusercontent.com/6472811/190361501-0150f0cf-67d1-4458-b694-8f7a18d272cc.png">
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/6472811/190361787-6321aef5-3a32-46ad-9607-4c6fdf1a01b3.png">
