### PR TITLE
C++: Add FP for `CWE-193`

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -677,6 +677,13 @@ edges
 | test.cpp:213:6:213:6 | Load | test.cpp:213:5:213:6 | * ... |
 | test.cpp:213:6:213:6 | Load | test.cpp:213:5:213:13 | Store: ... = ... |
 | test.cpp:213:6:213:6 | Load | test.cpp:213:5:213:13 | Store: ... = ... |
+| test.cpp:221:17:221:22 | call to malloc | test.cpp:222:5:222:5 | Load |
+| test.cpp:222:5:222:5 | Load | test.cpp:222:5:222:12 | access to array |
+| test.cpp:222:5:222:5 | Load | test.cpp:222:5:222:12 | access to array |
+| test.cpp:222:5:222:5 | Load | test.cpp:222:5:222:12 | access to array |
+| test.cpp:222:5:222:5 | Load | test.cpp:222:5:222:12 | access to array |
+| test.cpp:222:5:222:12 | access to array | test.cpp:222:5:222:18 | Store: ... = ... |
+| test.cpp:222:5:222:12 | access to array | test.cpp:222:5:222:18 | Store: ... = ... |
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
 | test.cpp:8:14:8:21 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -695,3 +702,4 @@ edges
 | test.cpp:171:9:171:14 | Store: ... = ... | test.cpp:143:18:143:23 | call to malloc | test.cpp:171:9:171:14 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:143:18:143:23 | call to malloc | call to malloc | test.cpp:144:29:144:32 | size | size |
 | test.cpp:201:5:201:19 | Store: ... = ... | test.cpp:194:23:194:28 | call to malloc | test.cpp:201:5:201:19 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:194:23:194:28 | call to malloc | call to malloc | test.cpp:195:21:195:23 | len | len |
 | test.cpp:213:5:213:13 | Store: ... = ... | test.cpp:205:23:205:28 | call to malloc | test.cpp:213:5:213:13 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:205:23:205:28 | call to malloc | call to malloc | test.cpp:206:21:206:23 | len | len |
+| test.cpp:222:5:222:18 | Store: ... = ... | test.cpp:221:17:221:22 | call to malloc | test.cpp:222:5:222:18 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:221:17:221:22 | call to malloc | call to malloc | test.cpp:222:7:222:11 | ... - ... | ... - ... |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -212,3 +212,13 @@ void test13(unsigned len, unsigned index) {
     
     *q = '\0'; // BAD
 }
+
+bool unknown();
+
+void test14(unsigned long n, char *p) {
+  while (unknown()) {
+    n++;
+    p = (char *)malloc(n);
+    p[n - 1] = 'a'; // GOOD [FALSE POSITIVE]
+  }
+}


### PR DESCRIPTION
This PR adds testcase with an FP that appears quite common on some codebases for the new `cpp/invalid-pointer-deref` query.