### PR TITLE
C#: deprecate/delete some unused code

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/CallableReturns.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/CallableReturns.qll
@@ -31,29 +31,3 @@ predicate alwaysNotNullCallable(Callable c) {
     forex(Expr e | c.canReturn(e) | e instanceof NonNullExpr)
   )
 }
-
-/** Holds if callable 'c' always throws an exception. */
-predicate alwaysThrowsCallable(Callable c) {
-  finalCallable(c) and
-  (
-    forex(ControlFlow::Node pre | pre = c.getExitPoint().getAPredecessor() |
-      pre.getElement() instanceof ThrowElement
-    )
-    or
-    exists(CIL::Method m | m.matchesHandle(c) | CR::alwaysThrowsMethod(m))
-  )
-}
-
-/** Holds if callable `c` always throws exception `ex`. */
-predicate alwaysThrowsException(Callable c, Class ex) {
-  finalCallable(c) and
-  (
-    forex(ControlFlow::Node pre | pre = c.getExitPoint().getAPredecessor() |
-      pre.getElement().(ThrowElement).getThrownExceptionType() = ex
-    )
-    or
-    exists(CIL::Method m, CIL::Type t | m.matchesHandle(c) |
-      CR::alwaysThrowsException(m, t) and t.matchesHandle(ex)
-    )
-  )
-}

--- a/csharp/ql/lib/semmle/code/csharp/security/cryptography/EncryptionKeyDataFlowQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/cryptography/EncryptionKeyDataFlowQuery.qll
@@ -6,7 +6,7 @@ import csharp
 private import semmle.code.csharp.frameworks.system.security.cryptography.SymmetricAlgorithm
 
 /** Array of type Byte */
-class ByteArray extends ArrayType {
+deprecated class ByteArray extends ArrayType {
   ByteArray() { getElementType() instanceof ByteType }
 }
 


### PR DESCRIPTION
I'm looking through some of the results of this yet-to-be-merged QL-for-QL query: https://github.com/github/codeql/pull/8454.  

The code I've deleted/deprecated is not used by any query (including test queries).  

You got plenty of unused code in public libraries (for completeness I assume). I haven't touched those.  