### PR TITLE
Go: Fix source/sanitizer class that were never used 

### DIFF
--- a/go/ql/lib/semmle/go/security/InsecureRandomness.qll
+++ b/go/ql/lib/semmle/go/security/InsecureRandomness.qll
@@ -29,5 +29,7 @@ module InsecureRandomness {
 
     /** Holds if `sink` is a sink for this configuration with kind `kind`. */
     predicate isSink(Sink sink, string kind) { kind = sink.getKind() }
+
+    override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
   }
 }

--- a/go/ql/lib/semmle/go/security/Xss.qll
+++ b/go/ql/lib/semmle/go/security/Xss.qll
@@ -6,8 +6,11 @@ import go
 
 /** Provides classes and predicates shared between the XSS queries. */
 module SharedXss {
-  /** A data flow source for XSS vulnerabilities. */
-  abstract class Source extends DataFlow::Node { }
+  /**
+   * DEPRECATED: This class is not used.
+   * A data flow source for XSS vulnerabilities.
+   */
+  abstract deprecated class Source extends DataFlow::Node { }
 
   /** A data flow sink for XSS vulnerabilities. */
   abstract class Sink extends DataFlow::Node {


### PR DESCRIPTION
The `Sanitizer` class in `insecure-randomness` was never used. The fix was to add a `isSanitizer()` predicate to the configuration.  

The `Source` class for the `Xss` classes was never used.  
This class isn't useful with the current queries, so I've deprecated it.  

[Evaluation was uneventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-10475-0-go/reports)