### PR TITLE
Swift: fix regression.

### DIFF
--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -155,7 +155,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
           or
           // `String.index`
           funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
-          paramName = "n"
+          paramName = ["n", "distance"]
           or
           // `String.formIndex`
           funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.expected
@@ -2,6 +2,7 @@ edges
 | StringLengthConflation2.swift:35:36:35:38 | .count :  | StringLengthConflation2.swift:35:36:35:46 | ... .-(_:_:) ... |
 | StringLengthConflation2.swift:37:34:37:36 | .count :  | StringLengthConflation2.swift:37:34:37:44 | ... .-(_:_:) ... |
 | StringLengthConflation.swift:36:30:36:37 | len :  | StringLengthConflation.swift:36:93:36:93 | len |
+| StringLengthConflation.swift:60:47:60:50 | .length :  | StringLengthConflation.swift:60:47:60:59 | ... ./(_:_:) ... |
 | StringLengthConflation.swift:66:33:66:36 | .length :  | StringLengthConflation.swift:66:33:66:45 | ... ./(_:_:) ... |
 | StringLengthConflation.swift:72:33:72:35 | .count :  | StringLengthConflation.swift:36:30:36:37 | len :  |
 | StringLengthConflation.swift:96:28:96:31 | .length :  | StringLengthConflation.swift:96:28:96:40 | ... .-(_:_:) ... |
@@ -18,6 +19,7 @@ edges
 | StringLengthConflation.swift:138:36:138:38 | .count :  | StringLengthConflation.swift:138:36:138:46 | ... .-(_:_:) ... |
 | StringLengthConflation.swift:144:28:144:30 | .count :  | StringLengthConflation.swift:144:28:144:38 | ... .-(_:_:) ... |
 | file://:0:0:0:0 | .length :  | StringLengthConflation.swift:53:43:53:46 | .length |
+| file://:0:0:0:0 | .length :  | StringLengthConflation.swift:60:47:60:50 | .length :  |
 | file://:0:0:0:0 | .length :  | StringLengthConflation.swift:66:33:66:36 | .length :  |
 | file://:0:0:0:0 | .length :  | StringLengthConflation.swift:96:28:96:31 | .length :  |
 | file://:0:0:0:0 | .length :  | StringLengthConflation.swift:100:27:100:30 | .length :  |
@@ -36,6 +38,8 @@ nodes
 | StringLengthConflation.swift:54:43:54:50 | .count | semmle.label | .count |
 | StringLengthConflation.swift:55:43:55:51 | .count | semmle.label | .count |
 | StringLengthConflation.swift:56:43:56:60 | .count | semmle.label | .count |
+| StringLengthConflation.swift:60:47:60:50 | .length :  | semmle.label | .length :  |
+| StringLengthConflation.swift:60:47:60:59 | ... ./(_:_:) ... | semmle.label | ... ./(_:_:) ... |
 | StringLengthConflation.swift:66:33:66:36 | .length :  | semmle.label | .length :  |
 | StringLengthConflation.swift:66:33:66:45 | ... ./(_:_:) ... | semmle.label | ... ./(_:_:) ... |
 | StringLengthConflation.swift:72:33:72:35 | .count | semmle.label | .count |
@@ -80,6 +84,8 @@ subpaths
 | StringLengthConflation.swift:54:43:54:50 | .count | StringLengthConflation.swift:54:43:54:50 | .count | StringLengthConflation.swift:54:43:54:50 | .count | This String.utf8 length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:55:43:55:51 | .count | StringLengthConflation.swift:55:43:55:51 | .count | StringLengthConflation.swift:55:43:55:51 | .count | This String.utf16 length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:56:43:56:60 | .count | StringLengthConflation.swift:56:43:56:60 | .count | StringLengthConflation.swift:56:43:56:60 | .count | This String.unicodeScalars length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:60:47:60:59 | ... ./(_:_:) ... | StringLengthConflation.swift:60:47:60:50 | .length :  | StringLengthConflation.swift:60:47:60:59 | ... ./(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
+| StringLengthConflation.swift:60:47:60:59 | ... ./(_:_:) ... | file://:0:0:0:0 | .length :  | StringLengthConflation.swift:60:47:60:59 | ... ./(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:66:33:66:45 | ... ./(_:_:) ... | StringLengthConflation.swift:66:33:66:36 | .length :  | StringLengthConflation.swift:66:33:66:45 | ... ./(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:66:33:66:45 | ... ./(_:_:) ... | file://:0:0:0:0 | .length :  | StringLengthConflation.swift:66:33:66:45 | ... ./(_:_:) ... | This NSString length is used in a String, but it may not be equivalent. |
 | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | StringLengthConflation.swift:72:33:72:35 | .count | This String length is used in an NSString, but it may not be equivalent. |

--- a/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
+++ b/swift/ql/test/query-tests/Security/CWE-135/StringLengthConflation.swift
@@ -42,7 +42,7 @@ func NSMakeRange(_ loc: Int, _ len: Int) -> NSRange { return NSRange(location: l
 func test(s: String) {
     let ns = NSString(string: s)
     let nms = NSMutableString(string: s)
- 
+
     print("'\(s)'")
     print("count \(s.count) length \(ns.length)")
     print("utf8.count \(s.utf8.count) utf16.count \(s.utf16.count) unicodeScalars.count \(s.unicodeScalars.count)")
@@ -57,7 +57,7 @@ func test(s: String) {
     print("String.Index '\(ix1.encodedOffset)' / '\(ix2.encodedOffset)' '\(ix3.encodedOffset)' '\(ix4.encodedOffset)' '\(ix5.encodedOffset)'")
 
     let ix6 = s.index(s.startIndex, offsetBy: s.count / 2) // GOOD
-    let ix7 = s.index(s.startIndex, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index [NOT DETECTED]
+    let ix7 = s.index(s.startIndex, offsetBy: ns.length / 2) // BAD: NSString length used in String.Index
     print("index '\(ix6.encodedOffset)' / '\(ix7.encodedOffset)'")
 
     var ix8 = s.startIndex


### PR DESCRIPTION
Fix the recent regression in `swift/string-length-conflation`.  It appears to have been caused by the 2nd parameter of `index(_:offsetBy:)` being renamed from `n` to `distance`.  *Hopefully* this kind of thing won't be too common, or we might have to change our strategy a little.