### PR TITLE
C: deprecate/delete some unused code 

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/commons/Strcat.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Strcat.qll
@@ -6,7 +6,7 @@ import cpp
  * A function that concatenates the string from its second argument
  * to the string from its first argument, for example `strcat`.
  */
-class StrcatFunction extends Function {
+deprecated class StrcatFunction extends Function {
   StrcatFunction() {
     getName() =
       [

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -267,9 +267,6 @@ Instruction getSourceAddressFromNode(Node node) {
   result = getSourceAddress(node.asOperand().(SideEffectOperand).getUse())
 }
 
-/** Gets the source value of `instr` if it's an instruction that behaves like a `LoadInstruction`. */
-Instruction getSourceValue(Instruction instr) { result = getSourceValueOperand(instr).getDef() }
-
 /**
  * Gets the operand that represents the source value of `instr` if it's an instruction
  * that behaves like a `LoadInstruction`.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -143,16 +143,6 @@ private module Cached {
     )
   }
 
-  cached
-  Instruction getRegisterOperandDefinition(Instruction instruction, RegisterOperandTag tag) {
-    exists(OldInstruction oldInstruction, OldIR::RegisterOperand oldOperand |
-      oldInstruction = getOldInstruction(instruction) and
-      oldOperand = oldInstruction.getAnOperand() and
-      tag = oldOperand.getOperandTag() and
-      result = getNewInstruction(oldOperand.getAnyDef())
-    )
-  }
-
   pragma[noopt]
   private predicate hasMemoryOperandDefinition(
     OldInstruction oldInstruction, OldIR::NonPhiMemoryOperand oldOperand, Overlap overlap,

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -256,12 +256,6 @@ CppType getInstructionOperandType(Instruction instruction, TypedOperandTag tag) 
         .getInstructionMemoryOperandType(getInstructionTag(instruction), tag)
 }
 
-Instruction getPhiOperandDefinition(
-  PhiInstruction instruction, IRBlock predecessorBlock, Overlap overlap
-) {
-  none()
-}
-
 Instruction getPhiInstructionBlockStart(PhiInstruction instr) { none() }
 
 Instruction getInstructionSuccessor(Instruction instruction, EdgeKind kind) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -143,16 +143,6 @@ private module Cached {
     )
   }
 
-  cached
-  Instruction getRegisterOperandDefinition(Instruction instruction, RegisterOperandTag tag) {
-    exists(OldInstruction oldInstruction, OldIR::RegisterOperand oldOperand |
-      oldInstruction = getOldInstruction(instruction) and
-      oldOperand = oldInstruction.getAnOperand() and
-      tag = oldOperand.getOperandTag() and
-      result = getNewInstruction(oldOperand.getAnyDef())
-    )
-  }
-
   pragma[noopt]
   private predicate hasMemoryOperandDefinition(
     OldInstruction oldInstruction, OldIR::NonPhiMemoryOperand oldOperand, Overlap overlap,

--- a/cpp/ql/src/Best Practices/Magic Constants/MagicConstants.qll
+++ b/cpp/ql/src/Best Practices/Magic Constants/MagicConstants.qll
@@ -72,18 +72,6 @@ predicate floatTrivial(Literal lit) {
 
 predicate charLiteral(Literal lit) { lit instanceof CharLiteral }
 
-Type literalType(Literal literal) { result = literal.getType() }
-
-predicate stringType(DerivedType t) {
-  t.getBaseType() instanceof CharType
-  or
-  exists(SpecifiedType constCharType |
-    t.getBaseType() = constCharType and
-    constCharType.isConst() and
-    constCharType.getBaseType() instanceof CharType
-  )
-}
-
 predicate numberType(Type t) { t instanceof FloatingPointType or t instanceof IntegralType }
 
 predicate stringLiteral(Literal literal) { literal instanceof StringLiteral }

--- a/cpp/ql/src/Security/CWE/CWE-457/UninitializedVariables.qll
+++ b/cpp/ql/src/Security/CWE/CWE-457/UninitializedVariables.qll
@@ -10,12 +10,6 @@ private predicate reaches(ControlFlowNode a, ControlFlowNode b) = fastTC(success
 
 private predicate successor(ControlFlowNode a, ControlFlowNode b) { b = a.getASuccessor() }
 
-class WhitelistedCallsConfig extends string {
-  WhitelistedCallsConfig() { this = "config" }
-
-  abstract predicate isWhitelisted(Call c);
-}
-
 abstract class WhitelistedCall extends Call {
   override Function getTarget() { none() }
 }

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -143,16 +143,6 @@ private module Cached {
     )
   }
 
-  cached
-  Instruction getRegisterOperandDefinition(Instruction instruction, RegisterOperandTag tag) {
-    exists(OldInstruction oldInstruction, OldIR::RegisterOperand oldOperand |
-      oldInstruction = getOldInstruction(instruction) and
-      oldOperand = oldInstruction.getAnOperand() and
-      tag = oldOperand.getOperandTag() and
-      result = getNewInstruction(oldOperand.getAnyDef())
-    )
-  }
-
   pragma[noopt]
   private predicate hasMemoryOperandDefinition(
     OldInstruction oldInstruction, OldIR::NonPhiMemoryOperand oldOperand, Overlap overlap,


### PR DESCRIPTION
I'm looking through some of the results of this yet-to-be-merged QL-for-QL query: https://github.com/github/codeql/pull/8454.  

The code I've deleted/deprecated are not used by any query (including test queries).  

You got plenty of unused code in public libraries (for completeness I assume). I haven't touched those.  

C# is included because of a shared SSA file.  