### PR TITLE
QL: A few more improvements to `ql/alert-message-style-violation`

### DIFF
--- a/ql/ql/src/codeql/GlobalValueNumbering.qll
+++ b/ql/ql/src/codeql/GlobalValueNumbering.qll
@@ -129,6 +129,7 @@ private predicate classPredicateCallValueNumber(
 
 private predicate literalValueNumber(Literal lit, string value, Type t) {
   lit.(String).getValue() = value and
+  value.length() <= 50 and
   t instanceof StringClass
   or
   lit.(Integer).getValue().toString() = value and

--- a/ql/ql/src/queries/style/AlertMessage.ql
+++ b/ql/ql/src/queries/style/AlertMessage.ql
@@ -102,11 +102,11 @@ String shouldStartCapital(Select sel) {
  * select foo(), "XSS from using a unsafe value." // <- good
  * ```
  */
-String avoidHere(string part) {
+String avoidHere(Select sel, string part) {
   part = ["here", "this location"] and
   (
     result.getValue().regexpMatch(".*\\b" + part + "\\b.*") and
-    result = getSelectPart(_, _)
+    result = getSelectPart(sel, _)
   )
 }
 
@@ -184,17 +184,18 @@ String doubleWhitespace(Select sel) {
   result.getValue().regexpMatch(".*\\s\\s.*")
 }
 
-from AstNode node, string msg
+from AstNode node, string msg, Select sel
 where
   not node.getLocation().getFile().getAbsolutePath().matches("%/test/%") and
+  sel.getQueryDoc().getQueryKind() = ["problem", "path-problem"] and
   (
-    node = shouldHaveFullStop(_) and
+    node = shouldHaveFullStop(sel) and
     msg = "Alert message should end with a full stop."
     or
-    node = shouldStartCapital(_) and
+    node = shouldStartCapital(sel) and
     msg = "Alert message should start with a capital letter."
     or
-    exists(string part | node = avoidHere(part) |
+    exists(string part | node = avoidHere(sel, part) |
       part = "here" and
       msg =
         "Try to use a descriptive phrase instead of \"here\". Use \"this location\" if you can't get around mentioning the current location."
@@ -203,19 +204,19 @@ where
       msg = "Try to more descriptive phrase instead of \"this location\" if possible."
     )
     or
-    node = avoidArticleInLinkText(_) and
+    node = avoidArticleInLinkText(sel) and
     msg = "Avoid starting a link text with an indefinite article."
     or
-    node = dontQuoteSubstitutions(_) and
+    node = dontQuoteSubstitutions(sel) and
     msg = "Don't quote substitutions in alert messages."
     or
-    node = wrongFlowsPhrase(_, "data") and
+    node = wrongFlowsPhrase(sel, "data") and
     msg = "Use \"flows to\" instead of \"depends on\" in data flow queries."
     or
-    node = wrongFlowsPhrase(_, "taint") and
+    node = wrongFlowsPhrase(sel, "taint") and
     msg = "Use \"depends on\" instead of \"flows to\" in taint tracking queries."
     or
-    node = doubleWhitespace(_) and
+    node = doubleWhitespace(sel) and
     msg = "Avoid using double whitespace in alert messages."
   )
 select node, msg

--- a/ql/ql/src/queries/style/AlertMessage.ql
+++ b/ql/ql/src/queries/style/AlertMessage.ql
@@ -23,6 +23,7 @@ private AstNode getSelectPart(Select sel, int index) {
       (
         n = getASubExpression(sel) and loc = n.getLocation()
         or
+        // TODO: Use dataflow instead.
         // the strings are behind a predicate call.
         exists(Call c, Predicate target | c = getASubExpression(sel) and loc = c.getLocation() |
           c.getTarget() = target and
@@ -188,6 +189,7 @@ String doubleWhitespace(Select sel) {
  * Gets an expression that repeats the alert-loc as a link.
  */
 VarAccess getAlertLocLink(Select sel) {
+  // TODO: Get this to work with GVN. I got an infinite loop when I tried.
   result = sel.getExpr(0).(VarAccess).getDeclaration().getAnAccess() and
   exists(int msgIndex | sel.getExpr(msgIndex) = sel.getMessage() |
     result = sel.getExpr(any(int i | i > msgIndex))

--- a/ql/ql/src/queries/style/AlertMessage.ql
+++ b/ql/ql/src/queries/style/AlertMessage.ql
@@ -184,6 +184,16 @@ String doubleWhitespace(Select sel) {
   result.getValue().regexpMatch(".*\\s\\s.*")
 }
 
+/**
+ * Gets an expression that repeats the alert-loc as a link.
+ */
+VarAccess getAlertLocLink(Select sel) {
+  result = sel.getExpr(0).(VarAccess).getDeclaration().getAnAccess() and
+  exists(int msgIndex | sel.getExpr(msgIndex) = sel.getMessage() |
+    result = sel.getExpr(any(int i | i > msgIndex))
+  )
+}
+
 from AstNode node, string msg, Select sel
 where
   not node.getLocation().getFile().getAbsolutePath().matches("%/test/%") and
@@ -218,5 +228,8 @@ where
     or
     node = doubleWhitespace(sel) and
     msg = "Avoid using double whitespace in alert messages."
+    or
+    node = getAlertLocLink(sel) and
+    msg = "Don't repeat the alert location as a link."
   )
 select node, msg

--- a/ql/ql/src/queries/style/AlertMessage.ql
+++ b/ql/ql/src/queries/style/AlertMessage.ql
@@ -185,12 +185,16 @@ String doubleWhitespace(Select sel) {
   result.getValue().regexpMatch(".*\\s\\s.*")
 }
 
+import codeql.GlobalValueNumbering as GVN
+
 /**
  * Gets an expression that repeats the alert-loc as a link.
  */
-VarAccess getAlertLocLink(Select sel) {
-  // TODO: Get this to work with GVN. I got an infinite loop when I tried.
-  result = sel.getExpr(0).(VarAccess).getDeclaration().getAnAccess() and
+AstNode getAlertLocLink(Select sel) {
+  exists(GVN::ValueNumber vn |
+    result = vn.getAnExpr() and
+    sel.getExpr(0) = vn.getAnExpr()
+  ) and
   exists(int msgIndex | sel.getExpr(msgIndex) = sel.getMessage() |
     result = sel.getExpr(any(int i | i > msgIndex))
   )


### PR DESCRIPTION
`don't repeat the alert-location as a link` is not currently part of the style guide, and I don't think it needs to be.  
(It's covered under: Keep the message concise).  

I tried to use GVN when I created [don't repeat the alert-location as a link](https://github.com/github/codeql/commit/76fef28c32eef22346f3c417ba55e9f45c5c8048).  
But that seemed to run into an infinite loop (I stopped it after ~100.000 iterations).  
/cc @MathiasVP 