### PR TITLE
Java: Improve performance of StaticInitializationVector.

### DIFF
--- a/java/ql/lib/semmle/code/java/security/StaticInitializationVectorQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/StaticInitializationVectorQuery.qll
@@ -2,7 +2,7 @@
 
 import java
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.TaintTracking2
+import semmle.code.java.dataflow.DataFlow2
 
 /**
  * Holds if `array` is initialized only with constants.
@@ -83,7 +83,7 @@ private class ArrayUpdate extends Expr {
 /**
  * A config that tracks dataflow from creating an array to an operation that updates it.
  */
-private class ArrayUpdateConfig extends TaintTracking2::Configuration {
+private class ArrayUpdateConfig extends DataFlow2::Configuration {
   ArrayUpdateConfig() { this = "ArrayUpdateConfig" }
 
   override predicate isSource(DataFlow::Node source) {
@@ -91,6 +91,8 @@ private class ArrayUpdateConfig extends TaintTracking2::Configuration {
   }
 
   override predicate isSink(DataFlow::Node sink) { sink.asExpr() = any(ArrayUpdate upd).getArray() }
+
+  override predicate isBarrierOut(DataFlow::Node node) { this.isSink(node) }
 }
 
 /**


### PR DESCRIPTION
As the comment suggests, it looks like `ArrayUpdateConfig` was meant to be value flow rather than taint flow, and this makes a big performance difference. Also, since we don't car about specific sinks, we might as well add an out-barrier on sinks for a little bit of added performance.