### PR TITLE
JavaScript: remove upper-case variable names

### DIFF
--- a/javascript/ql/src/meta/extraction-metrics/FileData.ql
+++ b/javascript/ql/src/meta/extraction-metrics/FileData.ql
@@ -16,10 +16,12 @@ FileWithExtractionMetrics getACacheHit(FileWithExtractionMetrics f) {
   result.isFromCache()
 }
 
-from FileWithExtractionMetrics file, boolean fromCache
-where (if file.isFromCache() then fromCache = true else fromCache = false)
-select file.getAbsolutePath() as FILE, file.getCpuTime() as CPU_NANO,
-  file.getNumberOfLines() as LINES, count(Locatable n | n.getFile() = file) as LOCATABLES,
-  count(TypeAnnotation n | n.getFile() = file) as TYPES, file.getLength() as LENGTH,
-  fromCache as FROM_CACHE, count(getACacheMember(file.getCacheFile())) as CACHE_MEMBERS,
-  count(getACacheHit(file)) as CACHE_HITS, file.getCacheFile() as CACHE_FILE
+from FileWithExtractionMetrics fileWithMetrics, boolean fromCache
+where (if fileWithMetrics.isFromCache() then fromCache = true else fromCache = false)
+select fileWithMetrics.getAbsolutePath() as file, fileWithMetrics.getCpuTime() as cpu_nano,
+  fileWithMetrics.getNumberOfLines() as lines,
+  count(Locatable n | n.getFile() = fileWithMetrics) as locatables,
+  count(TypeAnnotation n | n.getFile() = fileWithMetrics) as types,
+  fileWithMetrics.getLength() as length, fromCache as from_cache,
+  count(getACacheMember(fileWithMetrics.getCacheFile())) as cache_members,
+  count(getACacheHit(fileWithMetrics)) as cache_hits, fileWithMetrics.getCacheFile() as cache_file

--- a/javascript/ql/src/meta/extraction-metrics/PhaseTimings.ql
+++ b/javascript/ql/src/meta/extraction-metrics/PhaseTimings.ql
@@ -9,5 +9,5 @@
 import semmle.javascript.meta.ExtractionMetrics::ExtractionMetrics
 
 from PhaseName phaseName
-select phaseName, Aggregated::getCpuTime(phaseName) as CPU_NANO,
-  Aggregated::getWallclockTime(phaseName) as WALLCLOCK_NANO
+select phaseName, Aggregated::getCpuTime(phaseName) as cpu_nano,
+  Aggregated::getWallclockTime(phaseName) as wallclock_nano


### PR DESCRIPTION
Upper-case variable names are deprecated. Warnings were not correctly displayed for `NamedExpressions`, hence we missed some occurrences.