### PR TITLE
Java: Delete some unused code

### DIFF
--- a/java/ql/lib/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/lib/semmle/code/java/controlflow/Guards.qll
@@ -218,12 +218,12 @@ predicate guardControls_v1(Guard guard, BasicBlock controlled, boolean branch) {
 }
 
 /**
- * INTERNAL: Use `Guards.controls` instead.
+ * DEPRECATED: Use `Guards.controls` instead.
  *
  * Holds if `guard.controls(controlled, branch)`, except this doesn't rely on
  * RangeAnalysis.
  */
-predicate guardControls_v2(Guard guard, BasicBlock controlled, boolean branch) {
+deprecated predicate guardControls_v2(Guard guard, BasicBlock controlled, boolean branch) {
   guard.directlyControls(controlled, branch)
   or
   exists(Guard g, boolean b |

--- a/java/ql/lib/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/lib/semmle/code/java/controlflow/Guards.qll
@@ -218,12 +218,12 @@ predicate guardControls_v1(Guard guard, BasicBlock controlled, boolean branch) {
 }
 
 /**
- * DEPRECATED: Use `Guards.controls` instead.
+ * INTERNAL: Use `Guards.controls` instead.
  *
  * Holds if `guard.controls(controlled, branch)`, except this doesn't rely on
  * RangeAnalysis.
  */
-deprecated predicate guardControls_v2(Guard guard, BasicBlock controlled, boolean branch) {
+predicate guardControls_v2(Guard guard, BasicBlock controlled, boolean branch) {
   guard.directlyControls(controlled, branch)
   or
   exists(Guard g, boolean b |

--- a/java/ql/lib/semmle/code/java/security/regexp/NfaUtilsSpecific.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/NfaUtilsSpecific.qll
@@ -59,14 +59,6 @@ module RegExpFlags {
   }
 
   /**
-   * Gets the flags for `root`, or the empty string if `root` has no flags.
-   */
-  string getFlags(RegExpTerm root) {
-    root.isRootTerm() and
-    result = root.getLiteral().getFlags()
-  }
-
-  /**
    * Holds if `root` has the `s` flag for multi-line matching.
    */
   predicate isDotAll(RegExpTerm root) {

--- a/java/ql/lib/semmle/code/java/security/regexp/NfaUtilsSpecific.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/NfaUtilsSpecific.qll
@@ -59,6 +59,14 @@ module RegExpFlags {
   }
 
   /**
+   * Gets the flags for `root`, or the empty string if `root` has no flags.
+   */
+  deprecated string getFlags(RegExpTerm root) {
+    root.isRootTerm() and
+    result = root.getLiteral().getFlags()
+  }
+
+  /**
    * Holds if `root` has the `s` flag for multi-line matching.
    */
   predicate isDotAll(RegExpTerm root) {

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/Shadowing.qll
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/Shadowing.qll
@@ -1,9 +1,5 @@
 import java
 
-predicate initializedToField(LocalVariableDecl d, Field f) {
-  exists(LocalVariableDeclExpr e | e.getVariable() = d and f.getAnAccess() = e.getInit())
-}
-
 predicate getterFor(Method m, Field f) {
   m.getName().matches("get%") and
   m.getDeclaringType() = f.getDeclaringType() and


### PR DESCRIPTION
- The unused predicate in `NfaUtilsSpecific.qll` was not used anywhere, and people are not expected to use predicates from a `Specific.qll` file.  
- The `guardControls_v2` predicate in `Guards.qll` was only ever called by itself, and it was documented as being internal, so I deprecated it.  
- The `initializedToField` predicate was unused. It was in the `src/` folder, and it couldn't be imported from the outside, so I deleted it.  
