### PR TITLE
Java: Add `CompilationUnit.getATypeInScope()`

### DIFF
--- a/java/ql/lib/change-notes/2022-09-20-CompilationUnit-getATypeInScope.md
+++ b/java/ql/lib/change-notes/2022-09-20-CompilationUnit-getATypeInScope.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added the predicate `CompilationUnit.getATypeInScope()`.

--- a/java/ql/lib/change-notes/2022-09-20-CompilationUnit-simple-name-type.md
+++ b/java/ql/lib/change-notes/2022-09-20-CompilationUnit-simple-name-type.md
@@ -1,4 +1,0 @@
----
-category: feature
----
-* Added the predicate `CompilationUnit.getATypeAvailableBySimpleName()`.

--- a/java/ql/lib/change-notes/2022-09-20-CompilationUnit-simple-name-type.md
+++ b/java/ql/lib/change-notes/2022-09-20-CompilationUnit-simple-name-type.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added the predicate `CompilationUnit.getATypeAvailableBySimpleName()`.

--- a/java/ql/lib/semmle/code/java/CompilationUnit.qll
+++ b/java/ql/lib/semmle/code/java/CompilationUnit.qll
@@ -31,5 +31,50 @@ class CompilationUnit extends Element, File {
    */
   Module getModule() { cumodule(this, result) }
 
+  /**
+   * Gets a type which is available by its simple name in this compilation unit.
+   * Reasons for this can be:
+   * - The type is declared in this compilation unit as top-level type
+   * - The type is imported
+   * - The type is declared in the same package as this compilation unit
+   * - The type is declared in the package `java.lang`
+   */
+  ClassOrInterface getATypeAvailableBySimpleName() {
+    // See "Shadowing", https://docs.oracle.com/javase/specs/jls/se17/html/jls-6.html#jls-6.4.1
+    // Note: Currently the logic below does not consider shadowing and might have multiple results
+    // with the same type name
+    result.(TopLevelType).getCompilationUnit() = this
+    or
+    exists(ImportStaticTypeMember importDecl |
+      importDecl.getCompilationUnit() = this and
+      result = importDecl.getATypeImport()
+    )
+    or
+    exists(ImportType importDecl |
+      importDecl.getCompilationUnit() = this and
+      result = importDecl.getImportedType()
+    )
+    or
+    exists(ImportStaticOnDemand importDecl |
+      importDecl.getCompilationUnit() = this and
+      result = importDecl.getATypeImport()
+    )
+    or
+    exists(ImportOnDemandFromType importDecl |
+      importDecl.getCompilationUnit() = this and
+      result = importDecl.getAnImport()
+    )
+    or
+    exists(ImportOnDemandFromPackage importDecl |
+      importDecl.getCompilationUnit() = this and
+      result = importDecl.getAnImport()
+    )
+    or
+    // From same package or java.lang, see https://docs.oracle.com/javase/specs/jls/se17/html/jls-7.html
+    result.(TopLevelType).getPackage() = this.getPackage()
+    or
+    result.(TopLevelType).getPackage().hasName("java.lang")
+  }
+
   override string getAPrimaryQlClass() { result = "CompilationUnit" }
 }

--- a/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
+++ b/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
@@ -13,7 +13,7 @@ import java
 
 Class getTaggedType(ThrowsTag tag) {
   result.hasName(tag.getExceptionName()) and
-  result = tag.getFile().(CompilationUnit).getATypeAvailableBySimpleName()
+  result = tag.getFile().(CompilationUnit).getATypeInScope()
 }
 
 predicate canThrow(Callable callable, Class exception) {

--- a/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
+++ b/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
@@ -11,22 +11,18 @@
 
 import java
 
-RefType getTaggedType(ThrowsTag tag) {
+Class getTaggedType(ThrowsTag tag) {
   result.hasName(tag.getExceptionName()) and
-  exists(ImportType i | i.getFile() = tag.getFile() | i.getImportedType() = result)
+  result = tag.getFile().(CompilationUnit).getATypeAvailableBySimpleName()
 }
 
-predicate canThrow(Callable callable, RefType exception) {
-  exists(string uncheckedException |
-    uncheckedException = "RuntimeException" or uncheckedException = "Error"
-  |
-    exception.getAnAncestor().hasQualifiedName("java.lang", uncheckedException)
-  )
+predicate canThrow(Callable callable, Class exception) {
+  exception instanceof UncheckedThrowableType
   or
   callable.getAnException().getType().getADescendant() = exception
 }
 
-from ThrowsTag throwsTag, RefType thrownType, Callable docMethod
+from ThrowsTag throwsTag, Class thrownType, Callable docMethod
 where
   getTaggedType(throwsTag) = thrownType and
   docMethod.getDoc().getJavadoc().getAChild*() = throwsTag and

--- a/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
+++ b/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
@@ -11,7 +11,7 @@
 
 import java
 
-Class getTaggedType(ThrowsTag tag) {
+ClassOrInterface getTaggedType(ThrowsTag tag) {
   result.hasName(tag.getExceptionName()) and
   result = tag.getFile().(CompilationUnit).getATypeInScope()
 }
@@ -22,7 +22,9 @@ predicate canThrow(Callable callable, Class exception) {
   callable.getAnException().getType().getADescendant() = exception
 }
 
-from ThrowsTag throwsTag, Class thrownType, Callable docMethod
+// Uses ClassOrInterface as type for thrownType to also cover case where erroneously an interface
+// type is declared as thrown exception
+from ThrowsTag throwsTag, ClassOrInterface thrownType, Callable docMethod
 where
   getTaggedType(throwsTag) = thrownType and
   docMethod.getDoc().getJavadoc().getAChild*() = throwsTag and

--- a/java/ql/test/query-tests/Javadoc/ImpossibleJavadocThrows.expected
+++ b/java/ql/test/query-tests/Javadoc/ImpossibleJavadocThrows.expected
@@ -1,2 +1,3 @@
 | ImpossibleJavadocThrows.java:9:5:9:12 | @throws | Javadoc for bad1 claims to throw InterruptedException but this is impossible. |
 | ImpossibleJavadocThrows.java:16:5:16:15 | @exception | Javadoc for bad2 claims to throw Exception but this is impossible. |
+| ImpossibleJavadocThrows.java:23:5:23:12 | @throws | Javadoc for bad3 claims to throw Runnable but this is impossible. |

--- a/java/ql/test/query-tests/Javadoc/ImpossibleJavadocThrows.java
+++ b/java/ql/test/query-tests/Javadoc/ImpossibleJavadocThrows.java
@@ -20,6 +20,13 @@ class ImpossibleJavadocThrows {
 	
 	/**
 	 * 
+	 * @throws Runnable
+	 */
+	public void bad3() {
+	}
+	
+	/**
+	 * 
 	 * @throws InterruptedException
 	 */
 	public void goodDeclared() throws Exception{


### PR DESCRIPTION
This predicate is mainly helpful for Javadoc queries and for queries which check whether the name of an element shadows another type.

Resolves #4119
It makes probably most sense to implement the logic requested there for `CompilationUnit`, as done in this PR because there it is also possible to account for shadowing between different kinds of imports (though this is currently not implemented by this PR).

This PR is a bit experimental and does not have a dedicated test; feedback is appreciated.