### PR TITLE
QL: improve the `ql/alert-message-style-violation` query. 

### DIFF
--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -186,7 +186,9 @@ class QueryDoc extends QLDoc {
   override string getAPrimaryQlClass() { result = "QueryDoc" }
 
   /** Gets the @kind for the query */
-  string getQueryKind() { result = this.getContents().regexpCapture("(?s).*@kind (\\w+)\\s.*", 1) }
+  string getQueryKind() {
+    result = this.getContents().regexpCapture("(?s).*@kind ([\\w-]+)\\s.*", 1)
+  }
 
   /** Gets the id part (without language) of the @id */
   string getQueryId() {
@@ -241,6 +243,12 @@ class Select extends TSelect, AstNode {
    * Gets the `i`th expression in the `select` clause.
    */
   Expr getExpr(int i) { toQL(result) = sel.getChild(_).(QL::AsExprs).getChild(i) }
+
+  Expr getMessage() {
+    if this.getQueryDoc().getQueryKind() = "path-problem"
+    then result = this.getExpr(3)
+    else result = this.getExpr(1)
+  }
 
   // TODO: This gets the `i`th order-by, but some expressions might not have an order-by.
   Expr getOrderBy(int i) { toQL(result) = sel.getChild(_).(QL::OrderBys).getChild(i).getChild(0) }

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -1403,6 +1403,14 @@ class ComparisonFormula extends TComparisonFormula, Formula {
     or
     pred = directMember("getRightOperand") and result = this.getRightOperand()
   }
+
+  /** Hplds if this comparison has the operands `a` and `b` (in any order). */
+  pragma[noinline]
+  predicate hasOperands(Expr a, Expr b) {
+    this.getLeftOperand() = a and this.getRightOperand() = b
+    or
+    this.getLeftOperand() = b and this.getRightOperand() = a
+  }
 }
 
 /** A quantifier formula, such as `exists` or `forall`. */

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -1412,7 +1412,7 @@ class ComparisonFormula extends TComparisonFormula, Formula {
     pred = directMember("getRightOperand") and result = this.getRightOperand()
   }
 
-  /** Hplds if this comparison has the operands `a` and `b` (in any order). */
+  /** Holds if this comparison has the operands `a` and `b` (in any order). */
   pragma[noinline]
   predicate hasOperands(Expr a, Expr b) {
     this.getLeftOperand() = a and this.getRightOperand() = b

--- a/ql/ql/src/queries/style/AlertMessage.ql
+++ b/ql/ql/src/queries/style/AlertMessage.ql
@@ -164,6 +164,14 @@ String wrongFlowsPhrase(Select sel, string kind) {
   )
 }
 
+/**
+ * Gets a string element that contains double whitespace.
+ */
+String doubleWhitespace(Select sel) {
+  result = getSelectPart(sel, _) and
+  result.getValue().regexpMatch(".*\\s\\s.*")
+}
+
 from AstNode node, string msg
 where
   not node.getLocation().getFile().getAbsolutePath().matches("%/test/%") and
@@ -194,5 +202,8 @@ where
     or
     node = wrongFlowsPhrase(_, "taint") and
     msg = "Use \"depends on\" instead of \"flows to\" in taint tracking queries."
+    or
+    node = doubleWhitespace(_) and
+    msg = "Avoid using double whitespace in alert messages."
   )
 select node, msg

--- a/ql/ql/src/queries/style/AlertMessage.ql
+++ b/ql/ql/src/queries/style/AlertMessage.ql
@@ -64,7 +64,7 @@ private AstNode getSelectPart(Select sel, int index) {
 String shouldHaveFullStop(Select sel) {
   result =
     max(AstNode str, int i |
-      str.getParent*() = sel.getExpr(1) and str = getSelectPart(sel, i)
+      str.getParent*() = sel.getMessage() and str = getSelectPart(sel, i)
     |
       str order by i
     ) and
@@ -85,7 +85,7 @@ String shouldHaveFullStop(Select sel) {
 String shouldStartCapital(Select sel) {
   result =
     min(AstNode str, int i |
-      str.getParent*() = sel.getExpr(1) and str = getSelectPart(sel, i)
+      str.getParent*() = sel.getMessage() and str = getSelectPart(sel, i)
     |
       str order by i
     ) and

--- a/ql/ql/src/queries/style/AlertMessage.ql
+++ b/ql/ql/src/queries/style/AlertMessage.ql
@@ -52,7 +52,7 @@ private AstNode getSelectPart(Select sel, int index) {
 String shouldHaveFullStop(Select sel) {
   result =
     max(AstNode str, int i |
-      str.getParent+() = sel.getExpr(1) and str = getSelectPart(sel, i)
+      str.getParent*() = sel.getExpr(1) and str = getSelectPart(sel, i)
     |
       str order by i
     ) and
@@ -73,7 +73,7 @@ String shouldHaveFullStop(Select sel) {
 String shouldStartCapital(Select sel) {
   result =
     min(AstNode str, int i |
-      str.getParent+() = sel.getExpr(1) and str = getSelectPart(sel, i)
+      str.getParent*() = sel.getExpr(1) and str = getSelectPart(sel, i)
     |
       str order by i
     ) and


### PR DESCRIPTION
Each commit should describe itself. 

The `getASubExpression` predicate was outlined to try and improve a bad join-order 
I wasn't that succesful in improving the join-order, there is still a query specific predicate that takes ~7s on my machine.   
But there are still a few other queries that are slower, so it shouldn't affect the total runtime that much. 

These improvements finds ~~97~~ 181 more violations (see the code-scanning results).  
I'll look at fixing these in other PRs. E.g. [this upcoming one for C++](https://github.com/github/codeql/pull/10507). 