### PR TITLE
Java: Improve `ImportStaticTypeMember` and `ImportStaticOnDemand`

### DIFF
--- a/java/ql/lib/change-notes/2022-09-20-import-declaration-fixes.md
+++ b/java/ql/lib/change-notes/2022-09-20-import-declaration-fixes.md
@@ -1,0 +1,6 @@
+---
+category: fix
+---
+* `ImportStaticTypeMember` and `ImportStaticOnDemand` are now properly considering inherited members (except for inherited member types).
+* `ImportStaticOnDemand` predicates do not have non-`static` members and initializer methods as results anymore.
+* `ImportOnDemandFromPackage.getAnImport()` does not have nested types as result anymore.

--- a/java/ql/lib/semmle/code/java/Import.qll
+++ b/java/ql/lib/semmle/code/java/Import.qll
@@ -67,7 +67,7 @@ class ImportOnDemandFromPackage extends Import {
   Package getPackageHoldingImport() { imports(this, result, _, _) }
 
   /** Gets an imported type. */
-  RefType getAnImport() { result.getPackage() = this.getPackageHoldingImport() }
+  TopLevelType getAnImport() { result.getPackage() = this.getPackageHoldingImport() }
 
   /** Gets a printable representation of this import declaration. */
   override string toString() {
@@ -89,14 +89,26 @@ class ImportStaticOnDemand extends Import {
   /** Gets the type from which accessible static members are imported. */
   ClassOrInterface getTypeHoldingImport() { imports(this, result, _, _) }
 
+  /** Gets an imported member. */
+  Member getAMemberImport() {
+    (
+      this.getTypeHoldingImport().inherits(result)
+      or
+      // Workaround for member types, see https://github.com/github/codeql/issues/5596
+      this.getTypeHoldingImport().getAMember() = result
+    ) and
+    result.isStatic() and
+    not result instanceof StaticInitializer
+  }
+
   /** Gets an imported type. */
-  NestedType getATypeImport() { result.getEnclosingType() = this.getTypeHoldingImport() }
+  MemberType getATypeImport() { result = this.getAMemberImport() }
 
   /** Gets an imported method. */
-  Method getAMethodImport() { result.getDeclaringType() = this.getTypeHoldingImport() }
+  Method getAMethodImport() { result = this.getAMemberImport() }
 
   /** Gets an imported field. */
-  Field getAFieldImport() { result.getDeclaringType() = this.getTypeHoldingImport() }
+  Field getAFieldImport() { result = this.getAMemberImport() }
 
   /** Gets a printable representation of this import declaration. */
   override string toString() {
@@ -125,18 +137,23 @@ class ImportStaticTypeMember extends Import {
 
   /** Gets an imported member. */
   Member getAMemberImport() {
-    this.getTypeHoldingImport().getAMember() = result and
+    (
+      this.getTypeHoldingImport().inherits(result)
+      or
+      // Workaround for member types, see https://github.com/github/codeql/issues/5596
+      this.getTypeHoldingImport().getAMember() = result
+    ) and
     result.getName() = this.getName() and
     result.isStatic()
   }
 
-  /** Gets an imported type. */
-  NestedType getATypeImport() { result = this.getAMemberImport() }
+  /** Gets an imported type in case one or more member types with the name specified by this import exist. */
+  MemberType getATypeImport() { result = this.getAMemberImport() }
 
-  /** Gets an imported method. */
+  /** Gets an imported method in case one or more methods with the name specified by this import exist. */
   Method getAMethodImport() { result = this.getAMemberImport() }
 
-  /** Gets an imported field. */
+  /** Gets an imported field in case one or more fields with the name specified by this import exist. */
   Field getAFieldImport() { result = this.getAMemberImport() }
 
   /** Gets a printable representation of this import declaration. */

--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -841,11 +841,8 @@ class LocalClass extends LocalClassOrInterface, NestedClass {
 }
 
 /** A top-level type. */
-class TopLevelType extends RefType {
-  TopLevelType() {
-    not enclInReftype(this, _) and
-    (this instanceof Class or this instanceof Interface)
-  }
+class TopLevelType extends ClassOrInterface {
+  TopLevelType() { not enclInReftype(this, _) }
 }
 
 /** A top-level class. */

--- a/java/ql/test/library-tests/imports/ImportOnDemandFromPackage.expected
+++ b/java/ql/test/library-tests/imports/ImportOnDemandFromPackage.expected
@@ -1,0 +1,8 @@
+getAnImport
+| Test.java:1:1:1:18 | import packageA.* | packageA/Subclass.java:3:14:3:21 | Subclass |
+| Test.java:1:1:1:18 | import packageA.* | packageA/Subinterface.java:3:18:3:29 | Subinterface |
+| Test.java:1:1:1:18 | import packageA.* | packageA/Superclass.java:3:14:3:23 | Superclass |
+| Test.java:1:1:1:18 | import packageA.* | packageA/Superinterface2.java:3:18:3:32 | Superinterface2 |
+| Test.java:1:1:1:18 | import packageA.* | packageA/Superinterface.java:3:18:3:31 | Superinterface |
+#select
+| Test.java:1:1:1:18 | import packageA.* | file://:0:0:0:0 | packageA |

--- a/java/ql/test/library-tests/imports/ImportOnDemandFromPackage.ql
+++ b/java/ql/test/library-tests/imports/ImportOnDemandFromPackage.ql
@@ -1,0 +1,8 @@
+import java
+
+query ClassOrInterface getAnImport(ImportOnDemandFromPackage importDecl) {
+  result = importDecl.getAnImport()
+}
+
+from ImportOnDemandFromPackage importDecl
+select importDecl, importDecl.getPackageHoldingImport()

--- a/java/ql/test/library-tests/imports/ImportOnDemandFromType.expected
+++ b/java/ql/test/library-tests/imports/ImportOnDemandFromType.expected
@@ -1,0 +1,10 @@
+getAnImport
+| Test.java:7:1:7:27 | import Subclass.* | packageA/Subclass.java:4:18:4:22 | Inner |
+| Test.java:7:1:7:27 | import Subclass.* | packageA/Subclass.java:10:25:10:33 | nameClash |
+| Test.java:7:1:7:27 | import Subclass.* | packageA/Subclass.java:13:25:13:40 | HiddenMemberType |
+| Test.java:9:1:9:31 | import Subinterface.* | packageA/Subinterface.java:8:25:8:33 | nameClash |
+| Test.java:9:1:9:31 | import Subinterface.* | packageA/Subinterface.java:11:25:11:40 | HiddenMemberType |
+#select
+| Test.java:7:1:7:27 | import Subclass.* | packageA/Subclass.java:3:14:3:21 | Subclass |
+| Test.java:8:1:8:33 | import Inner.* | packageA/Subclass.java:4:18:4:22 | Inner |
+| Test.java:9:1:9:31 | import Subinterface.* | packageA/Subinterface.java:3:18:3:29 | Subinterface |

--- a/java/ql/test/library-tests/imports/ImportOnDemandFromType.ql
+++ b/java/ql/test/library-tests/imports/ImportOnDemandFromType.ql
@@ -1,0 +1,8 @@
+import java
+
+query ClassOrInterface getAnImport(ImportOnDemandFromType importDecl) {
+  result = importDecl.getAnImport()
+}
+
+from ImportOnDemandFromType importDecl
+select importDecl, importDecl.getTypeHoldingImport()

--- a/java/ql/test/library-tests/imports/ImportStaticOnDemand.expected
+++ b/java/ql/test/library-tests/imports/ImportStaticOnDemand.expected
@@ -1,0 +1,48 @@
+getAMemberImport
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:6:29:6:37 | nameClash |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:7:24:7:32 | nameClash |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:8:24:8:32 | nameClash |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:10:25:10:33 | nameClash |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:13:25:13:40 | HiddenMemberType |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:15:29:15:40 | HIDDEN_FIELD |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:16:24:16:35 | hiddenMethod |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Superclass.java:9:29:9:40 | STATIC_FIELD |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Superclass.java:11:24:11:35 | staticMethod |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Superinterface.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:24:1:24:49 | import static StaticNested.* | packageA/Superclass.java:6:28:6:28 | m |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:4:29:4:37 | nameClash |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:5:24:5:32 | nameClash |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:6:24:6:32 | nameClash |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:8:25:8:33 | nameClash |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:11:25:11:40 | HiddenMemberType |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:13:29:13:40 | HIDDEN_FIELD |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:14:24:14:35 | hiddenMethod |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Superinterface2.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Superinterface.java:8:9:8:20 | STATIC_FIELD |
+getATypeImport
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:10:25:10:33 | nameClash |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:13:25:13:40 | HiddenMemberType |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:8:25:8:33 | nameClash |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:11:25:11:40 | HiddenMemberType |
+getAMethodImport
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:7:24:7:32 | nameClash |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:8:24:8:32 | nameClash |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:16:24:16:35 | hiddenMethod |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Superclass.java:11:24:11:35 | staticMethod |
+| Test.java:24:1:24:49 | import static StaticNested.* | packageA/Superclass.java:6:28:6:28 | m |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:5:24:5:32 | nameClash |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:6:24:6:32 | nameClash |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:14:24:14:35 | hiddenMethod |
+getAFieldImport
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:6:29:6:37 | nameClash |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:15:29:15:40 | HIDDEN_FIELD |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Superclass.java:9:29:9:40 | STATIC_FIELD |
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Superinterface.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:4:29:4:37 | nameClash |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:13:29:13:40 | HIDDEN_FIELD |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Superinterface2.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Superinterface.java:8:9:8:20 | STATIC_FIELD |
+#select
+| Test.java:21:1:21:34 | import static Subclass.* | packageA/Subclass.java:3:14:3:21 | Subclass |
+| Test.java:24:1:24:49 | import static StaticNested.* | packageA/Superclass.java:5:25:5:36 | StaticNested |
+| Test.java:25:1:25:38 | import static Subinterface.* | packageA/Subinterface.java:3:18:3:29 | Subinterface |

--- a/java/ql/test/library-tests/imports/ImportStaticOnDemand.ql
+++ b/java/ql/test/library-tests/imports/ImportStaticOnDemand.ql
@@ -1,0 +1,20 @@
+import java
+
+query Member getAMemberImport(ImportStaticOnDemand importDecl) {
+  result = importDecl.getAMemberImport()
+}
+
+query MemberType getATypeImport(ImportStaticOnDemand importDecl) {
+  result = importDecl.getATypeImport()
+}
+
+query Method getAMethodImport(ImportStaticOnDemand importDecl) {
+  result = importDecl.getAMethodImport()
+}
+
+query Field getAFieldImport(ImportStaticOnDemand importDecl) {
+  result = importDecl.getAFieldImport()
+}
+
+from ImportStaticOnDemand importDecl
+select importDecl, importDecl.getTypeHoldingImport()

--- a/java/ql/test/library-tests/imports/ImportStaticTypeMember.expected
+++ b/java/ql/test/library-tests/imports/ImportStaticTypeMember.expected
@@ -1,0 +1,41 @@
+getAMemberImport
+| Test.java:12:1:12:45 | import static Subclass.STATIC_FIELD | packageA/Superclass.java:9:29:9:40 | STATIC_FIELD |
+| Test.java:12:1:12:45 | import static Subclass.STATIC_FIELD | packageA/Superinterface.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:13:1:13:45 | import static Subclass.staticMethod | packageA/Superclass.java:11:24:11:35 | staticMethod |
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:6:29:6:37 | nameClash |
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:7:24:7:32 | nameClash |
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:8:24:8:32 | nameClash |
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:10:25:10:33 | nameClash |
+| Test.java:17:1:17:49 | import static Subinterface.STATIC_FIELD | packageA/Superinterface2.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:17:1:17:49 | import static Subinterface.STATIC_FIELD | packageA/Superinterface.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:18:1:18:51 | import static Superinterface.staticMethod | packageA/Superinterface.java:10:24:10:35 | staticMethod |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:4:29:4:37 | nameClash |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:5:24:5:32 | nameClash |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:6:24:6:32 | nameClash |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:8:25:8:33 | nameClash |
+getATypeImport
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:10:25:10:33 | nameClash |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:8:25:8:33 | nameClash |
+getAMethodImport
+| Test.java:13:1:13:45 | import static Subclass.staticMethod | packageA/Superclass.java:11:24:11:35 | staticMethod |
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:7:24:7:32 | nameClash |
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:8:24:8:32 | nameClash |
+| Test.java:18:1:18:51 | import static Superinterface.staticMethod | packageA/Superinterface.java:10:24:10:35 | staticMethod |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:5:24:5:32 | nameClash |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:6:24:6:32 | nameClash |
+getAFieldImport
+| Test.java:12:1:12:45 | import static Subclass.STATIC_FIELD | packageA/Superclass.java:9:29:9:40 | STATIC_FIELD |
+| Test.java:12:1:12:45 | import static Subclass.STATIC_FIELD | packageA/Superinterface.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:6:29:6:37 | nameClash |
+| Test.java:17:1:17:49 | import static Subinterface.STATIC_FIELD | packageA/Superinterface2.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:17:1:17:49 | import static Subinterface.STATIC_FIELD | packageA/Superinterface.java:8:9:8:20 | STATIC_FIELD |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:4:29:4:37 | nameClash |
+#select
+| Test.java:11:1:11:45 | import static Subclass.StaticNested | packageA/Subclass.java:3:14:3:21 | Subclass | StaticNested |
+| Test.java:12:1:12:45 | import static Subclass.STATIC_FIELD | packageA/Subclass.java:3:14:3:21 | Subclass | STATIC_FIELD |
+| Test.java:13:1:13:45 | import static Subclass.staticMethod | packageA/Subclass.java:3:14:3:21 | Subclass | staticMethod |
+| Test.java:14:1:14:42 | import static Subclass.nameClash | packageA/Subclass.java:3:14:3:21 | Subclass | nameClash |
+| Test.java:16:1:16:49 | import static Subinterface.StaticNested | packageA/Subinterface.java:3:18:3:29 | Subinterface | StaticNested |
+| Test.java:17:1:17:49 | import static Subinterface.STATIC_FIELD | packageA/Subinterface.java:3:18:3:29 | Subinterface | STATIC_FIELD |
+| Test.java:18:1:18:51 | import static Superinterface.staticMethod | packageA/Superinterface.java:3:18:3:31 | Superinterface | staticMethod |
+| Test.java:19:1:19:46 | import static Subinterface.nameClash | packageA/Subinterface.java:3:18:3:29 | Subinterface | nameClash |

--- a/java/ql/test/library-tests/imports/ImportStaticTypeMember.ql
+++ b/java/ql/test/library-tests/imports/ImportStaticTypeMember.ql
@@ -1,0 +1,20 @@
+import java
+
+query Member getAMemberImport(ImportStaticTypeMember importDecl) {
+  result = importDecl.getAMemberImport()
+}
+
+query MemberType getATypeImport(ImportStaticTypeMember importDecl) {
+  result = importDecl.getATypeImport()
+}
+
+query Method getAMethodImport(ImportStaticTypeMember importDecl) {
+  result = importDecl.getAMethodImport()
+}
+
+query Field getAFieldImport(ImportStaticTypeMember importDecl) {
+  result = importDecl.getAFieldImport()
+}
+
+from ImportStaticTypeMember importDecl
+select importDecl, importDecl.getTypeHoldingImport(), importDecl.getName()

--- a/java/ql/test/library-tests/imports/ImportType.expected
+++ b/java/ql/test/library-tests/imports/ImportType.expected
@@ -1,0 +1,3 @@
+| Test.java:3:1:3:25 | import Subclass | packageA/Subclass.java:3:14:3:21 | Subclass |
+| Test.java:4:1:4:31 | import Inner | packageA/Subclass.java:4:18:4:22 | Inner |
+| Test.java:5:1:5:29 | import Subinterface | packageA/Subinterface.java:3:18:3:29 | Subinterface |

--- a/java/ql/test/library-tests/imports/ImportType.ql
+++ b/java/ql/test/library-tests/imports/ImportType.ql
@@ -1,0 +1,4 @@
+import java
+
+from ImportType importDecl
+select importDecl, importDecl.getImportedType()

--- a/java/ql/test/library-tests/imports/Test.java
+++ b/java/ql/test/library-tests/imports/Test.java
@@ -1,0 +1,27 @@
+import packageA.*;
+
+import packageA.Subclass;
+import packageA.Subclass.Inner;
+import packageA.Subinterface;
+
+import packageA.Subclass.*;
+import packageA.Subclass.Inner.*;
+import packageA.Subinterface.*;
+
+import static packageA.Subclass.StaticNested;
+import static packageA.Subclass.STATIC_FIELD;
+import static packageA.Subclass.staticMethod;
+import static packageA.Subclass.nameClash;
+
+import static packageA.Subinterface.StaticNested;
+import static packageA.Subinterface.STATIC_FIELD;
+import static packageA.Superinterface.staticMethod;
+import static packageA.Subinterface.nameClash;
+
+import static packageA.Subclass.*;
+// Apparently 'import static member' can import from inheriting class Subclass: `packageA.Subclass.StaticNested`,
+// but 'on demand' (wildcard) import here must use name of declaring type Superclass?
+import static packageA.Superclass.StaticNested.*;
+import static packageA.Subinterface.*;
+
+class Test {}

--- a/java/ql/test/library-tests/imports/packageA/Subclass.java
+++ b/java/ql/test/library-tests/imports/packageA/Subclass.java
@@ -1,0 +1,17 @@
+package packageA;
+
+public class Subclass extends Superclass implements Superinterface {
+    public class Inner {}
+
+    public static final int nameClash = 1;
+    public static void nameClash() {}
+    public static void nameClash(int i) {}
+
+    public static class nameClash {}
+
+    // Hides members from supertypes
+    public static class HiddenMemberType {}
+
+    public static final int HIDDEN_FIELD = 1;
+    public static void hiddenMethod() {}
+}

--- a/java/ql/test/library-tests/imports/packageA/Subinterface.java
+++ b/java/ql/test/library-tests/imports/packageA/Subinterface.java
@@ -1,0 +1,15 @@
+package packageA;
+
+public interface Subinterface extends Superinterface, Superinterface2 {
+    public static final int nameClash = 1;
+    public static void nameClash() {}
+    public static void nameClash(int i) {}
+
+    public static class nameClash {}
+
+    // Hides members from supertypes
+    public static class HiddenMemberType {}
+
+    public static final int HIDDEN_FIELD = 1;
+    public static void hiddenMethod() {}
+}

--- a/java/ql/test/library-tests/imports/packageA/Superclass.java
+++ b/java/ql/test/library-tests/imports/packageA/Superclass.java
@@ -1,0 +1,19 @@
+package packageA;
+
+public class Superclass {
+    public class Inner {}
+    public static class StaticNested {
+        public static void m() {}
+    }
+
+    public static final int STATIC_FIELD = 1;
+    
+    public static void staticMethod() {}
+
+    public void instanceMethod() {}
+
+    public static class HiddenMemberType {}
+
+    public static final int HIDDEN_FIELD = 1;
+    public static void hiddenMethod() {}
+}

--- a/java/ql/test/library-tests/imports/packageA/Superinterface.java
+++ b/java/ql/test/library-tests/imports/packageA/Superinterface.java
@@ -1,0 +1,18 @@
+package packageA;
+
+public interface Superinterface {
+    public static class StaticNested {
+        public static void m() {}
+    }
+
+    int STATIC_FIELD = 1;
+
+    public static void staticMethod() {}
+
+    default void instanceMethod() {}
+
+    public static class HiddenMemberType {}
+
+    int HIDDEN_FIELD = 1;
+    public static void hiddenMethod() {}
+}

--- a/java/ql/test/library-tests/imports/packageA/Superinterface2.java
+++ b/java/ql/test/library-tests/imports/packageA/Superinterface2.java
@@ -1,0 +1,11 @@
+package packageA;
+
+public interface Superinterface2 {
+    public static class StaticNested {
+        public static void m() {}
+    }
+
+    int STATIC_FIELD = 1;
+
+    public static void staticMethod() {}
+}


### PR DESCRIPTION
- `ImportStaticTypeMember` and `ImportStaticOnDemand` are now properly considering inherited members (except for inherited member types, see #5596).
- `ImportStaticOnDemand` predicates do not have non-`static` members and initializer methods as results anymore.
- `ImportOnDemandFromPackage.getAnImport()` does not have nested types as result anymore.
