### PR TITLE
Correct link to API docs for 'Get a CodeQL database for a repository'

### DIFF
--- a/docs/codeql/reusables/download-github-database.rst
+++ b/docs/codeql/reusables/download-github-database.rst
@@ -11,4 +11,4 @@ When you have confirmed that a CodeQL database exists for the language you are i
 
    gh api /repos/<owner>/<repo>/code-scanning/codeql/databases/<language> -H 'Accept: application/zip' > path/to/local/database.zip
 
-For more information, see the documentation for the `Get CodeQL database <https://docs.github.com/en/rest/reference/code-scanning#get-codeql-database>`__ endpoint in the GitHub REST API documentation.
+For more information, see the documentation for the `Get CodeQL database <https://docs.github.com/en/rest/code-scanning#get-a-codeql-database-for-a-repository>`__ endpoint in the GitHub REST API documentation.


### PR DESCRIPTION
We have an incorrect link in a reusable snippet about downloading CodeQL databases using the GitHub REST API. The link should point to https://docs.github.com/en/rest/code-scanning#get-a-codeql-database-for-a-repository.
