### PR TITLE
C++: remove more upper-case variable names

### DIFF
--- a/cpp/ql/src/Architecture/General Class-Level Information/HubClasses.ql
+++ b/cpp/ql/src/Architecture/General Class-Level Information/HubClasses.ql
@@ -12,5 +12,5 @@ import cpp
 
 from Class c
 where c.fromSource()
-select c as Class, c.getMetrics().getAfferentCoupling() as afferentCoupling,
+select c as class_, c.getMetrics().getAfferentCoupling() as afferentCoupling,
   c.getMetrics().getEfferentSourceCoupling() as efferentCoupling order by afferentCoupling desc

--- a/cpp/ql/src/PointsTo/TaintedFormatStrings.ql
+++ b/cpp/ql/src/PointsTo/TaintedFormatStrings.ql
@@ -119,4 +119,4 @@ predicate potentialViolation(InputBuffer source, FormatBuffer dest) {
 
 from InputBuffer source, FormatBuffer dest
 where potentialViolation(source, dest)
-select dest.getFile() as File, dest as FormatString
+select dest.getFile() as file, dest as formatString


### PR DESCRIPTION
This builds on https://github.com/github/codeql/pull/10420, apologies for not spotting all of these at once!