### PR TITLE
Java: Add `getJavadoc` predicate for `JavadocParent` and `JavadocElement`

### DIFF
--- a/java/ql/lib/change-notes/2022-09-20-javadoc-getJavadoc.md
+++ b/java/ql/lib/change-notes/2022-09-20-javadoc-getJavadoc.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added the predicates `JavadocParent.getJavadoc()` and `JavadocElement.getJavadoc()`.

--- a/java/ql/lib/semmle/code/java/Javadoc.qll
+++ b/java/ql/lib/semmle/code/java/Javadoc.qll
@@ -6,6 +6,12 @@ import semmle.code.Location
 
 /** A Javadoc parent is an element whose child can be some Javadoc documentation. */
 class JavadocParent extends @javadocParent, Top {
+  /**
+   * Gets the Javadoc comment that contains this element, or itself if this element
+   * is the Javadoc comment.
+   */
+  Javadoc getJavadoc() { result.getAChild*() = this }
+
   /** Gets a documentation element attached to this parent. */
   JavadocElement getAChild() { result.getParent() = this }
 
@@ -52,6 +58,8 @@ class Javadoc extends JavadocParent, @javadoc {
     )
   }
 
+  override Javadoc getJavadoc() { result = this }
+
   /** Gets the Java code element that is commented by this piece of Javadoc. */
   Documentable getCommentedElement() { result.getJavadoc() = this }
 
@@ -72,6 +80,9 @@ abstract class JavadocElement extends @javadocElement, Top {
   /** Gets the parent of this Javadoc element. */
   JavadocParent getParent() { javadocTag(this, _, result, _) or javadocText(this, _, result, _) }
 
+  /** Gets the Javadoc comment that contains this element. */
+  Javadoc getJavadoc() { result.getAChild+() = this }
+
   /** Gets the index of this child element relative to its parent. */
   int getIndex() { javadocTag(this, _, _, result) or javadocText(this, _, _, result) }
 
@@ -84,13 +95,15 @@ abstract class JavadocElement extends @javadocElement, Top {
 
 /** A Javadoc block tag. This does not include inline tags. */
 class JavadocTag extends JavadocElement, JavadocParent, @javadocTag {
+  override Javadoc getJavadoc() { result = JavadocElement.super.getJavadoc() }
+
   /** Gets the name of this Javadoc tag. */
   string getTagName() { javadocTag(this, result, _, _) }
 
   /** Gets a printable representation of this Javadoc tag. */
   override string toString() { result = this.getTagName() }
 
-  /** Gets the text associated with this Javadoc tag. */
+  /** Gets the text associated with this Javadoc tag. Has no result if this tag has no text. */
   override string getText() { result = this.getChild(0).toString() }
 
   override string getAPrimaryQlClass() { result = "JavadocTag" }
@@ -136,9 +149,6 @@ class AuthorTag extends JavadocTag {
 
 /** A piece of Javadoc text. */
 class JavadocText extends JavadocElement, @javadocText {
-  /** Gets the Javadoc comment that contains this piece of text. */
-  Javadoc getJavadoc() { result.getAChild+() = this }
-
   /** Gets the text itself. */
   override string getText() { javadocText(this, result, _, _) }
 

--- a/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
+++ b/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
@@ -29,7 +29,7 @@ predicate canThrow(Callable callable, RefType exception) {
 from ThrowsTag throwsTag, RefType thrownType, Callable docMethod
 where
   getTaggedType(throwsTag) = thrownType and
-  docMethod.getDoc().getJavadoc().getAChild*() = throwsTag and
+  throwsTag.getJavadoc().getCommentedElement() = docMethod and
   not canThrow(docMethod, thrownType)
 select throwsTag,
   "Javadoc for " + docMethod + " claims to throw " + thrownType.getName() +

--- a/java/ql/test/library-tests/javadoc/AllComments.expected
+++ b/java/ql/test/library-tests/javadoc/AllComments.expected
@@ -1,6 +1,6 @@
-| javadoc/Test.java:3:1:3:20 | /** A test class. */ | javadoc/Test.java:4:14:4:17 | Test |
-| javadoc/Test.java:5:2:6:14 | /** A javadoc ... */ | javadoc/Test.java:7:7:7:7 | f |
-| javadoc/Test.java:9:2:9:33 | /** Another javadoc comment */ | javadoc/Test.java:11:7:11:7 | g |
-| javadoc/Test.java:10:2:10:24 | // and a normal comment | javadoc/Test.java:11:7:11:7 | g |
-| javadoc/Test.java:13:2:13:29 | /* another normal comment */ | javadoc/Test.java:14:6:14:6 | x |
-| javadoc/Test.java:17:2:17:19 | /** @deprecated */ | javadoc/Test.java:18:7:18:7 | h |
+| javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | javadoc/Test.java:8:14:8:17 | Test |
+| javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | javadoc/Test.java:11:7:11:7 | f |
+| javadoc/Test.java:13:2:13:33 | /** Another javadoc comment */ | javadoc/Test.java:15:7:15:7 | g |
+| javadoc/Test.java:14:2:14:24 | // and a normal comment | javadoc/Test.java:15:7:15:7 | g |
+| javadoc/Test.java:17:2:17:29 | /* another normal comment */ | javadoc/Test.java:18:6:18:6 | x |
+| javadoc/Test.java:21:2:21:19 | /** @deprecated */ | javadoc/Test.java:22:7:22:7 | h |

--- a/java/ql/test/library-tests/javadoc/JavadocComments.expected
+++ b/java/ql/test/library-tests/javadoc/JavadocComments.expected
@@ -1,4 +1,4 @@
-| javadoc/Test.java:3:1:3:20 | /** A test class. */ | javadoc/Test.java:4:14:4:17 | Test |
-| javadoc/Test.java:5:2:6:14 | /** A javadoc ... */ | javadoc/Test.java:7:7:7:7 | f |
-| javadoc/Test.java:9:2:9:33 | /** Another javadoc comment */ | javadoc/Test.java:11:7:11:7 | g |
-| javadoc/Test.java:17:2:17:19 | /** @deprecated */ | javadoc/Test.java:18:7:18:7 | h |
+| javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | javadoc/Test.java:8:14:8:17 | Test |
+| javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | javadoc/Test.java:11:7:11:7 | f |
+| javadoc/Test.java:13:2:13:33 | /** Another javadoc comment */ | javadoc/Test.java:15:7:15:7 | g |
+| javadoc/Test.java:21:2:21:19 | /** @deprecated */ | javadoc/Test.java:22:7:22:7 | h |

--- a/java/ql/test/library-tests/javadoc/JavadocParent.expected
+++ b/java/ql/test/library-tests/javadoc/JavadocParent.expected
@@ -1,0 +1,19 @@
+getAChild
+| javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | javadoc/Test.java:4:4:4:16 | A test class. |
+| javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | javadoc/Test.java:6:4:6:10 | @since |
+| javadoc/Test.java:6:4:6:10 | @since | javadoc/Test.java:6:11:6:13 | 1.0 |
+| javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | javadoc/Test.java:9:6:9:14 | A javadoc |
+| javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | javadoc/Test.java:10:5:10:11 | comment |
+| javadoc/Test.java:13:2:13:33 | /** Another javadoc comment */ | javadoc/Test.java:13:6:13:28 | Another javadoc comment |
+| javadoc/Test.java:14:2:14:24 | // and a normal comment | javadoc/Test.java:14:4:14:24 |  and a normal comment |
+| javadoc/Test.java:17:2:17:29 | /* another normal comment */ | javadoc/Test.java:17:5:17:26 | another normal comment |
+| javadoc/Test.java:21:2:21:19 | /** @deprecated */ | javadoc/Test.java:21:6:21:17 | @deprecated |
+#select
+| javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | javadoc/Test.java:3:1:7:3 | /** A test class. ... */ |
+| javadoc/Test.java:6:4:6:10 | @since | javadoc/Test.java:3:1:7:3 | /** A test class. ... */ |
+| javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ |
+| javadoc/Test.java:13:2:13:33 | /** Another javadoc comment */ | javadoc/Test.java:13:2:13:33 | /** Another javadoc comment */ |
+| javadoc/Test.java:14:2:14:24 | // and a normal comment | javadoc/Test.java:14:2:14:24 | // and a normal comment |
+| javadoc/Test.java:17:2:17:29 | /* another normal comment */ | javadoc/Test.java:17:2:17:29 | /* another normal comment */ |
+| javadoc/Test.java:21:2:21:19 | /** @deprecated */ | javadoc/Test.java:21:2:21:19 | /** @deprecated */ |
+| javadoc/Test.java:21:6:21:17 | @deprecated | javadoc/Test.java:21:2:21:19 | /** @deprecated */ |

--- a/java/ql/test/library-tests/javadoc/JavadocParent.ql
+++ b/java/ql/test/library-tests/javadoc/JavadocParent.ql
@@ -1,0 +1,6 @@
+import java
+
+query JavadocElement getAChild(JavadocParent javadocParent) { result = javadocParent.getAChild() }
+
+from JavadocParent javadocParent
+select javadocParent, javadocParent.getJavadoc()

--- a/java/ql/test/library-tests/javadoc/JavadocTag.expected
+++ b/java/ql/test/library-tests/javadoc/JavadocTag.expected
@@ -1,0 +1,2 @@
+| javadoc/Test.java:6:4:6:10 | @since | javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | @since | 1.0 |
+| javadoc/Test.java:21:6:21:17 | @deprecated | javadoc/Test.java:21:2:21:19 | /** @deprecated */ | javadoc/Test.java:21:2:21:19 | /** @deprecated */ | @deprecated | <none> |

--- a/java/ql/test/library-tests/javadoc/JavadocTag.ql
+++ b/java/ql/test/library-tests/javadoc/JavadocTag.ql
@@ -1,0 +1,5 @@
+import java
+
+from JavadocTag javadocTag, string text
+where if exists(javadocTag.getText()) then text = javadocTag.getText() else text = "<none>"
+select javadocTag, javadocTag.getJavadoc(), javadocTag.getParent(), javadocTag.getTagName(), text

--- a/java/ql/test/library-tests/javadoc/JavadocText.expected
+++ b/java/ql/test/library-tests/javadoc/JavadocText.expected
@@ -1,0 +1,7 @@
+| javadoc/Test.java:4:4:4:16 | A test class. | javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | A test class. |
+| javadoc/Test.java:6:11:6:13 | 1.0 | javadoc/Test.java:3:1:7:3 | /** A test class. ... */ | javadoc/Test.java:6:4:6:10 | @since | 1.0 |
+| javadoc/Test.java:9:6:9:14 | A javadoc | javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | A javadoc |
+| javadoc/Test.java:10:5:10:11 | comment | javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | javadoc/Test.java:9:2:10:14 | /** A javadoc ... */ | comment |
+| javadoc/Test.java:13:6:13:28 | Another javadoc comment | javadoc/Test.java:13:2:13:33 | /** Another javadoc comment */ | javadoc/Test.java:13:2:13:33 | /** Another javadoc comment */ | Another javadoc comment |
+| javadoc/Test.java:14:4:14:24 |  and a normal comment | javadoc/Test.java:14:2:14:24 | // and a normal comment | javadoc/Test.java:14:2:14:24 | // and a normal comment |  and a normal comment |
+| javadoc/Test.java:17:5:17:26 | another normal comment | javadoc/Test.java:17:2:17:29 | /* another normal comment */ | javadoc/Test.java:17:2:17:29 | /* another normal comment */ | another normal comment |

--- a/java/ql/test/library-tests/javadoc/JavadocText.ql
+++ b/java/ql/test/library-tests/javadoc/JavadocText.ql
@@ -1,0 +1,4 @@
+import java
+
+from JavadocText javadocText
+select javadocText, javadocText.getJavadoc(), javadocText.getParent(), javadocText.getText()

--- a/java/ql/test/library-tests/javadoc/PrintAst.expected
+++ b/java/ql/test/library-tests/javadoc/PrintAst.expected
@@ -1,29 +1,31 @@
 javadoc/Test.java:
 #    0| [CompilationUnit] Test
-#    4|   1: [Class] Test
+#    8|   1: [Class] Test
 #-----|     -4: (Javadoc)
-#    3|       1: [Javadoc] /** A test class. */
-#    3|         0: [JavadocText] A test class.
-#    7|     2: [Method] f
+#    3|       1: [Javadoc] /** A test class. ... */
+#    4|         0: [JavadocText] A test class.
+#    6|         1: [JavadocTag] @since
+#    6|           0: [JavadocText] 1.0
+#   11|     2: [Method] f
 #-----|       0: (Javadoc)
-#    5|         1: [Javadoc] /** A javadoc ... */
-#    5|           0: [JavadocText] A javadoc
-#    6|           1: [JavadocText] comment
-#    7|       3: [TypeAccess] void
-#    7|       5: [BlockStmt] { ... }
-#   11|     3: [Method] g
-#-----|       0: (Javadoc)
-#    9|         1: [Javadoc] /** Another javadoc comment */
-#    9|           0: [JavadocText] Another javadoc comment
+#    9|         1: [Javadoc] /** A javadoc ... */
+#    9|           0: [JavadocText] A javadoc
+#   10|           1: [JavadocText] comment
 #   11|       3: [TypeAccess] void
 #   11|       5: [BlockStmt] { ... }
-#   14|     4: [FieldDeclaration] int x;
-#   14|       -1: [TypeAccess] int
-#   15|     5: [FieldDeclaration] int y;
-#   15|       -1: [TypeAccess] int
-#   18|     6: [Method] h
+#   15|     3: [Method] g
 #-----|       0: (Javadoc)
-#   17|         1: [Javadoc] /** @deprecated */
-#   17|           0: [JavadocTag] @deprecated
-#   18|       3: [TypeAccess] void
-#   18|       5: [BlockStmt] { ... }
+#   13|         1: [Javadoc] /** Another javadoc comment */
+#   13|           0: [JavadocText] Another javadoc comment
+#   15|       3: [TypeAccess] void
+#   15|       5: [BlockStmt] { ... }
+#   18|     4: [FieldDeclaration] int x;
+#   18|       -1: [TypeAccess] int
+#   19|     5: [FieldDeclaration] int y;
+#   19|       -1: [TypeAccess] int
+#   22|     6: [Method] h
+#-----|       0: (Javadoc)
+#   21|         1: [Javadoc] /** @deprecated */
+#   21|           0: [JavadocTag] @deprecated
+#   22|       3: [TypeAccess] void
+#   22|       5: [BlockStmt] { ... }

--- a/java/ql/test/library-tests/javadoc/javadoc/Test.java
+++ b/java/ql/test/library-tests/javadoc/javadoc/Test.java
@@ -1,6 +1,10 @@
 package javadoc;
 
-/** A test class. */
+/**
+ * A test class.
+ * 
+ * @since 1.0
+ */
 public class Test {
 	/** A javadoc
 	 * comment */


### PR DESCRIPTION
This hopefully makes it a bit easier to use the Javadoc class `JavadocParent` and `JavadocTag`.

Though if you think these changes are not worth it, feel free to close this PR.