### PR TITLE
C#: Remove `dotnet run` support in LUA tracer.

### DIFF
--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -36,26 +36,12 @@ function RegisterExtractorPack(id)
                     match = true
                     break
                 end
-                if arg == 'run' then
-                    -- for `dotnet run`, we need to make sure that `-p:UseSharedCompilation=false` is
-                    -- not passed in as an argument to the program that is run
-                    match = true
-                    needsSeparator = true
-                end
-            end
-            if arg == '--' then
-                needsSeparator = false
-                break
             end
         end
         if match then
-            local injections = { '-p:UseSharedCompilation=false' }
-            if needsSeparator then
-                table.insert(injections, '--')
-            end
             return {
                 order = ORDER_REPLACE,
-                invocation = BuildExtractorInvocation(id, compilerPath, compilerPath, compilerArguments, nil, injections)
+                invocation = BuildExtractorInvocation(id, compilerPath, compilerPath, compilerArguments, nil, { '-p:UseSharedCompilation=false' })
             }
         end
         return nil


### PR DESCRIPTION
It turns out that the current solution for `dotnet run` doesn't work as intended, so removing the support altogether.
If we want support for `dotnet run` it is not sufficient to prepend or append to the compiler argument list (we basically need to 'inject' in the middle of the provided arguments).
From the description of [dotnet run](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run) we see that everything after `--` is provided as command line arguments to the program.
This means that the LUA tracer will re-write
```bash
dotnet run -- hello
```
into
```bash
dotnet run -- hello -p:UseSharedCompilation=false
```
That is, the shared compilation flag is injected as a program input.
If we want proper support for `dotnet run` we need to rewrite the command line arguments and inject the flag *before*, if the user has supplied `--`.
Another easy option is that we only support `dotnet run` when the user provides no command line arguments.
