### PR TITLE
Swift: Update test for swift/cleartext-transmission

### DIFF
--- a/swift/ql/test/query-tests/Security/CWE-311/testURL.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testURL.swift
@@ -18,5 +18,5 @@ func test1(passwd : String, encrypted_passwd : String, account_no : String, cred
 	let base = URL(string: "http://example.com/"); // GOOD (not sensitive)
 	let e = URL(string: "abc", relativeTo: base); // GOOD (not sensitive)
 	let f = URL(string: passwd, relativeTo: base); // BAD
-	let g = URL(string: "abc", relativeTo: f); // BAD [NOT DETECTED]
+	let g = URL(string: "abc", relativeTo: f); // BAD (reported on line above)
 }


### PR DESCRIPTION
Update the test for `swift/cleartext-transmission`.  I thought we were missing taint to the result on line 21 for some reason, but it turns out this is just result deduplication - we don't allow taint flow through taint sinks because that can lead to reporting the same issue a silly number of times.  In this case the sink on line 20 for the sensitive data `passwd` is reported.