### PR TITLE
Fixing wrong example

### DIFF
--- a/docs/codeql/writing-codeql-queries/crown-the-rightful-heir.rst
+++ b/docs/codeql/writing-codeql-queries/crown-the-rightful-heir.rst
@@ -104,8 +104,8 @@ You can translate this into QL as follows:
 .. code-block:: ql
 
    Person ancestorOf(Person p) {
-     result = parentOf(p) or
-     result = parentOf(ancestorOf(p))
+     result = childOf(p) or
+     result = childOf(ancestorOf(p))
    }
 
 As you can see, you have used the predicate ``ancestorOf()`` inside its own definition. This is an example of :ref:`recursion <recursion>`.


### PR DESCRIPTION
The definition of the ``ancestorOf`` predicate doesn't really describe an ancestor relation, but its inverse (i.e., something one might call ``descendantOf``). The fix replaces ``parentOf`` with ``childOf``, so that the predicate actually describes the ancestor relation. I've tested the predicate against the tutorial dataset, and it now yields the expected results.