### PR TITLE
C++: Fix FPs for cpp/unused-static-function in files that were not extracted completely

### DIFF
--- a/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticFunctions.ql
+++ b/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticFunctions.ql
@@ -14,15 +14,28 @@
 import cpp
 
 predicate immediatelyReachableFunction(Function f) {
-  not f.isStatic() or
-  exists(BlockExpr be | be.getFunction() = f) or
-  f instanceof MemberFunction or
-  f instanceof TemplateFunction or
-  f.getFile() instanceof HeaderFile or
-  f.getAnAttribute().hasName("constructor") or
-  f.getAnAttribute().hasName("destructor") or
-  f.getAnAttribute().hasName("used") or
+  not f.isStatic()
+  or
+  exists(BlockExpr be | be.getFunction() = f)
+  or
+  f instanceof MemberFunction
+  or
+  f instanceof TemplateFunction
+  or
+  f.getFile() instanceof HeaderFile
+  or
+  f.getAnAttribute().hasName("constructor")
+  or
+  f.getAnAttribute().hasName("destructor")
+  or
+  f.getAnAttribute().hasName("used")
+  or
   f.getAnAttribute().hasName("unused")
+  or
+  // a compiler error in the same file suggests we may be missing data
+  exists(Diagnostic d | d.getFile() = f.getFile() and d.getSeverity() >= 3)
+  or
+  exists(ErrorExpr ee | ee.getFile() = f.getFile())
 }
 
 predicate immediatelyReachableVariable(Variable v) {

--- a/cpp/ql/src/change-notes/2022-09-21-unused-static-function.md
+++ b/cpp/ql/src/change-notes/2022-09-21-unused-static-function.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed false positives from the "Unused static function" (`cpp/unused-static-function`) query in files that had errors during compilation.

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticFunctions/UnusedStaticFunctions.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticFunctions/UnusedStaticFunctions.expected
@@ -1,5 +1,3 @@
-| extraction_error.c:4:13:4:43 | my_function2_called_after_error | Static function my_function2_called_after_error is unreachable | extraction_error.c:4:13:4:43 | my_function2_called_after_error | my_function2_called_after_error |
-| extraction_error.c:5:13:5:35 | my_function3_not_called | Static function my_function3_not_called is unreachable | extraction_error.c:5:13:5:35 | my_function3_not_called | my_function3_not_called |
 | unused_functions.c:16:13:16:27 | unused_function | Static function unused_function is unreachable | unused_functions.c:16:13:16:27 | unused_function | unused_function |
 | unused_functions.c:20:13:20:28 | unused_function2 | Static function unused_function2 is unreachable ($@ must be removed at the same time) | unused_functions.c:24:13:24:28 | unused_function3 | unused_function3 |
 | unused_functions.c:24:13:24:28 | unused_function3 | Static function unused_function3 is unreachable | unused_functions.c:24:13:24:28 | unused_function3 | unused_function3 |

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticFunctions/UnusedStaticFunctions.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticFunctions/UnusedStaticFunctions.expected
@@ -1,3 +1,5 @@
+| extraction_error.c:4:13:4:43 | my_function2_called_after_error | Static function my_function2_called_after_error is unreachable | extraction_error.c:4:13:4:43 | my_function2_called_after_error | my_function2_called_after_error |
+| extraction_error.c:5:13:5:35 | my_function3_not_called | Static function my_function3_not_called is unreachable | extraction_error.c:5:13:5:35 | my_function3_not_called | my_function3_not_called |
 | unused_functions.c:16:13:16:27 | unused_function | Static function unused_function is unreachable | unused_functions.c:16:13:16:27 | unused_function | unused_function |
 | unused_functions.c:20:13:20:28 | unused_function2 | Static function unused_function2 is unreachable ($@ must be removed at the same time) | unused_functions.c:24:13:24:28 | unused_function3 | unused_function3 |
 | unused_functions.c:24:13:24:28 | unused_function3 | Static function unused_function3 is unreachable | unused_functions.c:24:13:24:28 | unused_function3 | unused_function3 |

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticFunctions/extraction_error.c
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticFunctions/extraction_error.c
@@ -1,0 +1,15 @@
+// semmle-extractor-options: --expect_errors
+
+static void my_function1_called() {} // GOOD
+static void my_function2_called_after_error() {} // GOOD [FALSE POSITIVE]
+static void my_function3_not_called() {} // BAD
+
+int main(void) {
+	my_function1_called();
+
+--- compilation stops here because this line is not valid C code ---
+
+	my_function2_called_after_error();
+
+	return 0;
+}

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticFunctions/extraction_error.c
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticFunctions/extraction_error.c
@@ -1,8 +1,8 @@
 // semmle-extractor-options: --expect_errors
 
 static void my_function1_called() {} // GOOD
-static void my_function2_called_after_error() {} // GOOD [FALSE POSITIVE]
-static void my_function3_not_called() {} // BAD
+static void my_function2_called_after_error() {} // GOOD
+static void my_function3_not_called() {} // BAD [NOT DETECTED]
 
 int main(void) {
 	my_function1_called();


### PR DESCRIPTION
Fix FPs for `cpp/unused-static-function` in files that were not extracted completely, e.g. due to a compilation error part way through the file.  As the test shows, this may hide some good results as well, but we expect the majority of results in incompletely extracted files to be false positives caused by the incomplete extraction.