### PR TITLE
Java: remove upper-case variable name

### DIFF
--- a/java/ql/src/Architecture/Refactoring Opportunities/HubClasses.ql
+++ b/java/ql/src/Architecture/Refactoring Opportunities/HubClasses.ql
@@ -19,6 +19,6 @@ where
   eff = t.getMetrics().getEfferentSourceCoupling() and
   aff > 15 and
   eff > 15
-select t as Class,
+select t as class_,
   "Hub class: this class depends on " + eff.toString() + " classes and is used by " + aff.toString()
     + " classes."


### PR DESCRIPTION
Upper-case variable names are deprecated. Warnings were not correctly displayed for `NamedExpressions`, hence we missed some occurrences.