### PR TITLE
Ruby: Fix bad join-order

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
@@ -519,9 +519,9 @@ module ExposedForTestingOnly {
 private TMethodOrExpr lookupMethodOrConst0(Module m, string name) {
   result = lookupMethodOrConst0(m.getAPrependedModule(), name)
   or
-  not exists(getMethodOrConst(getAncestors(m.getAPrependedModule()), name)) and
+  not exists(getMethodOrConst(getAncestors(m.getAPrependedModule()), pragma[only_bind_into](name))) and
   (
-    result = getMethodOrConst(m, name)
+    result = getMethodOrConst(m, pragma[only_bind_into](name))
     or
     not exists(getMethodOrConst(m, name)) and
     result = lookupMethodOrConst0(m.getAnIncludedModule(), name)


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate Module#fe82a56b::lookupMethodOrConst0#2#fff#antijoin_rhs@e23c32nf with tuple counts:
          118006   ~0%    {3} r1 = SCAN Module#fe82a56b::getMethodOrConst#2#fff OUTPUT In.1, In.0, In.2
        35267848   ~3%    {4} r2 = JOIN r1 WITH project#Module#fe82a56b::getMethodOrConst#2#fff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2, Rhs.1
           21883   ~0%    {5} r3 = JOIN r2 WITH Module#fe82a56b::Cached::getAPrependedModule#1#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.3, Lhs.0, Lhs.1, Lhs.2
               7  ~16%    {3} r4 = JOIN r3 WITH Module#fe82a56b::getAncestors#1#ff ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4
                          return r4
```

After
```
Evaluated relational algebra for predicate Module#fe82a56b::lookupMethodOrConst0#2#fff#antijoin_rhs@839f6a1k with tuple counts:
        118006  ~1%    {3} r1 = SCAN Module#fe82a56b::getMethodOrConst#2#fff OUTPUT In.0, In.2, In.1
           151  ~0%    {4} r2 = JOIN r1 WITH Module#fe82a56b::Cached::getAPrependedModule#1#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Lhs.2
           155  ~1%    {4} r3 = JOIN r2 WITH Module#fe82a56b::getAncestors#1#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.3, Lhs.1, Lhs.2
             7  ~0%    {3} r4 = JOIN r3 WITH project#Module#fe82a56b::getMethodOrConst#2#fff ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.1
                       return r4
```