### PR TITLE
QL: recognize the names from all VarDefs

### DIFF
--- a/ql/ql/src/codeql_ql/style/NodeName.qll
+++ b/ql/ql/src/codeql_ql/style/NodeName.qll
@@ -20,7 +20,7 @@ string getName(AstNode node, string kind) {
   result = node.(NewType).getName() and
   kind = "newtype"
   or
-  result = node.(VarDecl).getName() and
+  result = node.(VarDef).getName() and
   kind = "variable" and
   not node = any(FieldDecl f).getVarDecl()
   or


### PR DESCRIPTION
We were missing the results that were fixed in e.g. https://github.com/github/codeql/pull/10439.  

All the errors that Code-scanning complains about are fixed by the above PR.  