### PR TITLE
Java: really return a unique location for non-source entities

### DIFF
--- a/java/ql/lib/semmle/code/Location.qll
+++ b/java/ql/lib/semmle/code/Location.qll
@@ -216,7 +216,7 @@ private predicate fixedHasLocation(Top l, Location loc, File f) {
     min(Location candidateLoc |
       hasLocation(l, candidateLoc)
     |
-      candidateLoc order by candidateLoc.getFile().toString()
+      candidateLoc order by candidateLoc.getFile().getAbsolutePath()
     ) and
   not hasSourceLocation(l, _, _) and
   locations_default(loc, f, _, _, _, _)


### PR DESCRIPTION
This was always supposed to pick one of several candidate non-source locations (usually for a generic type instantiation), but since `getFile().toString()` just produces the basename of the class file actually the results would almost always tie and all of the candidate locations would be returned. Use the full class file path as a tiebreaker instead.