### PR TITLE
Ruby: Add call graph tests for unsupported constructs

### DIFF
--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -1,7 +1,7 @@
-#-----| BasicObject
-
 #-----| Class
 #-----| super -> Module
+
+#-----| BasicObject
 
 #-----| Complex
 #-----| super -> Numeric
@@ -91,6 +91,11 @@ calls.rb:
 
 #  399| SingletonOverride2
 #-----| super -> SingletonOverride1
+
+#  414| ConditionalInstanceMethods
+#-----| super -> Object
+
+#  477| ExtendSingletonMethod
 
 hello.rb:
 #    1| EnglishWords

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -157,6 +157,26 @@ getTarget
 | calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:389:5:391:7 | call_singleton2 |
 | calls.rb:402:13:402:48 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:407:9:407:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:417:13:417:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:422:9:422:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:425:13:425:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:428:17:428:52 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:436:9:440:11 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:436:9:440:15 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:438:17:438:40 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:444:1:444:30 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:444:1:444:33 | call to m1 | calls.rb:416:9:418:11 | m1 |
+| calls.rb:445:1:445:30 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:446:1:446:30 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:446:1:446:33 | call to m2 | calls.rb:421:5:433:7 | m2 |
+| calls.rb:447:1:447:30 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:448:1:448:30 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:449:1:449:30 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:454:13:454:22 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:458:5:462:7 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:458:5:462:11 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:460:13:460:22 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:466:13:466:27 | call to puts | calls.rb:102:5:102:30 | puts |
 | hello.rb:12:5:12:24 | call to include | calls.rb:107:5:107:20 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
@@ -233,6 +253,37 @@ unresolvedCall
 | calls.rb:310:9:310:20 | call to instance |
 | calls.rb:411:1:411:34 | call to call_singleton1 |
 | calls.rb:412:1:412:34 | call to call_singleton2 |
+| calls.rb:415:8:415:13 | call to rand |
+| calls.rb:415:8:415:17 | ... > ... |
+| calls.rb:432:9:432:10 | call to m3 |
+| calls.rb:435:8:435:13 | call to rand |
+| calls.rb:435:8:435:17 | ... > ... |
+| calls.rb:436:9:440:18 | call to m5 |
+| calls.rb:445:1:445:33 | call to m3 |
+| calls.rb:447:1:447:33 | call to m3 |
+| calls.rb:448:1:448:33 | call to m4 |
+| calls.rb:449:1:449:33 | call to m5 |
+| calls.rb:450:1:450:4 | call to exit |
+| calls.rb:451:27:469:3 | call to new |
+| calls.rb:452:5:452:11 | call to [] |
+| calls.rb:452:5:456:7 | call to each |
+| calls.rb:458:5:462:15 | call to bar |
+| calls.rb:464:5:464:11 | call to [] |
+| calls.rb:464:5:468:7 | call to each |
+| calls.rb:465:9:467:11 | call to define_method |
+| calls.rb:471:1:471:27 | call to new |
+| calls.rb:471:1:471:31 | call to foo |
+| calls.rb:472:1:472:27 | call to new |
+| calls.rb:472:1:472:31 | call to bar |
+| calls.rb:473:1:473:27 | call to new |
+| calls.rb:473:1:473:33 | call to baz_0 |
+| calls.rb:474:1:474:27 | call to new |
+| calls.rb:474:1:474:33 | call to baz_1 |
+| calls.rb:475:1:475:27 | call to new |
+| calls.rb:475:1:475:33 | call to baz_2 |
+| calls.rb:479:9:479:46 | call to puts |
+| calls.rb:482:5:482:15 | call to extend |
+| calls.rb:485:1:485:31 | call to singleton |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |
@@ -257,6 +308,8 @@ privateMethod
 | calls.rb:275:1:283:3 | create |
 | calls.rb:340:1:356:3 | pattern_dispatch |
 | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:453:9:455:11 | foo |
+| calls.rb:459:9:461:11 | bar |
 | private.rb:2:11:3:5 | private1 |
 | private.rb:8:3:9:5 | private2 |
 | private.rb:14:3:15:5 | private3 |

--- a/ruby/ql/test/library-tests/modules/calls.rb
+++ b/ruby/ql/test/library-tests/modules/calls.rb
@@ -410,3 +410,76 @@ end
 
 SingletonOverride2.call_singleton1
 SingletonOverride2.call_singleton2
+
+class ConditionalInstanceMethods
+    if rand() > 0 then
+        def m1
+            puts "ConditionalInstanceMethods#m1"
+        end
+    end
+
+    def m2
+        puts "ConditionalInstanceMethods#m2"
+        
+        def m3
+            puts "ConditionalInstanceMethods#m3"
+
+            def m4
+                puts "ConditionalInstanceMethods#m4"
+            end
+        end
+
+        m3
+    end
+
+    if rand() > 0 then
+        Class.new do
+            def m5
+                puts "AnonymousClass#m5"
+            end
+        end.new.m5
+    end
+end
+
+ConditionalInstanceMethods.new.m1
+ConditionalInstanceMethods.new.m3 # NoMethodError
+ConditionalInstanceMethods.new.m2
+ConditionalInstanceMethods.new.m3 # currently unable to resolve
+ConditionalInstanceMethods.new.m4 # currently unable to resolve
+ConditionalInstanceMethods.new.m5 # NoMethodError
+exit
+EsotericInstanceMethods = Class.new do
+    [0,1,2].each do
+        def foo
+            puts "foo"
+        end
+    end
+
+    Class.new do
+        def bar
+            puts "bar"
+        end
+    end.new.bar
+
+    [0,1,2].each do |i|
+        define_method("baz_#{i}") do
+            puts "baz_#{i}"
+        end
+    end
+end
+
+EsotericInstanceMethods.new.foo # currently unable to resolve
+EsotericInstanceMethods.new.bar # NoMethodError
+EsotericInstanceMethods.new.baz_0 # currently unable to resolve
+EsotericInstanceMethods.new.baz_1 # currently unable to resolve
+EsotericInstanceMethods.new.baz_2 # currently unable to resolve
+
+module ExtendSingletonMethod
+    def singleton
+        puts "ExtendSingletonMethod#singleton"
+    end
+
+    extend self
+end
+
+ExtendSingletonMethod.singleton # currently unable to resolve

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -36,6 +36,9 @@ getMethod
 | calls.rb:322:1:326:3 | C1 | instance | calls.rb:323:5:325:7 | instance |
 | calls.rb:328:1:332:3 | C2 | instance | calls.rb:329:5:331:7 | instance |
 | calls.rb:334:1:338:3 | C3 | instance | calls.rb:335:5:337:7 | instance |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | m1 | calls.rb:416:9:418:11 | m1 |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | m2 | calls.rb:421:5:433:7 | m2 |
+| calls.rb:477:1:483:3 | ExtendSingletonMethod | singleton | calls.rb:478:5:480:7 | singleton |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
@@ -329,6 +332,23 @@ lookupMethod
 | calls.rb:399:1:409:3 | SingletonOverride2 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
 | calls.rb:399:1:409:3 | SingletonOverride2 | puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:399:1:409:3 | SingletonOverride2 | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | create | calls.rb:275:1:283:3 | create |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | m1 | calls.rb:416:9:418:11 | m1 |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | m2 | calls.rb:421:5:433:7 | m2 |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | new | calls.rb:114:5:114:16 | new |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:477:1:483:3 | ExtendSingletonMethod | singleton | calls.rb:478:5:480:7 | singleton |
 | file://:0:0:0:0 | Class | include | calls.rb:107:5:107:20 | include |
 | file://:0:0:0:0 | Class | module_eval | calls.rb:106:5:106:24 | module_eval |
 | file://:0:0:0:0 | Class | new | calls.rb:114:5:114:16 | new |
@@ -705,6 +725,42 @@ enclosingMethod
 | calls.rb:407:9:407:44 | self | calls.rb:406:5:408:7 | singleton2 |
 | calls.rb:407:14:407:44 | "SingletonOverride2#singleton2" | calls.rb:406:5:408:7 | singleton2 |
 | calls.rb:407:15:407:43 | SingletonOverride2#singleton2 | calls.rb:406:5:408:7 | singleton2 |
+| calls.rb:417:13:417:48 | call to puts | calls.rb:416:9:418:11 | m1 |
+| calls.rb:417:13:417:48 | self | calls.rb:416:9:418:11 | m1 |
+| calls.rb:417:18:417:48 | "ConditionalInstanceMethods#m1" | calls.rb:416:9:418:11 | m1 |
+| calls.rb:417:19:417:47 | ConditionalInstanceMethods#m1 | calls.rb:416:9:418:11 | m1 |
+| calls.rb:422:9:422:44 | call to puts | calls.rb:421:5:433:7 | m2 |
+| calls.rb:422:9:422:44 | self | calls.rb:421:5:433:7 | m2 |
+| calls.rb:422:14:422:44 | "ConditionalInstanceMethods#m2" | calls.rb:421:5:433:7 | m2 |
+| calls.rb:422:15:422:43 | ConditionalInstanceMethods#m2 | calls.rb:421:5:433:7 | m2 |
+| calls.rb:424:9:430:11 | m3 | calls.rb:421:5:433:7 | m2 |
+| calls.rb:425:13:425:48 | call to puts | calls.rb:424:9:430:11 | m3 |
+| calls.rb:425:13:425:48 | self | calls.rb:424:9:430:11 | m3 |
+| calls.rb:425:18:425:48 | "ConditionalInstanceMethods#m3" | calls.rb:424:9:430:11 | m3 |
+| calls.rb:425:19:425:47 | ConditionalInstanceMethods#m3 | calls.rb:424:9:430:11 | m3 |
+| calls.rb:427:13:429:15 | m4 | calls.rb:424:9:430:11 | m3 |
+| calls.rb:428:17:428:52 | call to puts | calls.rb:427:13:429:15 | m4 |
+| calls.rb:428:17:428:52 | self | calls.rb:427:13:429:15 | m4 |
+| calls.rb:428:22:428:52 | "ConditionalInstanceMethods#m4" | calls.rb:427:13:429:15 | m4 |
+| calls.rb:428:23:428:51 | ConditionalInstanceMethods#m4 | calls.rb:427:13:429:15 | m4 |
+| calls.rb:432:9:432:10 | call to m3 | calls.rb:421:5:433:7 | m2 |
+| calls.rb:432:9:432:10 | self | calls.rb:421:5:433:7 | m2 |
+| calls.rb:438:17:438:40 | call to puts | calls.rb:437:13:439:15 | m5 |
+| calls.rb:438:17:438:40 | self | calls.rb:437:13:439:15 | m5 |
+| calls.rb:438:22:438:40 | "AnonymousClass#m5" | calls.rb:437:13:439:15 | m5 |
+| calls.rb:438:23:438:39 | AnonymousClass#m5 | calls.rb:437:13:439:15 | m5 |
+| calls.rb:454:13:454:22 | call to puts | calls.rb:453:9:455:11 | foo |
+| calls.rb:454:13:454:22 | self | calls.rb:453:9:455:11 | foo |
+| calls.rb:454:18:454:22 | "foo" | calls.rb:453:9:455:11 | foo |
+| calls.rb:454:19:454:21 | foo | calls.rb:453:9:455:11 | foo |
+| calls.rb:460:13:460:22 | call to puts | calls.rb:459:9:461:11 | bar |
+| calls.rb:460:13:460:22 | self | calls.rb:459:9:461:11 | bar |
+| calls.rb:460:18:460:22 | "bar" | calls.rb:459:9:461:11 | bar |
+| calls.rb:460:19:460:21 | bar | calls.rb:459:9:461:11 | bar |
+| calls.rb:479:9:479:46 | call to puts | calls.rb:478:5:480:7 | singleton |
+| calls.rb:479:9:479:46 | self | calls.rb:478:5:480:7 | singleton |
+| calls.rb:479:14:479:46 | "ExtendSingletonMethod#singleton" | calls.rb:478:5:480:7 | singleton |
+| calls.rb:479:15:479:45 | ExtendSingletonMethod#singleton | calls.rb:478:5:480:7 | singleton |
 | hello.rb:3:9:3:22 | return | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:16:3:22 | "hello" | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:17:3:21 | hello | hello.rb:2:5:4:7 | hello |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -19,6 +19,8 @@ getModule
 | calls.rb:334:1:338:3 | C3 |
 | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:477:1:483:3 | ExtendSingletonMethod |
 | file://:0:0:0:0 | BasicObject |
 | file://:0:0:0:0 | Class |
 | file://:0:0:0:0 | Complex |
@@ -77,7 +79,7 @@ getADeclaration
 | calls.rb:96:1:98:3 | String | calls.rb:96:1:98:3 | String |
 | calls.rb:100:1:103:3 | Kernel | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:105:1:110:3 | Module | calls.rb:105:1:110:3 | Module |
-| calls.rb:112:1:115:3 | Object | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:112:1:115:3 | Object | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:112:1:115:3 | Object | calls.rb:112:1:115:3 | Object |
 | calls.rb:112:1:115:3 | Object | hello.rb:1:1:22:3 | hello.rb |
 | calls.rb:112:1:115:3 | Object | modules.rb:1:1:129:4 | modules.rb |
@@ -96,6 +98,8 @@ getADeclaration
 | calls.rb:334:1:338:3 | C3 | calls.rb:334:1:338:3 | C3 |
 | calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:399:1:409:3 | SingletonOverride2 |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:477:1:483:3 | ExtendSingletonMethod | calls.rb:477:1:483:3 | ExtendSingletonMethod |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
@@ -158,6 +162,7 @@ getSuperClass
 | calls.rb:334:1:338:3 | C3 | calls.rb:328:1:332:3 | C2 |
 | calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:112:1:115:3 | Object |
 | calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:374:1:394:3 | SingletonOverride1 |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:112:1:115:3 | Object |
 | file://:0:0:0:0 | Class | calls.rb:105:1:110:3 | Module |
 | file://:0:0:0:0 | Complex | file://:0:0:0:0 | Numeric |
 | file://:0:0:0:0 | FalseClass | calls.rb:112:1:115:3 | Object |
@@ -243,6 +248,18 @@ resolveConstantReadAccess
 | calls.rb:399:28:399:45 | SingletonOverride1 | SingletonOverride1 |
 | calls.rb:411:1:411:18 | SingletonOverride2 | SingletonOverride2 |
 | calls.rb:412:1:412:18 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:436:9:436:13 | Class | Class |
+| calls.rb:444:1:444:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:445:1:445:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:446:1:446:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:447:1:447:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:448:1:448:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:449:1:449:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:451:27:451:31 | Class | Class |
+| calls.rb:452:5:452:11 | Array | Array |
+| calls.rb:458:5:458:9 | Class | Class |
+| calls.rb:464:5:464:11 | Array | Array |
+| calls.rb:485:1:485:21 | ExtendSingletonMethod | ExtendSingletonMethod |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
 | modules.rb:48:8:48:10 | Foo | Foo |
@@ -299,6 +316,9 @@ resolveConstantWriteAccess
 | calls.rb:334:1:338:3 | C3 | C3 |
 | calls.rb:374:1:394:3 | SingletonOverride1 | SingletonOverride1 |
 | calls.rb:399:1:409:3 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:451:1:451:23 | EsotericInstanceMethods | EsotericInstanceMethods |
+| calls.rb:477:1:483:3 | ExtendSingletonMethod | ExtendSingletonMethod |
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |
@@ -353,32 +373,32 @@ resolveConstantWriteAccess
 | private.rb:62:1:74:3 | PrivateOverride1 | PrivateOverride1 |
 | private.rb:76:1:82:3 | PrivateOverride2 | PrivateOverride2 |
 enclosingModule
-| calls.rb:1:1:3:3 | foo | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:2:5:2:14 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:2:11:2:13 | foo | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:5:1:5:3 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:7:1:9:3 | bar | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:7:5:7:8 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:8:5:8:15 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:11:1:11:4 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:13:1:15:3 | bar | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:13:5:13:8 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:14:5:14:15 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:17:1:17:4 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:19:1:19:4 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:21:1:34:3 | M | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:1:1:3:3 | foo | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:5:1:5:3 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:7:1:9:3 | bar | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:7:5:7:8 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:8:5:8:15 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:11:1:11:4 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:13:1:15:3 | bar | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:13:5:13:8 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:14:5:14:15 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:17:1:17:4 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:19:1:19:4 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:21:1:34:3 | M | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:22:5:24:7 | instance_m | calls.rb:21:1:34:3 | M |
 | calls.rb:23:9:23:19 | call to singleton_m | calls.rb:21:1:34:3 | M |
 | calls.rb:23:9:23:19 | self | calls.rb:21:1:34:3 | M |
@@ -394,14 +414,14 @@ enclosingModule
 | calls.rb:32:5:32:15 | self | calls.rb:21:1:34:3 | M |
 | calls.rb:33:5:33:8 | self | calls.rb:21:1:34:3 | M |
 | calls.rb:33:5:33:20 | call to singleton_m | calls.rb:21:1:34:3 | M |
-| calls.rb:36:1:36:1 | M | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:37:1:37:1 | M | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:40:5:40:14 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:43:1:58:3 | C | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:36:1:36:1 | M | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:37:1:37:1 | M | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:40:5:40:14 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:43:1:58:3 | C | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:44:5:44:13 | call to include | calls.rb:43:1:58:3 | C |
 | calls.rb:44:5:44:13 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:44:13:44:13 | M | calls.rb:43:1:58:3 | C |
@@ -422,66 +442,66 @@ enclosingModule
 | calls.rb:55:9:55:19 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:56:9:56:12 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:56:9:56:24 | call to singleton_m | calls.rb:43:1:58:3 | C |
-| calls.rb:60:1:60:1 | c | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:60:5:60:5 | C | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:61:1:61:1 | c | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:62:1:62:1 | c | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:63:1:63:1 | c | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:65:1:69:3 | D | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:65:11:65:11 | C | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:60:1:60:1 | c | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:60:5:60:5 | C | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:61:1:61:1 | c | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:62:1:62:1 | c | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:63:1:63:1 | c | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:65:1:69:3 | D | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:65:11:65:11 | C | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:66:5:68:7 | baz | calls.rb:65:1:69:3 | D |
 | calls.rb:67:9:67:13 | call to super | calls.rb:65:1:69:3 | D |
-| calls.rb:71:1:71:1 | d | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:71:5:71:5 | D | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:72:1:72:1 | d | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:73:1:73:1 | d | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:74:1:74:1 | d | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:76:18:76:18 | a | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:76:18:76:18 | a | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:76:25:76:25 | b | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:76:25:76:25 | b | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:77:5:77:5 | a | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:78:5:78:5 | b | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:85:1:89:3 | foo | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:86:5:86:7 | var | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:87:5:87:7 | var | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:88:5:88:29 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:88:19:88:19 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:88:19:88:19 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:88:22:88:24 | var | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:88:26:88:26 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:71:1:71:1 | d | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:71:5:71:5 | D | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:72:1:72:1 | d | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:73:1:73:1 | d | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:74:1:74:1 | d | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:77:5:77:5 | a | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:78:5:78:5 | b | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:85:1:89:3 | foo | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:86:5:86:7 | var | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:87:5:87:7 | var | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:88:5:88:29 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:88:22:88:24 | var | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:88:26:88:26 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:92:5:92:23 | bit_length | calls.rb:91:1:94:3 | Integer |
 | calls.rb:93:5:93:16 | abs | calls.rb:91:1:94:3 | Integer |
-| calls.rb:96:1:98:3 | String | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:96:1:98:3 | String | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:97:5:97:23 | capitalize | calls.rb:96:1:98:3 | String |
-| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:101:5:101:25 | alias ... | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:101:11:101:19 | :old_puts | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:101:11:101:19 | old_puts | calls.rb:100:1:103:3 | Kernel |
@@ -493,18 +513,18 @@ enclosingModule
 | calls.rb:102:17:102:26 | call to old_puts | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:102:17:102:26 | self | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:102:26:102:26 | x | calls.rb:100:1:103:3 | Kernel |
-| calls.rb:105:1:110:3 | Module | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:105:1:110:3 | Module | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:106:5:106:24 | module_eval | calls.rb:105:1:110:3 | Module |
 | calls.rb:107:5:107:20 | include | calls.rb:105:1:110:3 | Module |
 | calls.rb:108:5:108:20 | prepend | calls.rb:105:1:110:3 | Module |
 | calls.rb:109:5:109:20 | private | calls.rb:105:1:110:3 | Module |
-| calls.rb:112:1:115:3 | Object | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:112:16:112:21 | Module | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:112:1:115:3 | Object | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:112:16:112:21 | Module | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:113:5:113:18 | call to include | calls.rb:112:1:115:3 | Object |
 | calls.rb:113:5:113:18 | self | calls.rb:112:1:115:3 | Object |
 | calls.rb:113:13:113:18 | Kernel | calls.rb:112:1:115:3 | Object |
 | calls.rb:114:5:114:16 | new | calls.rb:112:1:115:3 | Object |
-| calls.rb:117:1:120:3 | Hash | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:117:1:120:3 | Hash | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:118:5:118:25 | alias ... | calls.rb:117:1:120:3 | Hash |
 | calls.rb:118:11:118:21 | :old_lookup | calls.rb:117:1:120:3 | Hash |
 | calls.rb:118:11:118:21 | old_lookup | calls.rb:117:1:120:3 | Hash |
@@ -516,7 +536,7 @@ enclosingModule
 | calls.rb:119:15:119:27 | call to old_lookup | calls.rb:117:1:120:3 | Hash |
 | calls.rb:119:15:119:27 | self | calls.rb:117:1:120:3 | Hash |
 | calls.rb:119:26:119:26 | x | calls.rb:117:1:120:3 | Hash |
-| calls.rb:122:1:135:3 | Array | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:122:1:135:3 | Array | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:123:3:123:23 | alias ... | calls.rb:122:1:135:3 | Array |
 | calls.rb:123:9:123:19 | :old_lookup | calls.rb:122:1:135:3 | Array |
 | calls.rb:123:9:123:19 | old_lookup | calls.rb:122:1:135:3 | Array |
@@ -552,130 +572,130 @@ enclosingModule
 | calls.rb:132:9:132:14 | ... = ... | calls.rb:122:1:135:3 | Array |
 | calls.rb:132:11:132:12 | ... + ... | calls.rb:122:1:135:3 | Array |
 | calls.rb:132:14:132:14 | 1 | calls.rb:122:1:135:3 | Array |
-| calls.rb:137:1:139:3 | funny | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:138:5:138:20 | yield ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:138:11:138:20 | "prefix: " | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:138:12:138:19 | prefix:  | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:1:141:30 | call to funny | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:1:141:30 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:7:141:30 | { ... } | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:10:141:10 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:10:141:10 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:13:141:29 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:13:141:29 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:18:141:18 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:141:18:141:29 | call to capitalize | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:143:1:143:3 | "a" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:143:1:143:14 | call to capitalize | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:143:2:143:2 | a | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:144:1:144:1 | 1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:144:1:144:12 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:145:1:145:1 | 1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:145:1:145:5 | call to abs | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:1:147:13 | Array | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:1:147:13 | [...] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:1:147:13 | call to [] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:1:147:62 | call to foreach | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:2:147:4 | "a" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:3:147:3 | a | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:6:147:8 | "b" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:7:147:7 | b | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:10:147:12 | "c" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:11:147:11 | c | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:23:147:62 | { ... } | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:26:147:26 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:26:147:26 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:29:147:29 | v | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:29:147:29 | v | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:32:147:61 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:32:147:61 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:37:147:61 | "#{...} -> #{...}" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:38:147:41 | #{...} | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:40:147:40 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:42:147:45 |  ->  | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:46:147:60 | #{...} | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:48:147:48 | v | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:147:48:147:59 | call to capitalize | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:1:149:7 | Array | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:1:149:7 | [...] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:1:149:7 | call to [] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:1:149:35 | call to foreach | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:2:149:2 | 1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:4:149:4 | 2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:6:149:6 | 3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:17:149:35 | { ... } | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:20:149:20 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:20:149:20 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:23:149:23 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:149:23:149:34 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:1:151:7 | Array | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:1:151:7 | [...] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:1:151:7 | call to [] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:1:151:40 | call to foreach | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:2:151:2 | 1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:4:151:4 | 2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:6:151:6 | 3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:17:151:40 | { ... } | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:20:151:20 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:20:151:20 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:23:151:39 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:23:151:39 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:28:151:28 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:151:28:151:39 | call to capitalize | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:1:153:8 | Array | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:1:153:8 | [...] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:1:153:8 | call to [] | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:1:153:37 | call to foreach | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:2:153:2 | 1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:4:153:5 | - ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:5:153:5 | 2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:7:153:7 | 3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:18:153:37 | { ... } | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:21:153:21 | _ | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:21:153:21 | _ | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:24:153:24 | v | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:24:153:24 | v | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:27:153:36 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:27:153:36 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:32:153:32 | v | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:153:32:153:36 | call to abs | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:155:1:157:3 | indirect | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:155:14:155:15 | &b | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:155:15:155:15 | b | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:156:5:156:17 | call to call_block | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:156:5:156:17 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:156:16:156:17 | &... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:156:17:156:17 | b | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:159:1:159:28 | call to indirect | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:159:1:159:28 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:159:10:159:28 | { ... } | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:159:13:159:13 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:159:13:159:13 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:159:16:159:16 | i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:159:16:159:27 | call to bit_length | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:162:1:166:3 | S | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:137:1:139:3 | funny | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:138:5:138:20 | yield ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:138:11:138:20 | "prefix: " | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:138:12:138:19 | prefix:  | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:1:141:30 | call to funny | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:1:141:30 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:7:141:30 | { ... } | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:10:141:10 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:10:141:10 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:13:141:29 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:13:141:29 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:18:141:18 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:141:18:141:29 | call to capitalize | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:143:1:143:3 | "a" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:143:1:143:14 | call to capitalize | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:143:2:143:2 | a | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:144:1:144:1 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:144:1:144:12 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:145:1:145:1 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:145:1:145:5 | call to abs | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:1:147:13 | Array | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:1:147:13 | [...] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:1:147:13 | call to [] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:1:147:62 | call to foreach | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:2:147:4 | "a" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:3:147:3 | a | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:6:147:8 | "b" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:7:147:7 | b | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:10:147:12 | "c" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:11:147:11 | c | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:23:147:62 | { ... } | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:26:147:26 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:26:147:26 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:29:147:29 | v | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:29:147:29 | v | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:32:147:61 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:32:147:61 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:37:147:61 | "#{...} -> #{...}" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:38:147:41 | #{...} | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:40:147:40 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:42:147:45 |  ->  | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:46:147:60 | #{...} | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:48:147:48 | v | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:147:48:147:59 | call to capitalize | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:1:149:7 | Array | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:1:149:7 | [...] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:1:149:7 | call to [] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:1:149:35 | call to foreach | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:2:149:2 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:4:149:4 | 2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:6:149:6 | 3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:17:149:35 | { ... } | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:20:149:20 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:20:149:20 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:23:149:23 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:149:23:149:34 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:1:151:7 | Array | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:1:151:7 | [...] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:1:151:7 | call to [] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:1:151:40 | call to foreach | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:2:151:2 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:4:151:4 | 2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:6:151:6 | 3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:17:151:40 | { ... } | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:20:151:20 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:20:151:20 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:23:151:39 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:23:151:39 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:28:151:28 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:151:28:151:39 | call to capitalize | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:1:153:8 | Array | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:1:153:8 | [...] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:1:153:8 | call to [] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:1:153:37 | call to foreach | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:2:153:2 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:4:153:5 | - ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:5:153:5 | 2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:7:153:7 | 3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:18:153:37 | { ... } | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:21:153:21 | _ | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:21:153:21 | _ | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:24:153:24 | v | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:24:153:24 | v | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:27:153:36 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:27:153:36 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:32:153:32 | v | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:153:32:153:36 | call to abs | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:155:1:157:3 | indirect | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:155:14:155:15 | &b | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:155:15:155:15 | b | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:156:5:156:17 | call to call_block | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:156:5:156:17 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:156:16:156:17 | &... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:156:17:156:17 | b | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:159:1:159:28 | call to indirect | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:159:1:159:28 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:159:10:159:28 | { ... } | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:159:13:159:13 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:159:13:159:13 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:159:16:159:16 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:159:16:159:27 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:162:1:166:3 | S | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:163:5:165:7 | s_method | calls.rb:162:1:166:3 | S |
 | calls.rb:164:9:164:12 | self | calls.rb:162:1:166:3 | S |
 | calls.rb:164:9:164:17 | call to to_s | calls.rb:162:1:166:3 | S |
-| calls.rb:168:1:171:3 | A | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:168:11:168:11 | S | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:168:1:171:3 | A | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:168:11:168:11 | S | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:169:5:170:7 | to_s | calls.rb:168:1:171:3 | A |
-| calls.rb:173:1:176:3 | B | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:173:11:173:11 | S | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:173:1:176:3 | B | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:173:11:173:11 | S | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:174:5:175:7 | to_s | calls.rb:173:1:176:3 | B |
-| calls.rb:178:1:178:1 | S | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:178:1:178:5 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:178:1:178:14 | call to s_method | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:179:1:179:1 | A | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:179:1:179:5 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:179:1:179:14 | call to s_method | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:180:1:180:1 | B | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:180:1:180:5 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:180:1:180:14 | call to s_method | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:182:1:183:3 | private_on_main | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:185:1:185:15 | call to private_on_main | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:185:1:185:15 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:187:1:223:3 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:178:1:178:1 | S | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:178:1:178:5 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:178:1:178:14 | call to s_method | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:179:1:179:1 | A | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:179:1:179:5 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:179:1:179:14 | call to s_method | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:180:1:180:1 | B | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:180:1:180:5 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:180:1:180:14 | call to s_method | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:182:1:183:3 | private_on_main | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:185:1:185:15 | call to private_on_main | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:185:1:185:15 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:187:1:223:3 | Singletons | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:188:5:191:7 | singleton_a | calls.rb:187:1:223:3 | Singletons |
 | calls.rb:188:9:188:12 | self | calls.rb:187:1:223:3 | Singletons |
 | calls.rb:189:9:189:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
@@ -725,126 +745,126 @@ enclosingModule
 | calls.rb:220:5:222:7 | call_singleton_g | calls.rb:187:1:223:3 | Singletons |
 | calls.rb:221:9:221:12 | self | calls.rb:187:1:223:3 | Singletons |
 | calls.rb:221:9:221:24 | call to singleton_g | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:225:1:225:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:225:1:225:22 | call to singleton_a | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:226:1:226:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:226:1:226:22 | call to singleton_f | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:228:1:228:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:228:1:228:19 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:228:6:228:15 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:228:6:228:19 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:230:1:230:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:230:1:230:11 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:231:1:231:14 | call to singleton_e | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:233:1:235:3 | singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:233:5:233:6 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:234:5:234:24 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:234:5:234:24 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:234:10:234:24 | "singleton_g_1" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:234:11:234:23 | singleton_g_1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:237:1:237:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:237:1:237:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:238:1:238:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:238:1:238:19 | call to call_singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:240:1:242:3 | singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:240:5:240:6 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:241:5:241:24 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:241:5:241:24 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:241:10:241:24 | "singleton_g_2" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:241:11:241:23 | singleton_g_2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:244:1:244:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:244:1:244:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:245:1:245:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:245:1:245:19 | call to call_singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:247:1:251:3 | class << ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:247:10:247:11 | c1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:225:1:225:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:225:1:225:22 | call to singleton_a | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:226:1:226:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:226:1:226:22 | call to singleton_f | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:228:1:228:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:228:1:228:19 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:228:6:228:15 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:228:6:228:19 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:230:1:230:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:230:1:230:11 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:231:1:231:14 | call to singleton_e | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:233:1:235:3 | singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:233:5:233:6 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:234:5:234:24 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:234:5:234:24 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:234:10:234:24 | "singleton_g_1" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:234:11:234:23 | singleton_g_1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:237:1:237:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:237:1:237:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:238:1:238:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:238:1:238:19 | call to call_singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:240:1:242:3 | singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:240:5:240:6 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:241:5:241:24 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:241:5:241:24 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:241:10:241:24 | "singleton_g_2" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:241:11:241:23 | singleton_g_2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:244:1:244:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:244:1:244:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:245:1:245:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:245:1:245:19 | call to call_singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:247:1:251:3 | class << ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:247:10:247:11 | c1 | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:248:5:250:7 | singleton_g | calls.rb:247:1:251:3 | class << ... |
 | calls.rb:249:9:249:28 | call to puts | calls.rb:247:1:251:3 | class << ... |
 | calls.rb:249:9:249:28 | self | calls.rb:247:1:251:3 | class << ... |
 | calls.rb:249:14:249:28 | "singleton_g_3" | calls.rb:247:1:251:3 | class << ... |
 | calls.rb:249:15:249:27 | singleton_g_3 | calls.rb:247:1:251:3 | class << ... |
-| calls.rb:253:1:253:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:253:1:253:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:254:1:254:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:254:1:254:19 | call to call_singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:256:1:256:2 | c2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:256:1:256:19 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:256:6:256:15 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:256:6:256:19 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:257:1:257:2 | c2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:257:1:257:14 | call to singleton_e | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:258:1:258:2 | c2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:258:1:258:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:260:1:260:4 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:260:1:260:8 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:262:1:262:16 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:262:1:262:16 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:262:6:262:16 | "top-level" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:262:7:262:15 | top-level | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:264:1:266:3 | singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:264:5:264:14 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:265:5:265:22 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:265:5:265:22 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:265:10:265:22 | "singleton_g" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:265:11:265:21 | singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:268:1:268:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:268:1:268:22 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:269:1:269:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:270:1:270:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:270:1:270:19 | call to call_singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:271:1:271:2 | c2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:271:1:271:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:272:1:272:2 | c3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:272:1:272:19 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:272:6:272:15 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:272:6:272:19 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:273:1:273:2 | c3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:273:1:273:14 | call to singleton_g | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:275:1:283:3 | create | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:275:12:275:15 | type | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:275:12:275:15 | type | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:276:5:276:8 | type | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:276:5:276:12 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:276:5:276:21 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:278:5:280:7 | singleton_h | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:278:9:278:12 | type | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:279:9:279:26 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:279:9:279:26 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:279:14:279:26 | "singleton_h" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:279:15:279:25 | singleton_h | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:282:5:282:8 | type | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:285:1:285:17 | call to create | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:285:1:285:17 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:285:8:285:17 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:286:1:286:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:286:1:286:22 | call to singleton_h | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:288:1:288:1 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:288:1:288:14 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:288:5:288:14 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:290:1:294:3 | class << ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:290:10:290:10 | x | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:253:1:253:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:253:1:253:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:254:1:254:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:254:1:254:19 | call to call_singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:256:1:256:2 | c2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:256:1:256:19 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:256:6:256:15 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:256:6:256:19 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:257:1:257:2 | c2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:257:1:257:14 | call to singleton_e | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:258:1:258:2 | c2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:258:1:258:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:260:1:260:4 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:260:1:260:8 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:262:1:262:16 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:262:1:262:16 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:262:6:262:16 | "top-level" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:262:7:262:15 | top-level | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:264:1:266:3 | singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:264:5:264:14 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:265:5:265:22 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:265:5:265:22 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:265:10:265:22 | "singleton_g" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:265:11:265:21 | singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:268:1:268:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:268:1:268:22 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:269:1:269:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:270:1:270:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:270:1:270:19 | call to call_singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:271:1:271:2 | c2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:271:1:271:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:272:1:272:2 | c3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:272:1:272:19 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:272:6:272:15 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:272:6:272:19 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:273:1:273:2 | c3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:273:1:273:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:275:1:283:3 | create | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:275:12:275:15 | type | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:275:12:275:15 | type | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:276:5:276:8 | type | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:276:5:276:12 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:276:5:276:21 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:278:5:280:7 | singleton_h | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:278:9:278:12 | type | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:279:9:279:26 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:279:9:279:26 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:279:14:279:26 | "singleton_h" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:279:15:279:25 | singleton_h | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:282:5:282:8 | type | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:285:1:285:17 | call to create | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:285:1:285:17 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:285:8:285:17 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:286:1:286:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:286:1:286:22 | call to singleton_h | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:288:1:288:1 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:288:1:288:14 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:288:5:288:14 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:290:1:294:3 | class << ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:290:10:290:10 | x | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:291:5:293:7 | singleton_i | calls.rb:290:1:294:3 | class << ... |
 | calls.rb:292:9:292:26 | call to puts | calls.rb:290:1:294:3 | class << ... |
 | calls.rb:292:9:292:26 | self | calls.rb:290:1:294:3 | class << ... |
 | calls.rb:292:14:292:26 | "singleton_i" | calls.rb:290:1:294:3 | class << ... |
 | calls.rb:292:15:292:25 | singleton_i | calls.rb:290:1:294:3 | class << ... |
-| calls.rb:296:1:296:1 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:296:1:296:13 | call to singleton_i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:297:1:297:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:297:1:297:22 | call to singleton_i | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:299:1:303:3 | class << ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:299:10:299:19 | Singletons | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:296:1:296:1 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:296:1:296:13 | call to singleton_i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:297:1:297:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:297:1:297:22 | call to singleton_i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:299:1:303:3 | class << ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:299:10:299:19 | Singletons | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:300:5:302:7 | singleton_j | calls.rb:299:1:303:3 | class << ... |
 | calls.rb:301:9:301:26 | call to puts | calls.rb:299:1:303:3 | class << ... |
 | calls.rb:301:9:301:26 | self | calls.rb:299:1:303:3 | class << ... |
 | calls.rb:301:14:301:26 | "singleton_j" | calls.rb:299:1:303:3 | class << ... |
 | calls.rb:301:15:301:25 | singleton_j | calls.rb:299:1:303:3 | class << ... |
-| calls.rb:305:1:305:10 | Singletons | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:305:1:305:22 | call to singleton_j | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:307:1:318:3 | SelfNew | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:305:1:305:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:305:1:305:22 | call to singleton_j | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:307:1:318:3 | SelfNew | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:308:5:311:7 | instance | calls.rb:307:1:318:3 | SelfNew |
 | calls.rb:309:9:309:31 | call to puts | calls.rb:307:1:318:3 | SelfNew |
 | calls.rb:309:9:309:31 | self | calls.rb:307:1:318:3 | SelfNew |
@@ -861,110 +881,110 @@ enclosingModule
 | calls.rb:317:5:317:7 | call to new | calls.rb:307:1:318:3 | SelfNew |
 | calls.rb:317:5:317:7 | self | calls.rb:307:1:318:3 | SelfNew |
 | calls.rb:317:5:317:16 | call to instance | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:320:1:320:7 | SelfNew | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:320:1:320:17 | call to singleton | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:322:1:326:3 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:320:1:320:7 | SelfNew | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:320:1:320:17 | call to singleton | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:322:1:326:3 | C1 | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:323:5:325:7 | instance | calls.rb:322:1:326:3 | C1 |
 | calls.rb:324:9:324:26 | call to puts | calls.rb:322:1:326:3 | C1 |
 | calls.rb:324:9:324:26 | self | calls.rb:322:1:326:3 | C1 |
 | calls.rb:324:14:324:26 | "C1#instance" | calls.rb:322:1:326:3 | C1 |
 | calls.rb:324:15:324:25 | C1#instance | calls.rb:322:1:326:3 | C1 |
-| calls.rb:328:1:332:3 | C2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:328:12:328:13 | C1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:328:1:332:3 | C2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:328:12:328:13 | C1 | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:329:5:331:7 | instance | calls.rb:328:1:332:3 | C2 |
 | calls.rb:330:9:330:26 | call to puts | calls.rb:328:1:332:3 | C2 |
 | calls.rb:330:9:330:26 | self | calls.rb:328:1:332:3 | C2 |
 | calls.rb:330:14:330:26 | "C2#instance" | calls.rb:328:1:332:3 | C2 |
 | calls.rb:330:15:330:25 | C2#instance | calls.rb:328:1:332:3 | C2 |
-| calls.rb:334:1:338:3 | C3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:334:12:334:13 | C2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:334:1:338:3 | C3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:334:12:334:13 | C2 | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:335:5:337:7 | instance | calls.rb:334:1:338:3 | C3 |
 | calls.rb:336:9:336:26 | call to puts | calls.rb:334:1:338:3 | C3 |
 | calls.rb:336:9:336:26 | self | calls.rb:334:1:338:3 | C3 |
 | calls.rb:336:14:336:26 | "C3#instance" | calls.rb:334:1:338:3 | C3 |
 | calls.rb:336:15:336:25 | C3#instance | calls.rb:334:1:338:3 | C3 |
-| calls.rb:340:1:356:3 | pattern_dispatch | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:340:22:340:22 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:340:22:340:22 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:341:5:349:7 | case ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:341:10:341:10 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:342:5:343:18 | when ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:342:10:342:11 | C3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:342:12:343:18 | then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:343:9:343:9 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:343:9:343:18 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:344:5:345:18 | when ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:344:10:344:11 | C2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:344:12:345:18 | then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:345:9:345:9 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:345:9:345:18 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:346:5:347:18 | when ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:346:10:346:11 | C1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:346:12:347:18 | then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:347:9:347:9 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:347:9:347:18 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:348:5:348:8 | else ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:351:5:355:7 | case ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:351:10:351:10 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:352:9:352:29 | in ... then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:352:12:352:13 | C3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:352:15:352:29 | then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:352:20:352:20 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:352:20:352:29 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:353:9:353:36 | in ... then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:353:12:353:13 | C2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:353:12:353:19 | ... => ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:353:18:353:19 | c2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:353:21:353:36 | then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:353:26:353:27 | c2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:353:26:353:36 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:354:9:354:36 | in ... then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:354:12:354:13 | C1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:354:12:354:19 | ... => ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:354:18:354:19 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:354:21:354:36 | then ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:354:26:354:27 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:354:26:354:36 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:358:1:358:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:358:1:358:11 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:358:6:358:7 | C1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:358:6:358:11 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:359:1:359:2 | c1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:359:1:359:11 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:360:1:360:25 | call to pattern_dispatch | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:360:1:360:25 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:360:18:360:25 | ( ... ) | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:360:19:360:20 | C1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:360:19:360:24 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:361:1:361:25 | call to pattern_dispatch | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:361:1:361:25 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:361:18:361:25 | ( ... ) | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:361:19:361:20 | C2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:361:19:361:24 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:362:1:362:25 | call to pattern_dispatch | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:362:1:362:25 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:362:18:362:25 | ( ... ) | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:362:19:362:20 | C3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:362:19:362:24 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:364:1:368:3 | add_singleton | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:364:19:364:19 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:364:19:364:19 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:365:5:367:7 | instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:365:9:365:9 | x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:366:9:366:28 | call to puts | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:366:9:366:28 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:366:14:366:28 | "instance_on x" | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:366:15:366:27 | instance_on x | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:370:1:370:2 | c3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:370:1:370:11 | ... = ... | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:370:6:370:7 | C1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:370:6:370:11 | call to new | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:371:1:371:16 | call to add_singleton | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:371:1:371:16 | self | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:371:15:371:16 | c3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:372:1:372:2 | c3 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:372:1:372:11 | call to instance | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:340:1:356:3 | pattern_dispatch | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:340:22:340:22 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:340:22:340:22 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:341:5:349:7 | case ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:341:10:341:10 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:342:5:343:18 | when ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:342:10:342:11 | C3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:342:12:343:18 | then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:343:9:343:9 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:343:9:343:18 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:344:5:345:18 | when ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:344:10:344:11 | C2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:344:12:345:18 | then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:345:9:345:9 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:345:9:345:18 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:346:5:347:18 | when ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:346:10:346:11 | C1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:346:12:347:18 | then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:347:9:347:9 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:347:9:347:18 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:348:5:348:8 | else ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:351:5:355:7 | case ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:351:10:351:10 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:352:9:352:29 | in ... then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:352:12:352:13 | C3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:352:15:352:29 | then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:352:20:352:20 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:352:20:352:29 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:353:9:353:36 | in ... then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:353:12:353:13 | C2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:353:12:353:19 | ... => ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:353:18:353:19 | c2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:353:21:353:36 | then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:353:26:353:27 | c2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:353:26:353:36 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:354:9:354:36 | in ... then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:354:12:354:13 | C1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:354:12:354:19 | ... => ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:354:18:354:19 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:354:21:354:36 | then ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:354:26:354:27 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:354:26:354:36 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:358:1:358:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:358:1:358:11 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:358:6:358:7 | C1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:358:6:358:11 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:359:1:359:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:359:1:359:11 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:360:1:360:25 | call to pattern_dispatch | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:360:1:360:25 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:360:18:360:25 | ( ... ) | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:360:19:360:20 | C1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:360:19:360:24 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:361:1:361:25 | call to pattern_dispatch | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:361:1:361:25 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:361:18:361:25 | ( ... ) | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:361:19:361:20 | C2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:361:19:361:24 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:362:1:362:25 | call to pattern_dispatch | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:362:1:362:25 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:362:18:362:25 | ( ... ) | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:362:19:362:20 | C3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:362:19:362:24 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:364:1:368:3 | add_singleton | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:364:19:364:19 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:364:19:364:19 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:365:5:367:7 | instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:365:9:365:9 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:366:9:366:28 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:366:9:366:28 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:366:14:366:28 | "instance_on x" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:366:15:366:27 | instance_on x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:370:1:370:2 | c3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:370:1:370:11 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:370:6:370:7 | C1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:370:6:370:11 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:371:1:371:16 | call to add_singleton | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:371:1:371:16 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:371:15:371:16 | c3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:372:1:372:2 | c3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:372:1:372:11 | call to instance | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:375:5:383:7 | class << ... | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:375:14:375:17 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:376:9:378:11 | singleton1 | calls.rb:375:5:383:7 | class << ... |
@@ -987,12 +1007,12 @@ enclosingModule
 | calls.rb:390:9:390:18 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:393:5:393:14 | call to singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:393:5:393:14 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:396:1:396:18 | SingletonOverride1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:397:1:397:18 | SingletonOverride1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:399:28:399:45 | SingletonOverride1 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:396:1:396:18 | SingletonOverride1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:397:1:397:18 | SingletonOverride1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:399:28:399:45 | SingletonOverride1 | calls.rb:1:1:485:62 | calls.rb |
 | calls.rb:400:5:404:7 | class << ... | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:400:14:400:17 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:401:9:403:11 | singleton1 | calls.rb:400:5:404:7 | class << ... |
@@ -1006,10 +1026,152 @@ enclosingModule
 | calls.rb:407:9:407:44 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:407:14:407:44 | "SingletonOverride2#singleton2" | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:407:15:407:43 | SingletonOverride2#singleton2 | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:411:1:411:18 | SingletonOverride2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:411:1:411:34 | call to call_singleton1 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:412:1:412:18 | SingletonOverride2 | calls.rb:1:1:412:35 | calls.rb |
-| calls.rb:412:1:412:34 | call to call_singleton2 | calls.rb:1:1:412:35 | calls.rb |
+| calls.rb:411:1:411:18 | SingletonOverride2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:411:1:411:34 | call to call_singleton1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:412:1:412:18 | SingletonOverride2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:412:1:412:34 | call to call_singleton2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:415:5:419:7 | if ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:415:8:415:13 | call to rand | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:415:8:415:13 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:415:8:415:17 | ... > ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:415:17:415:17 | 0 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:415:19:418:11 | then ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:416:9:418:11 | m1 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:417:13:417:48 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:417:13:417:48 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:417:18:417:48 | "ConditionalInstanceMethods#m1" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:417:19:417:47 | ConditionalInstanceMethods#m1 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:421:5:433:7 | m2 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:422:9:422:44 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:422:9:422:44 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:422:14:422:44 | "ConditionalInstanceMethods#m2" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:422:15:422:43 | ConditionalInstanceMethods#m2 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:424:9:430:11 | m3 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:425:13:425:48 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:425:13:425:48 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:425:18:425:48 | "ConditionalInstanceMethods#m3" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:425:19:425:47 | ConditionalInstanceMethods#m3 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:427:13:429:15 | m4 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:428:17:428:52 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:428:17:428:52 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:428:22:428:52 | "ConditionalInstanceMethods#m4" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:428:23:428:51 | ConditionalInstanceMethods#m4 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:432:9:432:10 | call to m3 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:432:9:432:10 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:435:5:441:7 | if ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:435:8:435:13 | call to rand | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:435:8:435:13 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:435:8:435:17 | ... > ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:435:17:435:17 | 0 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:435:19:440:18 | then ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:436:9:436:13 | Class | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:436:9:440:11 | call to new | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:436:9:440:15 | call to new | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:436:9:440:18 | call to m5 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:436:19:440:11 | do ... end | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:437:13:439:15 | m5 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:438:17:438:40 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:438:17:438:40 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:438:22:438:40 | "AnonymousClass#m5" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:438:23:438:39 | AnonymousClass#m5 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
+| calls.rb:444:1:444:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:444:1:444:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:444:1:444:33 | call to m1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:445:1:445:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:445:1:445:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:445:1:445:33 | call to m3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:446:1:446:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:446:1:446:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:446:1:446:33 | call to m2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:447:1:447:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:447:1:447:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:447:1:447:33 | call to m3 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:448:1:448:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:448:1:448:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:448:1:448:33 | call to m4 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:449:1:449:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:449:1:449:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:449:1:449:33 | call to m5 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:450:1:450:4 | call to exit | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:450:1:450:4 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:451:1:451:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:451:1:469:3 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:451:27:451:31 | Class | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:451:27:469:3 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:451:37:469:3 | do ... end | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:452:5:452:11 | Array | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:452:5:452:11 | [...] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:452:5:452:11 | call to [] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:452:5:456:7 | call to each | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:452:6:452:6 | 0 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:452:8:452:8 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:452:10:452:10 | 2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:452:18:456:7 | do ... end | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:453:9:455:11 | foo | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:454:13:454:22 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:454:13:454:22 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:454:18:454:22 | "foo" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:454:19:454:21 | foo | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:458:5:458:9 | Class | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:458:5:462:7 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:458:5:462:11 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:458:5:462:15 | call to bar | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:458:15:462:7 | do ... end | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:459:9:461:11 | bar | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:460:13:460:22 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:460:13:460:22 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:460:18:460:22 | "bar" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:460:19:460:21 | bar | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:5:464:11 | Array | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:5:464:11 | [...] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:5:464:11 | call to [] | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:5:468:7 | call to each | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:6:464:6 | 0 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:8:464:8 | 1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:10:464:10 | 2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:18:468:7 | do ... end | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:22:464:22 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:464:22:464:22 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:465:9:467:11 | call to define_method | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:465:9:467:11 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:465:23:465:32 | "baz_#{...}" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:465:24:465:27 | baz_ | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:465:28:465:31 | #{...} | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:465:30:465:30 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:465:35:467:11 | do ... end | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:466:13:466:27 | call to puts | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:466:13:466:27 | self | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:466:18:466:27 | "baz_#{...}" | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:466:19:466:22 | baz_ | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:466:23:466:26 | #{...} | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:466:25:466:25 | i | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:471:1:471:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:471:1:471:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:471:1:471:31 | call to foo | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:472:1:472:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:472:1:472:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:472:1:472:31 | call to bar | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:473:1:473:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:473:1:473:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:473:1:473:33 | call to baz_0 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:474:1:474:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:474:1:474:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:474:1:474:33 | call to baz_1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:475:1:475:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:475:1:475:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:475:1:475:33 | call to baz_2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:477:1:483:3 | ExtendSingletonMethod | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:478:5:480:7 | singleton | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:479:9:479:46 | call to puts | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:479:9:479:46 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:479:14:479:46 | "ExtendSingletonMethod#singleton" | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:479:15:479:45 | ExtendSingletonMethod#singleton | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:482:5:482:15 | call to extend | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:482:5:482:15 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:482:12:482:15 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:485:1:485:21 | ExtendSingletonMethod | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:485:1:485:31 | call to singleton | calls.rb:1:1:485:62 | calls.rb |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:22:3 | hello.rb |
 | hello.rb:2:5:4:7 | hello | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:3:9:3:22 | return | hello.rb:1:1:8:3 | EnglishWords |

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -1,7 +1,7 @@
-#-----| BasicObject
-
 #-----| Class
 #-----|  -> Module
+
+#-----| BasicObject
 
 #-----| Complex
 #-----|  -> Numeric
@@ -87,6 +87,11 @@ calls.rb:
 
 #  399| SingletonOverride2
 #-----|  -> SingletonOverride1
+
+#  414| ConditionalInstanceMethods
+#-----|  -> Object
+
+#  477| ExtendSingletonMethod
 
 hello.rb:
 #    1| EnglishWords


### PR DESCRIPTION
This PR documents some (corner) cases that our call graph construction currently doesn't handle.