### PR TITLE
Swift: move toposort in `schema.py`

### DIFF
--- a/swift/codegen/generators/cppgen.py
+++ b/swift/codegen/generators/cppgen.py
@@ -16,7 +16,6 @@ import pathlib
 from typing import Dict
 
 import inflection
-from toposort import toposort_flatten
 
 from swift.codegen.lib import cpp, schema
 
@@ -71,13 +70,9 @@ class Processor:
         )
 
     def get_classes(self):
-        grouped = {pathlib.Path(): {}}
+        ret = {pathlib.Path(): []}
         for k, cls in self._classmap.items():
-            grouped.setdefault(cls.dir, {}).update({k: cls})
-        ret = {}
-        for dir, map in grouped.items():
-            inheritance_graph = {k: {b for b in cls.bases if b in map} for k, cls in map.items()}
-            ret[dir] = [self._get_class(cls) for cls in toposort_flatten(inheritance_graph)]
+            ret.setdefault(cls.dir, []).append(self._get_class(cls.name))
         return ret
 
 

--- a/swift/codegen/test/test_cppgen.py
+++ b/swift/codegen/test/test_cppgen.py
@@ -56,23 +56,6 @@ def test_two_class_hierarchy(generate):
     ]
 
 
-def test_complex_hierarchy_topologically_ordered(generate):
-    a = cpp.Class(name="A")
-    b = cpp.Class(name="B")
-    c = cpp.Class(name="C", bases=[a])
-    d = cpp.Class(name="D", bases=[a])
-    e = cpp.Class(name="E", bases=[b, c, d], final=True, trap_name="Es")
-    f = cpp.Class(name="F", bases=[c], final=True, trap_name="Fs")
-    assert generate([
-        schema.Class(name="F", bases=["C"]),
-        schema.Class(name="B", derived={"E"}),
-        schema.Class(name="D", bases=["A"], derived={"E"}),
-        schema.Class(name="C", bases=["A"], derived={"E", "F"}),
-        schema.Class(name="E", bases=["B", "C", "D"]),
-        schema.Class(name="A", derived={"C", "D"}),
-    ]) == [a, b, c, d, e, f]
-
-
 @pytest.mark.parametrize("type,expected", [
     ("a", "a"),
     ("string", "std::string"),
@@ -154,8 +137,8 @@ def test_classes_with_dirs(generate_grouped):
     assert generate_grouped([
         schema.Class(name="A"),
         schema.Class(name="B", dir=pathlib.Path("foo")),
-        schema.Class(name="C", bases=["CBase"], dir=pathlib.Path("bar")),
         schema.Class(name="CBase", derived={"C"}, dir=pathlib.Path("bar")),
+        schema.Class(name="C", bases=["CBase"], dir=pathlib.Path("bar")),
         schema.Class(name="D", dir=pathlib.Path("foo/bar/baz")),
     ]) == {
         ".": [cpp.Class(name="A", trap_name="As", final=True)],

--- a/swift/codegen/test/test_qlgen.py
+++ b/swift/codegen/test/test_qlgen.py
@@ -177,10 +177,10 @@ def test_hierarchy_imports(generate_import_list):
 
 def test_hierarchy_children(generate_children_implementations):
     assert generate_children_implementations([
-        schema.Class("D", bases=["B", "C"]),
-        schema.Class("C", bases=["A"], derived={"D"}),
-        schema.Class("B", bases=["A"], derived={"D"}),
         schema.Class("A", derived={"B", "C"}),
+        schema.Class("B", bases=["A"], derived={"D"}),
+        schema.Class("C", bases=["A"], derived={"D"}),
+        schema.Class("D", bases=["B", "C"]),
     ]) == ql.GetParentImplementation(
         classes=[ql.Class(name="A"),
                  ql.Class(name="B", bases=["A"], imports=[

--- a/swift/ql/lib/codeql/swift/generated/ParentChild.qll
+++ b/swift/ql/lib/codeql/swift/generated/ParentChild.qll
@@ -42,6 +42,142 @@ private module Impl {
     )
   }
 
+  private Element getImmediateChildOfLocatable(Locatable e, int index, string partialPredicateCall) {
+    exists(int b, int bElement, int n |
+      b = 0 and
+      bElement = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfElement(e, i, _)) | i) and
+      n = bElement and
+      (
+        none()
+        or
+        result = getImmediateChildOfElement(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLocation(Location e, int index, string partialPredicateCall) {
+    exists(int b, int bElement, int n |
+      b = 0 and
+      bElement = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfElement(e, i, _)) | i) and
+      n = bElement and
+      (
+        none()
+        or
+        result = getImmediateChildOfElement(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnresolvedElement(
+    UnresolvedElement e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bElement, int n |
+      b = 0 and
+      bElement = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfElement(e, i, _)) | i) and
+      n = bElement and
+      (
+        none()
+        or
+        result = getImmediateChildOfElement(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAstNode(AstNode e, int index, string partialPredicateCall) {
+    exists(int b, int bLocatable, int n |
+      b = 0 and
+      bLocatable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocatable(e, i, _)) | i) and
+      n = bLocatable and
+      (
+        none()
+        or
+        result = getImmediateChildOfLocatable(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfComment(Comment e, int index, string partialPredicateCall) {
+    exists(int b, int bLocatable, int n |
+      b = 0 and
+      bLocatable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocatable(e, i, _)) | i) and
+      n = bLocatable and
+      (
+        none()
+        or
+        result = getImmediateChildOfLocatable(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDbFile(DbFile e, int index, string partialPredicateCall) {
+    exists(int b, int bFile, int n |
+      b = 0 and
+      bFile = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfFile(e, i, _)) | i) and
+      n = bFile and
+      (
+        none()
+        or
+        result = getImmediateChildOfFile(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDbLocation(DbLocation e, int index, string partialPredicateCall) {
+    exists(int b, int bLocation, int n |
+      b = 0 and
+      bLocation = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocation(e, i, _)) | i) and
+      n = bLocation and
+      (
+        none()
+        or
+        result = getImmediateChildOfLocation(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnknownFile(
+    UnknownFile e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bFile, int n |
+      b = 0 and
+      bFile = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfFile(e, i, _)) | i) and
+      n = bFile and
+      (
+        none()
+        or
+        result = getImmediateChildOfFile(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnknownLocation(
+    UnknownLocation e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLocation, int n |
+      b = 0 and
+      bLocation = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocation(e, i, _)) | i) and
+      n = bLocation and
+      (
+        none()
+        or
+        result = getImmediateChildOfLocation(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDecl(Decl e, int index, string partialPredicateCall) {
+    exists(int b, int bAstNode, int n |
+      b = 0 and
+      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
+      n = bAstNode and
+      (
+        none()
+        or
+        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
   private Element getImmediateChildOfGenericContext(
     GenericContext e, int index, string partialPredicateCall
   ) {
@@ -81,28 +217,3489 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfLocatable(Locatable e, int index, string partialPredicateCall) {
-    exists(int b, int bElement, int n |
+  private Element getImmediateChildOfEnumCaseDecl(
+    EnumCaseDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDecl, int n |
       b = 0 and
-      bElement = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfElement(e, i, _)) | i) and
-      n = bElement and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
       (
         none()
         or
-        result = getImmediateChildOfElement(e, index - b, partialPredicateCall)
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
       )
     )
   }
 
-  private Element getImmediateChildOfLocation(Location e, int index, string partialPredicateCall) {
-    exists(int b, int bElement, int n |
+  private Element getImmediateChildOfExtensionDecl(
+    ExtensionDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bGenericContext, int bIterableDeclContext, int bDecl, int n |
       b = 0 and
-      bElement = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfElement(e, i, _)) | i) and
-      n = bElement and
+      bGenericContext =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
+      bIterableDeclContext =
+        bGenericContext + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
+      bDecl =
+        bIterableDeclContext + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
       (
         none()
         or
-        result = getImmediateChildOfElement(e, index - b, partialPredicateCall)
+        result = getImmediateChildOfGenericContext(e, index - b, partialPredicateCall)
+        or
+        result =
+          getImmediateChildOfIterableDeclContext(e, index - bGenericContext, partialPredicateCall)
+        or
+        result = getImmediateChildOfDecl(e, index - bIterableDeclContext, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfIfConfigDecl(
+    IfConfigDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDecl, int n, int nActiveElement |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      nActiveElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateActiveElement(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateActiveElement(index - n) and
+        partialPredicateCall = "ActiveElement(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfImportDecl(ImportDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bDecl, int n |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfMissingMemberDecl(
+    MissingMemberDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDecl, int n |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOperatorDecl(
+    OperatorDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDecl, int n |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPatternBindingDecl(
+    PatternBindingDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDecl, int n, int nInit, int nPattern |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      nInit = n + 1 + max(int i | i = -1 or exists(e.getImmediateInit(i)) | i) and
+      nPattern = nInit + 1 + max(int i | i = -1 or exists(e.getImmediatePattern(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateInit(index - n) and
+        partialPredicateCall = "Init(" + (index - n).toString() + ")"
+        or
+        result = e.getImmediatePattern(index - nInit) and
+        partialPredicateCall = "Pattern(" + (index - nInit).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPoundDiagnosticDecl(
+    PoundDiagnosticDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDecl, int n |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPrecedenceGroupDecl(
+    PrecedenceGroupDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDecl, int n |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTopLevelCodeDecl(
+    TopLevelCodeDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDecl, int n, int nBody |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      nBody = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfValueDecl(ValueDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bDecl, int n |
+      b = 0 and
+      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
+      n = bDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAbstractFunctionDecl(
+    AbstractFunctionDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bGenericContext, int bValueDecl, int bCallable, int n |
+      b = 0 and
+      bGenericContext =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
+      bValueDecl =
+        bGenericContext + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
+      bCallable =
+        bValueDecl + 1 + max(int i | i = -1 or exists(getImmediateChildOfCallable(e, i, _)) | i) and
+      n = bCallable and
+      (
+        none()
+        or
+        result = getImmediateChildOfGenericContext(e, index - b, partialPredicateCall)
+        or
+        result = getImmediateChildOfValueDecl(e, index - bGenericContext, partialPredicateCall)
+        or
+        result = getImmediateChildOfCallable(e, index - bValueDecl, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAbstractStorageDecl(
+    AbstractStorageDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bValueDecl, int n, int nAccessorDecl |
+      b = 0 and
+      bValueDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
+      n = bValueDecl and
+      nAccessorDecl = n + 1 + max(int i | i = -1 or exists(e.getImmediateAccessorDecl(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfValueDecl(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateAccessorDecl(index - n) and
+        partialPredicateCall = "AccessorDecl(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfEnumElementDecl(
+    EnumElementDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bValueDecl, int n, int nParam |
+      b = 0 and
+      bValueDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
+      n = bValueDecl and
+      nParam = n + 1 + max(int i | i = -1 or exists(e.getImmediateParam(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfValueDecl(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateParam(index - n) and
+        partialPredicateCall = "Param(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfInfixOperatorDecl(
+    InfixOperatorDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bOperatorDecl, int n |
+      b = 0 and
+      bOperatorDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfOperatorDecl(e, i, _)) | i) and
+      n = bOperatorDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfOperatorDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPostfixOperatorDecl(
+    PostfixOperatorDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bOperatorDecl, int n |
+      b = 0 and
+      bOperatorDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfOperatorDecl(e, i, _)) | i) and
+      n = bOperatorDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfOperatorDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPrefixOperatorDecl(
+    PrefixOperatorDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bOperatorDecl, int n |
+      b = 0 and
+      bOperatorDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfOperatorDecl(e, i, _)) | i) and
+      n = bOperatorDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfOperatorDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTypeDecl(TypeDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bValueDecl, int n |
+      b = 0 and
+      bValueDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
+      n = bValueDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfValueDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAbstractTypeParamDecl(
+    AbstractTypeParamDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bTypeDecl, int n |
+      b = 0 and
+      bTypeDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfTypeDecl(e, i, _)) | i) and
+      n = bTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfTypeDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfConstructorDecl(
+    ConstructorDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAbstractFunctionDecl, int n |
+      b = 0 and
+      bAbstractFunctionDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractFunctionDecl(e, i, _)) | i) and
+      n = bAbstractFunctionDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractFunctionDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDestructorDecl(
+    DestructorDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAbstractFunctionDecl, int n |
+      b = 0 and
+      bAbstractFunctionDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractFunctionDecl(e, i, _)) | i) and
+      n = bAbstractFunctionDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractFunctionDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfFuncDecl(FuncDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bAbstractFunctionDecl, int n |
+      b = 0 and
+      bAbstractFunctionDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractFunctionDecl(e, i, _)) | i) and
+      n = bAbstractFunctionDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractFunctionDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfGenericTypeDecl(
+    GenericTypeDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bGenericContext, int bTypeDecl, int n |
+      b = 0 and
+      bGenericContext =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
+      bTypeDecl =
+        bGenericContext + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfTypeDecl(e, i, _)) | i) and
+      n = bTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfGenericContext(e, index - b, partialPredicateCall)
+        or
+        result = getImmediateChildOfTypeDecl(e, index - bGenericContext, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfModuleDecl(ModuleDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bTypeDecl, int n |
+      b = 0 and
+      bTypeDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfTypeDecl(e, i, _)) | i) and
+      n = bTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfTypeDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfSubscriptDecl(
+    SubscriptDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAbstractStorageDecl, int bGenericContext, int n, int nParam |
+      b = 0 and
+      bAbstractStorageDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractStorageDecl(e, i, _)) | i) and
+      bGenericContext =
+        bAbstractStorageDecl + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
+      n = bGenericContext and
+      nParam = n + 1 + max(int i | i = -1 or exists(e.getImmediateParam(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractStorageDecl(e, index - b, partialPredicateCall)
+        or
+        result =
+          getImmediateChildOfGenericContext(e, index - bAbstractStorageDecl, partialPredicateCall)
+        or
+        result = e.getImmediateParam(index - n) and
+        partialPredicateCall = "Param(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfVarDecl(VarDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bAbstractStorageDecl, int n |
+      b = 0 and
+      bAbstractStorageDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractStorageDecl(e, i, _)) | i) and
+      n = bAbstractStorageDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractStorageDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAccessorDecl(
+    AccessorDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bFuncDecl, int n |
+      b = 0 and
+      bFuncDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfFuncDecl(e, i, _)) | i) and
+      n = bFuncDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfFuncDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAssociatedTypeDecl(
+    AssociatedTypeDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAbstractTypeParamDecl, int n |
+      b = 0 and
+      bAbstractTypeParamDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractTypeParamDecl(e, i, _)) | i) and
+      n = bAbstractTypeParamDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractTypeParamDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfConcreteFuncDecl(
+    ConcreteFuncDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bFuncDecl, int n |
+      b = 0 and
+      bFuncDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfFuncDecl(e, i, _)) | i) and
+      n = bFuncDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfFuncDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfConcreteVarDecl(
+    ConcreteVarDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bVarDecl, int n |
+      b = 0 and
+      bVarDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfVarDecl(e, i, _)) | i) and
+      n = bVarDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfVarDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfGenericTypeParamDecl(
+    GenericTypeParamDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAbstractTypeParamDecl, int n |
+      b = 0 and
+      bAbstractTypeParamDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractTypeParamDecl(e, i, _)) | i) and
+      n = bAbstractTypeParamDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractTypeParamDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfNominalTypeDecl(
+    NominalTypeDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bGenericTypeDecl, int bIterableDeclContext, int n |
+      b = 0 and
+      bGenericTypeDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
+      bIterableDeclContext =
+        bGenericTypeDecl + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
+      n = bIterableDeclContext and
+      (
+        none()
+        or
+        result = getImmediateChildOfGenericTypeDecl(e, index - b, partialPredicateCall)
+        or
+        result =
+          getImmediateChildOfIterableDeclContext(e, index - bGenericTypeDecl, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOpaqueTypeDecl(
+    OpaqueTypeDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bGenericTypeDecl, int n |
+      b = 0 and
+      bGenericTypeDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
+      n = bGenericTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfGenericTypeDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfParamDecl(ParamDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bVarDecl, int n |
+      b = 0 and
+      bVarDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfVarDecl(e, i, _)) | i) and
+      n = bVarDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfVarDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTypeAliasDecl(
+    TypeAliasDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bGenericTypeDecl, int n |
+      b = 0 and
+      bGenericTypeDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
+      n = bGenericTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfGenericTypeDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfClassDecl(ClassDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bNominalTypeDecl, int n |
+      b = 0 and
+      bNominalTypeDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNominalTypeDecl(e, i, _)) | i) and
+      n = bNominalTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfNominalTypeDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfEnumDecl(EnumDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bNominalTypeDecl, int n |
+      b = 0 and
+      bNominalTypeDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNominalTypeDecl(e, i, _)) | i) and
+      n = bNominalTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfNominalTypeDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfProtocolDecl(
+    ProtocolDecl e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bNominalTypeDecl, int n |
+      b = 0 and
+      bNominalTypeDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNominalTypeDecl(e, i, _)) | i) and
+      n = bNominalTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfNominalTypeDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfStructDecl(StructDecl e, int index, string partialPredicateCall) {
+    exists(int b, int bNominalTypeDecl, int n |
+      b = 0 and
+      bNominalTypeDecl =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNominalTypeDecl(e, i, _)) | i) and
+      n = bNominalTypeDecl and
+      (
+        none()
+        or
+        result = getImmediateChildOfNominalTypeDecl(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfArgument(Argument e, int index, string partialPredicateCall) {
+    exists(int b, int bLocatable, int n, int nExpr |
+      b = 0 and
+      bLocatable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocatable(e, i, _)) | i) and
+      n = bLocatable and
+      nExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLocatable(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateExpr() and partialPredicateCall = "Expr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfExpr(Expr e, int index, string partialPredicateCall) {
+    exists(int b, int bAstNode, int n |
+      b = 0 and
+      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
+      n = bAstNode and
+      (
+        none()
+        or
+        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAbstractClosureExpr(
+    AbstractClosureExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int bCallable, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      bCallable =
+        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfCallable(e, i, _)) | i) and
+      n = bCallable and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = getImmediateChildOfCallable(e, index - bExpr, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAnyTryExpr(AnyTryExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAppliedPropertyWrapperExpr(
+    AppliedPropertyWrapperExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfApplyExpr(ApplyExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nFunction, int nArgument |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nFunction = n + 1 and
+      nArgument = nFunction + 1 + max(int i | i = -1 or exists(e.getImmediateArgument(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateFunction() and partialPredicateCall = "Function()"
+        or
+        result = e.getImmediateArgument(index - nFunction) and
+        partialPredicateCall = "Argument(" + (index - nFunction).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfArrowExpr(ArrowExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAssignExpr(AssignExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nDest, int nSource |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nDest = n + 1 and
+      nSource = nDest + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateDest() and partialPredicateCall = "Dest()"
+        or
+        index = nDest and result = e.getImmediateSource() and partialPredicateCall = "Source()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBindOptionalExpr(
+    BindOptionalExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCaptureListExpr(
+    CaptureListExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nBindingDecl, int nClosureBody |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nBindingDecl = n + 1 + max(int i | i = -1 or exists(e.getImmediateBindingDecl(i)) | i) and
+      nClosureBody = nBindingDecl + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateBindingDecl(index - n) and
+        partialPredicateCall = "BindingDecl(" + (index - n).toString() + ")"
+        or
+        index = nBindingDecl and
+        result = e.getImmediateClosureBody() and
+        partialPredicateCall = "ClosureBody()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCodeCompletionExpr(
+    CodeCompletionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCollectionExpr(
+    CollectionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDeclRefExpr(
+    DeclRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDefaultArgumentExpr(
+    DefaultArgumentExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDiscardAssignmentExpr(
+    DiscardAssignmentExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDotSyntaxBaseIgnoredExpr(
+    DotSyntaxBaseIgnoredExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nQualifier, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nQualifier = n + 1 and
+      nSubExpr = nQualifier + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateQualifier() and partialPredicateCall = "Qualifier()"
+        or
+        index = nQualifier and
+        result = e.getImmediateSubExpr() and
+        partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDynamicTypeExpr(
+    DynamicTypeExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nBase |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nBase = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBase() and partialPredicateCall = "Base()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfEditorPlaceholderExpr(
+    EditorPlaceholderExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfEnumIsCaseExpr(
+    EnumIsCaseExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfErrorExpr(ErrorExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfExplicitCastExpr(
+    ExplicitCastExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfForceValueExpr(
+    ForceValueExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfIdentityExpr(
+    IdentityExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfIfExpr(IfExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nCondition, int nThenExpr, int nElseExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nCondition = n + 1 and
+      nThenExpr = nCondition + 1 and
+      nElseExpr = nThenExpr + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateCondition() and partialPredicateCall = "Condition()"
+        or
+        index = nCondition and
+        result = e.getImmediateThenExpr() and
+        partialPredicateCall = "ThenExpr()"
+        or
+        index = nThenExpr and
+        result = e.getImmediateElseExpr() and
+        partialPredicateCall = "ElseExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfImplicitConversionExpr(
+    ImplicitConversionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfInOutExpr(InOutExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfKeyPathApplicationExpr(
+    KeyPathApplicationExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nBase, int nKeyPath |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nBase = n + 1 and
+      nKeyPath = nBase + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBase() and partialPredicateCall = "Base()"
+        or
+        index = nBase and result = e.getImmediateKeyPath() and partialPredicateCall = "KeyPath()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfKeyPathDotExpr(
+    KeyPathDotExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfKeyPathExpr(
+    KeyPathExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nRoot, int nParsedPath |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nRoot = n + 1 and
+      nParsedPath = nRoot + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateRoot() and partialPredicateCall = "Root()"
+        or
+        index = nRoot and
+        result = e.getImmediateParsedPath() and
+        partialPredicateCall = "ParsedPath()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLazyInitializerExpr(
+    LazyInitializerExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLiteralExpr(
+    LiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLookupExpr(LookupExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nBase |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nBase = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBase() and partialPredicateCall = "Base()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfMakeTemporarilyEscapableExpr(
+    MakeTemporarilyEscapableExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nEscapingClosure, int nNonescapingClosure, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nEscapingClosure = n + 1 and
+      nNonescapingClosure = nEscapingClosure + 1 and
+      nSubExpr = nNonescapingClosure + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and
+        result = e.getImmediateEscapingClosure() and
+        partialPredicateCall = "EscapingClosure()"
+        or
+        index = nEscapingClosure and
+        result = e.getImmediateNonescapingClosure() and
+        partialPredicateCall = "NonescapingClosure()"
+        or
+        index = nNonescapingClosure and
+        result = e.getImmediateSubExpr() and
+        partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfObjCSelectorExpr(
+    ObjCSelectorExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOneWayExpr(OneWayExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOpaqueValueExpr(
+    OpaqueValueExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOpenExistentialExpr(
+    OpenExistentialExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr, int nExistential, int nOpaqueExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      nExistential = nSubExpr + 1 and
+      nOpaqueExpr = nExistential + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+        or
+        index = nSubExpr and
+        result = e.getImmediateExistential() and
+        partialPredicateCall = "Existential()"
+        or
+        index = nExistential and
+        result = e.getImmediateOpaqueExpr() and
+        partialPredicateCall = "OpaqueExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOptionalEvaluationExpr(
+    OptionalEvaluationExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOtherConstructorDeclRefExpr(
+    OtherConstructorDeclRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOverloadSetRefExpr(
+    OverloadSetRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPropertyWrapperValuePlaceholderExpr(
+    PropertyWrapperValuePlaceholderExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfRebindSelfInConstructorExpr(
+    RebindSelfInConstructorExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfSequenceExpr(
+    SequenceExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nElement |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateElement(index - n) and
+        partialPredicateCall = "Element(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfSuperRefExpr(
+    SuperRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTapExpr(TapExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nSubExpr, int nBody |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      nBody = nSubExpr + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+        or
+        index = nSubExpr and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTupleElementExpr(
+    TupleElementExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTupleExpr(TupleExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nElement |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateElement(index - n) and
+        partialPredicateCall = "Element(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTypeExpr(TypeExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExpr, int n, int nTypeRepr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nTypeRepr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateTypeRepr() and partialPredicateCall = "TypeRepr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnresolvedDeclRefExpr(
+    UnresolvedDeclRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int bUnresolvedElement, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      bUnresolvedElement =
+        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
+      n = bUnresolvedElement and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnresolvedDotExpr(
+    UnresolvedDotExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int bUnresolvedElement, int n, int nBase |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      bUnresolvedElement =
+        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
+      n = bUnresolvedElement and
+      nBase = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBase() and partialPredicateCall = "Base()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnresolvedMemberExpr(
+    UnresolvedMemberExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int bUnresolvedElement, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      bUnresolvedElement =
+        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
+      n = bUnresolvedElement and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnresolvedPatternExpr(
+    UnresolvedPatternExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int bUnresolvedElement, int n, int nSubPattern |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      bUnresolvedElement =
+        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
+      n = bUnresolvedElement and
+      nSubPattern = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnresolvedSpecializeExpr(
+    UnresolvedSpecializeExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int bUnresolvedElement, int n |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      bUnresolvedElement =
+        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
+      n = bUnresolvedElement and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfVarargExpansionExpr(
+    VarargExpansionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExpr, int n, int nSubExpr |
+      b = 0 and
+      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
+      n = bExpr and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAnyHashableErasureExpr(
+    AnyHashableErasureExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfArchetypeToSuperExpr(
+    ArchetypeToSuperExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfArrayExpr(ArrayExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bCollectionExpr, int n, int nElement |
+      b = 0 and
+      bCollectionExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCollectionExpr(e, i, _)) | i) and
+      n = bCollectionExpr and
+      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfCollectionExpr(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateElement(index - n) and
+        partialPredicateCall = "Element(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfArrayToPointerExpr(
+    ArrayToPointerExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAutoClosureExpr(
+    AutoClosureExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAbstractClosureExpr, int n |
+      b = 0 and
+      bAbstractClosureExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractClosureExpr(e, i, _)) | i) and
+      n = bAbstractClosureExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractClosureExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAwaitExpr(AwaitExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bIdentityExpr, int n |
+      b = 0 and
+      bIdentityExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIdentityExpr(e, i, _)) | i) and
+      n = bIdentityExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfIdentityExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBinaryExpr(BinaryExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bApplyExpr, int n |
+      b = 0 and
+      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
+      n = bApplyExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBridgeFromObjCExpr(
+    BridgeFromObjCExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBridgeToObjCExpr(
+    BridgeToObjCExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBuiltinLiteralExpr(
+    BuiltinLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLiteralExpr, int n |
+      b = 0 and
+      bLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
+      n = bLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCallExpr(CallExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bApplyExpr, int n |
+      b = 0 and
+      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
+      n = bApplyExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCheckedCastExpr(
+    CheckedCastExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bExplicitCastExpr, int n |
+      b = 0 and
+      bExplicitCastExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExplicitCastExpr(e, i, _)) | i) and
+      n = bExplicitCastExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExplicitCastExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfClassMetatypeToObjectExpr(
+    ClassMetatypeToObjectExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfClosureExpr(
+    ClosureExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAbstractClosureExpr, int n |
+      b = 0 and
+      bAbstractClosureExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractClosureExpr(e, i, _)) | i) and
+      n = bAbstractClosureExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfAbstractClosureExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCoerceExpr(CoerceExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bExplicitCastExpr, int n |
+      b = 0 and
+      bExplicitCastExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExplicitCastExpr(e, i, _)) | i) and
+      n = bExplicitCastExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfExplicitCastExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCollectionUpcastConversionExpr(
+    CollectionUpcastConversionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfConditionalBridgeFromObjCExpr(
+    ConditionalBridgeFromObjCExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCovariantFunctionConversionExpr(
+    CovariantFunctionConversionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCovariantReturnConversionExpr(
+    CovariantReturnConversionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDerivedToBaseExpr(
+    DerivedToBaseExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDestructureTupleExpr(
+    DestructureTupleExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDictionaryExpr(
+    DictionaryExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bCollectionExpr, int n, int nElement |
+      b = 0 and
+      bCollectionExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCollectionExpr(e, i, _)) | i) and
+      n = bCollectionExpr and
+      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfCollectionExpr(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateElement(index - n) and
+        partialPredicateCall = "Element(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDifferentiableFunctionExpr(
+    DifferentiableFunctionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDifferentiableFunctionExtractOriginalExpr(
+    DifferentiableFunctionExtractOriginalExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDotSelfExpr(
+    DotSelfExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bIdentityExpr, int n |
+      b = 0 and
+      bIdentityExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIdentityExpr(e, i, _)) | i) and
+      n = bIdentityExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfIdentityExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDynamicLookupExpr(
+    DynamicLookupExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLookupExpr, int n |
+      b = 0 and
+      bLookupExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLookupExpr(e, i, _)) | i) and
+      n = bLookupExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfLookupExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfErasureExpr(
+    ErasureExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfExistentialMetatypeToObjectExpr(
+    ExistentialMetatypeToObjectExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfForceTryExpr(
+    ForceTryExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAnyTryExpr, int n |
+      b = 0 and
+      bAnyTryExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAnyTryExpr(e, i, _)) | i) and
+      n = bAnyTryExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfAnyTryExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfForeignObjectConversionExpr(
+    ForeignObjectConversionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfFunctionConversionExpr(
+    FunctionConversionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfInOutToPointerExpr(
+    InOutToPointerExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfInjectIntoOptionalExpr(
+    InjectIntoOptionalExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfInterpolatedStringLiteralExpr(
+    InterpolatedStringLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(
+      int b, int bLiteralExpr, int n, int nInterpolationCountExpr, int nLiteralCapacityExpr,
+      int nAppendingExpr
+    |
+      b = 0 and
+      bLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
+      n = bLiteralExpr and
+      nInterpolationCountExpr = n + 1 and
+      nLiteralCapacityExpr = nInterpolationCountExpr + 1 and
+      nAppendingExpr = nLiteralCapacityExpr + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
+        or
+        index = n and
+        result = e.getImmediateInterpolationCountExpr() and
+        partialPredicateCall = "InterpolationCountExpr()"
+        or
+        index = nInterpolationCountExpr and
+        result = e.getImmediateLiteralCapacityExpr() and
+        partialPredicateCall = "LiteralCapacityExpr()"
+        or
+        index = nLiteralCapacityExpr and
+        result = e.getImmediateAppendingExpr() and
+        partialPredicateCall = "AppendingExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLinearFunctionExpr(
+    LinearFunctionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLinearFunctionExtractOriginalExpr(
+    LinearFunctionExtractOriginalExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLinearToDifferentiableFunctionExpr(
+    LinearToDifferentiableFunctionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLoadExpr(LoadExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfMemberRefExpr(
+    MemberRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLookupExpr, int n |
+      b = 0 and
+      bLookupExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLookupExpr(e, i, _)) | i) and
+      n = bLookupExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfLookupExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfMetatypeConversionExpr(
+    MetatypeConversionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfMethodRefExpr(
+    MethodRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLookupExpr, int n |
+      b = 0 and
+      bLookupExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLookupExpr(e, i, _)) | i) and
+      n = bLookupExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfLookupExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfNilLiteralExpr(
+    NilLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLiteralExpr, int n |
+      b = 0 and
+      bLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
+      n = bLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfObjectLiteralExpr(
+    ObjectLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLiteralExpr, int n |
+      b = 0 and
+      bLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
+      n = bLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOptionalTryExpr(
+    OptionalTryExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAnyTryExpr, int n |
+      b = 0 and
+      bAnyTryExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAnyTryExpr(e, i, _)) | i) and
+      n = bAnyTryExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfAnyTryExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOverloadedDeclRefExpr(
+    OverloadedDeclRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bOverloadSetRefExpr, int n |
+      b = 0 and
+      bOverloadSetRefExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfOverloadSetRefExpr(e, i, _)) | i) and
+      n = bOverloadSetRefExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfOverloadSetRefExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfParenExpr(ParenExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bIdentityExpr, int n |
+      b = 0 and
+      bIdentityExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIdentityExpr(e, i, _)) | i) and
+      n = bIdentityExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfIdentityExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPointerToPointerExpr(
+    PointerToPointerExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPostfixUnaryExpr(
+    PostfixUnaryExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bApplyExpr, int n |
+      b = 0 and
+      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
+      n = bApplyExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPrefixUnaryExpr(
+    PrefixUnaryExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bApplyExpr, int n |
+      b = 0 and
+      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
+      n = bApplyExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfProtocolMetatypeToObjectExpr(
+    ProtocolMetatypeToObjectExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfRegexLiteralExpr(
+    RegexLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLiteralExpr, int n |
+      b = 0 and
+      bLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
+      n = bLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfSelfApplyExpr(
+    SelfApplyExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bApplyExpr, int n |
+      b = 0 and
+      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
+      n = bApplyExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfStringToPointerExpr(
+    StringToPointerExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfSubscriptExpr(
+    SubscriptExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLookupExpr, int n, int nArgument |
+      b = 0 and
+      bLookupExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLookupExpr(e, i, _)) | i) and
+      n = bLookupExpr and
+      nArgument = n + 1 + max(int i | i = -1 or exists(e.getImmediateArgument(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfLookupExpr(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateArgument(index - n) and
+        partialPredicateCall = "Argument(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTryExpr(TryExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bAnyTryExpr, int n |
+      b = 0 and
+      bAnyTryExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAnyTryExpr(e, i, _)) | i) and
+      n = bAnyTryExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfAnyTryExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnderlyingToOpaqueExpr(
+    UnderlyingToOpaqueExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnevaluatedInstanceExpr(
+    UnevaluatedInstanceExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      n = bImplicitConversionExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnresolvedMemberChainResultExpr(
+    UnresolvedMemberChainResultExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bIdentityExpr, int bUnresolvedElement, int n |
+      b = 0 and
+      bIdentityExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIdentityExpr(e, i, _)) | i) and
+      bUnresolvedElement =
+        bIdentityExpr + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
+      n = bUnresolvedElement and
+      (
+        none()
+        or
+        result = getImmediateChildOfIdentityExpr(e, index - b, partialPredicateCall)
+        or
+        result =
+          getImmediateChildOfUnresolvedElement(e, index - bIdentityExpr, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfUnresolvedTypeConversionExpr(
+    UnresolvedTypeConversionExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bImplicitConversionExpr, int bUnresolvedElement, int n |
+      b = 0 and
+      bImplicitConversionExpr =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
+      bUnresolvedElement =
+        bImplicitConversionExpr + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
+      n = bUnresolvedElement and
+      (
+        none()
+        or
+        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
+        or
+        result =
+          getImmediateChildOfUnresolvedElement(e, index - bImplicitConversionExpr,
+            partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBooleanLiteralExpr(
+    BooleanLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bBuiltinLiteralExpr, int n |
+      b = 0 and
+      bBuiltinLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfBuiltinLiteralExpr(e, i, _)) | i) and
+      n = bBuiltinLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfBuiltinLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfConditionalCheckedCastExpr(
+    ConditionalCheckedCastExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bCheckedCastExpr, int n |
+      b = 0 and
+      bCheckedCastExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCheckedCastExpr(e, i, _)) | i) and
+      n = bCheckedCastExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfCheckedCastExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfConstructorRefCallExpr(
+    ConstructorRefCallExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bSelfApplyExpr, int n |
+      b = 0 and
+      bSelfApplyExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfSelfApplyExpr(e, i, _)) | i) and
+      n = bSelfApplyExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfSelfApplyExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDotSyntaxCallExpr(
+    DotSyntaxCallExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bSelfApplyExpr, int n |
+      b = 0 and
+      bSelfApplyExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfSelfApplyExpr(e, i, _)) | i) and
+      n = bSelfApplyExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfSelfApplyExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDynamicMemberRefExpr(
+    DynamicMemberRefExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDynamicLookupExpr, int n |
+      b = 0 and
+      bDynamicLookupExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDynamicLookupExpr(e, i, _)) | i) and
+      n = bDynamicLookupExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfDynamicLookupExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDynamicSubscriptExpr(
+    DynamicSubscriptExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bDynamicLookupExpr, int n |
+      b = 0 and
+      bDynamicLookupExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDynamicLookupExpr(e, i, _)) | i) and
+      n = bDynamicLookupExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfDynamicLookupExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfForcedCheckedCastExpr(
+    ForcedCheckedCastExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bCheckedCastExpr, int n |
+      b = 0 and
+      bCheckedCastExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCheckedCastExpr(e, i, _)) | i) and
+      n = bCheckedCastExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfCheckedCastExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfIsExpr(IsExpr e, int index, string partialPredicateCall) {
+    exists(int b, int bCheckedCastExpr, int n |
+      b = 0 and
+      bCheckedCastExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCheckedCastExpr(e, i, _)) | i) and
+      n = bCheckedCastExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfCheckedCastExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfMagicIdentifierLiteralExpr(
+    MagicIdentifierLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bBuiltinLiteralExpr, int n |
+      b = 0 and
+      bBuiltinLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfBuiltinLiteralExpr(e, i, _)) | i) and
+      n = bBuiltinLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfBuiltinLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfNumberLiteralExpr(
+    NumberLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bBuiltinLiteralExpr, int n |
+      b = 0 and
+      bBuiltinLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfBuiltinLiteralExpr(e, i, _)) | i) and
+      n = bBuiltinLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfBuiltinLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfStringLiteralExpr(
+    StringLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bBuiltinLiteralExpr, int n |
+      b = 0 and
+      bBuiltinLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfBuiltinLiteralExpr(e, i, _)) | i) and
+      n = bBuiltinLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfBuiltinLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfFloatLiteralExpr(
+    FloatLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bNumberLiteralExpr, int n |
+      b = 0 and
+      bNumberLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNumberLiteralExpr(e, i, _)) | i) and
+      n = bNumberLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfNumberLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfIntegerLiteralExpr(
+    IntegerLiteralExpr e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bNumberLiteralExpr, int n |
+      b = 0 and
+      bNumberLiteralExpr =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNumberLiteralExpr(e, i, _)) | i) and
+      n = bNumberLiteralExpr and
+      (
+        none()
+        or
+        result = getImmediateChildOfNumberLiteralExpr(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPattern(Pattern e, int index, string partialPredicateCall) {
+    exists(int b, int bAstNode, int n |
+      b = 0 and
+      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
+      n = bAstNode and
+      (
+        none()
+        or
+        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfAnyPattern(AnyPattern e, int index, string partialPredicateCall) {
+    exists(int b, int bPattern, int n |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBindingPattern(
+    BindingPattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n, int nSubPattern |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      nSubPattern = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBoolPattern(
+    BoolPattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfEnumElementPattern(
+    EnumElementPattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n, int nSubPattern |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      nSubPattern = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfExprPattern(
+    ExprPattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n, int nSubExpr |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfIsPattern(IsPattern e, int index, string partialPredicateCall) {
+    exists(int b, int bPattern, int n, int nCastTypeRepr, int nSubPattern |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      nCastTypeRepr = n + 1 and
+      nSubPattern = nCastTypeRepr + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+        or
+        index = n and
+        result = e.getImmediateCastTypeRepr() and
+        partialPredicateCall = "CastTypeRepr()"
+        or
+        index = nCastTypeRepr and
+        result = e.getImmediateSubPattern() and
+        partialPredicateCall = "SubPattern()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfNamedPattern(
+    NamedPattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfOptionalSomePattern(
+    OptionalSomePattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n, int nSubPattern |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      nSubPattern = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfParenPattern(
+    ParenPattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n, int nSubPattern |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      nSubPattern = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTuplePattern(
+    TuplePattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n, int nElement |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateElement(index - n) and
+        partialPredicateCall = "Element(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfTypedPattern(
+    TypedPattern e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bPattern, int n, int nSubPattern, int nTypeRepr |
+      b = 0 and
+      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
+      n = bPattern and
+      nSubPattern = n + 1 and
+      nTypeRepr = nSubPattern + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
+        or
+        index = nSubPattern and
+        result = e.getImmediateTypeRepr() and
+        partialPredicateCall = "TypeRepr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCaseLabelItem(
+    CaseLabelItem e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAstNode, int n, int nPattern, int nGuard |
+      b = 0 and
+      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
+      n = bAstNode and
+      nPattern = n + 1 and
+      nGuard = nPattern + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediatePattern() and partialPredicateCall = "Pattern()"
+        or
+        index = nPattern and result = e.getImmediateGuard() and partialPredicateCall = "Guard()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfConditionElement(
+    ConditionElement e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLocatable, int n, int nBoolean, int nPattern, int nInitializer |
+      b = 0 and
+      bLocatable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocatable(e, i, _)) | i) and
+      n = bLocatable and
+      nBoolean = n + 1 and
+      nPattern = nBoolean + 1 and
+      nInitializer = nPattern + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLocatable(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBoolean() and partialPredicateCall = "Boolean()"
+        or
+        index = nBoolean and result = e.getImmediatePattern() and partialPredicateCall = "Pattern()"
+        or
+        index = nPattern and
+        result = e.getImmediateInitializer() and
+        partialPredicateCall = "Initializer()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfStmt(Stmt e, int index, string partialPredicateCall) {
+    exists(int b, int bAstNode, int n |
+      b = 0 and
+      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
+      n = bAstNode and
+      (
+        none()
+        or
+        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfStmtCondition(
+    StmtCondition e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bAstNode, int n, int nElement |
+      b = 0 and
+      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
+      n = bAstNode and
+      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateElement(index - n) and
+        partialPredicateCall = "Element(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBraceStmt(BraceStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bStmt, int n, int nElement |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateElement(index - n) and
+        partialPredicateCall = "Element(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfBreakStmt(BreakStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bStmt, int n |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfCaseStmt(CaseStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bStmt, int n, int nBody, int nLabel |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      nBody = n + 1 and
+      nLabel = nBody + 1 + max(int i | i = -1 or exists(e.getImmediateLabel(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+        or
+        result = e.getImmediateLabel(index - nBody) and
+        partialPredicateCall = "Label(" + (index - nBody).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfContinueStmt(
+    ContinueStmt e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bStmt, int n |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDeferStmt(DeferStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bStmt, int n, int nBody |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      nBody = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfFailStmt(FailStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bStmt, int n |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfFallthroughStmt(
+    FallthroughStmt e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bStmt, int n |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLabeledStmt(
+    LabeledStmt e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bStmt, int n |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfPoundAssertStmt(
+    PoundAssertStmt e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bStmt, int n |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+      )
+    )
+  }
+
+  private Element getImmediateChildOfReturnStmt(ReturnStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bStmt, int n, int nResult |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      nResult = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateResult() and partialPredicateCall = "Result()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfThrowStmt(ThrowStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bStmt, int n, int nSubExpr |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      nSubExpr = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfYieldStmt(YieldStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bStmt, int n, int nResult |
+      b = 0 and
+      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
+      n = bStmt and
+      nResult = n + 1 + max(int i | i = -1 or exists(e.getImmediateResult(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
+        or
+        result = e.getImmediateResult(index - n) and
+        partialPredicateCall = "Result(" + (index - n).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDoCatchStmt(
+    DoCatchStmt e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLabeledStmt, int n, int nBody, int nCatch |
+      b = 0 and
+      bLabeledStmt =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
+      n = bLabeledStmt and
+      nBody = n + 1 and
+      nCatch = nBody + 1 + max(int i | i = -1 or exists(e.getImmediateCatch(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+        or
+        result = e.getImmediateCatch(index - nBody) and
+        partialPredicateCall = "Catch(" + (index - nBody).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfDoStmt(DoStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bLabeledStmt, int n, int nBody |
+      b = 0 and
+      bLabeledStmt =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
+      n = bLabeledStmt and
+      nBody = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfForEachStmt(
+    ForEachStmt e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLabeledStmt, int n, int nPattern, int nSequence, int nWhere, int nBody |
+      b = 0 and
+      bLabeledStmt =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
+      n = bLabeledStmt and
+      nPattern = n + 1 and
+      nSequence = nPattern + 1 and
+      nWhere = nSequence + 1 and
+      nBody = nWhere + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediatePattern() and partialPredicateCall = "Pattern()"
+        or
+        index = nPattern and
+        result = e.getImmediateSequence() and
+        partialPredicateCall = "Sequence()"
+        or
+        index = nSequence and result = e.getImmediateWhere() and partialPredicateCall = "Where()"
+        or
+        index = nWhere and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfLabeledConditionalStmt(
+    LabeledConditionalStmt e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLabeledStmt, int n, int nCondition |
+      b = 0 and
+      bLabeledStmt =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
+      n = bLabeledStmt and
+      nCondition = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateCondition() and partialPredicateCall = "Condition()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfRepeatWhileStmt(
+    RepeatWhileStmt e, int index, string partialPredicateCall
+  ) {
+    exists(int b, int bLabeledStmt, int n, int nCondition, int nBody |
+      b = 0 and
+      bLabeledStmt =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
+      n = bLabeledStmt and
+      nCondition = n + 1 and
+      nBody = nCondition + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateCondition() and partialPredicateCall = "Condition()"
+        or
+        index = nCondition and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfSwitchStmt(SwitchStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bLabeledStmt, int n, int nExpr, int nCase |
+      b = 0 and
+      bLabeledStmt =
+        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
+      n = bLabeledStmt and
+      nExpr = n + 1 and
+      nCase = nExpr + 1 + max(int i | i = -1 or exists(e.getImmediateCase(i)) | i) and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateExpr() and partialPredicateCall = "Expr()"
+        or
+        result = e.getImmediateCase(index - nExpr) and
+        partialPredicateCall = "Case(" + (index - nExpr).toString() + ")"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfGuardStmt(GuardStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bLabeledConditionalStmt, int n, int nBody |
+      b = 0 and
+      bLabeledConditionalStmt =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfLabeledConditionalStmt(e, i, _)) | i) and
+      n = bLabeledConditionalStmt and
+      nBody = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledConditionalStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfIfStmt(IfStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bLabeledConditionalStmt, int n, int nThen, int nElse |
+      b = 0 and
+      bLabeledConditionalStmt =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfLabeledConditionalStmt(e, i, _)) | i) and
+      n = bLabeledConditionalStmt and
+      nThen = n + 1 and
+      nElse = nThen + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledConditionalStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateThen() and partialPredicateCall = "Then()"
+        or
+        index = nThen and result = e.getImmediateElse() and partialPredicateCall = "Else()"
+      )
+    )
+  }
+
+  private Element getImmediateChildOfWhileStmt(WhileStmt e, int index, string partialPredicateCall) {
+    exists(int b, int bLabeledConditionalStmt, int n, int nBody |
+      b = 0 and
+      bLabeledConditionalStmt =
+        b + 1 +
+          max(int i | i = -1 or exists(getImmediateChildOfLabeledConditionalStmt(e, i, _)) | i) and
+      n = bLabeledConditionalStmt and
+      nBody = n + 1 and
+      (
+        none()
+        or
+        result = getImmediateChildOfLabeledConditionalStmt(e, index - b, partialPredicateCall)
+        or
+        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
       )
     )
   }
@@ -120,17 +3717,15 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfUnresolvedElement(
-    UnresolvedElement e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bElement, int n |
+  private Element getImmediateChildOfTypeRepr(TypeRepr e, int index, string partialPredicateCall) {
+    exists(int b, int bAstNode, int n |
       b = 0 and
-      bElement = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfElement(e, i, _)) | i) and
-      n = bElement and
+      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
+      n = bAstNode and
       (
         none()
         or
-        result = getImmediateChildOfElement(e, index - b, partialPredicateCall)
+        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
       )
     )
   }
@@ -180,35 +3775,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfArgument(Argument e, int index, string partialPredicateCall) {
-    exists(int b, int bLocatable, int n, int nExpr |
-      b = 0 and
-      bLocatable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocatable(e, i, _)) | i) and
-      n = bLocatable and
-      nExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLocatable(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateExpr() and partialPredicateCall = "Expr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAstNode(AstNode e, int index, string partialPredicateCall) {
-    exists(int b, int bLocatable, int n |
-      b = 0 and
-      bLocatable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocatable(e, i, _)) | i) and
-      n = bLocatable and
-      (
-        none()
-        or
-        result = getImmediateChildOfLocatable(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   private Element getImmediateChildOfBuiltinType(
     BuiltinType e, int index, string partialPredicateCall
   ) {
@@ -220,71 +3786,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfComment(Comment e, int index, string partialPredicateCall) {
-    exists(int b, int bLocatable, int n |
-      b = 0 and
-      bLocatable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocatable(e, i, _)) | i) and
-      n = bLocatable and
-      (
-        none()
-        or
-        result = getImmediateChildOfLocatable(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfConditionElement(
-    ConditionElement e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLocatable, int n, int nBoolean, int nPattern, int nInitializer |
-      b = 0 and
-      bLocatable = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocatable(e, i, _)) | i) and
-      n = bLocatable and
-      nBoolean = n + 1 and
-      nPattern = nBoolean + 1 and
-      nInitializer = nPattern + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLocatable(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBoolean() and partialPredicateCall = "Boolean()"
-        or
-        index = nBoolean and result = e.getImmediatePattern() and partialPredicateCall = "Pattern()"
-        or
-        index = nPattern and
-        result = e.getImmediateInitializer() and
-        partialPredicateCall = "Initializer()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDbFile(DbFile e, int index, string partialPredicateCall) {
-    exists(int b, int bFile, int n |
-      b = 0 and
-      bFile = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfFile(e, i, _)) | i) and
-      n = bFile and
-      (
-        none()
-        or
-        result = getImmediateChildOfFile(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDbLocation(DbLocation e, int index, string partialPredicateCall) {
-    exists(int b, int bLocation, int n |
-      b = 0 and
-      bLocation = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocation(e, i, _)) | i) and
-      n = bLocation and
-      (
-        none()
-        or
-        result = getImmediateChildOfLocation(e, index - b, partialPredicateCall)
       )
     )
   }
@@ -545,36 +4046,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfUnknownFile(
-    UnknownFile e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bFile, int n |
-      b = 0 and
-      bFile = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfFile(e, i, _)) | i) and
-      n = bFile and
-      (
-        none()
-        or
-        result = getImmediateChildOfFile(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnknownLocation(
-    UnknownLocation e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLocation, int n |
-      b = 0 and
-      bLocation = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLocation(e, i, _)) | i) and
-      n = bLocation and
-      (
-        none()
-        or
-        result = getImmediateChildOfLocation(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   private Element getImmediateChildOfUnresolvedType(
     UnresolvedType e, int index, string partialPredicateCall
   ) {
@@ -786,40 +4257,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfCaseLabelItem(
-    CaseLabelItem e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAstNode, int n, int nPattern, int nGuard |
-      b = 0 and
-      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
-      n = bAstNode and
-      nPattern = n + 1 and
-      nGuard = nPattern + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediatePattern() and partialPredicateCall = "Pattern()"
-        or
-        index = nPattern and result = e.getImmediateGuard() and partialPredicateCall = "Guard()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDecl(Decl e, int index, string partialPredicateCall) {
-    exists(int b, int bAstNode, int n |
-      b = 0 and
-      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
-      n = bAstNode and
-      (
-        none()
-        or
-        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   private Element getImmediateChildOfExistentialMetatypeType(
     ExistentialMetatypeType e, int index, string partialPredicateCall
   ) {
@@ -832,19 +4269,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfAnyMetatypeType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfExpr(Expr e, int index, string partialPredicateCall) {
-    exists(int b, int bAstNode, int n |
-      b = 0 and
-      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
-      n = bAstNode and
-      (
-        none()
-        or
-        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
       )
     )
   }
@@ -942,51 +4366,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfPattern(Pattern e, int index, string partialPredicateCall) {
-    exists(int b, int bAstNode, int n |
-      b = 0 and
-      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
-      n = bAstNode and
-      (
-        none()
-        or
-        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfStmt(Stmt e, int index, string partialPredicateCall) {
-    exists(int b, int bAstNode, int n |
-      b = 0 and
-      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
-      n = bAstNode and
-      (
-        none()
-        or
-        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfStmtCondition(
-    StmtCondition e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAstNode, int n, int nElement |
-      b = 0 and
-      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
-      n = bAstNode and
-      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateElement(index - n) and
-        partialPredicateCall = "Element(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
   private Element getImmediateChildOfSyntaxSugarType(
     SyntaxSugarType e, int index, string partialPredicateCall
   ) {
@@ -1013,19 +4392,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfSugarType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTypeRepr(TypeRepr e, int index, string partialPredicateCall) {
-    exists(int b, int bAstNode, int n |
-      b = 0 and
-      bAstNode = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAstNode(e, i, _)) | i) and
-      n = bAstNode and
-      (
-        none()
-        or
-        result = getImmediateChildOfAstNode(e, index - b, partialPredicateCall)
       )
     )
   }
@@ -1094,172 +4460,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfAbstractClosureExpr(
-    AbstractClosureExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int bCallable, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      bCallable =
-        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfCallable(e, i, _)) | i) and
-      n = bCallable and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfCallable(e, index - bExpr, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAnyPattern(AnyPattern e, int index, string partialPredicateCall) {
-    exists(int b, int bPattern, int n |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAnyTryExpr(AnyTryExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAppliedPropertyWrapperExpr(
-    AppliedPropertyWrapperExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfApplyExpr(ApplyExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nFunction, int nArgument |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nFunction = n + 1 and
-      nArgument = nFunction + 1 + max(int i | i = -1 or exists(e.getImmediateArgument(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateFunction() and partialPredicateCall = "Function()"
-        or
-        result = e.getImmediateArgument(index - nFunction) and
-        partialPredicateCall = "Argument(" + (index - nFunction).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfArrowExpr(ArrowExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAssignExpr(AssignExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nDest, int nSource |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nDest = n + 1 and
-      nSource = nDest + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateDest() and partialPredicateCall = "Dest()"
-        or
-        index = nDest and result = e.getImmediateSource() and partialPredicateCall = "Source()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBindOptionalExpr(
-    BindOptionalExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBindingPattern(
-    BindingPattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n, int nSubPattern |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      nSubPattern = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBoolPattern(
-    BoolPattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   private Element getImmediateChildOfBoundGenericType(
     BoundGenericType e, int index, string partialPredicateCall
   ) {
@@ -1278,36 +4478,6 @@ private module Impl {
         or
         result =
           getImmediateChildOfNominalOrBoundGenericNominalType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBraceStmt(BraceStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bStmt, int n, int nElement |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateElement(index - n) and
-        partialPredicateCall = "Element(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBreakStmt(BreakStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bStmt, int n |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
       )
     )
   }
@@ -1344,141 +4514,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfCaptureListExpr(
-    CaptureListExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nBindingDecl, int nClosureBody |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nBindingDecl = n + 1 + max(int i | i = -1 or exists(e.getImmediateBindingDecl(i)) | i) and
-      nClosureBody = nBindingDecl + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateBindingDecl(index - n) and
-        partialPredicateCall = "BindingDecl(" + (index - n).toString() + ")"
-        or
-        index = nBindingDecl and
-        result = e.getImmediateClosureBody() and
-        partialPredicateCall = "ClosureBody()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCaseStmt(CaseStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bStmt, int n, int nBody, int nLabel |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      nBody = n + 1 and
-      nLabel = nBody + 1 + max(int i | i = -1 or exists(e.getImmediateLabel(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-        or
-        result = e.getImmediateLabel(index - nBody) and
-        partialPredicateCall = "Label(" + (index - nBody).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCodeCompletionExpr(
-    CodeCompletionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCollectionExpr(
-    CollectionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfContinueStmt(
-    ContinueStmt e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bStmt, int n |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDeclRefExpr(
-    DeclRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDefaultArgumentExpr(
-    DefaultArgumentExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDeferStmt(DeferStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bStmt, int n, int nBody |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      nBody = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-      )
-    )
-  }
-
   private Element getImmediateChildOfDictionaryType(
     DictionaryType e, int index, string partialPredicateCall
   ) {
@@ -1491,566 +4526,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfSyntaxSugarType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDiscardAssignmentExpr(
-    DiscardAssignmentExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDotSyntaxBaseIgnoredExpr(
-    DotSyntaxBaseIgnoredExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nQualifier, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nQualifier = n + 1 and
-      nSubExpr = nQualifier + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateQualifier() and partialPredicateCall = "Qualifier()"
-        or
-        index = nQualifier and
-        result = e.getImmediateSubExpr() and
-        partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDynamicTypeExpr(
-    DynamicTypeExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nBase |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nBase = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBase() and partialPredicateCall = "Base()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfEditorPlaceholderExpr(
-    EditorPlaceholderExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfEnumCaseDecl(
-    EnumCaseDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDecl, int n |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfEnumElementPattern(
-    EnumElementPattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n, int nSubPattern |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      nSubPattern = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfEnumIsCaseExpr(
-    EnumIsCaseExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfErrorExpr(ErrorExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfExplicitCastExpr(
-    ExplicitCastExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfExprPattern(
-    ExprPattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n, int nSubExpr |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfExtensionDecl(
-    ExtensionDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bGenericContext, int bIterableDeclContext, int bDecl, int n |
-      b = 0 and
-      bGenericContext =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
-      bIterableDeclContext =
-        bGenericContext + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
-      bDecl =
-        bIterableDeclContext + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfGenericContext(e, index - b, partialPredicateCall)
-        or
-        result =
-          getImmediateChildOfIterableDeclContext(e, index - bGenericContext, partialPredicateCall)
-        or
-        result = getImmediateChildOfDecl(e, index - bIterableDeclContext, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfFailStmt(FailStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bStmt, int n |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfFallthroughStmt(
-    FallthroughStmt e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bStmt, int n |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfForceValueExpr(
-    ForceValueExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfIdentityExpr(
-    IdentityExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfIfConfigDecl(
-    IfConfigDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDecl, int n, int nActiveElement |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      nActiveElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateActiveElement(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateActiveElement(index - n) and
-        partialPredicateCall = "ActiveElement(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfIfExpr(IfExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nCondition, int nThenExpr, int nElseExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nCondition = n + 1 and
-      nThenExpr = nCondition + 1 and
-      nElseExpr = nThenExpr + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateCondition() and partialPredicateCall = "Condition()"
-        or
-        index = nCondition and
-        result = e.getImmediateThenExpr() and
-        partialPredicateCall = "ThenExpr()"
-        or
-        index = nThenExpr and
-        result = e.getImmediateElseExpr() and
-        partialPredicateCall = "ElseExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfImplicitConversionExpr(
-    ImplicitConversionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfImportDecl(ImportDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bDecl, int n |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfInOutExpr(InOutExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfIsPattern(IsPattern e, int index, string partialPredicateCall) {
-    exists(int b, int bPattern, int n, int nCastTypeRepr, int nSubPattern |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      nCastTypeRepr = n + 1 and
-      nSubPattern = nCastTypeRepr + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-        or
-        index = n and
-        result = e.getImmediateCastTypeRepr() and
-        partialPredicateCall = "CastTypeRepr()"
-        or
-        index = nCastTypeRepr and
-        result = e.getImmediateSubPattern() and
-        partialPredicateCall = "SubPattern()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfKeyPathApplicationExpr(
-    KeyPathApplicationExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nBase, int nKeyPath |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nBase = n + 1 and
-      nKeyPath = nBase + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBase() and partialPredicateCall = "Base()"
-        or
-        index = nBase and result = e.getImmediateKeyPath() and partialPredicateCall = "KeyPath()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfKeyPathDotExpr(
-    KeyPathDotExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfKeyPathExpr(
-    KeyPathExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nRoot, int nParsedPath |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nRoot = n + 1 and
-      nParsedPath = nRoot + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateRoot() and partialPredicateCall = "Root()"
-        or
-        index = nRoot and
-        result = e.getImmediateParsedPath() and
-        partialPredicateCall = "ParsedPath()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLabeledStmt(
-    LabeledStmt e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bStmt, int n |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLazyInitializerExpr(
-    LazyInitializerExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLiteralExpr(
-    LiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLookupExpr(LookupExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nBase |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nBase = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBase() and partialPredicateCall = "Base()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfMakeTemporarilyEscapableExpr(
-    MakeTemporarilyEscapableExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nEscapingClosure, int nNonescapingClosure, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nEscapingClosure = n + 1 and
-      nNonescapingClosure = nEscapingClosure + 1 and
-      nSubExpr = nNonescapingClosure + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and
-        result = e.getImmediateEscapingClosure() and
-        partialPredicateCall = "EscapingClosure()"
-        or
-        index = nEscapingClosure and
-        result = e.getImmediateNonescapingClosure() and
-        partialPredicateCall = "NonescapingClosure()"
-        or
-        index = nNonescapingClosure and
-        result = e.getImmediateSubExpr() and
-        partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfMissingMemberDecl(
-    MissingMemberDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDecl, int n |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfNamedPattern(
-    NamedPattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
       )
     )
   }
@@ -2093,40 +4568,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfObjCSelectorExpr(
-    ObjCSelectorExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOneWayExpr(OneWayExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
   private Element getImmediateChildOfOpaqueTypeArchetypeType(
     OpaqueTypeArchetypeType e, int index, string partialPredicateCall
   ) {
@@ -2139,49 +4580,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfArchetypeType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOpaqueValueExpr(
-    OpaqueValueExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOpenExistentialExpr(
-    OpenExistentialExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr, int nExistential, int nOpaqueExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      nExistential = nSubExpr + 1 and
-      nOpaqueExpr = nExistential + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-        or
-        index = nSubExpr and
-        result = e.getImmediateExistential() and
-        partialPredicateCall = "Existential()"
-        or
-        index = nExistential and
-        result = e.getImmediateOpaqueExpr() and
-        partialPredicateCall = "OpaqueExpr()"
       )
     )
   }
@@ -2202,173 +4600,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfOperatorDecl(
-    OperatorDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDecl, int n |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOptionalEvaluationExpr(
-    OptionalEvaluationExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOptionalSomePattern(
-    OptionalSomePattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n, int nSubPattern |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      nSubPattern = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOtherConstructorDeclRefExpr(
-    OtherConstructorDeclRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOverloadSetRefExpr(
-    OverloadSetRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfParenPattern(
-    ParenPattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n, int nSubPattern |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      nSubPattern = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPatternBindingDecl(
-    PatternBindingDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDecl, int n, int nInit, int nPattern |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      nInit = n + 1 + max(int i | i = -1 or exists(e.getImmediateInit(i)) | i) and
-      nPattern = nInit + 1 + max(int i | i = -1 or exists(e.getImmediatePattern(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateInit(index - n) and
-        partialPredicateCall = "Init(" + (index - n).toString() + ")"
-        or
-        result = e.getImmediatePattern(index - nInit) and
-        partialPredicateCall = "Pattern(" + (index - nInit).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPoundAssertStmt(
-    PoundAssertStmt e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bStmt, int n |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPoundDiagnosticDecl(
-    PoundDiagnosticDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDecl, int n |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPrecedenceGroupDecl(
-    PrecedenceGroupDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDecl, int n |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   private Element getImmediateChildOfPrimaryArchetypeType(
     PrimaryArchetypeType e, int index, string partialPredicateCall
   ) {
@@ -2381,55 +4612,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfArchetypeType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPropertyWrapperValuePlaceholderExpr(
-    PropertyWrapperValuePlaceholderExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfRebindSelfInConstructorExpr(
-    RebindSelfInConstructorExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfReturnStmt(ReturnStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bStmt, int n, int nResult |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      nResult = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateResult() and partialPredicateCall = "Result()"
       )
     )
   }
@@ -2450,186 +4632,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfSequenceExpr(
-    SequenceExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nElement |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateElement(index - n) and
-        partialPredicateCall = "Element(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfSuperRefExpr(
-    SuperRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTapExpr(TapExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nSubExpr, int nBody |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      nBody = nSubExpr + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-        or
-        index = nSubExpr and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfThrowStmt(ThrowStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bStmt, int n, int nSubExpr |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTopLevelCodeDecl(
-    TopLevelCodeDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDecl, int n, int nBody |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      nBody = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTupleElementExpr(
-    TupleElementExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTupleExpr(TupleExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nElement |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateElement(index - n) and
-        partialPredicateCall = "Element(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTuplePattern(
-    TuplePattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n, int nElement |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateElement(index - n) and
-        partialPredicateCall = "Element(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTypeExpr(TypeExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExpr, int n, int nTypeRepr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nTypeRepr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateTypeRepr() and partialPredicateCall = "TypeRepr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTypedPattern(
-    TypedPattern e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bPattern, int n, int nSubPattern, int nTypeRepr |
-      b = 0 and
-      bPattern = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfPattern(e, i, _)) | i) and
-      n = bPattern and
-      nSubPattern = n + 1 and
-      nTypeRepr = nSubPattern + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfPattern(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
-        or
-        index = nSubPattern and
-        result = e.getImmediateTypeRepr() and
-        partialPredicateCall = "TypeRepr()"
-      )
-    )
-  }
-
   private Element getImmediateChildOfUnarySyntaxSugarType(
     UnarySyntaxSugarType e, int index, string partialPredicateCall
   ) {
@@ -2646,251 +4648,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfUnresolvedDeclRefExpr(
-    UnresolvedDeclRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int bUnresolvedElement, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      bUnresolvedElement =
-        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
-      n = bUnresolvedElement and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnresolvedDotExpr(
-    UnresolvedDotExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int bUnresolvedElement, int n, int nBase |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      bUnresolvedElement =
-        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
-      n = bUnresolvedElement and
-      nBase = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBase() and partialPredicateCall = "Base()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnresolvedMemberExpr(
-    UnresolvedMemberExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int bUnresolvedElement, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      bUnresolvedElement =
-        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
-      n = bUnresolvedElement and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnresolvedPatternExpr(
-    UnresolvedPatternExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int bUnresolvedElement, int n, int nSubPattern |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      bUnresolvedElement =
-        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
-      n = bUnresolvedElement and
-      nSubPattern = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubPattern() and partialPredicateCall = "SubPattern()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnresolvedSpecializeExpr(
-    UnresolvedSpecializeExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int bUnresolvedElement, int n |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      bUnresolvedElement =
-        bExpr + 1 + max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
-      n = bUnresolvedElement and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfUnresolvedElement(e, index - bExpr, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfValueDecl(ValueDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bDecl, int n |
-      b = 0 and
-      bDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDecl(e, i, _)) | i) and
-      n = bDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfVarargExpansionExpr(
-    VarargExpansionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExpr, int n, int nSubExpr |
-      b = 0 and
-      bExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExpr(e, i, _)) | i) and
-      n = bExpr and
-      nSubExpr = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateSubExpr() and partialPredicateCall = "SubExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfYieldStmt(YieldStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bStmt, int n, int nResult |
-      b = 0 and
-      bStmt = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfStmt(e, i, _)) | i) and
-      n = bStmt and
-      nResult = n + 1 + max(int i | i = -1 or exists(e.getImmediateResult(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfStmt(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateResult(index - n) and
-        partialPredicateCall = "Result(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAbstractFunctionDecl(
-    AbstractFunctionDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bGenericContext, int bValueDecl, int bCallable, int n |
-      b = 0 and
-      bGenericContext =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
-      bValueDecl =
-        bGenericContext + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
-      bCallable =
-        bValueDecl + 1 + max(int i | i = -1 or exists(getImmediateChildOfCallable(e, i, _)) | i) and
-      n = bCallable and
-      (
-        none()
-        or
-        result = getImmediateChildOfGenericContext(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfValueDecl(e, index - bGenericContext, partialPredicateCall)
-        or
-        result = getImmediateChildOfCallable(e, index - bValueDecl, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAbstractStorageDecl(
-    AbstractStorageDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bValueDecl, int n, int nAccessorDecl |
-      b = 0 and
-      bValueDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
-      n = bValueDecl and
-      nAccessorDecl = n + 1 + max(int i | i = -1 or exists(e.getImmediateAccessorDecl(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfValueDecl(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateAccessorDecl(index - n) and
-        partialPredicateCall = "AccessorDecl(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAnyHashableErasureExpr(
-    AnyHashableErasureExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfArchetypeToSuperExpr(
-    ArchetypeToSuperExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfArrayExpr(ArrayExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bCollectionExpr, int n, int nElement |
-      b = 0 and
-      bCollectionExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCollectionExpr(e, i, _)) | i) and
-      n = bCollectionExpr and
-      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfCollectionExpr(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateElement(index - n) and
-        partialPredicateCall = "Element(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
   private Element getImmediateChildOfArraySliceType(
     ArraySliceType e, int index, string partialPredicateCall
   ) {
@@ -2903,66 +4660,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfUnarySyntaxSugarType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfArrayToPointerExpr(
-    ArrayToPointerExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAutoClosureExpr(
-    AutoClosureExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAbstractClosureExpr, int n |
-      b = 0 and
-      bAbstractClosureExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractClosureExpr(e, i, _)) | i) and
-      n = bAbstractClosureExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractClosureExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAwaitExpr(AwaitExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bIdentityExpr, int n |
-      b = 0 and
-      bIdentityExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIdentityExpr(e, i, _)) | i) and
-      n = bIdentityExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfIdentityExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBinaryExpr(BinaryExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bApplyExpr, int n |
-      b = 0 and
-      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
-      n = bApplyExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
       )
     )
   }
@@ -3015,102 +4712,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfBridgeFromObjCExpr(
-    BridgeFromObjCExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBridgeToObjCExpr(
-    BridgeToObjCExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBuiltinLiteralExpr(
-    BuiltinLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLiteralExpr, int n |
-      b = 0 and
-      bLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
-      n = bLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCallExpr(CallExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bApplyExpr, int n |
-      b = 0 and
-      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
-      n = bApplyExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCheckedCastExpr(
-    CheckedCastExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bExplicitCastExpr, int n |
-      b = 0 and
-      bExplicitCastExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExplicitCastExpr(e, i, _)) | i) and
-      n = bExplicitCastExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExplicitCastExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfClassMetatypeToObjectExpr(
-    ClassMetatypeToObjectExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   private Element getImmediateChildOfClassType(ClassType e, int index, string partialPredicateCall) {
     exists(int b, int bNominalType, int n |
       b = 0 and
@@ -3125,283 +4726,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfClosureExpr(
-    ClosureExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAbstractClosureExpr, int n |
-      b = 0 and
-      bAbstractClosureExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractClosureExpr(e, i, _)) | i) and
-      n = bAbstractClosureExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractClosureExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCoerceExpr(CoerceExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bExplicitCastExpr, int n |
-      b = 0 and
-      bExplicitCastExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfExplicitCastExpr(e, i, _)) | i) and
-      n = bExplicitCastExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfExplicitCastExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCollectionUpcastConversionExpr(
-    CollectionUpcastConversionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfConditionalBridgeFromObjCExpr(
-    ConditionalBridgeFromObjCExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCovariantFunctionConversionExpr(
-    CovariantFunctionConversionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfCovariantReturnConversionExpr(
-    CovariantReturnConversionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDerivedToBaseExpr(
-    DerivedToBaseExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDestructureTupleExpr(
-    DestructureTupleExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDictionaryExpr(
-    DictionaryExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bCollectionExpr, int n, int nElement |
-      b = 0 and
-      bCollectionExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCollectionExpr(e, i, _)) | i) and
-      n = bCollectionExpr and
-      nElement = n + 1 + max(int i | i = -1 or exists(e.getImmediateElement(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfCollectionExpr(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateElement(index - n) and
-        partialPredicateCall = "Element(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDifferentiableFunctionExpr(
-    DifferentiableFunctionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDifferentiableFunctionExtractOriginalExpr(
-    DifferentiableFunctionExtractOriginalExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDoCatchStmt(
-    DoCatchStmt e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLabeledStmt, int n, int nBody, int nCatch |
-      b = 0 and
-      bLabeledStmt =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
-      n = bLabeledStmt and
-      nBody = n + 1 and
-      nCatch = nBody + 1 + max(int i | i = -1 or exists(e.getImmediateCatch(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-        or
-        result = e.getImmediateCatch(index - nBody) and
-        partialPredicateCall = "Catch(" + (index - nBody).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDoStmt(DoStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bLabeledStmt, int n, int nBody |
-      b = 0 and
-      bLabeledStmt =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
-      n = bLabeledStmt and
-      nBody = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDotSelfExpr(
-    DotSelfExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bIdentityExpr, int n |
-      b = 0 and
-      bIdentityExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIdentityExpr(e, i, _)) | i) and
-      n = bIdentityExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfIdentityExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDynamicLookupExpr(
-    DynamicLookupExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLookupExpr, int n |
-      b = 0 and
-      bLookupExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLookupExpr(e, i, _)) | i) and
-      n = bLookupExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfLookupExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfEnumElementDecl(
-    EnumElementDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bValueDecl, int n, int nParam |
-      b = 0 and
-      bValueDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
-      n = bValueDecl and
-      nParam = n + 1 + max(int i | i = -1 or exists(e.getImmediateParam(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfValueDecl(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateParam(index - n) and
-        partialPredicateCall = "Param(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
   private Element getImmediateChildOfEnumType(EnumType e, int index, string partialPredicateCall) {
     exists(int b, int bNominalType, int n |
       b = 0 and
@@ -3412,386 +4736,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfNominalType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfErasureExpr(
-    ErasureExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfExistentialMetatypeToObjectExpr(
-    ExistentialMetatypeToObjectExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfForEachStmt(
-    ForEachStmt e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLabeledStmt, int n, int nPattern, int nSequence, int nWhere, int nBody |
-      b = 0 and
-      bLabeledStmt =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
-      n = bLabeledStmt and
-      nPattern = n + 1 and
-      nSequence = nPattern + 1 and
-      nWhere = nSequence + 1 and
-      nBody = nWhere + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediatePattern() and partialPredicateCall = "Pattern()"
-        or
-        index = nPattern and
-        result = e.getImmediateSequence() and
-        partialPredicateCall = "Sequence()"
-        or
-        index = nSequence and result = e.getImmediateWhere() and partialPredicateCall = "Where()"
-        or
-        index = nWhere and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfForceTryExpr(
-    ForceTryExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAnyTryExpr, int n |
-      b = 0 and
-      bAnyTryExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAnyTryExpr(e, i, _)) | i) and
-      n = bAnyTryExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfAnyTryExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfForeignObjectConversionExpr(
-    ForeignObjectConversionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfFunctionConversionExpr(
-    FunctionConversionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfInOutToPointerExpr(
-    InOutToPointerExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfInfixOperatorDecl(
-    InfixOperatorDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bOperatorDecl, int n |
-      b = 0 and
-      bOperatorDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfOperatorDecl(e, i, _)) | i) and
-      n = bOperatorDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfOperatorDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfInjectIntoOptionalExpr(
-    InjectIntoOptionalExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfInterpolatedStringLiteralExpr(
-    InterpolatedStringLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(
-      int b, int bLiteralExpr, int n, int nInterpolationCountExpr, int nLiteralCapacityExpr,
-      int nAppendingExpr
-    |
-      b = 0 and
-      bLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
-      n = bLiteralExpr and
-      nInterpolationCountExpr = n + 1 and
-      nLiteralCapacityExpr = nInterpolationCountExpr + 1 and
-      nAppendingExpr = nLiteralCapacityExpr + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
-        or
-        index = n and
-        result = e.getImmediateInterpolationCountExpr() and
-        partialPredicateCall = "InterpolationCountExpr()"
-        or
-        index = nInterpolationCountExpr and
-        result = e.getImmediateLiteralCapacityExpr() and
-        partialPredicateCall = "LiteralCapacityExpr()"
-        or
-        index = nLiteralCapacityExpr and
-        result = e.getImmediateAppendingExpr() and
-        partialPredicateCall = "AppendingExpr()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLabeledConditionalStmt(
-    LabeledConditionalStmt e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLabeledStmt, int n, int nCondition |
-      b = 0 and
-      bLabeledStmt =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
-      n = bLabeledStmt and
-      nCondition = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateCondition() and partialPredicateCall = "Condition()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLinearFunctionExpr(
-    LinearFunctionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLinearFunctionExtractOriginalExpr(
-    LinearFunctionExtractOriginalExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLinearToDifferentiableFunctionExpr(
-    LinearToDifferentiableFunctionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfLoadExpr(LoadExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfMemberRefExpr(
-    MemberRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLookupExpr, int n |
-      b = 0 and
-      bLookupExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLookupExpr(e, i, _)) | i) and
-      n = bLookupExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfLookupExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfMetatypeConversionExpr(
-    MetatypeConversionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfMethodRefExpr(
-    MethodRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLookupExpr, int n |
-      b = 0 and
-      bLookupExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLookupExpr(e, i, _)) | i) and
-      n = bLookupExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfLookupExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfNilLiteralExpr(
-    NilLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLiteralExpr, int n |
-      b = 0 and
-      bLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
-      n = bLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfObjectLiteralExpr(
-    ObjectLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLiteralExpr, int n |
-      b = 0 and
-      bLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
-      n = bLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOptionalTryExpr(
-    OptionalTryExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAnyTryExpr, int n |
-      b = 0 and
-      bAnyTryExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAnyTryExpr(e, i, _)) | i) and
-      n = bAnyTryExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfAnyTryExpr(e, index - b, partialPredicateCall)
       )
     )
   }
@@ -3812,132 +4756,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfOverloadedDeclRefExpr(
-    OverloadedDeclRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bOverloadSetRefExpr, int n |
-      b = 0 and
-      bOverloadSetRefExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfOverloadSetRefExpr(e, i, _)) | i) and
-      n = bOverloadSetRefExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfOverloadSetRefExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfParenExpr(ParenExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bIdentityExpr, int n |
-      b = 0 and
-      bIdentityExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIdentityExpr(e, i, _)) | i) and
-      n = bIdentityExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfIdentityExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPointerToPointerExpr(
-    PointerToPointerExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPostfixOperatorDecl(
-    PostfixOperatorDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bOperatorDecl, int n |
-      b = 0 and
-      bOperatorDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfOperatorDecl(e, i, _)) | i) and
-      n = bOperatorDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfOperatorDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPostfixUnaryExpr(
-    PostfixUnaryExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bApplyExpr, int n |
-      b = 0 and
-      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
-      n = bApplyExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPrefixOperatorDecl(
-    PrefixOperatorDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bOperatorDecl, int n |
-      b = 0 and
-      bOperatorDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfOperatorDecl(e, i, _)) | i) and
-      n = bOperatorDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfOperatorDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfPrefixUnaryExpr(
-    PrefixUnaryExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bApplyExpr, int n |
-      b = 0 and
-      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
-      n = bApplyExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfProtocolMetatypeToObjectExpr(
-    ProtocolMetatypeToObjectExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   private Element getImmediateChildOfProtocolType(
     ProtocolType e, int index, string partialPredicateCall
   ) {
@@ -3954,76 +4772,6 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfRegexLiteralExpr(
-    RegexLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLiteralExpr, int n |
-      b = 0 and
-      bLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLiteralExpr(e, i, _)) | i) and
-      n = bLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfRepeatWhileStmt(
-    RepeatWhileStmt e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLabeledStmt, int n, int nCondition, int nBody |
-      b = 0 and
-      bLabeledStmt =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
-      n = bLabeledStmt and
-      nCondition = n + 1 and
-      nBody = nCondition + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateCondition() and partialPredicateCall = "Condition()"
-        or
-        index = nCondition and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfSelfApplyExpr(
-    SelfApplyExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bApplyExpr, int n |
-      b = 0 and
-      bApplyExpr = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfApplyExpr(e, i, _)) | i) and
-      n = bApplyExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfApplyExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfStringToPointerExpr(
-    StringToPointerExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   private Element getImmediateChildOfStructType(StructType e, int index, string partialPredicateCall) {
     exists(int b, int bNominalType, int n |
       b = 0 and
@@ -4034,154 +4782,6 @@ private module Impl {
         none()
         or
         result = getImmediateChildOfNominalType(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfSubscriptExpr(
-    SubscriptExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bLookupExpr, int n, int nArgument |
-      b = 0 and
-      bLookupExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLookupExpr(e, i, _)) | i) and
-      n = bLookupExpr and
-      nArgument = n + 1 + max(int i | i = -1 or exists(e.getImmediateArgument(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfLookupExpr(e, index - b, partialPredicateCall)
-        or
-        result = e.getImmediateArgument(index - n) and
-        partialPredicateCall = "Argument(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfSwitchStmt(SwitchStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bLabeledStmt, int n, int nExpr, int nCase |
-      b = 0 and
-      bLabeledStmt =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfLabeledStmt(e, i, _)) | i) and
-      n = bLabeledStmt and
-      nExpr = n + 1 and
-      nCase = nExpr + 1 + max(int i | i = -1 or exists(e.getImmediateCase(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateExpr() and partialPredicateCall = "Expr()"
-        or
-        result = e.getImmediateCase(index - nExpr) and
-        partialPredicateCall = "Case(" + (index - nExpr).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTryExpr(TryExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bAnyTryExpr, int n |
-      b = 0 and
-      bAnyTryExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAnyTryExpr(e, i, _)) | i) and
-      n = bAnyTryExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfAnyTryExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTypeDecl(TypeDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bValueDecl, int n |
-      b = 0 and
-      bValueDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfValueDecl(e, i, _)) | i) and
-      n = bValueDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfValueDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnderlyingToOpaqueExpr(
-    UnderlyingToOpaqueExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnevaluatedInstanceExpr(
-    UnevaluatedInstanceExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      n = bImplicitConversionExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnresolvedMemberChainResultExpr(
-    UnresolvedMemberChainResultExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bIdentityExpr, int bUnresolvedElement, int n |
-      b = 0 and
-      bIdentityExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfIdentityExpr(e, i, _)) | i) and
-      bUnresolvedElement =
-        bIdentityExpr + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
-      n = bUnresolvedElement and
-      (
-        none()
-        or
-        result = getImmediateChildOfIdentityExpr(e, index - b, partialPredicateCall)
-        or
-        result =
-          getImmediateChildOfUnresolvedElement(e, index - bIdentityExpr, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfUnresolvedTypeConversionExpr(
-    UnresolvedTypeConversionExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bImplicitConversionExpr, int bUnresolvedElement, int n |
-      b = 0 and
-      bImplicitConversionExpr =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfImplicitConversionExpr(e, i, _)) | i) and
-      bUnresolvedElement =
-        bImplicitConversionExpr + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfUnresolvedElement(e, i, _)) | i) and
-      n = bUnresolvedElement and
-      (
-        none()
-        or
-        result = getImmediateChildOfImplicitConversionExpr(e, index - b, partialPredicateCall)
-        or
-        result =
-          getImmediateChildOfUnresolvedElement(e, index - bImplicitConversionExpr,
-            partialPredicateCall)
       )
     )
   }
@@ -4202,621 +4802,367 @@ private module Impl {
     )
   }
 
-  private Element getImmediateChildOfAbstractTypeParamDecl(
-    AbstractTypeParamDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bTypeDecl, int n |
-      b = 0 and
-      bTypeDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfTypeDecl(e, i, _)) | i) and
-      n = bTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfTypeDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfBooleanLiteralExpr(
-    BooleanLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bBuiltinLiteralExpr, int n |
-      b = 0 and
-      bBuiltinLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfBuiltinLiteralExpr(e, i, _)) | i) and
-      n = bBuiltinLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfBuiltinLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfConditionalCheckedCastExpr(
-    ConditionalCheckedCastExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bCheckedCastExpr, int n |
-      b = 0 and
-      bCheckedCastExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCheckedCastExpr(e, i, _)) | i) and
-      n = bCheckedCastExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfCheckedCastExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfConstructorDecl(
-    ConstructorDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAbstractFunctionDecl, int n |
-      b = 0 and
-      bAbstractFunctionDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractFunctionDecl(e, i, _)) | i) and
-      n = bAbstractFunctionDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractFunctionDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfConstructorRefCallExpr(
-    ConstructorRefCallExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bSelfApplyExpr, int n |
-      b = 0 and
-      bSelfApplyExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfSelfApplyExpr(e, i, _)) | i) and
-      n = bSelfApplyExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfSelfApplyExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDestructorDecl(
-    DestructorDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAbstractFunctionDecl, int n |
-      b = 0 and
-      bAbstractFunctionDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractFunctionDecl(e, i, _)) | i) and
-      n = bAbstractFunctionDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractFunctionDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDotSyntaxCallExpr(
-    DotSyntaxCallExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bSelfApplyExpr, int n |
-      b = 0 and
-      bSelfApplyExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfSelfApplyExpr(e, i, _)) | i) and
-      n = bSelfApplyExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfSelfApplyExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDynamicMemberRefExpr(
-    DynamicMemberRefExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDynamicLookupExpr, int n |
-      b = 0 and
-      bDynamicLookupExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDynamicLookupExpr(e, i, _)) | i) and
-      n = bDynamicLookupExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfDynamicLookupExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfDynamicSubscriptExpr(
-    DynamicSubscriptExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bDynamicLookupExpr, int n |
-      b = 0 and
-      bDynamicLookupExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfDynamicLookupExpr(e, i, _)) | i) and
-      n = bDynamicLookupExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfDynamicLookupExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfForcedCheckedCastExpr(
-    ForcedCheckedCastExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bCheckedCastExpr, int n |
-      b = 0 and
-      bCheckedCastExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCheckedCastExpr(e, i, _)) | i) and
-      n = bCheckedCastExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfCheckedCastExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfFuncDecl(FuncDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bAbstractFunctionDecl, int n |
-      b = 0 and
-      bAbstractFunctionDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractFunctionDecl(e, i, _)) | i) and
-      n = bAbstractFunctionDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractFunctionDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfGenericTypeDecl(
-    GenericTypeDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bGenericContext, int bTypeDecl, int n |
-      b = 0 and
-      bGenericContext =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
-      bTypeDecl =
-        bGenericContext + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfTypeDecl(e, i, _)) | i) and
-      n = bTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfGenericContext(e, index - b, partialPredicateCall)
-        or
-        result = getImmediateChildOfTypeDecl(e, index - bGenericContext, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfGuardStmt(GuardStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bLabeledConditionalStmt, int n, int nBody |
-      b = 0 and
-      bLabeledConditionalStmt =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfLabeledConditionalStmt(e, i, _)) | i) and
-      n = bLabeledConditionalStmt and
-      nBody = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledConditionalStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfIfStmt(IfStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bLabeledConditionalStmt, int n, int nThen, int nElse |
-      b = 0 and
-      bLabeledConditionalStmt =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfLabeledConditionalStmt(e, i, _)) | i) and
-      n = bLabeledConditionalStmt and
-      nThen = n + 1 and
-      nElse = nThen + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledConditionalStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateThen() and partialPredicateCall = "Then()"
-        or
-        index = nThen and result = e.getImmediateElse() and partialPredicateCall = "Else()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfIsExpr(IsExpr e, int index, string partialPredicateCall) {
-    exists(int b, int bCheckedCastExpr, int n |
-      b = 0 and
-      bCheckedCastExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfCheckedCastExpr(e, i, _)) | i) and
-      n = bCheckedCastExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfCheckedCastExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfMagicIdentifierLiteralExpr(
-    MagicIdentifierLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bBuiltinLiteralExpr, int n |
-      b = 0 and
-      bBuiltinLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfBuiltinLiteralExpr(e, i, _)) | i) and
-      n = bBuiltinLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfBuiltinLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfModuleDecl(ModuleDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bTypeDecl, int n |
-      b = 0 and
-      bTypeDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfTypeDecl(e, i, _)) | i) and
-      n = bTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfTypeDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfNumberLiteralExpr(
-    NumberLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bBuiltinLiteralExpr, int n |
-      b = 0 and
-      bBuiltinLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfBuiltinLiteralExpr(e, i, _)) | i) and
-      n = bBuiltinLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfBuiltinLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfStringLiteralExpr(
-    StringLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bBuiltinLiteralExpr, int n |
-      b = 0 and
-      bBuiltinLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfBuiltinLiteralExpr(e, i, _)) | i) and
-      n = bBuiltinLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfBuiltinLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfSubscriptDecl(
-    SubscriptDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAbstractStorageDecl, int bGenericContext, int n, int nParam |
-      b = 0 and
-      bAbstractStorageDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractStorageDecl(e, i, _)) | i) and
-      bGenericContext =
-        bAbstractStorageDecl + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfGenericContext(e, i, _)) | i) and
-      n = bGenericContext and
-      nParam = n + 1 + max(int i | i = -1 or exists(e.getImmediateParam(i)) | i) and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractStorageDecl(e, index - b, partialPredicateCall)
-        or
-        result =
-          getImmediateChildOfGenericContext(e, index - bAbstractStorageDecl, partialPredicateCall)
-        or
-        result = e.getImmediateParam(index - n) and
-        partialPredicateCall = "Param(" + (index - n).toString() + ")"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfVarDecl(VarDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bAbstractStorageDecl, int n |
-      b = 0 and
-      bAbstractStorageDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractStorageDecl(e, i, _)) | i) and
-      n = bAbstractStorageDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractStorageDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfWhileStmt(WhileStmt e, int index, string partialPredicateCall) {
-    exists(int b, int bLabeledConditionalStmt, int n, int nBody |
-      b = 0 and
-      bLabeledConditionalStmt =
-        b + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfLabeledConditionalStmt(e, i, _)) | i) and
-      n = bLabeledConditionalStmt and
-      nBody = n + 1 and
-      (
-        none()
-        or
-        result = getImmediateChildOfLabeledConditionalStmt(e, index - b, partialPredicateCall)
-        or
-        index = n and result = e.getImmediateBody() and partialPredicateCall = "Body()"
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAccessorDecl(
-    AccessorDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bFuncDecl, int n |
-      b = 0 and
-      bFuncDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfFuncDecl(e, i, _)) | i) and
-      n = bFuncDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfFuncDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfAssociatedTypeDecl(
-    AssociatedTypeDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAbstractTypeParamDecl, int n |
-      b = 0 and
-      bAbstractTypeParamDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractTypeParamDecl(e, i, _)) | i) and
-      n = bAbstractTypeParamDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractTypeParamDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfConcreteFuncDecl(
-    ConcreteFuncDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bFuncDecl, int n |
-      b = 0 and
-      bFuncDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfFuncDecl(e, i, _)) | i) and
-      n = bFuncDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfFuncDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfConcreteVarDecl(
-    ConcreteVarDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bVarDecl, int n |
-      b = 0 and
-      bVarDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfVarDecl(e, i, _)) | i) and
-      n = bVarDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfVarDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfFloatLiteralExpr(
-    FloatLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bNumberLiteralExpr, int n |
-      b = 0 and
-      bNumberLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNumberLiteralExpr(e, i, _)) | i) and
-      n = bNumberLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfNumberLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfGenericTypeParamDecl(
-    GenericTypeParamDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bAbstractTypeParamDecl, int n |
-      b = 0 and
-      bAbstractTypeParamDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfAbstractTypeParamDecl(e, i, _)) | i) and
-      n = bAbstractTypeParamDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfAbstractTypeParamDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfIntegerLiteralExpr(
-    IntegerLiteralExpr e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bNumberLiteralExpr, int n |
-      b = 0 and
-      bNumberLiteralExpr =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNumberLiteralExpr(e, i, _)) | i) and
-      n = bNumberLiteralExpr and
-      (
-        none()
-        or
-        result = getImmediateChildOfNumberLiteralExpr(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfNominalTypeDecl(
-    NominalTypeDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bGenericTypeDecl, int bIterableDeclContext, int n |
-      b = 0 and
-      bGenericTypeDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
-      bIterableDeclContext =
-        bGenericTypeDecl + 1 +
-          max(int i | i = -1 or exists(getImmediateChildOfIterableDeclContext(e, i, _)) | i) and
-      n = bIterableDeclContext and
-      (
-        none()
-        or
-        result = getImmediateChildOfGenericTypeDecl(e, index - b, partialPredicateCall)
-        or
-        result =
-          getImmediateChildOfIterableDeclContext(e, index - bGenericTypeDecl, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfOpaqueTypeDecl(
-    OpaqueTypeDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bGenericTypeDecl, int n |
-      b = 0 and
-      bGenericTypeDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
-      n = bGenericTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfGenericTypeDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfParamDecl(ParamDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bVarDecl, int n |
-      b = 0 and
-      bVarDecl = b + 1 + max(int i | i = -1 or exists(getImmediateChildOfVarDecl(e, i, _)) | i) and
-      n = bVarDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfVarDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfTypeAliasDecl(
-    TypeAliasDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bGenericTypeDecl, int n |
-      b = 0 and
-      bGenericTypeDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfGenericTypeDecl(e, i, _)) | i) and
-      n = bGenericTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfGenericTypeDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfClassDecl(ClassDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bNominalTypeDecl, int n |
-      b = 0 and
-      bNominalTypeDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNominalTypeDecl(e, i, _)) | i) and
-      n = bNominalTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfNominalTypeDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfEnumDecl(EnumDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bNominalTypeDecl, int n |
-      b = 0 and
-      bNominalTypeDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNominalTypeDecl(e, i, _)) | i) and
-      n = bNominalTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfNominalTypeDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfProtocolDecl(
-    ProtocolDecl e, int index, string partialPredicateCall
-  ) {
-    exists(int b, int bNominalTypeDecl, int n |
-      b = 0 and
-      bNominalTypeDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNominalTypeDecl(e, i, _)) | i) and
-      n = bNominalTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfNominalTypeDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
-  private Element getImmediateChildOfStructDecl(StructDecl e, int index, string partialPredicateCall) {
-    exists(int b, int bNominalTypeDecl, int n |
-      b = 0 and
-      bNominalTypeDecl =
-        b + 1 + max(int i | i = -1 or exists(getImmediateChildOfNominalTypeDecl(e, i, _)) | i) and
-      n = bNominalTypeDecl and
-      (
-        none()
-        or
-        result = getImmediateChildOfNominalTypeDecl(e, index - b, partialPredicateCall)
-      )
-    )
-  }
-
   cached
   Element getImmediateChild(Element e, int index, string partialAccessor) {
     // why does this look more complicated than it should?
     // * none() simplifies generation, as we can append `or ...` without a special case for the first item
     none()
     or
-    result = getImmediateChildOfArgument(e, index, partialAccessor)
-    or
     result = getImmediateChildOfComment(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfConditionElement(e, index, partialAccessor)
     or
     result = getImmediateChildOfDbFile(e, index, partialAccessor)
     or
     result = getImmediateChildOfDbLocation(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnknownFile(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnknownLocation(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfEnumCaseDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfExtensionDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfIfConfigDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfImportDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfMissingMemberDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPatternBindingDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPoundDiagnosticDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPrecedenceGroupDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTopLevelCodeDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfEnumElementDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfInfixOperatorDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPostfixOperatorDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPrefixOperatorDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfConstructorDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDestructorDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfModuleDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfSubscriptDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfAccessorDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfAssociatedTypeDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfConcreteFuncDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfConcreteVarDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfGenericTypeParamDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOpaqueTypeDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfParamDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTypeAliasDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfClassDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfEnumDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfProtocolDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfStructDecl(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfArgument(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfAppliedPropertyWrapperExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfArrowExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfAssignExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBindOptionalExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCaptureListExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCodeCompletionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDeclRefExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDefaultArgumentExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDiscardAssignmentExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDotSyntaxBaseIgnoredExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDynamicTypeExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfEditorPlaceholderExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfEnumIsCaseExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfErrorExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfForceValueExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfIfExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfInOutExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfKeyPathApplicationExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfKeyPathDotExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfKeyPathExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfLazyInitializerExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfMakeTemporarilyEscapableExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfObjCSelectorExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOneWayExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOpaqueValueExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOpenExistentialExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOptionalEvaluationExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOtherConstructorDeclRefExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPropertyWrapperValuePlaceholderExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfRebindSelfInConstructorExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfSequenceExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfSuperRefExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTapExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTupleElementExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTupleExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTypeExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnresolvedDeclRefExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnresolvedDotExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnresolvedMemberExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnresolvedPatternExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnresolvedSpecializeExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfVarargExpansionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfAnyHashableErasureExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfArchetypeToSuperExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfArrayExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfArrayToPointerExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfAutoClosureExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfAwaitExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBinaryExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBridgeFromObjCExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBridgeToObjCExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCallExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfClassMetatypeToObjectExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfClosureExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCoerceExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCollectionUpcastConversionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfConditionalBridgeFromObjCExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCovariantFunctionConversionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCovariantReturnConversionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDerivedToBaseExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDestructureTupleExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDictionaryExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDifferentiableFunctionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDifferentiableFunctionExtractOriginalExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDotSelfExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfErasureExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfExistentialMetatypeToObjectExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfForceTryExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfForeignObjectConversionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfFunctionConversionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfInOutToPointerExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfInjectIntoOptionalExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfInterpolatedStringLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfLinearFunctionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfLinearFunctionExtractOriginalExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfLinearToDifferentiableFunctionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfLoadExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfMemberRefExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfMetatypeConversionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfMethodRefExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfNilLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfObjectLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOptionalTryExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOverloadedDeclRefExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfParenExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPointerToPointerExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPostfixUnaryExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPrefixUnaryExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfProtocolMetatypeToObjectExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfRegexLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfStringToPointerExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfSubscriptExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTryExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnderlyingToOpaqueExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnevaluatedInstanceExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnresolvedMemberChainResultExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfUnresolvedTypeConversionExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBooleanLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfConditionalCheckedCastExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfConstructorRefCallExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDotSyntaxCallExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDynamicMemberRefExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDynamicSubscriptExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfForcedCheckedCastExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfIsExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfMagicIdentifierLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfStringLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfFloatLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfIntegerLiteralExpr(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfAnyPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBindingPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBoolPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfEnumElementPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfExprPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfIsPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfNamedPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfOptionalSomePattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfParenPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTuplePattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTypedPattern(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCaseLabelItem(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfConditionElement(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfStmtCondition(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBraceStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfBreakStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfCaseStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfContinueStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDeferStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfFailStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfFallthroughStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfPoundAssertStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfReturnStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfThrowStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfYieldStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDoCatchStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfDoStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfForEachStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfRepeatWhileStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfSwitchStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfGuardStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfIfStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfWhileStmt(e, index, partialAccessor)
+    or
+    result = getImmediateChildOfTypeRepr(e, index, partialAccessor)
     or
     result = getImmediateChildOfDependentMemberType(e, index, partialAccessor)
     or
@@ -4848,10 +5194,6 @@ private module Impl {
     or
     result = getImmediateChildOfTypeVariableType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfUnknownFile(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnknownLocation(e, index, partialAccessor)
-    or
     result = getImmediateChildOfUnresolvedType(e, index, partialAccessor)
     or
     result = getImmediateChildOfBuiltinBridgeObjectType(e, index, partialAccessor)
@@ -4874,8 +5216,6 @@ private module Impl {
     or
     result = getImmediateChildOfBuiltinVectorType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfCaseLabelItem(e, index, partialAccessor)
-    or
     result = getImmediateChildOfExistentialMetatypeType(e, index, partialAccessor)
     or
     result = getImmediateChildOfFunctionType(e, index, partialAccessor)
@@ -4888,11 +5228,7 @@ private module Impl {
     or
     result = getImmediateChildOfParenType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfStmtCondition(e, index, partialAccessor)
-    or
     result = getImmediateChildOfTypeAliasType(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTypeRepr(e, index, partialAccessor)
     or
     result = getImmediateChildOfUnboundGenericType(e, index, partialAccessor)
     or
@@ -4902,183 +5238,23 @@ private module Impl {
     or
     result = getImmediateChildOfWeakStorageType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfAnyPattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfAppliedPropertyWrapperExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfArrowExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfAssignExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfBindOptionalExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfBindingPattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfBoolPattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfBraceStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfBreakStmt(e, index, partialAccessor)
-    or
     result = getImmediateChildOfBuiltinIntegerLiteralType(e, index, partialAccessor)
     or
     result = getImmediateChildOfBuiltinIntegerType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfCaptureListExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfCaseStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfCodeCompletionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfContinueStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDeclRefExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDefaultArgumentExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDeferStmt(e, index, partialAccessor)
-    or
     result = getImmediateChildOfDictionaryType(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDiscardAssignmentExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDotSyntaxBaseIgnoredExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDynamicTypeExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfEditorPlaceholderExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfEnumCaseDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfEnumElementPattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfEnumIsCaseExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfErrorExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfExprPattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfExtensionDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfFailStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfFallthroughStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfForceValueExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfIfConfigDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfIfExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfImportDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfInOutExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfIsPattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfKeyPathApplicationExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfKeyPathDotExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfKeyPathExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfLazyInitializerExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfMakeTemporarilyEscapableExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfMissingMemberDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfNamedPattern(e, index, partialAccessor)
     or
     result = getImmediateChildOfNestedArchetypeType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfObjCSelectorExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfOneWayExpr(e, index, partialAccessor)
-    or
     result = getImmediateChildOfOpaqueTypeArchetypeType(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfOpaqueValueExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfOpenExistentialExpr(e, index, partialAccessor)
     or
     result = getImmediateChildOfOpenedArchetypeType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfOptionalEvaluationExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfOptionalSomePattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfOtherConstructorDeclRefExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfParenPattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPatternBindingDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPoundAssertStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPoundDiagnosticDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPrecedenceGroupDecl(e, index, partialAccessor)
-    or
     result = getImmediateChildOfPrimaryArchetypeType(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPropertyWrapperValuePlaceholderExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfRebindSelfInConstructorExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfReturnStmt(e, index, partialAccessor)
     or
     result = getImmediateChildOfSequenceArchetypeType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfSequenceExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfSuperRefExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTapExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfThrowStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTopLevelCodeDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTupleElementExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTupleExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTuplePattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTypeExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTypedPattern(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnresolvedDeclRefExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnresolvedDotExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnresolvedMemberExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnresolvedPatternExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnresolvedSpecializeExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfVarargExpansionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfYieldStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfAnyHashableErasureExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfArchetypeToSuperExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfArrayExpr(e, index, partialAccessor)
-    or
     result = getImmediateChildOfArraySliceType(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfArrayToPointerExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfAutoClosureExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfAwaitExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfBinaryExpr(e, index, partialAccessor)
     or
     result = getImmediateChildOfBoundGenericClassType(e, index, partialAccessor)
     or
@@ -5086,193 +5262,17 @@ private module Impl {
     or
     result = getImmediateChildOfBoundGenericStructType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfBridgeFromObjCExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfBridgeToObjCExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfCallExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfClassMetatypeToObjectExpr(e, index, partialAccessor)
-    or
     result = getImmediateChildOfClassType(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfClosureExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfCoerceExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfCollectionUpcastConversionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfConditionalBridgeFromObjCExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfCovariantFunctionConversionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfCovariantReturnConversionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDerivedToBaseExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDestructureTupleExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDictionaryExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDifferentiableFunctionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDifferentiableFunctionExtractOriginalExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDoCatchStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDoStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDotSelfExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfEnumElementDecl(e, index, partialAccessor)
     or
     result = getImmediateChildOfEnumType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfErasureExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfExistentialMetatypeToObjectExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfForEachStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfForceTryExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfForeignObjectConversionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfFunctionConversionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfInOutToPointerExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfInfixOperatorDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfInjectIntoOptionalExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfInterpolatedStringLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfLinearFunctionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfLinearFunctionExtractOriginalExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfLinearToDifferentiableFunctionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfLoadExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfMemberRefExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfMetatypeConversionExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfMethodRefExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfNilLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfObjectLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfOptionalTryExpr(e, index, partialAccessor)
-    or
     result = getImmediateChildOfOptionalType(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfOverloadedDeclRefExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfParenExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPointerToPointerExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPostfixOperatorDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPostfixUnaryExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPrefixOperatorDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfPrefixUnaryExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfProtocolMetatypeToObjectExpr(e, index, partialAccessor)
     or
     result = getImmediateChildOfProtocolType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfRegexLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfRepeatWhileStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfStringToPointerExpr(e, index, partialAccessor)
-    or
     result = getImmediateChildOfStructType(e, index, partialAccessor)
     or
-    result = getImmediateChildOfSubscriptExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfSwitchStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTryExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnderlyingToOpaqueExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnevaluatedInstanceExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnresolvedMemberChainResultExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfUnresolvedTypeConversionExpr(e, index, partialAccessor)
-    or
     result = getImmediateChildOfVariadicSequenceType(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfBooleanLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfConditionalCheckedCastExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfConstructorDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfConstructorRefCallExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDestructorDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDotSyntaxCallExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDynamicMemberRefExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfDynamicSubscriptExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfForcedCheckedCastExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfGuardStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfIfStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfIsExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfMagicIdentifierLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfModuleDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfStringLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfSubscriptDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfWhileStmt(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfAccessorDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfAssociatedTypeDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfConcreteFuncDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfConcreteVarDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfFloatLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfGenericTypeParamDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfIntegerLiteralExpr(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfOpaqueTypeDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfParamDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfTypeAliasDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfClassDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfEnumDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfProtocolDecl(e, index, partialAccessor)
-    or
-    result = getImmediateChildOfStructDecl(e, index, partialAccessor)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/generated/Raw.qll
+++ b/swift/ql/lib/codeql/swift/generated/Raw.qll
@@ -17,16 +17,6 @@ module Raw {
     string getName() { files(this, result) }
   }
 
-  class GenericContext extends @generic_context, Element {
-    GenericTypeParamDecl getGenericTypeParam(int index) {
-      generic_context_generic_type_params(this, index, result)
-    }
-  }
-
-  class IterableDeclContext extends @iterable_decl_context, Element {
-    Decl getMember(int index) { iterable_decl_context_members(this, index, result) }
-  }
-
   class Locatable extends @locatable, Element {
     Location getLocation() { locatable_locations(this, result) }
   }
@@ -43,13 +33,1166 @@ module Raw {
     int getEndColumn() { locations(this, _, _, _, _, result) }
   }
 
+  class UnresolvedElement extends @unresolved_element, Element { }
+
+  class AstNode extends @ast_node, Locatable { }
+
+  class Comment extends @comment, Locatable {
+    override string toString() { result = "Comment" }
+
+    string getText() { comments(this, result) }
+  }
+
+  class DbFile extends @db_file, File {
+    override string toString() { result = "DbFile" }
+  }
+
+  class DbLocation extends @db_location, Location {
+    override string toString() { result = "DbLocation" }
+  }
+
+  class Decl extends @decl, AstNode {
+    ModuleDecl getModule() { decls(this, result) }
+  }
+
+  class GenericContext extends @generic_context, Element {
+    GenericTypeParamDecl getGenericTypeParam(int index) {
+      generic_context_generic_type_params(this, index, result)
+    }
+  }
+
+  class IterableDeclContext extends @iterable_decl_context, Element {
+    Decl getMember(int index) { iterable_decl_context_members(this, index, result) }
+  }
+
+  class EnumCaseDecl extends @enum_case_decl, Decl {
+    override string toString() { result = "EnumCaseDecl" }
+
+    EnumElementDecl getElement(int index) { enum_case_decl_elements(this, index, result) }
+  }
+
+  class ExtensionDecl extends @extension_decl, GenericContext, IterableDeclContext, Decl {
+    override string toString() { result = "ExtensionDecl" }
+
+    NominalTypeDecl getExtendedTypeDecl() { extension_decls(this, result) }
+  }
+
+  class IfConfigDecl extends @if_config_decl, Decl {
+    override string toString() { result = "IfConfigDecl" }
+
+    AstNode getActiveElement(int index) { if_config_decl_active_elements(this, index, result) }
+  }
+
+  class ImportDecl extends @import_decl, Decl {
+    override string toString() { result = "ImportDecl" }
+
+    predicate isExported() { import_decl_is_exported(this) }
+
+    ModuleDecl getImportedModule() { import_decl_imported_modules(this, result) }
+
+    ValueDecl getDeclaration(int index) { import_decl_declarations(this, index, result) }
+  }
+
+  class MissingMemberDecl extends @missing_member_decl, Decl {
+    override string toString() { result = "MissingMemberDecl" }
+  }
+
+  class OperatorDecl extends @operator_decl, Decl {
+    string getName() { operator_decls(this, result) }
+  }
+
+  class PatternBindingDecl extends @pattern_binding_decl, Decl {
+    override string toString() { result = "PatternBindingDecl" }
+
+    Expr getInit(int index) { pattern_binding_decl_inits(this, index, result) }
+
+    Pattern getPattern(int index) { pattern_binding_decl_patterns(this, index, result) }
+  }
+
+  class PoundDiagnosticDecl extends @pound_diagnostic_decl, Decl {
+    override string toString() { result = "PoundDiagnosticDecl" }
+  }
+
+  class PrecedenceGroupDecl extends @precedence_group_decl, Decl {
+    override string toString() { result = "PrecedenceGroupDecl" }
+  }
+
+  class TopLevelCodeDecl extends @top_level_code_decl, Decl {
+    override string toString() { result = "TopLevelCodeDecl" }
+
+    BraceStmt getBody() { top_level_code_decls(this, result) }
+  }
+
+  class ValueDecl extends @value_decl, Decl {
+    Type getInterfaceType() { value_decls(this, result) }
+  }
+
+  class AbstractFunctionDecl extends @abstract_function_decl, GenericContext, ValueDecl, Callable {
+    string getName() { abstract_function_decls(this, result) }
+  }
+
+  class AbstractStorageDecl extends @abstract_storage_decl, ValueDecl {
+    AccessorDecl getAccessorDecl(int index) {
+      abstract_storage_decl_accessor_decls(this, index, result)
+    }
+  }
+
+  class EnumElementDecl extends @enum_element_decl, ValueDecl {
+    override string toString() { result = "EnumElementDecl" }
+
+    string getName() { enum_element_decls(this, result) }
+
+    ParamDecl getParam(int index) { enum_element_decl_params(this, index, result) }
+  }
+
+  class InfixOperatorDecl extends @infix_operator_decl, OperatorDecl {
+    override string toString() { result = "InfixOperatorDecl" }
+
+    PrecedenceGroupDecl getPrecedenceGroup() { infix_operator_decl_precedence_groups(this, result) }
+  }
+
+  class PostfixOperatorDecl extends @postfix_operator_decl, OperatorDecl {
+    override string toString() { result = "PostfixOperatorDecl" }
+  }
+
+  class PrefixOperatorDecl extends @prefix_operator_decl, OperatorDecl {
+    override string toString() { result = "PrefixOperatorDecl" }
+  }
+
+  class TypeDecl extends @type_decl, ValueDecl {
+    string getName() { type_decls(this, result) }
+
+    Type getBaseType(int index) { type_decl_base_types(this, index, result) }
+  }
+
+  class AbstractTypeParamDecl extends @abstract_type_param_decl, TypeDecl { }
+
+  class ConstructorDecl extends @constructor_decl, AbstractFunctionDecl {
+    override string toString() { result = "ConstructorDecl" }
+  }
+
+  class DestructorDecl extends @destructor_decl, AbstractFunctionDecl {
+    override string toString() { result = "DestructorDecl" }
+  }
+
+  class FuncDecl extends @func_decl, AbstractFunctionDecl { }
+
+  class GenericTypeDecl extends @generic_type_decl, GenericContext, TypeDecl { }
+
+  class ModuleDecl extends @module_decl, TypeDecl {
+    override string toString() { result = "ModuleDecl" }
+
+    predicate isBuiltinModule() { module_decl_is_builtin_module(this) }
+
+    predicate isSystemModule() { module_decl_is_system_module(this) }
+
+    ModuleDecl getImportedModule(int index) { module_decl_imported_modules(this, index, result) }
+
+    ModuleDecl getExportedModule(int index) { module_decl_exported_modules(this, index, result) }
+  }
+
+  class SubscriptDecl extends @subscript_decl, AbstractStorageDecl, GenericContext {
+    override string toString() { result = "SubscriptDecl" }
+
+    ParamDecl getParam(int index) { subscript_decl_params(this, index, result) }
+
+    Type getElementType() { subscript_decls(this, result) }
+  }
+
+  class VarDecl extends @var_decl, AbstractStorageDecl {
+    string getName() { var_decls(this, result, _) }
+
+    Type getType() { var_decls(this, _, result) }
+
+    Type getAttachedPropertyWrapperType() { var_decl_attached_property_wrapper_types(this, result) }
+
+    Pattern getParentPattern() { var_decl_parent_patterns(this, result) }
+
+    Expr getParentInitializer() { var_decl_parent_initializers(this, result) }
+  }
+
+  class AccessorDecl extends @accessor_decl, FuncDecl {
+    override string toString() { result = "AccessorDecl" }
+
+    predicate isGetter() { accessor_decl_is_getter(this) }
+
+    predicate isSetter() { accessor_decl_is_setter(this) }
+
+    predicate isWillSet() { accessor_decl_is_will_set(this) }
+
+    predicate isDidSet() { accessor_decl_is_did_set(this) }
+  }
+
+  class AssociatedTypeDecl extends @associated_type_decl, AbstractTypeParamDecl {
+    override string toString() { result = "AssociatedTypeDecl" }
+  }
+
+  class ConcreteFuncDecl extends @concrete_func_decl, FuncDecl {
+    override string toString() { result = "ConcreteFuncDecl" }
+  }
+
+  class ConcreteVarDecl extends @concrete_var_decl, VarDecl {
+    override string toString() { result = "ConcreteVarDecl" }
+
+    int getIntroducerInt() { concrete_var_decls(this, result) }
+  }
+
+  class GenericTypeParamDecl extends @generic_type_param_decl, AbstractTypeParamDecl {
+    override string toString() { result = "GenericTypeParamDecl" }
+  }
+
+  class NominalTypeDecl extends @nominal_type_decl, GenericTypeDecl, IterableDeclContext {
+    Type getType() { nominal_type_decls(this, result) }
+  }
+
+  class OpaqueTypeDecl extends @opaque_type_decl, GenericTypeDecl {
+    override string toString() { result = "OpaqueTypeDecl" }
+  }
+
+  class ParamDecl extends @param_decl, VarDecl {
+    override string toString() { result = "ParamDecl" }
+
+    predicate isInout() { param_decl_is_inout(this) }
+  }
+
+  class TypeAliasDecl extends @type_alias_decl, GenericTypeDecl {
+    override string toString() { result = "TypeAliasDecl" }
+  }
+
+  class ClassDecl extends @class_decl, NominalTypeDecl {
+    override string toString() { result = "ClassDecl" }
+  }
+
+  class EnumDecl extends @enum_decl, NominalTypeDecl {
+    override string toString() { result = "EnumDecl" }
+  }
+
+  class ProtocolDecl extends @protocol_decl, NominalTypeDecl {
+    override string toString() { result = "ProtocolDecl" }
+  }
+
+  class StructDecl extends @struct_decl, NominalTypeDecl {
+    override string toString() { result = "StructDecl" }
+  }
+
+  class Argument extends @argument, Locatable {
+    override string toString() { result = "Argument" }
+
+    string getLabel() { arguments(this, result, _) }
+
+    Expr getExpr() { arguments(this, _, result) }
+  }
+
+  class Expr extends @expr, AstNode {
+    Type getType() { expr_types(this, result) }
+  }
+
+  class AbstractClosureExpr extends @abstract_closure_expr, Expr, Callable { }
+
+  class AnyTryExpr extends @any_try_expr, Expr {
+    Expr getSubExpr() { any_try_exprs(this, result) }
+  }
+
+  class AppliedPropertyWrapperExpr extends @applied_property_wrapper_expr, Expr {
+    override string toString() { result = "AppliedPropertyWrapperExpr" }
+  }
+
+  class ApplyExpr extends @apply_expr, Expr {
+    Expr getFunction() { apply_exprs(this, result) }
+
+    Argument getArgument(int index) { apply_expr_arguments(this, index, result) }
+  }
+
+  class ArrowExpr extends @arrow_expr, Expr {
+    override string toString() { result = "ArrowExpr" }
+  }
+
+  class AssignExpr extends @assign_expr, Expr {
+    override string toString() { result = "AssignExpr" }
+
+    Expr getDest() { assign_exprs(this, result, _) }
+
+    Expr getSource() { assign_exprs(this, _, result) }
+  }
+
+  class BindOptionalExpr extends @bind_optional_expr, Expr {
+    override string toString() { result = "BindOptionalExpr" }
+
+    Expr getSubExpr() { bind_optional_exprs(this, result) }
+  }
+
+  class CaptureListExpr extends @capture_list_expr, Expr {
+    override string toString() { result = "CaptureListExpr" }
+
+    PatternBindingDecl getBindingDecl(int index) {
+      capture_list_expr_binding_decls(this, index, result)
+    }
+
+    ClosureExpr getClosureBody() { capture_list_exprs(this, result) }
+  }
+
+  class CodeCompletionExpr extends @code_completion_expr, Expr {
+    override string toString() { result = "CodeCompletionExpr" }
+  }
+
+  class CollectionExpr extends @collection_expr, Expr { }
+
+  class DeclRefExpr extends @decl_ref_expr, Expr {
+    override string toString() { result = "DeclRefExpr" }
+
+    Decl getDecl() { decl_ref_exprs(this, result) }
+
+    Type getReplacementType(int index) { decl_ref_expr_replacement_types(this, index, result) }
+
+    predicate hasDirectToStorageSemantics() { decl_ref_expr_has_direct_to_storage_semantics(this) }
+
+    predicate hasDirectToImplementationSemantics() {
+      decl_ref_expr_has_direct_to_implementation_semantics(this)
+    }
+
+    predicate hasOrdinarySemantics() { decl_ref_expr_has_ordinary_semantics(this) }
+  }
+
+  class DefaultArgumentExpr extends @default_argument_expr, Expr {
+    override string toString() { result = "DefaultArgumentExpr" }
+
+    ParamDecl getParamDecl() { default_argument_exprs(this, result, _) }
+
+    int getParamIndex() { default_argument_exprs(this, _, result) }
+
+    Expr getCallerSideDefault() { default_argument_expr_caller_side_defaults(this, result) }
+  }
+
+  class DiscardAssignmentExpr extends @discard_assignment_expr, Expr {
+    override string toString() { result = "DiscardAssignmentExpr" }
+  }
+
+  class DotSyntaxBaseIgnoredExpr extends @dot_syntax_base_ignored_expr, Expr {
+    override string toString() { result = "DotSyntaxBaseIgnoredExpr" }
+
+    Expr getQualifier() { dot_syntax_base_ignored_exprs(this, result, _) }
+
+    Expr getSubExpr() { dot_syntax_base_ignored_exprs(this, _, result) }
+  }
+
+  class DynamicTypeExpr extends @dynamic_type_expr, Expr {
+    override string toString() { result = "DynamicTypeExpr" }
+
+    Expr getBase() { dynamic_type_exprs(this, result) }
+  }
+
+  class EditorPlaceholderExpr extends @editor_placeholder_expr, Expr {
+    override string toString() { result = "EditorPlaceholderExpr" }
+  }
+
+  class EnumIsCaseExpr extends @enum_is_case_expr, Expr {
+    override string toString() { result = "EnumIsCaseExpr" }
+
+    Expr getSubExpr() { enum_is_case_exprs(this, result, _) }
+
+    EnumElementDecl getElement() { enum_is_case_exprs(this, _, result) }
+  }
+
+  class ErrorExpr extends @error_expr, Expr {
+    override string toString() { result = "ErrorExpr" }
+  }
+
+  class ExplicitCastExpr extends @explicit_cast_expr, Expr {
+    Expr getSubExpr() { explicit_cast_exprs(this, result) }
+  }
+
+  class ForceValueExpr extends @force_value_expr, Expr {
+    override string toString() { result = "ForceValueExpr" }
+
+    Expr getSubExpr() { force_value_exprs(this, result) }
+  }
+
+  class IdentityExpr extends @identity_expr, Expr {
+    Expr getSubExpr() { identity_exprs(this, result) }
+  }
+
+  class IfExpr extends @if_expr, Expr {
+    override string toString() { result = "IfExpr" }
+
+    Expr getCondition() { if_exprs(this, result, _, _) }
+
+    Expr getThenExpr() { if_exprs(this, _, result, _) }
+
+    Expr getElseExpr() { if_exprs(this, _, _, result) }
+  }
+
+  class ImplicitConversionExpr extends @implicit_conversion_expr, Expr {
+    Expr getSubExpr() { implicit_conversion_exprs(this, result) }
+  }
+
+  class InOutExpr extends @in_out_expr, Expr {
+    override string toString() { result = "InOutExpr" }
+
+    Expr getSubExpr() { in_out_exprs(this, result) }
+  }
+
+  class KeyPathApplicationExpr extends @key_path_application_expr, Expr {
+    override string toString() { result = "KeyPathApplicationExpr" }
+
+    Expr getBase() { key_path_application_exprs(this, result, _) }
+
+    Expr getKeyPath() { key_path_application_exprs(this, _, result) }
+  }
+
+  class KeyPathDotExpr extends @key_path_dot_expr, Expr {
+    override string toString() { result = "KeyPathDotExpr" }
+  }
+
+  class KeyPathExpr extends @key_path_expr, Expr {
+    override string toString() { result = "KeyPathExpr" }
+
+    TypeRepr getRoot() { key_path_expr_roots(this, result) }
+
+    Expr getParsedPath() { key_path_expr_parsed_paths(this, result) }
+  }
+
+  class LazyInitializerExpr extends @lazy_initializer_expr, Expr {
+    override string toString() { result = "LazyInitializerExpr" }
+
+    Expr getSubExpr() { lazy_initializer_exprs(this, result) }
+  }
+
+  class LiteralExpr extends @literal_expr, Expr { }
+
+  class LookupExpr extends @lookup_expr, Expr {
+    Expr getBase() { lookup_exprs(this, result) }
+
+    Decl getMember() { lookup_expr_members(this, result) }
+  }
+
+  class MakeTemporarilyEscapableExpr extends @make_temporarily_escapable_expr, Expr {
+    override string toString() { result = "MakeTemporarilyEscapableExpr" }
+
+    OpaqueValueExpr getEscapingClosure() { make_temporarily_escapable_exprs(this, result, _, _) }
+
+    Expr getNonescapingClosure() { make_temporarily_escapable_exprs(this, _, result, _) }
+
+    Expr getSubExpr() { make_temporarily_escapable_exprs(this, _, _, result) }
+  }
+
+  class ObjCSelectorExpr extends @obj_c_selector_expr, Expr {
+    override string toString() { result = "ObjCSelectorExpr" }
+
+    Expr getSubExpr() { obj_c_selector_exprs(this, result, _) }
+
+    AbstractFunctionDecl getMethod() { obj_c_selector_exprs(this, _, result) }
+  }
+
+  class OneWayExpr extends @one_way_expr, Expr {
+    override string toString() { result = "OneWayExpr" }
+
+    Expr getSubExpr() { one_way_exprs(this, result) }
+  }
+
+  class OpaqueValueExpr extends @opaque_value_expr, Expr {
+    override string toString() { result = "OpaqueValueExpr" }
+  }
+
+  class OpenExistentialExpr extends @open_existential_expr, Expr {
+    override string toString() { result = "OpenExistentialExpr" }
+
+    Expr getSubExpr() { open_existential_exprs(this, result, _, _) }
+
+    Expr getExistential() { open_existential_exprs(this, _, result, _) }
+
+    OpaqueValueExpr getOpaqueExpr() { open_existential_exprs(this, _, _, result) }
+  }
+
+  class OptionalEvaluationExpr extends @optional_evaluation_expr, Expr {
+    override string toString() { result = "OptionalEvaluationExpr" }
+
+    Expr getSubExpr() { optional_evaluation_exprs(this, result) }
+  }
+
+  class OtherConstructorDeclRefExpr extends @other_constructor_decl_ref_expr, Expr {
+    override string toString() { result = "OtherConstructorDeclRefExpr" }
+
+    ConstructorDecl getConstructorDecl() { other_constructor_decl_ref_exprs(this, result) }
+  }
+
+  class OverloadSetRefExpr extends @overload_set_ref_expr, Expr { }
+
+  class PropertyWrapperValuePlaceholderExpr extends @property_wrapper_value_placeholder_expr, Expr {
+    override string toString() { result = "PropertyWrapperValuePlaceholderExpr" }
+  }
+
+  class RebindSelfInConstructorExpr extends @rebind_self_in_constructor_expr, Expr {
+    override string toString() { result = "RebindSelfInConstructorExpr" }
+
+    Expr getSubExpr() { rebind_self_in_constructor_exprs(this, result, _) }
+
+    VarDecl getSelf() { rebind_self_in_constructor_exprs(this, _, result) }
+  }
+
+  class SequenceExpr extends @sequence_expr, Expr {
+    override string toString() { result = "SequenceExpr" }
+
+    Expr getElement(int index) { sequence_expr_elements(this, index, result) }
+  }
+
+  class SuperRefExpr extends @super_ref_expr, Expr {
+    override string toString() { result = "SuperRefExpr" }
+
+    VarDecl getSelf() { super_ref_exprs(this, result) }
+  }
+
+  class TapExpr extends @tap_expr, Expr {
+    override string toString() { result = "TapExpr" }
+
+    Expr getSubExpr() { tap_expr_sub_exprs(this, result) }
+
+    BraceStmt getBody() { tap_exprs(this, result, _) }
+
+    VarDecl getVar() { tap_exprs(this, _, result) }
+  }
+
+  class TupleElementExpr extends @tuple_element_expr, Expr {
+    override string toString() { result = "TupleElementExpr" }
+
+    Expr getSubExpr() { tuple_element_exprs(this, result, _) }
+
+    int getIndex() { tuple_element_exprs(this, _, result) }
+  }
+
+  class TupleExpr extends @tuple_expr, Expr {
+    override string toString() { result = "TupleExpr" }
+
+    Expr getElement(int index) { tuple_expr_elements(this, index, result) }
+  }
+
+  class TypeExpr extends @type_expr, Expr {
+    override string toString() { result = "TypeExpr" }
+
+    TypeRepr getTypeRepr() { type_expr_type_reprs(this, result) }
+  }
+
+  class UnresolvedDeclRefExpr extends @unresolved_decl_ref_expr, Expr, UnresolvedElement {
+    override string toString() { result = "UnresolvedDeclRefExpr" }
+
+    string getName() { unresolved_decl_ref_expr_names(this, result) }
+  }
+
+  class UnresolvedDotExpr extends @unresolved_dot_expr, Expr, UnresolvedElement {
+    override string toString() { result = "UnresolvedDotExpr" }
+
+    Expr getBase() { unresolved_dot_exprs(this, result, _) }
+
+    string getName() { unresolved_dot_exprs(this, _, result) }
+  }
+
+  class UnresolvedMemberExpr extends @unresolved_member_expr, Expr, UnresolvedElement {
+    override string toString() { result = "UnresolvedMemberExpr" }
+
+    string getName() { unresolved_member_exprs(this, result) }
+  }
+
+  class UnresolvedPatternExpr extends @unresolved_pattern_expr, Expr, UnresolvedElement {
+    override string toString() { result = "UnresolvedPatternExpr" }
+
+    Pattern getSubPattern() { unresolved_pattern_exprs(this, result) }
+  }
+
+  class UnresolvedSpecializeExpr extends @unresolved_specialize_expr, Expr, UnresolvedElement {
+    override string toString() { result = "UnresolvedSpecializeExpr" }
+  }
+
+  class VarargExpansionExpr extends @vararg_expansion_expr, Expr {
+    override string toString() { result = "VarargExpansionExpr" }
+
+    Expr getSubExpr() { vararg_expansion_exprs(this, result) }
+  }
+
+  class AnyHashableErasureExpr extends @any_hashable_erasure_expr, ImplicitConversionExpr {
+    override string toString() { result = "AnyHashableErasureExpr" }
+  }
+
+  class ArchetypeToSuperExpr extends @archetype_to_super_expr, ImplicitConversionExpr {
+    override string toString() { result = "ArchetypeToSuperExpr" }
+  }
+
+  class ArrayExpr extends @array_expr, CollectionExpr {
+    override string toString() { result = "ArrayExpr" }
+
+    Expr getElement(int index) { array_expr_elements(this, index, result) }
+  }
+
+  class ArrayToPointerExpr extends @array_to_pointer_expr, ImplicitConversionExpr {
+    override string toString() { result = "ArrayToPointerExpr" }
+  }
+
+  class AutoClosureExpr extends @auto_closure_expr, AbstractClosureExpr {
+    override string toString() { result = "AutoClosureExpr" }
+  }
+
+  class AwaitExpr extends @await_expr, IdentityExpr {
+    override string toString() { result = "AwaitExpr" }
+  }
+
+  class BinaryExpr extends @binary_expr, ApplyExpr {
+    override string toString() { result = "BinaryExpr" }
+  }
+
+  class BridgeFromObjCExpr extends @bridge_from_obj_c_expr, ImplicitConversionExpr {
+    override string toString() { result = "BridgeFromObjCExpr" }
+  }
+
+  class BridgeToObjCExpr extends @bridge_to_obj_c_expr, ImplicitConversionExpr {
+    override string toString() { result = "BridgeToObjCExpr" }
+  }
+
+  class BuiltinLiteralExpr extends @builtin_literal_expr, LiteralExpr { }
+
+  class CallExpr extends @call_expr, ApplyExpr {
+    override string toString() { result = "CallExpr" }
+  }
+
+  class CheckedCastExpr extends @checked_cast_expr, ExplicitCastExpr { }
+
+  class ClassMetatypeToObjectExpr extends @class_metatype_to_object_expr, ImplicitConversionExpr {
+    override string toString() { result = "ClassMetatypeToObjectExpr" }
+  }
+
+  class ClosureExpr extends @closure_expr, AbstractClosureExpr {
+    override string toString() { result = "ClosureExpr" }
+  }
+
+  class CoerceExpr extends @coerce_expr, ExplicitCastExpr {
+    override string toString() { result = "CoerceExpr" }
+  }
+
+  class CollectionUpcastConversionExpr extends @collection_upcast_conversion_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "CollectionUpcastConversionExpr" }
+  }
+
+  class ConditionalBridgeFromObjCExpr extends @conditional_bridge_from_obj_c_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "ConditionalBridgeFromObjCExpr" }
+  }
+
+  class CovariantFunctionConversionExpr extends @covariant_function_conversion_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "CovariantFunctionConversionExpr" }
+  }
+
+  class CovariantReturnConversionExpr extends @covariant_return_conversion_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "CovariantReturnConversionExpr" }
+  }
+
+  class DerivedToBaseExpr extends @derived_to_base_expr, ImplicitConversionExpr {
+    override string toString() { result = "DerivedToBaseExpr" }
+  }
+
+  class DestructureTupleExpr extends @destructure_tuple_expr, ImplicitConversionExpr {
+    override string toString() { result = "DestructureTupleExpr" }
+  }
+
+  class DictionaryExpr extends @dictionary_expr, CollectionExpr {
+    override string toString() { result = "DictionaryExpr" }
+
+    Expr getElement(int index) { dictionary_expr_elements(this, index, result) }
+  }
+
+  class DifferentiableFunctionExpr extends @differentiable_function_expr, ImplicitConversionExpr {
+    override string toString() { result = "DifferentiableFunctionExpr" }
+  }
+
+  class DifferentiableFunctionExtractOriginalExpr extends @differentiable_function_extract_original_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "DifferentiableFunctionExtractOriginalExpr" }
+  }
+
+  class DotSelfExpr extends @dot_self_expr, IdentityExpr {
+    override string toString() { result = "DotSelfExpr" }
+  }
+
+  class DynamicLookupExpr extends @dynamic_lookup_expr, LookupExpr { }
+
+  class ErasureExpr extends @erasure_expr, ImplicitConversionExpr {
+    override string toString() { result = "ErasureExpr" }
+  }
+
+  class ExistentialMetatypeToObjectExpr extends @existential_metatype_to_object_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "ExistentialMetatypeToObjectExpr" }
+  }
+
+  class ForceTryExpr extends @force_try_expr, AnyTryExpr {
+    override string toString() { result = "ForceTryExpr" }
+  }
+
+  class ForeignObjectConversionExpr extends @foreign_object_conversion_expr, ImplicitConversionExpr {
+    override string toString() { result = "ForeignObjectConversionExpr" }
+  }
+
+  class FunctionConversionExpr extends @function_conversion_expr, ImplicitConversionExpr {
+    override string toString() { result = "FunctionConversionExpr" }
+  }
+
+  class InOutToPointerExpr extends @in_out_to_pointer_expr, ImplicitConversionExpr {
+    override string toString() { result = "InOutToPointerExpr" }
+  }
+
+  class InjectIntoOptionalExpr extends @inject_into_optional_expr, ImplicitConversionExpr {
+    override string toString() { result = "InjectIntoOptionalExpr" }
+  }
+
+  class InterpolatedStringLiteralExpr extends @interpolated_string_literal_expr, LiteralExpr {
+    override string toString() { result = "InterpolatedStringLiteralExpr" }
+
+    OpaqueValueExpr getInterpolationExpr() {
+      interpolated_string_literal_expr_interpolation_exprs(this, result)
+    }
+
+    Expr getInterpolationCountExpr() {
+      interpolated_string_literal_expr_interpolation_count_exprs(this, result)
+    }
+
+    Expr getLiteralCapacityExpr() {
+      interpolated_string_literal_expr_literal_capacity_exprs(this, result)
+    }
+
+    TapExpr getAppendingExpr() { interpolated_string_literal_expr_appending_exprs(this, result) }
+  }
+
+  class LinearFunctionExpr extends @linear_function_expr, ImplicitConversionExpr {
+    override string toString() { result = "LinearFunctionExpr" }
+  }
+
+  class LinearFunctionExtractOriginalExpr extends @linear_function_extract_original_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "LinearFunctionExtractOriginalExpr" }
+  }
+
+  class LinearToDifferentiableFunctionExpr extends @linear_to_differentiable_function_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "LinearToDifferentiableFunctionExpr" }
+  }
+
+  class LoadExpr extends @load_expr, ImplicitConversionExpr {
+    override string toString() { result = "LoadExpr" }
+  }
+
+  class MemberRefExpr extends @member_ref_expr, LookupExpr {
+    override string toString() { result = "MemberRefExpr" }
+
+    predicate hasDirectToStorageSemantics() {
+      member_ref_expr_has_direct_to_storage_semantics(this)
+    }
+
+    predicate hasDirectToImplementationSemantics() {
+      member_ref_expr_has_direct_to_implementation_semantics(this)
+    }
+
+    predicate hasOrdinarySemantics() { member_ref_expr_has_ordinary_semantics(this) }
+  }
+
+  class MetatypeConversionExpr extends @metatype_conversion_expr, ImplicitConversionExpr {
+    override string toString() { result = "MetatypeConversionExpr" }
+  }
+
+  class NilLiteralExpr extends @nil_literal_expr, LiteralExpr {
+    override string toString() { result = "NilLiteralExpr" }
+  }
+
+  class ObjectLiteralExpr extends @object_literal_expr, LiteralExpr {
+    override string toString() { result = "ObjectLiteralExpr" }
+  }
+
+  class OptionalTryExpr extends @optional_try_expr, AnyTryExpr {
+    override string toString() { result = "OptionalTryExpr" }
+  }
+
+  class OverloadedDeclRefExpr extends @overloaded_decl_ref_expr, OverloadSetRefExpr {
+    override string toString() { result = "OverloadedDeclRefExpr" }
+  }
+
+  class ParenExpr extends @paren_expr, IdentityExpr {
+    override string toString() { result = "ParenExpr" }
+  }
+
+  class PointerToPointerExpr extends @pointer_to_pointer_expr, ImplicitConversionExpr {
+    override string toString() { result = "PointerToPointerExpr" }
+  }
+
+  class PostfixUnaryExpr extends @postfix_unary_expr, ApplyExpr {
+    override string toString() { result = "PostfixUnaryExpr" }
+  }
+
+  class PrefixUnaryExpr extends @prefix_unary_expr, ApplyExpr {
+    override string toString() { result = "PrefixUnaryExpr" }
+  }
+
+  class ProtocolMetatypeToObjectExpr extends @protocol_metatype_to_object_expr,
+    ImplicitConversionExpr {
+    override string toString() { result = "ProtocolMetatypeToObjectExpr" }
+  }
+
+  class RegexLiteralExpr extends @regex_literal_expr, LiteralExpr {
+    override string toString() { result = "RegexLiteralExpr" }
+  }
+
+  class SelfApplyExpr extends @self_apply_expr, ApplyExpr {
+    Expr getBase() { self_apply_exprs(this, result) }
+  }
+
+  class StringToPointerExpr extends @string_to_pointer_expr, ImplicitConversionExpr {
+    override string toString() { result = "StringToPointerExpr" }
+  }
+
+  class SubscriptExpr extends @subscript_expr, LookupExpr {
+    override string toString() { result = "SubscriptExpr" }
+
+    Argument getArgument(int index) { subscript_expr_arguments(this, index, result) }
+
+    predicate hasDirectToStorageSemantics() { subscript_expr_has_direct_to_storage_semantics(this) }
+
+    predicate hasDirectToImplementationSemantics() {
+      subscript_expr_has_direct_to_implementation_semantics(this)
+    }
+
+    predicate hasOrdinarySemantics() { subscript_expr_has_ordinary_semantics(this) }
+  }
+
+  class TryExpr extends @try_expr, AnyTryExpr {
+    override string toString() { result = "TryExpr" }
+  }
+
+  class UnderlyingToOpaqueExpr extends @underlying_to_opaque_expr, ImplicitConversionExpr {
+    override string toString() { result = "UnderlyingToOpaqueExpr" }
+  }
+
+  class UnevaluatedInstanceExpr extends @unevaluated_instance_expr, ImplicitConversionExpr {
+    override string toString() { result = "UnevaluatedInstanceExpr" }
+  }
+
+  class UnresolvedMemberChainResultExpr extends @unresolved_member_chain_result_expr, IdentityExpr,
+    UnresolvedElement {
+    override string toString() { result = "UnresolvedMemberChainResultExpr" }
+  }
+
+  class UnresolvedTypeConversionExpr extends @unresolved_type_conversion_expr,
+    ImplicitConversionExpr, UnresolvedElement {
+    override string toString() { result = "UnresolvedTypeConversionExpr" }
+  }
+
+  class BooleanLiteralExpr extends @boolean_literal_expr, BuiltinLiteralExpr {
+    override string toString() { result = "BooleanLiteralExpr" }
+
+    boolean getValue() { boolean_literal_exprs(this, result) }
+  }
+
+  class ConditionalCheckedCastExpr extends @conditional_checked_cast_expr, CheckedCastExpr {
+    override string toString() { result = "ConditionalCheckedCastExpr" }
+  }
+
+  class ConstructorRefCallExpr extends @constructor_ref_call_expr, SelfApplyExpr {
+    override string toString() { result = "ConstructorRefCallExpr" }
+  }
+
+  class DotSyntaxCallExpr extends @dot_syntax_call_expr, SelfApplyExpr {
+    override string toString() { result = "DotSyntaxCallExpr" }
+  }
+
+  class DynamicMemberRefExpr extends @dynamic_member_ref_expr, DynamicLookupExpr {
+    override string toString() { result = "DynamicMemberRefExpr" }
+  }
+
+  class DynamicSubscriptExpr extends @dynamic_subscript_expr, DynamicLookupExpr {
+    override string toString() { result = "DynamicSubscriptExpr" }
+  }
+
+  class ForcedCheckedCastExpr extends @forced_checked_cast_expr, CheckedCastExpr {
+    override string toString() { result = "ForcedCheckedCastExpr" }
+  }
+
+  class IsExpr extends @is_expr, CheckedCastExpr {
+    override string toString() { result = "IsExpr" }
+  }
+
+  class MagicIdentifierLiteralExpr extends @magic_identifier_literal_expr, BuiltinLiteralExpr {
+    override string toString() { result = "MagicIdentifierLiteralExpr" }
+
+    string getKind() { magic_identifier_literal_exprs(this, result) }
+  }
+
+  class NumberLiteralExpr extends @number_literal_expr, BuiltinLiteralExpr { }
+
+  class StringLiteralExpr extends @string_literal_expr, BuiltinLiteralExpr {
+    override string toString() { result = "StringLiteralExpr" }
+
+    string getValue() { string_literal_exprs(this, result) }
+  }
+
+  class FloatLiteralExpr extends @float_literal_expr, NumberLiteralExpr {
+    override string toString() { result = "FloatLiteralExpr" }
+
+    string getStringValue() { float_literal_exprs(this, result) }
+  }
+
+  class IntegerLiteralExpr extends @integer_literal_expr, NumberLiteralExpr {
+    override string toString() { result = "IntegerLiteralExpr" }
+
+    string getStringValue() { integer_literal_exprs(this, result) }
+  }
+
+  class Pattern extends @pattern, AstNode { }
+
+  class AnyPattern extends @any_pattern, Pattern {
+    override string toString() { result = "AnyPattern" }
+  }
+
+  class BindingPattern extends @binding_pattern, Pattern {
+    override string toString() { result = "BindingPattern" }
+
+    Pattern getSubPattern() { binding_patterns(this, result) }
+  }
+
+  class BoolPattern extends @bool_pattern, Pattern {
+    override string toString() { result = "BoolPattern" }
+
+    boolean getValue() { bool_patterns(this, result) }
+  }
+
+  class EnumElementPattern extends @enum_element_pattern, Pattern {
+    override string toString() { result = "EnumElementPattern" }
+
+    EnumElementDecl getElement() { enum_element_patterns(this, result) }
+
+    Pattern getSubPattern() { enum_element_pattern_sub_patterns(this, result) }
+  }
+
+  class ExprPattern extends @expr_pattern, Pattern {
+    override string toString() { result = "ExprPattern" }
+
+    Expr getSubExpr() { expr_patterns(this, result) }
+  }
+
+  class IsPattern extends @is_pattern, Pattern {
+    override string toString() { result = "IsPattern" }
+
+    TypeRepr getCastTypeRepr() { is_pattern_cast_type_reprs(this, result) }
+
+    Pattern getSubPattern() { is_pattern_sub_patterns(this, result) }
+  }
+
+  class NamedPattern extends @named_pattern, Pattern {
+    override string toString() { result = "NamedPattern" }
+
+    string getName() { named_patterns(this, result) }
+  }
+
+  class OptionalSomePattern extends @optional_some_pattern, Pattern {
+    override string toString() { result = "OptionalSomePattern" }
+
+    Pattern getSubPattern() { optional_some_patterns(this, result) }
+  }
+
+  class ParenPattern extends @paren_pattern, Pattern {
+    override string toString() { result = "ParenPattern" }
+
+    Pattern getSubPattern() { paren_patterns(this, result) }
+  }
+
+  class TuplePattern extends @tuple_pattern, Pattern {
+    override string toString() { result = "TuplePattern" }
+
+    Pattern getElement(int index) { tuple_pattern_elements(this, index, result) }
+  }
+
+  class TypedPattern extends @typed_pattern, Pattern {
+    override string toString() { result = "TypedPattern" }
+
+    Pattern getSubPattern() { typed_patterns(this, result) }
+
+    TypeRepr getTypeRepr() { typed_pattern_type_reprs(this, result) }
+  }
+
+  class CaseLabelItem extends @case_label_item, AstNode {
+    override string toString() { result = "CaseLabelItem" }
+
+    Pattern getPattern() { case_label_items(this, result) }
+
+    Expr getGuard() { case_label_item_guards(this, result) }
+  }
+
+  class ConditionElement extends @condition_element, Locatable {
+    override string toString() { result = "ConditionElement" }
+
+    Expr getBoolean() { condition_element_booleans(this, result) }
+
+    Pattern getPattern() { condition_element_patterns(this, result) }
+
+    Expr getInitializer() { condition_element_initializers(this, result) }
+  }
+
+  class Stmt extends @stmt, AstNode { }
+
+  class StmtCondition extends @stmt_condition, AstNode {
+    override string toString() { result = "StmtCondition" }
+
+    ConditionElement getElement(int index) { stmt_condition_elements(this, index, result) }
+  }
+
+  class BraceStmt extends @brace_stmt, Stmt {
+    override string toString() { result = "BraceStmt" }
+
+    AstNode getElement(int index) { brace_stmt_elements(this, index, result) }
+  }
+
+  class BreakStmt extends @break_stmt, Stmt {
+    override string toString() { result = "BreakStmt" }
+
+    string getTargetName() { break_stmt_target_names(this, result) }
+
+    Stmt getTarget() { break_stmt_targets(this, result) }
+  }
+
+  class CaseStmt extends @case_stmt, Stmt {
+    override string toString() { result = "CaseStmt" }
+
+    Stmt getBody() { case_stmts(this, result) }
+
+    CaseLabelItem getLabel(int index) { case_stmt_labels(this, index, result) }
+
+    VarDecl getVariable(int index) { case_stmt_variables(this, index, result) }
+  }
+
+  class ContinueStmt extends @continue_stmt, Stmt {
+    override string toString() { result = "ContinueStmt" }
+
+    string getTargetName() { continue_stmt_target_names(this, result) }
+
+    Stmt getTarget() { continue_stmt_targets(this, result) }
+  }
+
+  class DeferStmt extends @defer_stmt, Stmt {
+    override string toString() { result = "DeferStmt" }
+
+    BraceStmt getBody() { defer_stmts(this, result) }
+  }
+
+  class FailStmt extends @fail_stmt, Stmt {
+    override string toString() { result = "FailStmt" }
+  }
+
+  class FallthroughStmt extends @fallthrough_stmt, Stmt {
+    override string toString() { result = "FallthroughStmt" }
+
+    CaseStmt getFallthroughSource() { fallthrough_stmts(this, result, _) }
+
+    CaseStmt getFallthroughDest() { fallthrough_stmts(this, _, result) }
+  }
+
+  class LabeledStmt extends @labeled_stmt, Stmt {
+    string getLabel() { labeled_stmt_labels(this, result) }
+  }
+
+  class PoundAssertStmt extends @pound_assert_stmt, Stmt {
+    override string toString() { result = "PoundAssertStmt" }
+  }
+
+  class ReturnStmt extends @return_stmt, Stmt {
+    override string toString() { result = "ReturnStmt" }
+
+    Expr getResult() { return_stmt_results(this, result) }
+  }
+
+  class ThrowStmt extends @throw_stmt, Stmt {
+    override string toString() { result = "ThrowStmt" }
+
+    Expr getSubExpr() { throw_stmts(this, result) }
+  }
+
+  class YieldStmt extends @yield_stmt, Stmt {
+    override string toString() { result = "YieldStmt" }
+
+    Expr getResult(int index) { yield_stmt_results(this, index, result) }
+  }
+
+  class DoCatchStmt extends @do_catch_stmt, LabeledStmt {
+    override string toString() { result = "DoCatchStmt" }
+
+    Stmt getBody() { do_catch_stmts(this, result) }
+
+    CaseStmt getCatch(int index) { do_catch_stmt_catches(this, index, result) }
+  }
+
+  class DoStmt extends @do_stmt, LabeledStmt {
+    override string toString() { result = "DoStmt" }
+
+    BraceStmt getBody() { do_stmts(this, result) }
+  }
+
+  class ForEachStmt extends @for_each_stmt, LabeledStmt {
+    override string toString() { result = "ForEachStmt" }
+
+    Pattern getPattern() { for_each_stmts(this, result, _, _) }
+
+    Expr getSequence() { for_each_stmts(this, _, result, _) }
+
+    Expr getWhere() { for_each_stmt_wheres(this, result) }
+
+    BraceStmt getBody() { for_each_stmts(this, _, _, result) }
+  }
+
+  class LabeledConditionalStmt extends @labeled_conditional_stmt, LabeledStmt {
+    StmtCondition getCondition() { labeled_conditional_stmts(this, result) }
+  }
+
+  class RepeatWhileStmt extends @repeat_while_stmt, LabeledStmt {
+    override string toString() { result = "RepeatWhileStmt" }
+
+    Expr getCondition() { repeat_while_stmts(this, result, _) }
+
+    Stmt getBody() { repeat_while_stmts(this, _, result) }
+  }
+
+  class SwitchStmt extends @switch_stmt, LabeledStmt {
+    override string toString() { result = "SwitchStmt" }
+
+    Expr getExpr() { switch_stmts(this, result) }
+
+    CaseStmt getCase(int index) { switch_stmt_cases(this, index, result) }
+  }
+
+  class GuardStmt extends @guard_stmt, LabeledConditionalStmt {
+    override string toString() { result = "GuardStmt" }
+
+    BraceStmt getBody() { guard_stmts(this, result) }
+  }
+
+  class IfStmt extends @if_stmt, LabeledConditionalStmt {
+    override string toString() { result = "IfStmt" }
+
+    Stmt getThen() { if_stmts(this, result) }
+
+    Stmt getElse() { if_stmt_elses(this, result) }
+  }
+
+  class WhileStmt extends @while_stmt, LabeledConditionalStmt {
+    override string toString() { result = "WhileStmt" }
+
+    Stmt getBody() { while_stmts(this, result) }
+  }
+
   class Type extends @type, Element {
     string getName() { types(this, result, _) }
 
     Type getCanonicalType() { types(this, _, result) }
   }
 
-  class UnresolvedElement extends @unresolved_element, Element { }
+  class TypeRepr extends @type_repr, AstNode {
+    override string toString() { result = "TypeRepr" }
+
+    Type getType() { type_reprs(this, result) }
+  }
 
   class AnyFunctionType extends @any_function_type, Type {
     Type getResult() { any_function_types(this, result) }
@@ -71,41 +1214,7 @@ module Raw {
 
   class AnyMetatypeType extends @any_metatype_type, Type { }
 
-  class Argument extends @argument, Locatable {
-    override string toString() { result = "Argument" }
-
-    string getLabel() { arguments(this, result, _) }
-
-    Expr getExpr() { arguments(this, _, result) }
-  }
-
-  class AstNode extends @ast_node, Locatable { }
-
   class BuiltinType extends @builtin_type, Type { }
-
-  class Comment extends @comment, Locatable {
-    override string toString() { result = "Comment" }
-
-    string getText() { comments(this, result) }
-  }
-
-  class ConditionElement extends @condition_element, Locatable {
-    override string toString() { result = "ConditionElement" }
-
-    Expr getBoolean() { condition_element_booleans(this, result) }
-
-    Pattern getPattern() { condition_element_patterns(this, result) }
-
-    Expr getInitializer() { condition_element_initializers(this, result) }
-  }
-
-  class DbFile extends @db_file, File {
-    override string toString() { result = "DbFile" }
-  }
-
-  class DbLocation extends @db_location, Location {
-    override string toString() { result = "DbLocation" }
-  }
 
   class DependentMemberType extends @dependent_member_type, Type {
     override string toString() { result = "DependentMemberType" }
@@ -249,24 +1358,8 @@ module Raw {
     override string toString() { result = "BuiltinVectorType" }
   }
 
-  class CaseLabelItem extends @case_label_item, AstNode {
-    override string toString() { result = "CaseLabelItem" }
-
-    Pattern getPattern() { case_label_items(this, result) }
-
-    Expr getGuard() { case_label_item_guards(this, result) }
-  }
-
-  class Decl extends @decl, AstNode {
-    ModuleDecl getModule() { decls(this, result) }
-  }
-
   class ExistentialMetatypeType extends @existential_metatype_type, AnyMetatypeType {
     override string toString() { result = "ExistentialMetatypeType" }
-  }
-
-  class Expr extends @expr, AstNode {
-    Type getType() { expr_types(this, result) }
   }
 
   class FunctionType extends @function_type, AnyFunctionType {
@@ -298,28 +1391,12 @@ module Raw {
     Type getType() { paren_types(this, result) }
   }
 
-  class Pattern extends @pattern, AstNode { }
-
-  class Stmt extends @stmt, AstNode { }
-
-  class StmtCondition extends @stmt_condition, AstNode {
-    override string toString() { result = "StmtCondition" }
-
-    ConditionElement getElement(int index) { stmt_condition_elements(this, index, result) }
-  }
-
   class SyntaxSugarType extends @syntax_sugar_type, SugarType { }
 
   class TypeAliasType extends @type_alias_type, SugarType {
     override string toString() { result = "TypeAliasType" }
 
     TypeAliasDecl getDecl() { type_alias_types(this, result) }
-  }
-
-  class TypeRepr extends @type_repr, AstNode {
-    override string toString() { result = "TypeRepr" }
-
-    Type getType() { type_reprs(this, result) }
   }
 
   class UnboundGenericType extends @unbound_generic_type, AnyGenericType {
@@ -338,72 +1415,8 @@ module Raw {
     override string toString() { result = "WeakStorageType" }
   }
 
-  class AbstractClosureExpr extends @abstract_closure_expr, Expr, Callable { }
-
-  class AnyPattern extends @any_pattern, Pattern {
-    override string toString() { result = "AnyPattern" }
-  }
-
-  class AnyTryExpr extends @any_try_expr, Expr {
-    Expr getSubExpr() { any_try_exprs(this, result) }
-  }
-
-  class AppliedPropertyWrapperExpr extends @applied_property_wrapper_expr, Expr {
-    override string toString() { result = "AppliedPropertyWrapperExpr" }
-  }
-
-  class ApplyExpr extends @apply_expr, Expr {
-    Expr getFunction() { apply_exprs(this, result) }
-
-    Argument getArgument(int index) { apply_expr_arguments(this, index, result) }
-  }
-
-  class ArrowExpr extends @arrow_expr, Expr {
-    override string toString() { result = "ArrowExpr" }
-  }
-
-  class AssignExpr extends @assign_expr, Expr {
-    override string toString() { result = "AssignExpr" }
-
-    Expr getDest() { assign_exprs(this, result, _) }
-
-    Expr getSource() { assign_exprs(this, _, result) }
-  }
-
-  class BindOptionalExpr extends @bind_optional_expr, Expr {
-    override string toString() { result = "BindOptionalExpr" }
-
-    Expr getSubExpr() { bind_optional_exprs(this, result) }
-  }
-
-  class BindingPattern extends @binding_pattern, Pattern {
-    override string toString() { result = "BindingPattern" }
-
-    Pattern getSubPattern() { binding_patterns(this, result) }
-  }
-
-  class BoolPattern extends @bool_pattern, Pattern {
-    override string toString() { result = "BoolPattern" }
-
-    boolean getValue() { bool_patterns(this, result) }
-  }
-
   class BoundGenericType extends @bound_generic_type, NominalOrBoundGenericNominalType {
     Type getArgType(int index) { bound_generic_type_arg_types(this, index, result) }
-  }
-
-  class BraceStmt extends @brace_stmt, Stmt {
-    override string toString() { result = "BraceStmt" }
-
-    AstNode getElement(int index) { brace_stmt_elements(this, index, result) }
-  }
-
-  class BreakStmt extends @break_stmt, Stmt {
-    override string toString() { result = "BreakStmt" }
-
-    string getTargetName() { break_stmt_target_names(this, result) }
-
-    Stmt getTarget() { break_stmt_targets(this, result) }
   }
 
   class BuiltinIntegerLiteralType extends @builtin_integer_literal_type, AnyBuiltinIntegerType {
@@ -416,266 +1429,12 @@ module Raw {
     int getWidth() { builtin_integer_type_widths(this, result) }
   }
 
-  class CaptureListExpr extends @capture_list_expr, Expr {
-    override string toString() { result = "CaptureListExpr" }
-
-    PatternBindingDecl getBindingDecl(int index) {
-      capture_list_expr_binding_decls(this, index, result)
-    }
-
-    ClosureExpr getClosureBody() { capture_list_exprs(this, result) }
-  }
-
-  class CaseStmt extends @case_stmt, Stmt {
-    override string toString() { result = "CaseStmt" }
-
-    Stmt getBody() { case_stmts(this, result) }
-
-    CaseLabelItem getLabel(int index) { case_stmt_labels(this, index, result) }
-
-    VarDecl getVariable(int index) { case_stmt_variables(this, index, result) }
-  }
-
-  class CodeCompletionExpr extends @code_completion_expr, Expr {
-    override string toString() { result = "CodeCompletionExpr" }
-  }
-
-  class CollectionExpr extends @collection_expr, Expr { }
-
-  class ContinueStmt extends @continue_stmt, Stmt {
-    override string toString() { result = "ContinueStmt" }
-
-    string getTargetName() { continue_stmt_target_names(this, result) }
-
-    Stmt getTarget() { continue_stmt_targets(this, result) }
-  }
-
-  class DeclRefExpr extends @decl_ref_expr, Expr {
-    override string toString() { result = "DeclRefExpr" }
-
-    Decl getDecl() { decl_ref_exprs(this, result) }
-
-    Type getReplacementType(int index) { decl_ref_expr_replacement_types(this, index, result) }
-
-    predicate hasDirectToStorageSemantics() { decl_ref_expr_has_direct_to_storage_semantics(this) }
-
-    predicate hasDirectToImplementationSemantics() {
-      decl_ref_expr_has_direct_to_implementation_semantics(this)
-    }
-
-    predicate hasOrdinarySemantics() { decl_ref_expr_has_ordinary_semantics(this) }
-  }
-
-  class DefaultArgumentExpr extends @default_argument_expr, Expr {
-    override string toString() { result = "DefaultArgumentExpr" }
-
-    ParamDecl getParamDecl() { default_argument_exprs(this, result, _) }
-
-    int getParamIndex() { default_argument_exprs(this, _, result) }
-
-    Expr getCallerSideDefault() { default_argument_expr_caller_side_defaults(this, result) }
-  }
-
-  class DeferStmt extends @defer_stmt, Stmt {
-    override string toString() { result = "DeferStmt" }
-
-    BraceStmt getBody() { defer_stmts(this, result) }
-  }
-
   class DictionaryType extends @dictionary_type, SyntaxSugarType {
     override string toString() { result = "DictionaryType" }
 
     Type getKeyType() { dictionary_types(this, result, _) }
 
     Type getValueType() { dictionary_types(this, _, result) }
-  }
-
-  class DiscardAssignmentExpr extends @discard_assignment_expr, Expr {
-    override string toString() { result = "DiscardAssignmentExpr" }
-  }
-
-  class DotSyntaxBaseIgnoredExpr extends @dot_syntax_base_ignored_expr, Expr {
-    override string toString() { result = "DotSyntaxBaseIgnoredExpr" }
-
-    Expr getQualifier() { dot_syntax_base_ignored_exprs(this, result, _) }
-
-    Expr getSubExpr() { dot_syntax_base_ignored_exprs(this, _, result) }
-  }
-
-  class DynamicTypeExpr extends @dynamic_type_expr, Expr {
-    override string toString() { result = "DynamicTypeExpr" }
-
-    Expr getBase() { dynamic_type_exprs(this, result) }
-  }
-
-  class EditorPlaceholderExpr extends @editor_placeholder_expr, Expr {
-    override string toString() { result = "EditorPlaceholderExpr" }
-  }
-
-  class EnumCaseDecl extends @enum_case_decl, Decl {
-    override string toString() { result = "EnumCaseDecl" }
-
-    EnumElementDecl getElement(int index) { enum_case_decl_elements(this, index, result) }
-  }
-
-  class EnumElementPattern extends @enum_element_pattern, Pattern {
-    override string toString() { result = "EnumElementPattern" }
-
-    EnumElementDecl getElement() { enum_element_patterns(this, result) }
-
-    Pattern getSubPattern() { enum_element_pattern_sub_patterns(this, result) }
-  }
-
-  class EnumIsCaseExpr extends @enum_is_case_expr, Expr {
-    override string toString() { result = "EnumIsCaseExpr" }
-
-    Expr getSubExpr() { enum_is_case_exprs(this, result, _) }
-
-    EnumElementDecl getElement() { enum_is_case_exprs(this, _, result) }
-  }
-
-  class ErrorExpr extends @error_expr, Expr {
-    override string toString() { result = "ErrorExpr" }
-  }
-
-  class ExplicitCastExpr extends @explicit_cast_expr, Expr {
-    Expr getSubExpr() { explicit_cast_exprs(this, result) }
-  }
-
-  class ExprPattern extends @expr_pattern, Pattern {
-    override string toString() { result = "ExprPattern" }
-
-    Expr getSubExpr() { expr_patterns(this, result) }
-  }
-
-  class ExtensionDecl extends @extension_decl, GenericContext, IterableDeclContext, Decl {
-    override string toString() { result = "ExtensionDecl" }
-
-    NominalTypeDecl getExtendedTypeDecl() { extension_decls(this, result) }
-  }
-
-  class FailStmt extends @fail_stmt, Stmt {
-    override string toString() { result = "FailStmt" }
-  }
-
-  class FallthroughStmt extends @fallthrough_stmt, Stmt {
-    override string toString() { result = "FallthroughStmt" }
-
-    CaseStmt getFallthroughSource() { fallthrough_stmts(this, result, _) }
-
-    CaseStmt getFallthroughDest() { fallthrough_stmts(this, _, result) }
-  }
-
-  class ForceValueExpr extends @force_value_expr, Expr {
-    override string toString() { result = "ForceValueExpr" }
-
-    Expr getSubExpr() { force_value_exprs(this, result) }
-  }
-
-  class IdentityExpr extends @identity_expr, Expr {
-    Expr getSubExpr() { identity_exprs(this, result) }
-  }
-
-  class IfConfigDecl extends @if_config_decl, Decl {
-    override string toString() { result = "IfConfigDecl" }
-
-    AstNode getActiveElement(int index) { if_config_decl_active_elements(this, index, result) }
-  }
-
-  class IfExpr extends @if_expr, Expr {
-    override string toString() { result = "IfExpr" }
-
-    Expr getCondition() { if_exprs(this, result, _, _) }
-
-    Expr getThenExpr() { if_exprs(this, _, result, _) }
-
-    Expr getElseExpr() { if_exprs(this, _, _, result) }
-  }
-
-  class ImplicitConversionExpr extends @implicit_conversion_expr, Expr {
-    Expr getSubExpr() { implicit_conversion_exprs(this, result) }
-  }
-
-  class ImportDecl extends @import_decl, Decl {
-    override string toString() { result = "ImportDecl" }
-
-    predicate isExported() { import_decl_is_exported(this) }
-
-    ModuleDecl getImportedModule() { import_decl_imported_modules(this, result) }
-
-    ValueDecl getDeclaration(int index) { import_decl_declarations(this, index, result) }
-  }
-
-  class InOutExpr extends @in_out_expr, Expr {
-    override string toString() { result = "InOutExpr" }
-
-    Expr getSubExpr() { in_out_exprs(this, result) }
-  }
-
-  class IsPattern extends @is_pattern, Pattern {
-    override string toString() { result = "IsPattern" }
-
-    TypeRepr getCastTypeRepr() { is_pattern_cast_type_reprs(this, result) }
-
-    Pattern getSubPattern() { is_pattern_sub_patterns(this, result) }
-  }
-
-  class KeyPathApplicationExpr extends @key_path_application_expr, Expr {
-    override string toString() { result = "KeyPathApplicationExpr" }
-
-    Expr getBase() { key_path_application_exprs(this, result, _) }
-
-    Expr getKeyPath() { key_path_application_exprs(this, _, result) }
-  }
-
-  class KeyPathDotExpr extends @key_path_dot_expr, Expr {
-    override string toString() { result = "KeyPathDotExpr" }
-  }
-
-  class KeyPathExpr extends @key_path_expr, Expr {
-    override string toString() { result = "KeyPathExpr" }
-
-    TypeRepr getRoot() { key_path_expr_roots(this, result) }
-
-    Expr getParsedPath() { key_path_expr_parsed_paths(this, result) }
-  }
-
-  class LabeledStmt extends @labeled_stmt, Stmt {
-    string getLabel() { labeled_stmt_labels(this, result) }
-  }
-
-  class LazyInitializerExpr extends @lazy_initializer_expr, Expr {
-    override string toString() { result = "LazyInitializerExpr" }
-
-    Expr getSubExpr() { lazy_initializer_exprs(this, result) }
-  }
-
-  class LiteralExpr extends @literal_expr, Expr { }
-
-  class LookupExpr extends @lookup_expr, Expr {
-    Expr getBase() { lookup_exprs(this, result) }
-
-    Decl getMember() { lookup_expr_members(this, result) }
-  }
-
-  class MakeTemporarilyEscapableExpr extends @make_temporarily_escapable_expr, Expr {
-    override string toString() { result = "MakeTemporarilyEscapableExpr" }
-
-    OpaqueValueExpr getEscapingClosure() { make_temporarily_escapable_exprs(this, result, _, _) }
-
-    Expr getNonescapingClosure() { make_temporarily_escapable_exprs(this, _, result, _) }
-
-    Expr getSubExpr() { make_temporarily_escapable_exprs(this, _, _, result) }
-  }
-
-  class MissingMemberDecl extends @missing_member_decl, Decl {
-    override string toString() { result = "MissingMemberDecl" }
-  }
-
-  class NamedPattern extends @named_pattern, Pattern {
-    override string toString() { result = "NamedPattern" }
-
-    string getName() { named_patterns(this, result) }
   }
 
   class NestedArchetypeType extends @nested_archetype_type, ArchetypeType {
@@ -688,278 +1447,28 @@ module Raw {
 
   class NominalType extends @nominal_type, NominalOrBoundGenericNominalType { }
 
-  class ObjCSelectorExpr extends @obj_c_selector_expr, Expr {
-    override string toString() { result = "ObjCSelectorExpr" }
-
-    Expr getSubExpr() { obj_c_selector_exprs(this, result, _) }
-
-    AbstractFunctionDecl getMethod() { obj_c_selector_exprs(this, _, result) }
-  }
-
-  class OneWayExpr extends @one_way_expr, Expr {
-    override string toString() { result = "OneWayExpr" }
-
-    Expr getSubExpr() { one_way_exprs(this, result) }
-  }
-
   class OpaqueTypeArchetypeType extends @opaque_type_archetype_type, ArchetypeType {
     override string toString() { result = "OpaqueTypeArchetypeType" }
-  }
-
-  class OpaqueValueExpr extends @opaque_value_expr, Expr {
-    override string toString() { result = "OpaqueValueExpr" }
-  }
-
-  class OpenExistentialExpr extends @open_existential_expr, Expr {
-    override string toString() { result = "OpenExistentialExpr" }
-
-    Expr getSubExpr() { open_existential_exprs(this, result, _, _) }
-
-    Expr getExistential() { open_existential_exprs(this, _, result, _) }
-
-    OpaqueValueExpr getOpaqueExpr() { open_existential_exprs(this, _, _, result) }
   }
 
   class OpenedArchetypeType extends @opened_archetype_type, ArchetypeType {
     override string toString() { result = "OpenedArchetypeType" }
   }
 
-  class OperatorDecl extends @operator_decl, Decl {
-    string getName() { operator_decls(this, result) }
-  }
-
-  class OptionalEvaluationExpr extends @optional_evaluation_expr, Expr {
-    override string toString() { result = "OptionalEvaluationExpr" }
-
-    Expr getSubExpr() { optional_evaluation_exprs(this, result) }
-  }
-
-  class OptionalSomePattern extends @optional_some_pattern, Pattern {
-    override string toString() { result = "OptionalSomePattern" }
-
-    Pattern getSubPattern() { optional_some_patterns(this, result) }
-  }
-
-  class OtherConstructorDeclRefExpr extends @other_constructor_decl_ref_expr, Expr {
-    override string toString() { result = "OtherConstructorDeclRefExpr" }
-
-    ConstructorDecl getConstructorDecl() { other_constructor_decl_ref_exprs(this, result) }
-  }
-
-  class OverloadSetRefExpr extends @overload_set_ref_expr, Expr { }
-
-  class ParenPattern extends @paren_pattern, Pattern {
-    override string toString() { result = "ParenPattern" }
-
-    Pattern getSubPattern() { paren_patterns(this, result) }
-  }
-
-  class PatternBindingDecl extends @pattern_binding_decl, Decl {
-    override string toString() { result = "PatternBindingDecl" }
-
-    Expr getInit(int index) { pattern_binding_decl_inits(this, index, result) }
-
-    Pattern getPattern(int index) { pattern_binding_decl_patterns(this, index, result) }
-  }
-
-  class PoundAssertStmt extends @pound_assert_stmt, Stmt {
-    override string toString() { result = "PoundAssertStmt" }
-  }
-
-  class PoundDiagnosticDecl extends @pound_diagnostic_decl, Decl {
-    override string toString() { result = "PoundDiagnosticDecl" }
-  }
-
-  class PrecedenceGroupDecl extends @precedence_group_decl, Decl {
-    override string toString() { result = "PrecedenceGroupDecl" }
-  }
-
   class PrimaryArchetypeType extends @primary_archetype_type, ArchetypeType {
     override string toString() { result = "PrimaryArchetypeType" }
-  }
-
-  class PropertyWrapperValuePlaceholderExpr extends @property_wrapper_value_placeholder_expr, Expr {
-    override string toString() { result = "PropertyWrapperValuePlaceholderExpr" }
-  }
-
-  class RebindSelfInConstructorExpr extends @rebind_self_in_constructor_expr, Expr {
-    override string toString() { result = "RebindSelfInConstructorExpr" }
-
-    Expr getSubExpr() { rebind_self_in_constructor_exprs(this, result, _) }
-
-    VarDecl getSelf() { rebind_self_in_constructor_exprs(this, _, result) }
-  }
-
-  class ReturnStmt extends @return_stmt, Stmt {
-    override string toString() { result = "ReturnStmt" }
-
-    Expr getResult() { return_stmt_results(this, result) }
   }
 
   class SequenceArchetypeType extends @sequence_archetype_type, ArchetypeType {
     override string toString() { result = "SequenceArchetypeType" }
   }
 
-  class SequenceExpr extends @sequence_expr, Expr {
-    override string toString() { result = "SequenceExpr" }
-
-    Expr getElement(int index) { sequence_expr_elements(this, index, result) }
-  }
-
-  class SuperRefExpr extends @super_ref_expr, Expr {
-    override string toString() { result = "SuperRefExpr" }
-
-    VarDecl getSelf() { super_ref_exprs(this, result) }
-  }
-
-  class TapExpr extends @tap_expr, Expr {
-    override string toString() { result = "TapExpr" }
-
-    Expr getSubExpr() { tap_expr_sub_exprs(this, result) }
-
-    BraceStmt getBody() { tap_exprs(this, result, _) }
-
-    VarDecl getVar() { tap_exprs(this, _, result) }
-  }
-
-  class ThrowStmt extends @throw_stmt, Stmt {
-    override string toString() { result = "ThrowStmt" }
-
-    Expr getSubExpr() { throw_stmts(this, result) }
-  }
-
-  class TopLevelCodeDecl extends @top_level_code_decl, Decl {
-    override string toString() { result = "TopLevelCodeDecl" }
-
-    BraceStmt getBody() { top_level_code_decls(this, result) }
-  }
-
-  class TupleElementExpr extends @tuple_element_expr, Expr {
-    override string toString() { result = "TupleElementExpr" }
-
-    Expr getSubExpr() { tuple_element_exprs(this, result, _) }
-
-    int getIndex() { tuple_element_exprs(this, _, result) }
-  }
-
-  class TupleExpr extends @tuple_expr, Expr {
-    override string toString() { result = "TupleExpr" }
-
-    Expr getElement(int index) { tuple_expr_elements(this, index, result) }
-  }
-
-  class TuplePattern extends @tuple_pattern, Pattern {
-    override string toString() { result = "TuplePattern" }
-
-    Pattern getElement(int index) { tuple_pattern_elements(this, index, result) }
-  }
-
-  class TypeExpr extends @type_expr, Expr {
-    override string toString() { result = "TypeExpr" }
-
-    TypeRepr getTypeRepr() { type_expr_type_reprs(this, result) }
-  }
-
-  class TypedPattern extends @typed_pattern, Pattern {
-    override string toString() { result = "TypedPattern" }
-
-    Pattern getSubPattern() { typed_patterns(this, result) }
-
-    TypeRepr getTypeRepr() { typed_pattern_type_reprs(this, result) }
-  }
-
   class UnarySyntaxSugarType extends @unary_syntax_sugar_type, SyntaxSugarType {
     Type getBaseType() { unary_syntax_sugar_types(this, result) }
   }
 
-  class UnresolvedDeclRefExpr extends @unresolved_decl_ref_expr, Expr, UnresolvedElement {
-    override string toString() { result = "UnresolvedDeclRefExpr" }
-
-    string getName() { unresolved_decl_ref_expr_names(this, result) }
-  }
-
-  class UnresolvedDotExpr extends @unresolved_dot_expr, Expr, UnresolvedElement {
-    override string toString() { result = "UnresolvedDotExpr" }
-
-    Expr getBase() { unresolved_dot_exprs(this, result, _) }
-
-    string getName() { unresolved_dot_exprs(this, _, result) }
-  }
-
-  class UnresolvedMemberExpr extends @unresolved_member_expr, Expr, UnresolvedElement {
-    override string toString() { result = "UnresolvedMemberExpr" }
-
-    string getName() { unresolved_member_exprs(this, result) }
-  }
-
-  class UnresolvedPatternExpr extends @unresolved_pattern_expr, Expr, UnresolvedElement {
-    override string toString() { result = "UnresolvedPatternExpr" }
-
-    Pattern getSubPattern() { unresolved_pattern_exprs(this, result) }
-  }
-
-  class UnresolvedSpecializeExpr extends @unresolved_specialize_expr, Expr, UnresolvedElement {
-    override string toString() { result = "UnresolvedSpecializeExpr" }
-  }
-
-  class ValueDecl extends @value_decl, Decl {
-    Type getInterfaceType() { value_decls(this, result) }
-  }
-
-  class VarargExpansionExpr extends @vararg_expansion_expr, Expr {
-    override string toString() { result = "VarargExpansionExpr" }
-
-    Expr getSubExpr() { vararg_expansion_exprs(this, result) }
-  }
-
-  class YieldStmt extends @yield_stmt, Stmt {
-    override string toString() { result = "YieldStmt" }
-
-    Expr getResult(int index) { yield_stmt_results(this, index, result) }
-  }
-
-  class AbstractFunctionDecl extends @abstract_function_decl, GenericContext, ValueDecl, Callable {
-    string getName() { abstract_function_decls(this, result) }
-  }
-
-  class AbstractStorageDecl extends @abstract_storage_decl, ValueDecl {
-    AccessorDecl getAccessorDecl(int index) {
-      abstract_storage_decl_accessor_decls(this, index, result)
-    }
-  }
-
-  class AnyHashableErasureExpr extends @any_hashable_erasure_expr, ImplicitConversionExpr {
-    override string toString() { result = "AnyHashableErasureExpr" }
-  }
-
-  class ArchetypeToSuperExpr extends @archetype_to_super_expr, ImplicitConversionExpr {
-    override string toString() { result = "ArchetypeToSuperExpr" }
-  }
-
-  class ArrayExpr extends @array_expr, CollectionExpr {
-    override string toString() { result = "ArrayExpr" }
-
-    Expr getElement(int index) { array_expr_elements(this, index, result) }
-  }
-
   class ArraySliceType extends @array_slice_type, UnarySyntaxSugarType {
     override string toString() { result = "ArraySliceType" }
-  }
-
-  class ArrayToPointerExpr extends @array_to_pointer_expr, ImplicitConversionExpr {
-    override string toString() { result = "ArrayToPointerExpr" }
-  }
-
-  class AutoClosureExpr extends @auto_closure_expr, AbstractClosureExpr {
-    override string toString() { result = "AutoClosureExpr" }
-  }
-
-  class AwaitExpr extends @await_expr, IdentityExpr {
-    override string toString() { result = "AwaitExpr" }
-  }
-
-  class BinaryExpr extends @binary_expr, ApplyExpr {
-    override string toString() { result = "BinaryExpr" }
   }
 
   class BoundGenericClassType extends @bound_generic_class_type, BoundGenericType {
@@ -974,536 +1483,27 @@ module Raw {
     override string toString() { result = "BoundGenericStructType" }
   }
 
-  class BridgeFromObjCExpr extends @bridge_from_obj_c_expr, ImplicitConversionExpr {
-    override string toString() { result = "BridgeFromObjCExpr" }
-  }
-
-  class BridgeToObjCExpr extends @bridge_to_obj_c_expr, ImplicitConversionExpr {
-    override string toString() { result = "BridgeToObjCExpr" }
-  }
-
-  class BuiltinLiteralExpr extends @builtin_literal_expr, LiteralExpr { }
-
-  class CallExpr extends @call_expr, ApplyExpr {
-    override string toString() { result = "CallExpr" }
-  }
-
-  class CheckedCastExpr extends @checked_cast_expr, ExplicitCastExpr { }
-
-  class ClassMetatypeToObjectExpr extends @class_metatype_to_object_expr, ImplicitConversionExpr {
-    override string toString() { result = "ClassMetatypeToObjectExpr" }
-  }
-
   class ClassType extends @class_type, NominalType {
     override string toString() { result = "ClassType" }
-  }
-
-  class ClosureExpr extends @closure_expr, AbstractClosureExpr {
-    override string toString() { result = "ClosureExpr" }
-  }
-
-  class CoerceExpr extends @coerce_expr, ExplicitCastExpr {
-    override string toString() { result = "CoerceExpr" }
-  }
-
-  class CollectionUpcastConversionExpr extends @collection_upcast_conversion_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "CollectionUpcastConversionExpr" }
-  }
-
-  class ConditionalBridgeFromObjCExpr extends @conditional_bridge_from_obj_c_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "ConditionalBridgeFromObjCExpr" }
-  }
-
-  class CovariantFunctionConversionExpr extends @covariant_function_conversion_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "CovariantFunctionConversionExpr" }
-  }
-
-  class CovariantReturnConversionExpr extends @covariant_return_conversion_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "CovariantReturnConversionExpr" }
-  }
-
-  class DerivedToBaseExpr extends @derived_to_base_expr, ImplicitConversionExpr {
-    override string toString() { result = "DerivedToBaseExpr" }
-  }
-
-  class DestructureTupleExpr extends @destructure_tuple_expr, ImplicitConversionExpr {
-    override string toString() { result = "DestructureTupleExpr" }
-  }
-
-  class DictionaryExpr extends @dictionary_expr, CollectionExpr {
-    override string toString() { result = "DictionaryExpr" }
-
-    Expr getElement(int index) { dictionary_expr_elements(this, index, result) }
-  }
-
-  class DifferentiableFunctionExpr extends @differentiable_function_expr, ImplicitConversionExpr {
-    override string toString() { result = "DifferentiableFunctionExpr" }
-  }
-
-  class DifferentiableFunctionExtractOriginalExpr extends @differentiable_function_extract_original_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "DifferentiableFunctionExtractOriginalExpr" }
-  }
-
-  class DoCatchStmt extends @do_catch_stmt, LabeledStmt {
-    override string toString() { result = "DoCatchStmt" }
-
-    Stmt getBody() { do_catch_stmts(this, result) }
-
-    CaseStmt getCatch(int index) { do_catch_stmt_catches(this, index, result) }
-  }
-
-  class DoStmt extends @do_stmt, LabeledStmt {
-    override string toString() { result = "DoStmt" }
-
-    BraceStmt getBody() { do_stmts(this, result) }
-  }
-
-  class DotSelfExpr extends @dot_self_expr, IdentityExpr {
-    override string toString() { result = "DotSelfExpr" }
-  }
-
-  class DynamicLookupExpr extends @dynamic_lookup_expr, LookupExpr { }
-
-  class EnumElementDecl extends @enum_element_decl, ValueDecl {
-    override string toString() { result = "EnumElementDecl" }
-
-    string getName() { enum_element_decls(this, result) }
-
-    ParamDecl getParam(int index) { enum_element_decl_params(this, index, result) }
   }
 
   class EnumType extends @enum_type, NominalType {
     override string toString() { result = "EnumType" }
   }
 
-  class ErasureExpr extends @erasure_expr, ImplicitConversionExpr {
-    override string toString() { result = "ErasureExpr" }
-  }
-
-  class ExistentialMetatypeToObjectExpr extends @existential_metatype_to_object_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "ExistentialMetatypeToObjectExpr" }
-  }
-
-  class ForEachStmt extends @for_each_stmt, LabeledStmt {
-    override string toString() { result = "ForEachStmt" }
-
-    Pattern getPattern() { for_each_stmts(this, result, _, _) }
-
-    Expr getSequence() { for_each_stmts(this, _, result, _) }
-
-    Expr getWhere() { for_each_stmt_wheres(this, result) }
-
-    BraceStmt getBody() { for_each_stmts(this, _, _, result) }
-  }
-
-  class ForceTryExpr extends @force_try_expr, AnyTryExpr {
-    override string toString() { result = "ForceTryExpr" }
-  }
-
-  class ForeignObjectConversionExpr extends @foreign_object_conversion_expr, ImplicitConversionExpr {
-    override string toString() { result = "ForeignObjectConversionExpr" }
-  }
-
-  class FunctionConversionExpr extends @function_conversion_expr, ImplicitConversionExpr {
-    override string toString() { result = "FunctionConversionExpr" }
-  }
-
-  class InOutToPointerExpr extends @in_out_to_pointer_expr, ImplicitConversionExpr {
-    override string toString() { result = "InOutToPointerExpr" }
-  }
-
-  class InfixOperatorDecl extends @infix_operator_decl, OperatorDecl {
-    override string toString() { result = "InfixOperatorDecl" }
-
-    PrecedenceGroupDecl getPrecedenceGroup() { infix_operator_decl_precedence_groups(this, result) }
-  }
-
-  class InjectIntoOptionalExpr extends @inject_into_optional_expr, ImplicitConversionExpr {
-    override string toString() { result = "InjectIntoOptionalExpr" }
-  }
-
-  class InterpolatedStringLiteralExpr extends @interpolated_string_literal_expr, LiteralExpr {
-    override string toString() { result = "InterpolatedStringLiteralExpr" }
-
-    OpaqueValueExpr getInterpolationExpr() {
-      interpolated_string_literal_expr_interpolation_exprs(this, result)
-    }
-
-    Expr getInterpolationCountExpr() {
-      interpolated_string_literal_expr_interpolation_count_exprs(this, result)
-    }
-
-    Expr getLiteralCapacityExpr() {
-      interpolated_string_literal_expr_literal_capacity_exprs(this, result)
-    }
-
-    TapExpr getAppendingExpr() { interpolated_string_literal_expr_appending_exprs(this, result) }
-  }
-
-  class LabeledConditionalStmt extends @labeled_conditional_stmt, LabeledStmt {
-    StmtCondition getCondition() { labeled_conditional_stmts(this, result) }
-  }
-
-  class LinearFunctionExpr extends @linear_function_expr, ImplicitConversionExpr {
-    override string toString() { result = "LinearFunctionExpr" }
-  }
-
-  class LinearFunctionExtractOriginalExpr extends @linear_function_extract_original_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "LinearFunctionExtractOriginalExpr" }
-  }
-
-  class LinearToDifferentiableFunctionExpr extends @linear_to_differentiable_function_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "LinearToDifferentiableFunctionExpr" }
-  }
-
-  class LoadExpr extends @load_expr, ImplicitConversionExpr {
-    override string toString() { result = "LoadExpr" }
-  }
-
-  class MemberRefExpr extends @member_ref_expr, LookupExpr {
-    override string toString() { result = "MemberRefExpr" }
-
-    predicate hasDirectToStorageSemantics() {
-      member_ref_expr_has_direct_to_storage_semantics(this)
-    }
-
-    predicate hasDirectToImplementationSemantics() {
-      member_ref_expr_has_direct_to_implementation_semantics(this)
-    }
-
-    predicate hasOrdinarySemantics() { member_ref_expr_has_ordinary_semantics(this) }
-  }
-
-  class MetatypeConversionExpr extends @metatype_conversion_expr, ImplicitConversionExpr {
-    override string toString() { result = "MetatypeConversionExpr" }
-  }
-
-  class NilLiteralExpr extends @nil_literal_expr, LiteralExpr {
-    override string toString() { result = "NilLiteralExpr" }
-  }
-
-  class ObjectLiteralExpr extends @object_literal_expr, LiteralExpr {
-    override string toString() { result = "ObjectLiteralExpr" }
-  }
-
-  class OptionalTryExpr extends @optional_try_expr, AnyTryExpr {
-    override string toString() { result = "OptionalTryExpr" }
-  }
-
   class OptionalType extends @optional_type, UnarySyntaxSugarType {
     override string toString() { result = "OptionalType" }
-  }
-
-  class OverloadedDeclRefExpr extends @overloaded_decl_ref_expr, OverloadSetRefExpr {
-    override string toString() { result = "OverloadedDeclRefExpr" }
-  }
-
-  class ParenExpr extends @paren_expr, IdentityExpr {
-    override string toString() { result = "ParenExpr" }
-  }
-
-  class PointerToPointerExpr extends @pointer_to_pointer_expr, ImplicitConversionExpr {
-    override string toString() { result = "PointerToPointerExpr" }
-  }
-
-  class PostfixOperatorDecl extends @postfix_operator_decl, OperatorDecl {
-    override string toString() { result = "PostfixOperatorDecl" }
-  }
-
-  class PostfixUnaryExpr extends @postfix_unary_expr, ApplyExpr {
-    override string toString() { result = "PostfixUnaryExpr" }
-  }
-
-  class PrefixOperatorDecl extends @prefix_operator_decl, OperatorDecl {
-    override string toString() { result = "PrefixOperatorDecl" }
-  }
-
-  class PrefixUnaryExpr extends @prefix_unary_expr, ApplyExpr {
-    override string toString() { result = "PrefixUnaryExpr" }
-  }
-
-  class ProtocolMetatypeToObjectExpr extends @protocol_metatype_to_object_expr,
-    ImplicitConversionExpr {
-    override string toString() { result = "ProtocolMetatypeToObjectExpr" }
   }
 
   class ProtocolType extends @protocol_type, NominalType {
     override string toString() { result = "ProtocolType" }
   }
 
-  class RegexLiteralExpr extends @regex_literal_expr, LiteralExpr {
-    override string toString() { result = "RegexLiteralExpr" }
-  }
-
-  class RepeatWhileStmt extends @repeat_while_stmt, LabeledStmt {
-    override string toString() { result = "RepeatWhileStmt" }
-
-    Expr getCondition() { repeat_while_stmts(this, result, _) }
-
-    Stmt getBody() { repeat_while_stmts(this, _, result) }
-  }
-
-  class SelfApplyExpr extends @self_apply_expr, ApplyExpr {
-    Expr getBase() { self_apply_exprs(this, result) }
-  }
-
-  class StringToPointerExpr extends @string_to_pointer_expr, ImplicitConversionExpr {
-    override string toString() { result = "StringToPointerExpr" }
-  }
-
   class StructType extends @struct_type, NominalType {
     override string toString() { result = "StructType" }
   }
 
-  class SubscriptExpr extends @subscript_expr, LookupExpr {
-    override string toString() { result = "SubscriptExpr" }
-
-    Argument getArgument(int index) { subscript_expr_arguments(this, index, result) }
-
-    predicate hasDirectToStorageSemantics() { subscript_expr_has_direct_to_storage_semantics(this) }
-
-    predicate hasDirectToImplementationSemantics() {
-      subscript_expr_has_direct_to_implementation_semantics(this)
-    }
-
-    predicate hasOrdinarySemantics() { subscript_expr_has_ordinary_semantics(this) }
-  }
-
-  class SwitchStmt extends @switch_stmt, LabeledStmt {
-    override string toString() { result = "SwitchStmt" }
-
-    Expr getExpr() { switch_stmts(this, result) }
-
-    CaseStmt getCase(int index) { switch_stmt_cases(this, index, result) }
-  }
-
-  class TryExpr extends @try_expr, AnyTryExpr {
-    override string toString() { result = "TryExpr" }
-  }
-
-  class TypeDecl extends @type_decl, ValueDecl {
-    string getName() { type_decls(this, result) }
-
-    Type getBaseType(int index) { type_decl_base_types(this, index, result) }
-  }
-
-  class UnderlyingToOpaqueExpr extends @underlying_to_opaque_expr, ImplicitConversionExpr {
-    override string toString() { result = "UnderlyingToOpaqueExpr" }
-  }
-
-  class UnevaluatedInstanceExpr extends @unevaluated_instance_expr, ImplicitConversionExpr {
-    override string toString() { result = "UnevaluatedInstanceExpr" }
-  }
-
-  class UnresolvedMemberChainResultExpr extends @unresolved_member_chain_result_expr, IdentityExpr,
-    UnresolvedElement {
-    override string toString() { result = "UnresolvedMemberChainResultExpr" }
-  }
-
-  class UnresolvedTypeConversionExpr extends @unresolved_type_conversion_expr,
-    ImplicitConversionExpr, UnresolvedElement {
-    override string toString() { result = "UnresolvedTypeConversionExpr" }
-  }
-
   class VariadicSequenceType extends @variadic_sequence_type, UnarySyntaxSugarType {
     override string toString() { result = "VariadicSequenceType" }
-  }
-
-  class AbstractTypeParamDecl extends @abstract_type_param_decl, TypeDecl { }
-
-  class BooleanLiteralExpr extends @boolean_literal_expr, BuiltinLiteralExpr {
-    override string toString() { result = "BooleanLiteralExpr" }
-
-    boolean getValue() { boolean_literal_exprs(this, result) }
-  }
-
-  class ConditionalCheckedCastExpr extends @conditional_checked_cast_expr, CheckedCastExpr {
-    override string toString() { result = "ConditionalCheckedCastExpr" }
-  }
-
-  class ConstructorDecl extends @constructor_decl, AbstractFunctionDecl {
-    override string toString() { result = "ConstructorDecl" }
-  }
-
-  class ConstructorRefCallExpr extends @constructor_ref_call_expr, SelfApplyExpr {
-    override string toString() { result = "ConstructorRefCallExpr" }
-  }
-
-  class DestructorDecl extends @destructor_decl, AbstractFunctionDecl {
-    override string toString() { result = "DestructorDecl" }
-  }
-
-  class DotSyntaxCallExpr extends @dot_syntax_call_expr, SelfApplyExpr {
-    override string toString() { result = "DotSyntaxCallExpr" }
-  }
-
-  class DynamicMemberRefExpr extends @dynamic_member_ref_expr, DynamicLookupExpr {
-    override string toString() { result = "DynamicMemberRefExpr" }
-  }
-
-  class DynamicSubscriptExpr extends @dynamic_subscript_expr, DynamicLookupExpr {
-    override string toString() { result = "DynamicSubscriptExpr" }
-  }
-
-  class ForcedCheckedCastExpr extends @forced_checked_cast_expr, CheckedCastExpr {
-    override string toString() { result = "ForcedCheckedCastExpr" }
-  }
-
-  class FuncDecl extends @func_decl, AbstractFunctionDecl { }
-
-  class GenericTypeDecl extends @generic_type_decl, GenericContext, TypeDecl { }
-
-  class GuardStmt extends @guard_stmt, LabeledConditionalStmt {
-    override string toString() { result = "GuardStmt" }
-
-    BraceStmt getBody() { guard_stmts(this, result) }
-  }
-
-  class IfStmt extends @if_stmt, LabeledConditionalStmt {
-    override string toString() { result = "IfStmt" }
-
-    Stmt getThen() { if_stmts(this, result) }
-
-    Stmt getElse() { if_stmt_elses(this, result) }
-  }
-
-  class IsExpr extends @is_expr, CheckedCastExpr {
-    override string toString() { result = "IsExpr" }
-  }
-
-  class MagicIdentifierLiteralExpr extends @magic_identifier_literal_expr, BuiltinLiteralExpr {
-    override string toString() { result = "MagicIdentifierLiteralExpr" }
-
-    string getKind() { magic_identifier_literal_exprs(this, result) }
-  }
-
-  class ModuleDecl extends @module_decl, TypeDecl {
-    override string toString() { result = "ModuleDecl" }
-
-    predicate isBuiltinModule() { module_decl_is_builtin_module(this) }
-
-    predicate isSystemModule() { module_decl_is_system_module(this) }
-
-    ModuleDecl getImportedModule(int index) { module_decl_imported_modules(this, index, result) }
-
-    ModuleDecl getExportedModule(int index) { module_decl_exported_modules(this, index, result) }
-  }
-
-  class NumberLiteralExpr extends @number_literal_expr, BuiltinLiteralExpr { }
-
-  class StringLiteralExpr extends @string_literal_expr, BuiltinLiteralExpr {
-    override string toString() { result = "StringLiteralExpr" }
-
-    string getValue() { string_literal_exprs(this, result) }
-  }
-
-  class SubscriptDecl extends @subscript_decl, AbstractStorageDecl, GenericContext {
-    override string toString() { result = "SubscriptDecl" }
-
-    ParamDecl getParam(int index) { subscript_decl_params(this, index, result) }
-
-    Type getElementType() { subscript_decls(this, result) }
-  }
-
-  class VarDecl extends @var_decl, AbstractStorageDecl {
-    string getName() { var_decls(this, result, _) }
-
-    Type getType() { var_decls(this, _, result) }
-
-    Type getAttachedPropertyWrapperType() { var_decl_attached_property_wrapper_types(this, result) }
-
-    Pattern getParentPattern() { var_decl_parent_patterns(this, result) }
-
-    Expr getParentInitializer() { var_decl_parent_initializers(this, result) }
-  }
-
-  class WhileStmt extends @while_stmt, LabeledConditionalStmt {
-    override string toString() { result = "WhileStmt" }
-
-    Stmt getBody() { while_stmts(this, result) }
-  }
-
-  class AccessorDecl extends @accessor_decl, FuncDecl {
-    override string toString() { result = "AccessorDecl" }
-
-    predicate isGetter() { accessor_decl_is_getter(this) }
-
-    predicate isSetter() { accessor_decl_is_setter(this) }
-
-    predicate isWillSet() { accessor_decl_is_will_set(this) }
-
-    predicate isDidSet() { accessor_decl_is_did_set(this) }
-  }
-
-  class AssociatedTypeDecl extends @associated_type_decl, AbstractTypeParamDecl {
-    override string toString() { result = "AssociatedTypeDecl" }
-  }
-
-  class ConcreteFuncDecl extends @concrete_func_decl, FuncDecl {
-    override string toString() { result = "ConcreteFuncDecl" }
-  }
-
-  class ConcreteVarDecl extends @concrete_var_decl, VarDecl {
-    override string toString() { result = "ConcreteVarDecl" }
-
-    int getIntroducerInt() { concrete_var_decls(this, result) }
-  }
-
-  class FloatLiteralExpr extends @float_literal_expr, NumberLiteralExpr {
-    override string toString() { result = "FloatLiteralExpr" }
-
-    string getStringValue() { float_literal_exprs(this, result) }
-  }
-
-  class GenericTypeParamDecl extends @generic_type_param_decl, AbstractTypeParamDecl {
-    override string toString() { result = "GenericTypeParamDecl" }
-  }
-
-  class IntegerLiteralExpr extends @integer_literal_expr, NumberLiteralExpr {
-    override string toString() { result = "IntegerLiteralExpr" }
-
-    string getStringValue() { integer_literal_exprs(this, result) }
-  }
-
-  class NominalTypeDecl extends @nominal_type_decl, GenericTypeDecl, IterableDeclContext {
-    Type getType() { nominal_type_decls(this, result) }
-  }
-
-  class OpaqueTypeDecl extends @opaque_type_decl, GenericTypeDecl {
-    override string toString() { result = "OpaqueTypeDecl" }
-  }
-
-  class ParamDecl extends @param_decl, VarDecl {
-    override string toString() { result = "ParamDecl" }
-
-    predicate isInout() { param_decl_is_inout(this) }
-  }
-
-  class TypeAliasDecl extends @type_alias_decl, GenericTypeDecl {
-    override string toString() { result = "TypeAliasDecl" }
-  }
-
-  class ClassDecl extends @class_decl, NominalTypeDecl {
-    override string toString() { result = "ClassDecl" }
-  }
-
-  class EnumDecl extends @enum_decl, NominalTypeDecl {
-    override string toString() { result = "EnumDecl" }
-  }
-
-  class ProtocolDecl extends @protocol_decl, NominalTypeDecl {
-    override string toString() { result = "ProtocolDecl" }
-  }
-
-  class StructDecl extends @struct_decl, NominalTypeDecl {
-    override string toString() { result = "StructDecl" }
   }
 }

--- a/swift/ql/lib/swift.dbscheme
+++ b/swift/ql/lib/swift.dbscheme
@@ -28,16 +28,29 @@ element_is_unknown(
   int id: @element ref
 );
 
-@unresolved_element =
-  @unresolved_decl_ref_expr
-| @unresolved_dot_expr
-| @unresolved_member_chain_result_expr
-| @unresolved_member_expr
-| @unresolved_pattern_expr
-| @unresolved_specialize_expr
-| @unresolved_type
-| @unresolved_type_conversion_expr
+@callable =
+  @abstract_closure_expr
+| @abstract_function_decl
 ;
+
+#keyset[id]
+callable_self_params(
+  int id: @callable ref,
+  int self_param: @param_decl ref
+);
+
+#keyset[id, index]
+callable_params(
+  int id: @callable ref,
+  int index: int ref,
+  int param: @param_decl ref
+);
+
+#keyset[id]
+callable_bodies(
+  int id: @callable ref,
+  int body: @brace_stmt ref
+);
 
 @file =
   @db_file
@@ -48,14 +61,6 @@ element_is_unknown(
 files(
   int id: @file ref,
   string name: string ref
-);
-
-db_files(
-  unique int id: @db_file
-);
-
-unknown_files(
-  unique int id: @unknown_file
 );
 
 @locatable =
@@ -86,81 +91,16 @@ locations(
   int end_column: int ref
 );
 
-db_locations(
-  unique int id: @db_location
-);
-
-unknown_locations(
-  unique int id: @unknown_location
-);
-
-comments(
-  unique int id: @comment,
-  string text: string ref
-);
-
-@type =
-  @any_function_type
-| @any_generic_type
-| @any_metatype_type
-| @builtin_type
-| @dependent_member_type
-| @dynamic_self_type
-| @error_type
-| @existential_type
-| @in_out_type
-| @l_value_type
-| @module_type
-| @placeholder_type
-| @protocol_composition_type
-| @reference_storage_type
-| @sil_block_storage_type
-| @sil_box_type
-| @sil_function_type
-| @sil_token_type
-| @substitutable_type
-| @sugar_type
-| @tuple_type
-| @type_variable_type
+@unresolved_element =
+  @unresolved_decl_ref_expr
+| @unresolved_dot_expr
+| @unresolved_member_chain_result_expr
+| @unresolved_member_expr
+| @unresolved_pattern_expr
+| @unresolved_specialize_expr
 | @unresolved_type
+| @unresolved_type_conversion_expr
 ;
-
-#keyset[id]
-types(  //dir=type
-  int id: @type ref,
-  string name: string ref,
-  int canonical_type: @type ref
-);
-
-@iterable_decl_context =
-  @extension_decl
-| @nominal_type_decl
-;
-
-#keyset[id, index]
-iterable_decl_context_members(  //dir=decl
-  int id: @iterable_decl_context ref,
-  int index: int ref,
-  int member: @decl ref
-);
-
-extension_decls(  //dir=decl
-  unique int id: @extension_decl,
-  int extended_type_decl: @nominal_type_decl ref
-);
-
-@nominal_type_decl =
-  @class_decl
-| @enum_decl
-| @protocol_decl
-| @struct_decl
-;
-
-#keyset[id]
-nominal_type_decls(  //dir=decl
-  int id: @nominal_type_decl ref,
-  int type_: @type ref
-);
 
 @ast_node =
   @case_label_item
@@ -172,252 +112,25 @@ nominal_type_decls(  //dir=decl
 | @type_repr
 ;
 
-@callable =
-  @abstract_closure_expr
-| @abstract_function_decl
-;
-
-#keyset[id]
-callable_self_params(
-  int id: @callable ref,
-  int self_param: @param_decl ref
+comments(
+  unique int id: @comment,
+  string text: string ref
 );
 
-#keyset[id, index]
-callable_params(
-  int id: @callable ref,
-  int index: int ref,
-  int param: @param_decl ref
+db_files(
+  unique int id: @db_file
 );
 
-#keyset[id]
-callable_bodies(
-  int id: @callable ref,
-  int body: @brace_stmt ref
+db_locations(
+  unique int id: @db_location
 );
 
-condition_elements(  //dir=stmt
-  unique int id: @condition_element
+unknown_files(
+  unique int id: @unknown_file
 );
 
-#keyset[id]
-condition_element_booleans(  //dir=stmt
-  int id: @condition_element ref,
-  int boolean_: @expr ref
-);
-
-#keyset[id]
-condition_element_patterns(  //dir=stmt
-  int id: @condition_element ref,
-  int pattern: @pattern ref
-);
-
-#keyset[id]
-condition_element_initializers(  //dir=stmt
-  int id: @condition_element ref,
-  int initializer: @expr ref
-);
-
-@any_function_type =
-  @function_type
-| @generic_function_type
-;
-
-#keyset[id]
-any_function_types(  //dir=type
-  int id: @any_function_type ref,
-  int result: @type ref
-);
-
-#keyset[id, index]
-any_function_type_param_types(  //dir=type
-  int id: @any_function_type ref,
-  int index: int ref,
-  int param_type: @type ref
-);
-
-#keyset[id, index]
-any_function_type_param_labels(  //dir=type
-  int id: @any_function_type ref,
-  int index: int ref,
-  string param_label: string ref
-);
-
-#keyset[id]
-any_function_type_is_throwing(  //dir=type
-  int id: @any_function_type ref
-);
-
-#keyset[id]
-any_function_type_is_async(  //dir=type
-  int id: @any_function_type ref
-);
-
-@any_generic_type =
-  @nominal_or_bound_generic_nominal_type
-| @unbound_generic_type
-;
-
-#keyset[id]
-any_generic_types(  //dir=type
-  int id: @any_generic_type ref,
-  int declaration: @decl ref
-);
-
-#keyset[id]
-any_generic_type_parents(  //dir=type
-  int id: @any_generic_type ref,
-  int parent: @type ref
-);
-
-@any_metatype_type =
-  @existential_metatype_type
-| @metatype_type
-;
-
-@builtin_type =
-  @any_builtin_integer_type
-| @builtin_bridge_object_type
-| @builtin_default_actor_storage_type
-| @builtin_executor_type
-| @builtin_float_type
-| @builtin_job_type
-| @builtin_native_object_type
-| @builtin_raw_pointer_type
-| @builtin_raw_unsafe_continuation_type
-| @builtin_unsafe_value_buffer_type
-| @builtin_vector_type
-;
-
-dependent_member_types(  //dir=type
-  unique int id: @dependent_member_type,
-  int baseType: @type ref,
-  int associated_type_decl: @associated_type_decl ref
-);
-
-dynamic_self_types(  //dir=type
-  unique int id: @dynamic_self_type,
-  int static_self_type: @type ref
-);
-
-error_types(  //dir=type
-  unique int id: @error_type
-);
-
-in_out_types(  //dir=type
-  unique int id: @in_out_type,
-  int object_type: @type ref
-);
-
-l_value_types(  //dir=type
-  unique int id: @l_value_type,
-  int object_type: @type ref
-);
-
-module_types(  //dir=type
-  unique int id: @module_type,
-  int module: @module_decl ref
-);
-
-placeholder_types(  //dir=type
-  unique int id: @placeholder_type
-);
-
-protocol_composition_types(  //dir=type
-  unique int id: @protocol_composition_type
-);
-
-#keyset[id, index]
-protocol_composition_type_members(  //dir=type
-  int id: @protocol_composition_type ref,
-  int index: int ref,
-  int member: @type ref
-);
-
-existential_types(  //dir=type
-  unique int id: @existential_type,
-  int constraint: @type ref
-);
-
-@reference_storage_type =
-  @unmanaged_storage_type
-| @unowned_storage_type
-| @weak_storage_type
-;
-
-#keyset[id]
-reference_storage_types(  //dir=type
-  int id: @reference_storage_type ref,
-  int referent_type: @type ref
-);
-
-sil_block_storage_types(  //dir=type
-  unique int id: @sil_block_storage_type
-);
-
-sil_box_types(  //dir=type
-  unique int id: @sil_box_type
-);
-
-sil_function_types(  //dir=type
-  unique int id: @sil_function_type
-);
-
-sil_token_types(  //dir=type
-  unique int id: @sil_token_type
-);
-
-@substitutable_type =
-  @archetype_type
-| @generic_type_param_type
-;
-
-@sugar_type =
-  @paren_type
-| @syntax_sugar_type
-| @type_alias_type
-;
-
-tuple_types(  //dir=type
-  unique int id: @tuple_type
-);
-
-#keyset[id, index]
-tuple_type_types(  //dir=type
-  int id: @tuple_type ref,
-  int index: int ref,
-  int type_: @type ref
-);
-
-#keyset[id, index]
-tuple_type_names(  //dir=type
-  int id: @tuple_type ref,
-  int index: int ref,
-  string name: string ref
-);
-
-type_variable_types(  //dir=type
-  unique int id: @type_variable_type
-);
-
-unresolved_types(  //dir=type
-  unique int id: @unresolved_type
-);
-
-class_decls(  //dir=decl
-  unique int id: @class_decl
-);
-
-enum_decls(  //dir=decl
-  unique int id: @enum_decl
-);
-
-protocol_decls(  //dir=decl
-  unique int id: @protocol_decl
-);
-
-struct_decls(  //dir=decl
-  unique int id: @struct_decl
+unknown_locations(
+  unique int id: @unknown_location
 );
 
 @decl =
@@ -440,234 +153,30 @@ decls(  //dir=decl
   int module: @module_decl ref
 );
 
-@expr =
-  @abstract_closure_expr
-| @any_try_expr
-| @applied_property_wrapper_expr
-| @apply_expr
-| @arrow_expr
-| @assign_expr
-| @bind_optional_expr
-| @capture_list_expr
-| @code_completion_expr
-| @collection_expr
-| @decl_ref_expr
-| @default_argument_expr
-| @discard_assignment_expr
-| @dot_syntax_base_ignored_expr
-| @dynamic_type_expr
-| @editor_placeholder_expr
-| @enum_is_case_expr
-| @error_expr
-| @explicit_cast_expr
-| @force_value_expr
-| @identity_expr
-| @if_expr
-| @implicit_conversion_expr
-| @in_out_expr
-| @key_path_application_expr
-| @key_path_dot_expr
-| @key_path_expr
-| @lazy_initializer_expr
-| @literal_expr
-| @lookup_expr
-| @make_temporarily_escapable_expr
-| @obj_c_selector_expr
-| @one_way_expr
-| @opaque_value_expr
-| @open_existential_expr
-| @optional_evaluation_expr
-| @other_constructor_decl_ref_expr
-| @overload_set_ref_expr
-| @property_wrapper_value_placeholder_expr
-| @rebind_self_in_constructor_expr
-| @sequence_expr
-| @super_ref_expr
-| @tap_expr
-| @tuple_element_expr
-| @tuple_expr
-| @type_expr
-| @unresolved_decl_ref_expr
-| @unresolved_dot_expr
-| @unresolved_member_expr
-| @unresolved_pattern_expr
-| @unresolved_specialize_expr
-| @vararg_expansion_expr
+@generic_context =
+  @abstract_function_decl
+| @extension_decl
+| @generic_type_decl
+| @subscript_decl
 ;
-
-#keyset[id]
-expr_types(  //dir=expr
-  int id: @expr ref,
-  int type_: @type ref
-);
-
-@pattern =
-  @any_pattern
-| @binding_pattern
-| @bool_pattern
-| @enum_element_pattern
-| @expr_pattern
-| @is_pattern
-| @named_pattern
-| @optional_some_pattern
-| @paren_pattern
-| @tuple_pattern
-| @typed_pattern
-;
-
-@stmt =
-  @brace_stmt
-| @break_stmt
-| @case_stmt
-| @continue_stmt
-| @defer_stmt
-| @fail_stmt
-| @fallthrough_stmt
-| @labeled_stmt
-| @pound_assert_stmt
-| @return_stmt
-| @throw_stmt
-| @yield_stmt
-;
-
-type_reprs(  //dir=type
-  unique int id: @type_repr,
-  int type_: @type ref
-);
-
-function_types(  //dir=type
-  unique int id: @function_type
-);
-
-generic_function_types(  //dir=type
-  unique int id: @generic_function_type
-);
 
 #keyset[id, index]
-generic_function_type_generic_params(  //dir=type
-  int id: @generic_function_type ref,
+generic_context_generic_type_params(  //dir=decl
+  int id: @generic_context ref,
   int index: int ref,
-  int generic_param: @generic_type_param_type ref
+  int generic_type_param: @generic_type_param_decl ref
 );
 
-@nominal_or_bound_generic_nominal_type =
-  @bound_generic_type
-| @nominal_type
+@iterable_decl_context =
+  @extension_decl
+| @nominal_type_decl
 ;
-
-unbound_generic_types(  //dir=type
-  unique int id: @unbound_generic_type
-);
-
-existential_metatype_types(  //dir=type
-  unique int id: @existential_metatype_type
-);
-
-metatype_types(  //dir=type
-  unique int id: @metatype_type
-);
-
-@any_builtin_integer_type =
-  @builtin_integer_literal_type
-| @builtin_integer_type
-;
-
-builtin_bridge_object_types(  //dir=type
-  unique int id: @builtin_bridge_object_type
-);
-
-builtin_default_actor_storage_types(  //dir=type
-  unique int id: @builtin_default_actor_storage_type
-);
-
-builtin_executor_types(  //dir=type
-  unique int id: @builtin_executor_type
-);
-
-builtin_float_types(  //dir=type
-  unique int id: @builtin_float_type
-);
-
-builtin_job_types(  //dir=type
-  unique int id: @builtin_job_type
-);
-
-builtin_native_object_types(  //dir=type
-  unique int id: @builtin_native_object_type
-);
-
-builtin_raw_pointer_types(  //dir=type
-  unique int id: @builtin_raw_pointer_type
-);
-
-builtin_raw_unsafe_continuation_types(  //dir=type
-  unique int id: @builtin_raw_unsafe_continuation_type
-);
-
-builtin_unsafe_value_buffer_types(  //dir=type
-  unique int id: @builtin_unsafe_value_buffer_type
-);
-
-builtin_vector_types(  //dir=type
-  unique int id: @builtin_vector_type
-);
-
-unmanaged_storage_types(  //dir=type
-  unique int id: @unmanaged_storage_type
-);
-
-unowned_storage_types(  //dir=type
-  unique int id: @unowned_storage_type
-);
-
-weak_storage_types(  //dir=type
-  unique int id: @weak_storage_type
-);
-
-@archetype_type =
-  @nested_archetype_type
-| @opaque_type_archetype_type
-| @opened_archetype_type
-| @primary_archetype_type
-| @sequence_archetype_type
-;
-
-#keyset[id]
-archetype_types(  //dir=type
-  int id: @archetype_type ref,
-  int interface_type: @type ref
-);
-
-#keyset[id]
-archetype_type_superclasses(  //dir=type
-  int id: @archetype_type ref,
-  int superclass: @type ref
-);
 
 #keyset[id, index]
-archetype_type_protocols(  //dir=type
-  int id: @archetype_type ref,
+iterable_decl_context_members(  //dir=decl
+  int id: @iterable_decl_context ref,
   int index: int ref,
-  int protocol: @protocol_decl ref
-);
-
-generic_type_param_types(  //dir=type
-  unique int id: @generic_type_param_type
-);
-
-paren_types(  //dir=type
-  unique int id: @paren_type,
-  int type_: @type ref
-);
-
-@syntax_sugar_type =
-  @dictionary_type
-| @unary_syntax_sugar_type
-;
-
-type_alias_types(  //dir=type
-  unique int id: @type_alias_type,
-  int decl: @type_alias_decl ref
+  int member: @decl ref
 );
 
 enum_case_decls(  //dir=decl
@@ -679,6 +188,11 @@ enum_case_decl_elements(  //dir=decl
   int id: @enum_case_decl ref,
   int index: int ref,
   int element: @enum_element_decl ref
+);
+
+extension_decls(  //dir=decl
+  unique int id: @extension_decl,
+  int extended_type_decl: @nominal_type_decl ref
 );
 
 if_config_decls(  //dir=decl
@@ -774,6 +288,327 @@ value_decls(  //dir=decl
   int interface_type: @type ref
 );
 
+@abstract_function_decl =
+  @constructor_decl
+| @destructor_decl
+| @func_decl
+;
+
+#keyset[id]
+abstract_function_decls(  //dir=decl
+  int id: @abstract_function_decl ref,
+  string name: string ref
+);
+
+@abstract_storage_decl =
+  @subscript_decl
+| @var_decl
+;
+
+#keyset[id, index]
+abstract_storage_decl_accessor_decls(  //dir=decl
+  int id: @abstract_storage_decl ref,
+  int index: int ref,
+  int accessor_decl: @accessor_decl ref
+);
+
+enum_element_decls(  //dir=decl
+  unique int id: @enum_element_decl,
+  string name: string ref
+);
+
+#keyset[id, index]
+enum_element_decl_params(  //dir=decl
+  int id: @enum_element_decl ref,
+  int index: int ref,
+  int param: @param_decl ref
+);
+
+infix_operator_decls(  //dir=decl
+  unique int id: @infix_operator_decl
+);
+
+#keyset[id]
+infix_operator_decl_precedence_groups(  //dir=decl
+  int id: @infix_operator_decl ref,
+  int precedence_group: @precedence_group_decl ref
+);
+
+postfix_operator_decls(  //dir=decl
+  unique int id: @postfix_operator_decl
+);
+
+prefix_operator_decls(  //dir=decl
+  unique int id: @prefix_operator_decl
+);
+
+@type_decl =
+  @abstract_type_param_decl
+| @generic_type_decl
+| @module_decl
+;
+
+#keyset[id]
+type_decls(  //dir=decl
+  int id: @type_decl ref,
+  string name: string ref
+);
+
+#keyset[id, index]
+type_decl_base_types(  //dir=decl
+  int id: @type_decl ref,
+  int index: int ref,
+  int base_type: @type ref
+);
+
+@abstract_type_param_decl =
+  @associated_type_decl
+| @generic_type_param_decl
+;
+
+constructor_decls(  //dir=decl
+  unique int id: @constructor_decl
+);
+
+destructor_decls(  //dir=decl
+  unique int id: @destructor_decl
+);
+
+@func_decl =
+  @accessor_decl
+| @concrete_func_decl
+;
+
+@generic_type_decl =
+  @nominal_type_decl
+| @opaque_type_decl
+| @type_alias_decl
+;
+
+module_decls(  //dir=decl
+  unique int id: @module_decl
+);
+
+#keyset[id]
+module_decl_is_builtin_module(  //dir=decl
+  int id: @module_decl ref
+);
+
+#keyset[id]
+module_decl_is_system_module(  //dir=decl
+  int id: @module_decl ref
+);
+
+#keyset[id, index]
+module_decl_imported_modules(  //dir=decl
+  int id: @module_decl ref,
+  int index: int ref,
+  int imported_module: @module_decl ref
+);
+
+#keyset[id, index]
+module_decl_exported_modules(  //dir=decl
+  int id: @module_decl ref,
+  int index: int ref,
+  int exported_module: @module_decl ref
+);
+
+subscript_decls(  //dir=decl
+  unique int id: @subscript_decl,
+  int element_type: @type ref
+);
+
+#keyset[id, index]
+subscript_decl_params(  //dir=decl
+  int id: @subscript_decl ref,
+  int index: int ref,
+  int param: @param_decl ref
+);
+
+@var_decl =
+  @concrete_var_decl
+| @param_decl
+;
+
+#keyset[id]
+var_decls(  //dir=decl
+  int id: @var_decl ref,
+  string name: string ref,
+  int type_: @type ref
+);
+
+#keyset[id]
+var_decl_attached_property_wrapper_types(  //dir=decl
+  int id: @var_decl ref,
+  int attached_property_wrapper_type: @type ref
+);
+
+#keyset[id]
+var_decl_parent_patterns(  //dir=decl
+  int id: @var_decl ref,
+  int parent_pattern: @pattern ref
+);
+
+#keyset[id]
+var_decl_parent_initializers(  //dir=decl
+  int id: @var_decl ref,
+  int parent_initializer: @expr ref
+);
+
+accessor_decls(  //dir=decl
+  unique int id: @accessor_decl
+);
+
+#keyset[id]
+accessor_decl_is_getter(  //dir=decl
+  int id: @accessor_decl ref
+);
+
+#keyset[id]
+accessor_decl_is_setter(  //dir=decl
+  int id: @accessor_decl ref
+);
+
+#keyset[id]
+accessor_decl_is_will_set(  //dir=decl
+  int id: @accessor_decl ref
+);
+
+#keyset[id]
+accessor_decl_is_did_set(  //dir=decl
+  int id: @accessor_decl ref
+);
+
+associated_type_decls(  //dir=decl
+  unique int id: @associated_type_decl
+);
+
+concrete_func_decls(  //dir=decl
+  unique int id: @concrete_func_decl
+);
+
+concrete_var_decls(  //dir=decl
+  unique int id: @concrete_var_decl,
+  int introducer_int: int ref
+);
+
+generic_type_param_decls(  //dir=decl
+  unique int id: @generic_type_param_decl
+);
+
+@nominal_type_decl =
+  @class_decl
+| @enum_decl
+| @protocol_decl
+| @struct_decl
+;
+
+#keyset[id]
+nominal_type_decls(  //dir=decl
+  int id: @nominal_type_decl ref,
+  int type_: @type ref
+);
+
+opaque_type_decls(  //dir=decl
+  unique int id: @opaque_type_decl
+);
+
+param_decls(  //dir=decl
+  unique int id: @param_decl
+);
+
+#keyset[id]
+param_decl_is_inout(  //dir=decl
+  int id: @param_decl ref
+);
+
+type_alias_decls(  //dir=decl
+  unique int id: @type_alias_decl
+);
+
+class_decls(  //dir=decl
+  unique int id: @class_decl
+);
+
+enum_decls(  //dir=decl
+  unique int id: @enum_decl
+);
+
+protocol_decls(  //dir=decl
+  unique int id: @protocol_decl
+);
+
+struct_decls(  //dir=decl
+  unique int id: @struct_decl
+);
+
+arguments(  //dir=expr
+  unique int id: @argument,
+  string label: string ref,
+  int expr: @expr ref
+);
+
+@expr =
+  @abstract_closure_expr
+| @any_try_expr
+| @applied_property_wrapper_expr
+| @apply_expr
+| @arrow_expr
+| @assign_expr
+| @bind_optional_expr
+| @capture_list_expr
+| @code_completion_expr
+| @collection_expr
+| @decl_ref_expr
+| @default_argument_expr
+| @discard_assignment_expr
+| @dot_syntax_base_ignored_expr
+| @dynamic_type_expr
+| @editor_placeholder_expr
+| @enum_is_case_expr
+| @error_expr
+| @explicit_cast_expr
+| @force_value_expr
+| @identity_expr
+| @if_expr
+| @implicit_conversion_expr
+| @in_out_expr
+| @key_path_application_expr
+| @key_path_dot_expr
+| @key_path_expr
+| @lazy_initializer_expr
+| @literal_expr
+| @lookup_expr
+| @make_temporarily_escapable_expr
+| @obj_c_selector_expr
+| @one_way_expr
+| @opaque_value_expr
+| @open_existential_expr
+| @optional_evaluation_expr
+| @other_constructor_decl_ref_expr
+| @overload_set_ref_expr
+| @property_wrapper_value_placeholder_expr
+| @rebind_self_in_constructor_expr
+| @sequence_expr
+| @super_ref_expr
+| @tap_expr
+| @tuple_element_expr
+| @tuple_expr
+| @type_expr
+| @unresolved_decl_ref_expr
+| @unresolved_dot_expr
+| @unresolved_member_expr
+| @unresolved_pattern_expr
+| @unresolved_specialize_expr
+| @vararg_expansion_expr
+;
+
+#keyset[id]
+expr_types(  //dir=expr
+  int id: @expr ref,
+  int type_: @type ref
+);
+
 @abstract_closure_expr =
   @auto_closure_expr
 | @closure_expr
@@ -793,12 +628,6 @@ any_try_exprs(  //dir=expr
 
 applied_property_wrapper_exprs(  //dir=expr
   unique int id: @applied_property_wrapper_expr
-);
-
-arguments(  //dir=expr
-  unique int id: @argument,
-  string label: string ref,
-  int expr: @expr ref
 );
 
 @apply_expr =
@@ -1208,6 +1037,402 @@ vararg_expansion_exprs(  //dir=expr
   int sub_expr: @expr ref
 );
 
+any_hashable_erasure_exprs(  //dir=expr
+  unique int id: @any_hashable_erasure_expr
+);
+
+archetype_to_super_exprs(  //dir=expr
+  unique int id: @archetype_to_super_expr
+);
+
+array_exprs(  //dir=expr
+  unique int id: @array_expr
+);
+
+#keyset[id, index]
+array_expr_elements(  //dir=expr
+  int id: @array_expr ref,
+  int index: int ref,
+  int element: @expr ref
+);
+
+array_to_pointer_exprs(  //dir=expr
+  unique int id: @array_to_pointer_expr
+);
+
+auto_closure_exprs(  //dir=expr
+  unique int id: @auto_closure_expr
+);
+
+await_exprs(  //dir=expr
+  unique int id: @await_expr
+);
+
+binary_exprs(  //dir=expr
+  unique int id: @binary_expr
+);
+
+bridge_from_obj_c_exprs(  //dir=expr
+  unique int id: @bridge_from_obj_c_expr
+);
+
+bridge_to_obj_c_exprs(  //dir=expr
+  unique int id: @bridge_to_obj_c_expr
+);
+
+@builtin_literal_expr =
+  @boolean_literal_expr
+| @magic_identifier_literal_expr
+| @number_literal_expr
+| @string_literal_expr
+;
+
+call_exprs(  //dir=expr
+  unique int id: @call_expr
+);
+
+@checked_cast_expr =
+  @conditional_checked_cast_expr
+| @forced_checked_cast_expr
+| @is_expr
+;
+
+class_metatype_to_object_exprs(  //dir=expr
+  unique int id: @class_metatype_to_object_expr
+);
+
+closure_exprs(  //dir=expr
+  unique int id: @closure_expr
+);
+
+coerce_exprs(  //dir=expr
+  unique int id: @coerce_expr
+);
+
+collection_upcast_conversion_exprs(  //dir=expr
+  unique int id: @collection_upcast_conversion_expr
+);
+
+conditional_bridge_from_obj_c_exprs(  //dir=expr
+  unique int id: @conditional_bridge_from_obj_c_expr
+);
+
+covariant_function_conversion_exprs(  //dir=expr
+  unique int id: @covariant_function_conversion_expr
+);
+
+covariant_return_conversion_exprs(  //dir=expr
+  unique int id: @covariant_return_conversion_expr
+);
+
+derived_to_base_exprs(  //dir=expr
+  unique int id: @derived_to_base_expr
+);
+
+destructure_tuple_exprs(  //dir=expr
+  unique int id: @destructure_tuple_expr
+);
+
+dictionary_exprs(  //dir=expr
+  unique int id: @dictionary_expr
+);
+
+#keyset[id, index]
+dictionary_expr_elements(  //dir=expr
+  int id: @dictionary_expr ref,
+  int index: int ref,
+  int element: @expr ref
+);
+
+differentiable_function_exprs(  //dir=expr
+  unique int id: @differentiable_function_expr
+);
+
+differentiable_function_extract_original_exprs(  //dir=expr
+  unique int id: @differentiable_function_extract_original_expr
+);
+
+dot_self_exprs(  //dir=expr
+  unique int id: @dot_self_expr
+);
+
+@dynamic_lookup_expr =
+  @dynamic_member_ref_expr
+| @dynamic_subscript_expr
+;
+
+erasure_exprs(  //dir=expr
+  unique int id: @erasure_expr
+);
+
+existential_metatype_to_object_exprs(  //dir=expr
+  unique int id: @existential_metatype_to_object_expr
+);
+
+force_try_exprs(  //dir=expr
+  unique int id: @force_try_expr
+);
+
+foreign_object_conversion_exprs(  //dir=expr
+  unique int id: @foreign_object_conversion_expr
+);
+
+function_conversion_exprs(  //dir=expr
+  unique int id: @function_conversion_expr
+);
+
+in_out_to_pointer_exprs(  //dir=expr
+  unique int id: @in_out_to_pointer_expr
+);
+
+inject_into_optional_exprs(  //dir=expr
+  unique int id: @inject_into_optional_expr
+);
+
+interpolated_string_literal_exprs(  //dir=expr
+  unique int id: @interpolated_string_literal_expr
+);
+
+#keyset[id]
+interpolated_string_literal_expr_interpolation_exprs(  //dir=expr
+  int id: @interpolated_string_literal_expr ref,
+  int interpolation_expr: @opaque_value_expr ref
+);
+
+#keyset[id]
+interpolated_string_literal_expr_interpolation_count_exprs(  //dir=expr
+  int id: @interpolated_string_literal_expr ref,
+  int interpolation_count_expr: @expr ref
+);
+
+#keyset[id]
+interpolated_string_literal_expr_literal_capacity_exprs(  //dir=expr
+  int id: @interpolated_string_literal_expr ref,
+  int literal_capacity_expr: @expr ref
+);
+
+#keyset[id]
+interpolated_string_literal_expr_appending_exprs(  //dir=expr
+  int id: @interpolated_string_literal_expr ref,
+  int appending_expr: @tap_expr ref
+);
+
+linear_function_exprs(  //dir=expr
+  unique int id: @linear_function_expr
+);
+
+linear_function_extract_original_exprs(  //dir=expr
+  unique int id: @linear_function_extract_original_expr
+);
+
+linear_to_differentiable_function_exprs(  //dir=expr
+  unique int id: @linear_to_differentiable_function_expr
+);
+
+load_exprs(  //dir=expr
+  unique int id: @load_expr
+);
+
+member_ref_exprs(  //dir=expr
+  unique int id: @member_ref_expr
+);
+
+#keyset[id]
+member_ref_expr_has_direct_to_storage_semantics(  //dir=expr
+  int id: @member_ref_expr ref
+);
+
+#keyset[id]
+member_ref_expr_has_direct_to_implementation_semantics(  //dir=expr
+  int id: @member_ref_expr ref
+);
+
+#keyset[id]
+member_ref_expr_has_ordinary_semantics(  //dir=expr
+  int id: @member_ref_expr ref
+);
+
+metatype_conversion_exprs(  //dir=expr
+  unique int id: @metatype_conversion_expr
+);
+
+method_ref_exprs(  //dir=expr
+  unique int id: @method_ref_expr
+);
+
+nil_literal_exprs(  //dir=expr
+  unique int id: @nil_literal_expr
+);
+
+object_literal_exprs(  //dir=expr
+  unique int id: @object_literal_expr
+);
+
+optional_try_exprs(  //dir=expr
+  unique int id: @optional_try_expr
+);
+
+overloaded_decl_ref_exprs(  //dir=expr
+  unique int id: @overloaded_decl_ref_expr
+);
+
+paren_exprs(  //dir=expr
+  unique int id: @paren_expr
+);
+
+pointer_to_pointer_exprs(  //dir=expr
+  unique int id: @pointer_to_pointer_expr
+);
+
+postfix_unary_exprs(  //dir=expr
+  unique int id: @postfix_unary_expr
+);
+
+prefix_unary_exprs(  //dir=expr
+  unique int id: @prefix_unary_expr
+);
+
+protocol_metatype_to_object_exprs(  //dir=expr
+  unique int id: @protocol_metatype_to_object_expr
+);
+
+regex_literal_exprs(  //dir=expr
+  unique int id: @regex_literal_expr
+);
+
+@self_apply_expr =
+  @constructor_ref_call_expr
+| @dot_syntax_call_expr
+;
+
+#keyset[id]
+self_apply_exprs(  //dir=expr
+  int id: @self_apply_expr ref,
+  int base: @expr ref
+);
+
+string_to_pointer_exprs(  //dir=expr
+  unique int id: @string_to_pointer_expr
+);
+
+subscript_exprs(  //dir=expr
+  unique int id: @subscript_expr
+);
+
+#keyset[id, index]
+subscript_expr_arguments(  //dir=expr
+  int id: @subscript_expr ref,
+  int index: int ref,
+  int argument: @argument ref
+);
+
+#keyset[id]
+subscript_expr_has_direct_to_storage_semantics(  //dir=expr
+  int id: @subscript_expr ref
+);
+
+#keyset[id]
+subscript_expr_has_direct_to_implementation_semantics(  //dir=expr
+  int id: @subscript_expr ref
+);
+
+#keyset[id]
+subscript_expr_has_ordinary_semantics(  //dir=expr
+  int id: @subscript_expr ref
+);
+
+try_exprs(  //dir=expr
+  unique int id: @try_expr
+);
+
+underlying_to_opaque_exprs(  //dir=expr
+  unique int id: @underlying_to_opaque_expr
+);
+
+unevaluated_instance_exprs(  //dir=expr
+  unique int id: @unevaluated_instance_expr
+);
+
+unresolved_member_chain_result_exprs(  //dir=expr
+  unique int id: @unresolved_member_chain_result_expr
+);
+
+unresolved_type_conversion_exprs(  //dir=expr
+  unique int id: @unresolved_type_conversion_expr
+);
+
+boolean_literal_exprs(  //dir=expr
+  unique int id: @boolean_literal_expr,
+  boolean value: boolean ref
+);
+
+conditional_checked_cast_exprs(  //dir=expr
+  unique int id: @conditional_checked_cast_expr
+);
+
+constructor_ref_call_exprs(  //dir=expr
+  unique int id: @constructor_ref_call_expr
+);
+
+dot_syntax_call_exprs(  //dir=expr
+  unique int id: @dot_syntax_call_expr
+);
+
+dynamic_member_ref_exprs(  //dir=expr
+  unique int id: @dynamic_member_ref_expr
+);
+
+dynamic_subscript_exprs(  //dir=expr
+  unique int id: @dynamic_subscript_expr
+);
+
+forced_checked_cast_exprs(  //dir=expr
+  unique int id: @forced_checked_cast_expr
+);
+
+is_exprs(  //dir=expr
+  unique int id: @is_expr
+);
+
+magic_identifier_literal_exprs(  //dir=expr
+  unique int id: @magic_identifier_literal_expr,
+  string kind: string ref
+);
+
+@number_literal_expr =
+  @float_literal_expr
+| @integer_literal_expr
+;
+
+string_literal_exprs(  //dir=expr
+  unique int id: @string_literal_expr,
+  string value: string ref
+);
+
+float_literal_exprs(  //dir=expr
+  unique int id: @float_literal_expr,
+  string string_value: string ref
+);
+
+integer_literal_exprs(  //dir=expr
+  unique int id: @integer_literal_expr,
+  string string_value: string ref
+);
+
+@pattern =
+  @any_pattern
+| @binding_pattern
+| @bool_pattern
+| @enum_element_pattern
+| @expr_pattern
+| @is_pattern
+| @named_pattern
+| @optional_some_pattern
+| @paren_pattern
+| @tuple_pattern
+| @typed_pattern
+;
+
 any_patterns(  //dir=pattern
   unique int id: @any_pattern
 );
@@ -1291,6 +1516,65 @@ typed_pattern_type_reprs(  //dir=pattern
   int type_repr: @type_repr ref
 );
 
+case_label_items(  //dir=stmt
+  unique int id: @case_label_item,
+  int pattern: @pattern ref
+);
+
+#keyset[id]
+case_label_item_guards(  //dir=stmt
+  int id: @case_label_item ref,
+  int guard: @expr ref
+);
+
+condition_elements(  //dir=stmt
+  unique int id: @condition_element
+);
+
+#keyset[id]
+condition_element_booleans(  //dir=stmt
+  int id: @condition_element ref,
+  int boolean_: @expr ref
+);
+
+#keyset[id]
+condition_element_patterns(  //dir=stmt
+  int id: @condition_element ref,
+  int pattern: @pattern ref
+);
+
+#keyset[id]
+condition_element_initializers(  //dir=stmt
+  int id: @condition_element ref,
+  int initializer: @expr ref
+);
+
+@stmt =
+  @brace_stmt
+| @break_stmt
+| @case_stmt
+| @continue_stmt
+| @defer_stmt
+| @fail_stmt
+| @fallthrough_stmt
+| @labeled_stmt
+| @pound_assert_stmt
+| @return_stmt
+| @throw_stmt
+| @yield_stmt
+;
+
+stmt_conditions(  //dir=stmt
+  unique int id: @stmt_condition
+);
+
+#keyset[id, index]
+stmt_condition_elements(  //dir=stmt
+  int id: @stmt_condition ref,
+  int index: int ref,
+  int element: @condition_element ref
+);
+
 brace_stmts(  //dir=stmt
   unique int id: @brace_stmt
 );
@@ -1335,17 +1619,6 @@ case_stmt_variables(  //dir=stmt
   int id: @case_stmt ref,
   int index: int ref,
   int variable: @var_decl ref
-);
-
-case_label_items(  //dir=stmt
-  unique int id: @case_label_item,
-  int pattern: @pattern ref
-);
-
-#keyset[id]
-case_label_item_guards(  //dir=stmt
-  int id: @case_label_item ref,
-  int guard: @expr ref
 );
 
 continue_stmts(  //dir=stmt
@@ -1424,477 +1697,6 @@ yield_stmt_results(  //dir=stmt
   int result: @expr ref
 );
 
-@bound_generic_type =
-  @bound_generic_class_type
-| @bound_generic_enum_type
-| @bound_generic_struct_type
-;
-
-#keyset[id, index]
-bound_generic_type_arg_types(  //dir=type
-  int id: @bound_generic_type ref,
-  int index: int ref,
-  int arg_type: @type ref
-);
-
-@nominal_type =
-  @class_type
-| @enum_type
-| @protocol_type
-| @struct_type
-;
-
-builtin_integer_literal_types(  //dir=type
-  unique int id: @builtin_integer_literal_type
-);
-
-builtin_integer_types(  //dir=type
-  unique int id: @builtin_integer_type
-);
-
-#keyset[id]
-builtin_integer_type_widths(  //dir=type
-  int id: @builtin_integer_type ref,
-  int width: int ref
-);
-
-nested_archetype_types(  //dir=type
-  unique int id: @nested_archetype_type,
-  int parent: @archetype_type ref,
-  int associated_type_declaration: @associated_type_decl ref
-);
-
-sequence_archetype_types(  //dir=type
-  unique int id: @sequence_archetype_type
-);
-
-opaque_type_archetype_types(  //dir=type
-  unique int id: @opaque_type_archetype_type
-);
-
-opened_archetype_types(  //dir=type
-  unique int id: @opened_archetype_type
-);
-
-primary_archetype_types(  //dir=type
-  unique int id: @primary_archetype_type
-);
-
-dictionary_types(  //dir=type
-  unique int id: @dictionary_type,
-  int key_type: @type ref,
-  int value_type: @type ref
-);
-
-@unary_syntax_sugar_type =
-  @array_slice_type
-| @optional_type
-| @variadic_sequence_type
-;
-
-#keyset[id]
-unary_syntax_sugar_types(  //dir=type
-  int id: @unary_syntax_sugar_type ref,
-  int base_type: @type ref
-);
-
-infix_operator_decls(  //dir=decl
-  unique int id: @infix_operator_decl
-);
-
-#keyset[id]
-infix_operator_decl_precedence_groups(  //dir=decl
-  int id: @infix_operator_decl ref,
-  int precedence_group: @precedence_group_decl ref
-);
-
-postfix_operator_decls(  //dir=decl
-  unique int id: @postfix_operator_decl
-);
-
-prefix_operator_decls(  //dir=decl
-  unique int id: @prefix_operator_decl
-);
-
-@abstract_function_decl =
-  @constructor_decl
-| @destructor_decl
-| @func_decl
-;
-
-#keyset[id]
-abstract_function_decls(  //dir=decl
-  int id: @abstract_function_decl ref,
-  string name: string ref
-);
-
-@abstract_storage_decl =
-  @subscript_decl
-| @var_decl
-;
-
-#keyset[id, index]
-abstract_storage_decl_accessor_decls(  //dir=decl
-  int id: @abstract_storage_decl ref,
-  int index: int ref,
-  int accessor_decl: @accessor_decl ref
-);
-
-enum_element_decls(  //dir=decl
-  unique int id: @enum_element_decl,
-  string name: string ref
-);
-
-#keyset[id, index]
-enum_element_decl_params(  //dir=decl
-  int id: @enum_element_decl ref,
-  int index: int ref,
-  int param: @param_decl ref
-);
-
-@type_decl =
-  @abstract_type_param_decl
-| @generic_type_decl
-| @module_decl
-;
-
-#keyset[id]
-type_decls(  //dir=decl
-  int id: @type_decl ref,
-  string name: string ref
-);
-
-#keyset[id, index]
-type_decl_base_types(  //dir=decl
-  int id: @type_decl ref,
-  int index: int ref,
-  int base_type: @type ref
-);
-
-auto_closure_exprs(  //dir=expr
-  unique int id: @auto_closure_expr
-);
-
-closure_exprs(  //dir=expr
-  unique int id: @closure_expr
-);
-
-force_try_exprs(  //dir=expr
-  unique int id: @force_try_expr
-);
-
-optional_try_exprs(  //dir=expr
-  unique int id: @optional_try_expr
-);
-
-try_exprs(  //dir=expr
-  unique int id: @try_expr
-);
-
-binary_exprs(  //dir=expr
-  unique int id: @binary_expr
-);
-
-call_exprs(  //dir=expr
-  unique int id: @call_expr
-);
-
-postfix_unary_exprs(  //dir=expr
-  unique int id: @postfix_unary_expr
-);
-
-prefix_unary_exprs(  //dir=expr
-  unique int id: @prefix_unary_expr
-);
-
-@self_apply_expr =
-  @constructor_ref_call_expr
-| @dot_syntax_call_expr
-;
-
-#keyset[id]
-self_apply_exprs(  //dir=expr
-  int id: @self_apply_expr ref,
-  int base: @expr ref
-);
-
-array_exprs(  //dir=expr
-  unique int id: @array_expr
-);
-
-#keyset[id, index]
-array_expr_elements(  //dir=expr
-  int id: @array_expr ref,
-  int index: int ref,
-  int element: @expr ref
-);
-
-dictionary_exprs(  //dir=expr
-  unique int id: @dictionary_expr
-);
-
-#keyset[id, index]
-dictionary_expr_elements(  //dir=expr
-  int id: @dictionary_expr ref,
-  int index: int ref,
-  int element: @expr ref
-);
-
-@checked_cast_expr =
-  @conditional_checked_cast_expr
-| @forced_checked_cast_expr
-| @is_expr
-;
-
-coerce_exprs(  //dir=expr
-  unique int id: @coerce_expr
-);
-
-await_exprs(  //dir=expr
-  unique int id: @await_expr
-);
-
-dot_self_exprs(  //dir=expr
-  unique int id: @dot_self_expr
-);
-
-paren_exprs(  //dir=expr
-  unique int id: @paren_expr
-);
-
-unresolved_member_chain_result_exprs(  //dir=expr
-  unique int id: @unresolved_member_chain_result_expr
-);
-
-any_hashable_erasure_exprs(  //dir=expr
-  unique int id: @any_hashable_erasure_expr
-);
-
-archetype_to_super_exprs(  //dir=expr
-  unique int id: @archetype_to_super_expr
-);
-
-array_to_pointer_exprs(  //dir=expr
-  unique int id: @array_to_pointer_expr
-);
-
-bridge_from_obj_c_exprs(  //dir=expr
-  unique int id: @bridge_from_obj_c_expr
-);
-
-bridge_to_obj_c_exprs(  //dir=expr
-  unique int id: @bridge_to_obj_c_expr
-);
-
-class_metatype_to_object_exprs(  //dir=expr
-  unique int id: @class_metatype_to_object_expr
-);
-
-collection_upcast_conversion_exprs(  //dir=expr
-  unique int id: @collection_upcast_conversion_expr
-);
-
-conditional_bridge_from_obj_c_exprs(  //dir=expr
-  unique int id: @conditional_bridge_from_obj_c_expr
-);
-
-covariant_function_conversion_exprs(  //dir=expr
-  unique int id: @covariant_function_conversion_expr
-);
-
-covariant_return_conversion_exprs(  //dir=expr
-  unique int id: @covariant_return_conversion_expr
-);
-
-derived_to_base_exprs(  //dir=expr
-  unique int id: @derived_to_base_expr
-);
-
-destructure_tuple_exprs(  //dir=expr
-  unique int id: @destructure_tuple_expr
-);
-
-differentiable_function_exprs(  //dir=expr
-  unique int id: @differentiable_function_expr
-);
-
-differentiable_function_extract_original_exprs(  //dir=expr
-  unique int id: @differentiable_function_extract_original_expr
-);
-
-erasure_exprs(  //dir=expr
-  unique int id: @erasure_expr
-);
-
-existential_metatype_to_object_exprs(  //dir=expr
-  unique int id: @existential_metatype_to_object_expr
-);
-
-foreign_object_conversion_exprs(  //dir=expr
-  unique int id: @foreign_object_conversion_expr
-);
-
-function_conversion_exprs(  //dir=expr
-  unique int id: @function_conversion_expr
-);
-
-in_out_to_pointer_exprs(  //dir=expr
-  unique int id: @in_out_to_pointer_expr
-);
-
-inject_into_optional_exprs(  //dir=expr
-  unique int id: @inject_into_optional_expr
-);
-
-linear_function_exprs(  //dir=expr
-  unique int id: @linear_function_expr
-);
-
-linear_function_extract_original_exprs(  //dir=expr
-  unique int id: @linear_function_extract_original_expr
-);
-
-linear_to_differentiable_function_exprs(  //dir=expr
-  unique int id: @linear_to_differentiable_function_expr
-);
-
-load_exprs(  //dir=expr
-  unique int id: @load_expr
-);
-
-metatype_conversion_exprs(  //dir=expr
-  unique int id: @metatype_conversion_expr
-);
-
-pointer_to_pointer_exprs(  //dir=expr
-  unique int id: @pointer_to_pointer_expr
-);
-
-protocol_metatype_to_object_exprs(  //dir=expr
-  unique int id: @protocol_metatype_to_object_expr
-);
-
-string_to_pointer_exprs(  //dir=expr
-  unique int id: @string_to_pointer_expr
-);
-
-underlying_to_opaque_exprs(  //dir=expr
-  unique int id: @underlying_to_opaque_expr
-);
-
-unevaluated_instance_exprs(  //dir=expr
-  unique int id: @unevaluated_instance_expr
-);
-
-unresolved_type_conversion_exprs(  //dir=expr
-  unique int id: @unresolved_type_conversion_expr
-);
-
-@builtin_literal_expr =
-  @boolean_literal_expr
-| @magic_identifier_literal_expr
-| @number_literal_expr
-| @string_literal_expr
-;
-
-interpolated_string_literal_exprs(  //dir=expr
-  unique int id: @interpolated_string_literal_expr
-);
-
-#keyset[id]
-interpolated_string_literal_expr_interpolation_exprs(  //dir=expr
-  int id: @interpolated_string_literal_expr ref,
-  int interpolation_expr: @opaque_value_expr ref
-);
-
-#keyset[id]
-interpolated_string_literal_expr_interpolation_count_exprs(  //dir=expr
-  int id: @interpolated_string_literal_expr ref,
-  int interpolation_count_expr: @expr ref
-);
-
-#keyset[id]
-interpolated_string_literal_expr_literal_capacity_exprs(  //dir=expr
-  int id: @interpolated_string_literal_expr ref,
-  int literal_capacity_expr: @expr ref
-);
-
-#keyset[id]
-interpolated_string_literal_expr_appending_exprs(  //dir=expr
-  int id: @interpolated_string_literal_expr ref,
-  int appending_expr: @tap_expr ref
-);
-
-regex_literal_exprs(  //dir=expr
-  unique int id: @regex_literal_expr
-);
-
-nil_literal_exprs(  //dir=expr
-  unique int id: @nil_literal_expr
-);
-
-object_literal_exprs(  //dir=expr
-  unique int id: @object_literal_expr
-);
-
-@dynamic_lookup_expr =
-  @dynamic_member_ref_expr
-| @dynamic_subscript_expr
-;
-
-member_ref_exprs(  //dir=expr
-  unique int id: @member_ref_expr
-);
-
-#keyset[id]
-member_ref_expr_has_direct_to_storage_semantics(  //dir=expr
-  int id: @member_ref_expr ref
-);
-
-#keyset[id]
-member_ref_expr_has_direct_to_implementation_semantics(  //dir=expr
-  int id: @member_ref_expr ref
-);
-
-#keyset[id]
-member_ref_expr_has_ordinary_semantics(  //dir=expr
-  int id: @member_ref_expr ref
-);
-
-method_ref_exprs(  //dir=expr
-  unique int id: @method_ref_expr
-);
-
-subscript_exprs(  //dir=expr
-  unique int id: @subscript_expr
-);
-
-#keyset[id, index]
-subscript_expr_arguments(  //dir=expr
-  int id: @subscript_expr ref,
-  int index: int ref,
-  int argument: @argument ref
-);
-
-#keyset[id]
-subscript_expr_has_direct_to_storage_semantics(  //dir=expr
-  int id: @subscript_expr ref
-);
-
-#keyset[id]
-subscript_expr_has_direct_to_implementation_semantics(  //dir=expr
-  int id: @subscript_expr ref
-);
-
-#keyset[id]
-subscript_expr_has_ordinary_semantics(  //dir=expr
-  int id: @subscript_expr ref
-);
-
-overloaded_decl_ref_exprs(  //dir=expr
-  unique int id: @overloaded_decl_ref_expr
-);
-
 do_catch_stmts(  //dir=stmt
   unique int id: @do_catch_stmt,
   int body: @stmt ref
@@ -1937,17 +1739,6 @@ labeled_conditional_stmts(  //dir=stmt
   int condition: @stmt_condition ref
 );
 
-stmt_conditions(  //dir=stmt
-  unique int id: @stmt_condition
-);
-
-#keyset[id, index]
-stmt_condition_elements(  //dir=stmt
-  int id: @stmt_condition ref,
-  int index: int ref,
-  int element: @condition_element ref
-);
-
 repeat_while_stmts(  //dir=stmt
   unique int id: @repeat_while_stmt,
   int condition: @expr ref,
@@ -1964,202 +1755,6 @@ switch_stmt_cases(  //dir=stmt
   int id: @switch_stmt ref,
   int index: int ref,
   int case_: @case_stmt ref
-);
-
-bound_generic_class_types(  //dir=type
-  unique int id: @bound_generic_class_type
-);
-
-bound_generic_enum_types(  //dir=type
-  unique int id: @bound_generic_enum_type
-);
-
-bound_generic_struct_types(  //dir=type
-  unique int id: @bound_generic_struct_type
-);
-
-class_types(  //dir=type
-  unique int id: @class_type
-);
-
-enum_types(  //dir=type
-  unique int id: @enum_type
-);
-
-protocol_types(  //dir=type
-  unique int id: @protocol_type
-);
-
-struct_types(  //dir=type
-  unique int id: @struct_type
-);
-
-array_slice_types(  //dir=type
-  unique int id: @array_slice_type
-);
-
-optional_types(  //dir=type
-  unique int id: @optional_type
-);
-
-variadic_sequence_types(  //dir=type
-  unique int id: @variadic_sequence_type
-);
-
-constructor_decls(  //dir=decl
-  unique int id: @constructor_decl
-);
-
-destructor_decls(  //dir=decl
-  unique int id: @destructor_decl
-);
-
-@func_decl =
-  @accessor_decl
-| @concrete_func_decl
-;
-
-subscript_decls(  //dir=decl
-  unique int id: @subscript_decl,
-  int element_type: @type ref
-);
-
-#keyset[id, index]
-subscript_decl_params(  //dir=decl
-  int id: @subscript_decl ref,
-  int index: int ref,
-  int param: @param_decl ref
-);
-
-@var_decl =
-  @concrete_var_decl
-| @param_decl
-;
-
-#keyset[id]
-var_decls(  //dir=decl
-  int id: @var_decl ref,
-  string name: string ref,
-  int type_: @type ref
-);
-
-#keyset[id]
-var_decl_attached_property_wrapper_types(  //dir=decl
-  int id: @var_decl ref,
-  int attached_property_wrapper_type: @type ref
-);
-
-#keyset[id]
-var_decl_parent_patterns(  //dir=decl
-  int id: @var_decl ref,
-  int parent_pattern: @pattern ref
-);
-
-#keyset[id]
-var_decl_parent_initializers(  //dir=decl
-  int id: @var_decl ref,
-  int parent_initializer: @expr ref
-);
-
-@abstract_type_param_decl =
-  @associated_type_decl
-| @generic_type_param_decl
-;
-
-@generic_context =
-  @abstract_function_decl
-| @extension_decl
-| @generic_type_decl
-| @subscript_decl
-;
-
-#keyset[id, index]
-generic_context_generic_type_params(  //dir=decl
-  int id: @generic_context ref,
-  int index: int ref,
-  int generic_type_param: @generic_type_param_decl ref
-);
-
-@generic_type_decl =
-  @nominal_type_decl
-| @opaque_type_decl
-| @type_alias_decl
-;
-
-module_decls(  //dir=decl
-  unique int id: @module_decl
-);
-
-#keyset[id]
-module_decl_is_builtin_module(  //dir=decl
-  int id: @module_decl ref
-);
-
-#keyset[id]
-module_decl_is_system_module(  //dir=decl
-  int id: @module_decl ref
-);
-
-#keyset[id, index]
-module_decl_imported_modules(  //dir=decl
-  int id: @module_decl ref,
-  int index: int ref,
-  int imported_module: @module_decl ref
-);
-
-#keyset[id, index]
-module_decl_exported_modules(  //dir=decl
-  int id: @module_decl ref,
-  int index: int ref,
-  int exported_module: @module_decl ref
-);
-
-constructor_ref_call_exprs(  //dir=expr
-  unique int id: @constructor_ref_call_expr
-);
-
-dot_syntax_call_exprs(  //dir=expr
-  unique int id: @dot_syntax_call_expr
-);
-
-conditional_checked_cast_exprs(  //dir=expr
-  unique int id: @conditional_checked_cast_expr
-);
-
-forced_checked_cast_exprs(  //dir=expr
-  unique int id: @forced_checked_cast_expr
-);
-
-is_exprs(  //dir=expr
-  unique int id: @is_expr
-);
-
-boolean_literal_exprs(  //dir=expr
-  unique int id: @boolean_literal_expr,
-  boolean value: boolean ref
-);
-
-magic_identifier_literal_exprs(  //dir=expr
-  unique int id: @magic_identifier_literal_expr,
-  string kind: string ref
-);
-
-@number_literal_expr =
-  @float_literal_expr
-| @integer_literal_expr
-;
-
-string_literal_exprs(  //dir=expr
-  unique int id: @string_literal_expr,
-  string value: string ref
-);
-
-dynamic_member_ref_exprs(  //dir=expr
-  unique int id: @dynamic_member_ref_expr
-);
-
-dynamic_subscript_exprs(  //dir=expr
-  unique int id: @dynamic_subscript_expr
 );
 
 guard_stmts(  //dir=stmt
@@ -2183,70 +1778,475 @@ while_stmts(  //dir=stmt
   int body: @stmt ref
 );
 
-accessor_decls(  //dir=decl
-  unique int id: @accessor_decl
+@type =
+  @any_function_type
+| @any_generic_type
+| @any_metatype_type
+| @builtin_type
+| @dependent_member_type
+| @dynamic_self_type
+| @error_type
+| @existential_type
+| @in_out_type
+| @l_value_type
+| @module_type
+| @placeholder_type
+| @protocol_composition_type
+| @reference_storage_type
+| @sil_block_storage_type
+| @sil_box_type
+| @sil_function_type
+| @sil_token_type
+| @substitutable_type
+| @sugar_type
+| @tuple_type
+| @type_variable_type
+| @unresolved_type
+;
+
+#keyset[id]
+types(  //dir=type
+  int id: @type ref,
+  string name: string ref,
+  int canonical_type: @type ref
+);
+
+type_reprs(  //dir=type
+  unique int id: @type_repr,
+  int type_: @type ref
+);
+
+@any_function_type =
+  @function_type
+| @generic_function_type
+;
+
+#keyset[id]
+any_function_types(  //dir=type
+  int id: @any_function_type ref,
+  int result: @type ref
+);
+
+#keyset[id, index]
+any_function_type_param_types(  //dir=type
+  int id: @any_function_type ref,
+  int index: int ref,
+  int param_type: @type ref
+);
+
+#keyset[id, index]
+any_function_type_param_labels(  //dir=type
+  int id: @any_function_type ref,
+  int index: int ref,
+  string param_label: string ref
 );
 
 #keyset[id]
-accessor_decl_is_getter(  //dir=decl
-  int id: @accessor_decl ref
+any_function_type_is_throwing(  //dir=type
+  int id: @any_function_type ref
 );
 
 #keyset[id]
-accessor_decl_is_setter(  //dir=decl
-  int id: @accessor_decl ref
+any_function_type_is_async(  //dir=type
+  int id: @any_function_type ref
+);
+
+@any_generic_type =
+  @nominal_or_bound_generic_nominal_type
+| @unbound_generic_type
+;
+
+#keyset[id]
+any_generic_types(  //dir=type
+  int id: @any_generic_type ref,
+  int declaration: @decl ref
 );
 
 #keyset[id]
-accessor_decl_is_will_set(  //dir=decl
-  int id: @accessor_decl ref
+any_generic_type_parents(  //dir=type
+  int id: @any_generic_type ref,
+  int parent: @type ref
+);
+
+@any_metatype_type =
+  @existential_metatype_type
+| @metatype_type
+;
+
+@builtin_type =
+  @any_builtin_integer_type
+| @builtin_bridge_object_type
+| @builtin_default_actor_storage_type
+| @builtin_executor_type
+| @builtin_float_type
+| @builtin_job_type
+| @builtin_native_object_type
+| @builtin_raw_pointer_type
+| @builtin_raw_unsafe_continuation_type
+| @builtin_unsafe_value_buffer_type
+| @builtin_vector_type
+;
+
+dependent_member_types(  //dir=type
+  unique int id: @dependent_member_type,
+  int baseType: @type ref,
+  int associated_type_decl: @associated_type_decl ref
+);
+
+dynamic_self_types(  //dir=type
+  unique int id: @dynamic_self_type,
+  int static_self_type: @type ref
+);
+
+error_types(  //dir=type
+  unique int id: @error_type
+);
+
+existential_types(  //dir=type
+  unique int id: @existential_type,
+  int constraint: @type ref
+);
+
+in_out_types(  //dir=type
+  unique int id: @in_out_type,
+  int object_type: @type ref
+);
+
+l_value_types(  //dir=type
+  unique int id: @l_value_type,
+  int object_type: @type ref
+);
+
+module_types(  //dir=type
+  unique int id: @module_type,
+  int module: @module_decl ref
+);
+
+placeholder_types(  //dir=type
+  unique int id: @placeholder_type
+);
+
+protocol_composition_types(  //dir=type
+  unique int id: @protocol_composition_type
+);
+
+#keyset[id, index]
+protocol_composition_type_members(  //dir=type
+  int id: @protocol_composition_type ref,
+  int index: int ref,
+  int member: @type ref
+);
+
+@reference_storage_type =
+  @unmanaged_storage_type
+| @unowned_storage_type
+| @weak_storage_type
+;
+
+#keyset[id]
+reference_storage_types(  //dir=type
+  int id: @reference_storage_type ref,
+  int referent_type: @type ref
+);
+
+sil_block_storage_types(  //dir=type
+  unique int id: @sil_block_storage_type
+);
+
+sil_box_types(  //dir=type
+  unique int id: @sil_box_type
+);
+
+sil_function_types(  //dir=type
+  unique int id: @sil_function_type
+);
+
+sil_token_types(  //dir=type
+  unique int id: @sil_token_type
+);
+
+@substitutable_type =
+  @archetype_type
+| @generic_type_param_type
+;
+
+@sugar_type =
+  @paren_type
+| @syntax_sugar_type
+| @type_alias_type
+;
+
+tuple_types(  //dir=type
+  unique int id: @tuple_type
+);
+
+#keyset[id, index]
+tuple_type_types(  //dir=type
+  int id: @tuple_type ref,
+  int index: int ref,
+  int type_: @type ref
+);
+
+#keyset[id, index]
+tuple_type_names(  //dir=type
+  int id: @tuple_type ref,
+  int index: int ref,
+  string name: string ref
+);
+
+type_variable_types(  //dir=type
+  unique int id: @type_variable_type
+);
+
+unresolved_types(  //dir=type
+  unique int id: @unresolved_type
+);
+
+@any_builtin_integer_type =
+  @builtin_integer_literal_type
+| @builtin_integer_type
+;
+
+@archetype_type =
+  @nested_archetype_type
+| @opaque_type_archetype_type
+| @opened_archetype_type
+| @primary_archetype_type
+| @sequence_archetype_type
+;
+
+#keyset[id]
+archetype_types(  //dir=type
+  int id: @archetype_type ref,
+  int interface_type: @type ref
 );
 
 #keyset[id]
-accessor_decl_is_did_set(  //dir=decl
-  int id: @accessor_decl ref
+archetype_type_superclasses(  //dir=type
+  int id: @archetype_type ref,
+  int superclass: @type ref
 );
 
-concrete_func_decls(  //dir=decl
-  unique int id: @concrete_func_decl
+#keyset[id, index]
+archetype_type_protocols(  //dir=type
+  int id: @archetype_type ref,
+  int index: int ref,
+  int protocol: @protocol_decl ref
 );
 
-concrete_var_decls(  //dir=decl
-  unique int id: @concrete_var_decl,
-  int introducer_int: int ref
+builtin_bridge_object_types(  //dir=type
+  unique int id: @builtin_bridge_object_type
 );
 
-param_decls(  //dir=decl
-  unique int id: @param_decl
+builtin_default_actor_storage_types(  //dir=type
+  unique int id: @builtin_default_actor_storage_type
+);
+
+builtin_executor_types(  //dir=type
+  unique int id: @builtin_executor_type
+);
+
+builtin_float_types(  //dir=type
+  unique int id: @builtin_float_type
+);
+
+builtin_job_types(  //dir=type
+  unique int id: @builtin_job_type
+);
+
+builtin_native_object_types(  //dir=type
+  unique int id: @builtin_native_object_type
+);
+
+builtin_raw_pointer_types(  //dir=type
+  unique int id: @builtin_raw_pointer_type
+);
+
+builtin_raw_unsafe_continuation_types(  //dir=type
+  unique int id: @builtin_raw_unsafe_continuation_type
+);
+
+builtin_unsafe_value_buffer_types(  //dir=type
+  unique int id: @builtin_unsafe_value_buffer_type
+);
+
+builtin_vector_types(  //dir=type
+  unique int id: @builtin_vector_type
+);
+
+existential_metatype_types(  //dir=type
+  unique int id: @existential_metatype_type
+);
+
+function_types(  //dir=type
+  unique int id: @function_type
+);
+
+generic_function_types(  //dir=type
+  unique int id: @generic_function_type
+);
+
+#keyset[id, index]
+generic_function_type_generic_params(  //dir=type
+  int id: @generic_function_type ref,
+  int index: int ref,
+  int generic_param: @generic_type_param_type ref
+);
+
+generic_type_param_types(  //dir=type
+  unique int id: @generic_type_param_type
+);
+
+metatype_types(  //dir=type
+  unique int id: @metatype_type
+);
+
+@nominal_or_bound_generic_nominal_type =
+  @bound_generic_type
+| @nominal_type
+;
+
+paren_types(  //dir=type
+  unique int id: @paren_type,
+  int type_: @type ref
+);
+
+@syntax_sugar_type =
+  @dictionary_type
+| @unary_syntax_sugar_type
+;
+
+type_alias_types(  //dir=type
+  unique int id: @type_alias_type,
+  int decl: @type_alias_decl ref
+);
+
+unbound_generic_types(  //dir=type
+  unique int id: @unbound_generic_type
+);
+
+unmanaged_storage_types(  //dir=type
+  unique int id: @unmanaged_storage_type
+);
+
+unowned_storage_types(  //dir=type
+  unique int id: @unowned_storage_type
+);
+
+weak_storage_types(  //dir=type
+  unique int id: @weak_storage_type
+);
+
+@bound_generic_type =
+  @bound_generic_class_type
+| @bound_generic_enum_type
+| @bound_generic_struct_type
+;
+
+#keyset[id, index]
+bound_generic_type_arg_types(  //dir=type
+  int id: @bound_generic_type ref,
+  int index: int ref,
+  int arg_type: @type ref
+);
+
+builtin_integer_literal_types(  //dir=type
+  unique int id: @builtin_integer_literal_type
+);
+
+builtin_integer_types(  //dir=type
+  unique int id: @builtin_integer_type
 );
 
 #keyset[id]
-param_decl_is_inout(  //dir=decl
-  int id: @param_decl ref
+builtin_integer_type_widths(  //dir=type
+  int id: @builtin_integer_type ref,
+  int width: int ref
 );
 
-associated_type_decls(  //dir=decl
-  unique int id: @associated_type_decl
+dictionary_types(  //dir=type
+  unique int id: @dictionary_type,
+  int key_type: @type ref,
+  int value_type: @type ref
 );
 
-generic_type_param_decls(  //dir=decl
-  unique int id: @generic_type_param_decl
+nested_archetype_types(  //dir=type
+  unique int id: @nested_archetype_type,
+  int parent: @archetype_type ref,
+  int associated_type_declaration: @associated_type_decl ref
 );
 
-opaque_type_decls(  //dir=decl
-  unique int id: @opaque_type_decl
+@nominal_type =
+  @class_type
+| @enum_type
+| @protocol_type
+| @struct_type
+;
+
+opaque_type_archetype_types(  //dir=type
+  unique int id: @opaque_type_archetype_type
 );
 
-type_alias_decls(  //dir=decl
-  unique int id: @type_alias_decl
+opened_archetype_types(  //dir=type
+  unique int id: @opened_archetype_type
 );
 
-float_literal_exprs(  //dir=expr
-  unique int id: @float_literal_expr,
-  string string_value: string ref
+primary_archetype_types(  //dir=type
+  unique int id: @primary_archetype_type
 );
 
-integer_literal_exprs(  //dir=expr
-  unique int id: @integer_literal_expr,
-  string string_value: string ref
+sequence_archetype_types(  //dir=type
+  unique int id: @sequence_archetype_type
+);
+
+@unary_syntax_sugar_type =
+  @array_slice_type
+| @optional_type
+| @variadic_sequence_type
+;
+
+#keyset[id]
+unary_syntax_sugar_types(  //dir=type
+  int id: @unary_syntax_sugar_type ref,
+  int base_type: @type ref
+);
+
+array_slice_types(  //dir=type
+  unique int id: @array_slice_type
+);
+
+bound_generic_class_types(  //dir=type
+  unique int id: @bound_generic_class_type
+);
+
+bound_generic_enum_types(  //dir=type
+  unique int id: @bound_generic_enum_type
+);
+
+bound_generic_struct_types(  //dir=type
+  unique int id: @bound_generic_struct_type
+);
+
+class_types(  //dir=type
+  unique int id: @class_type
+);
+
+enum_types(  //dir=type
+  unique int id: @enum_type
+);
+
+optional_types(  //dir=type
+  unique int id: @optional_type
+);
+
+protocol_types(  //dir=type
+  unique int id: @protocol_type
+);
+
+struct_types(  //dir=type
+  unique int id: @struct_type
+);
+
+variadic_sequence_types(  //dir=type
+  unique int id: @variadic_sequence_type
 );


### PR DESCRIPTION
This makes the result of code generation independent of the order in which classes are defined in the schema, and makes additional topological sorting not required.

Being independent from schema order will be important for reviewing the move to a pure python schema, as generated code will be left untouched.

In this PR the changes to the generated code is only about order. The topological sorting used takes into account the directory grouping (so that for example all `Expr` get bunched together) which was not the case before, hence the order difference.