### PR TITLE
Java: Rename column name to 'info' for Telemetry queries.

### DIFF
--- a/csharp/ql/src/utils/model-generator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/csharp/ql/src/utils/model-generator/internal/CaptureTypeBasedSummaryModels.qll
@@ -188,7 +188,7 @@ class TypeBasedFlowTargetApi extends Specific::TargetApiSpecific {
    * Gets the string representation of all type based summaries for `this`
    * inspired by the Theorems for Free approach.
    *
-   * Examples could be (see C# psuedo code below)
+   * Examples could be (see C# pseudo code below):
    * (1) `Get` returns a value of type `T`. We assume that the returned
    *     value was fetched from a (synthetic) field.
    * (2) `Set` consumes a value of type `T`. We assume that the value is stored in

--- a/java/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/java/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -33,4 +33,4 @@ where
   jarname = api.jarContainer() and
   getRelevantUsages(jarname, usages) and
   getOrder(jarname) <= resultLimit()
-select jarname, usages order by usages desc
+select jarname as info, usages order by usages desc

--- a/java/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -21,4 +21,4 @@ private predicate getRelevantUsages(ExternalApi api, int usages) {
 
 from ExternalApi api, int usages
 where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getApiName() as apiname, usages order by usages desc
+select api.getApiName() as info, usages order by usages desc

--- a/java/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSources.ql
@@ -21,4 +21,4 @@ private predicate getRelevantUsages(ExternalApi api, int usages) {
 
 from ExternalApi api, int usages
 where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getApiName() as apiname, usages order by usages desc
+select api.getApiName() as info, usages order by usages desc

--- a/java/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/java/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -21,4 +21,4 @@ private predicate getRelevantUsages(ExternalApi api, int usages) {
 
 from ExternalApi api, int usages
 where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getApiName() as apiname, usages order by usages desc
+select api.getApiName() as info, usages order by usages desc

--- a/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -24,4 +24,4 @@ private predicate getRelevantUsages(ExternalApi api, int usages) {
 
 from ExternalApi api, int usages
 where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getApiName() as apiname, usages order by usages desc
+select api.getApiName() as info, usages order by usages desc


### PR DESCRIPTION
The change is to align the naming in Java and C#.