### PR TITLE
C#: Postupdate notes for ternary expressions.

### DIFF
--- a/csharp/ql/consistency-queries/DataFlowConsistency.ql
+++ b/csharp/ql/consistency-queries/DataFlowConsistency.ql
@@ -35,7 +35,7 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
   override predicate argHasPostUpdateExclude(ArgumentNode n) {
     n instanceof SummaryNode
     or
-    not exists(LocalFlow::getAPostUpdateNodeForArg(n.asExpr()))
+    not exists(LocalFlow::getAPostUpdateNodeForArg(n.getControlFlowNode()))
     or
     n instanceof ImplicitCapturedArgumentNode
     or
@@ -46,7 +46,7 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
 
   override predicate postHasUniquePreExclude(PostUpdateNode n) {
     exists(ControlFlow::Nodes::ExprNode e, ControlFlow::Nodes::ExprNode arg |
-      e = LocalFlow::getAPostUpdateNodeForArg(arg.getExpr()) and
+      e = LocalFlow::getAPostUpdateNodeForArg(arg) and
       e != arg and
       n = TExprPostUpdateNode(e)
     )
@@ -54,7 +54,7 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
 
   override predicate uniquePostUpdateExclude(Node n) {
     exists(ControlFlow::Nodes::ExprNode e, ControlFlow::Nodes::ExprNode arg |
-      e = LocalFlow::getAPostUpdateNodeForArg(arg.getExpr()) and
+      e = LocalFlow::getAPostUpdateNodeForArg(arg) and
       e != arg and
       n.asExpr() = arg.getExpr()
     )

--- a/csharp/ql/consistency-queries/DataFlowConsistency.ql
+++ b/csharp/ql/consistency-queries/DataFlowConsistency.ql
@@ -35,19 +35,29 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
   override predicate argHasPostUpdateExclude(ArgumentNode n) {
     n instanceof SummaryNode
     or
-    n.asExpr().(Expr).stripCasts().getType() =
-      any(Type t |
-        not t instanceof RefType and
-        not t = any(TypeParameter tp | not tp.isValueType())
-        or
-        t instanceof NullType
-      )
+    not exists(getAPostUpdateNodeForArg(n.asExpr()))
     or
     n instanceof ImplicitCapturedArgumentNode
     or
     n instanceof ParamsArgumentNode
     or
     n.asExpr() instanceof CIL::Expr
+  }
+
+  override predicate postHasUniquePreExclude(PostUpdateNode n) {
+    exists(ControlFlow::Nodes::ExprNode e, ControlFlow::Nodes::ExprNode arg |
+      e = getAPostUpdateNodeForArg(arg.getExpr()) and
+      e != arg and
+      n = TExprPostUpdateNode(e)
+    )
+  }
+
+  override predicate uniquePostUpdateExclude(Node n) {
+    exists(ControlFlow::Nodes::ExprNode e, ControlFlow::Nodes::ExprNode arg |
+      e = getAPostUpdateNodeForArg(arg.getExpr()) and
+      e != arg and
+      n.asExpr() = arg.getExpr()
+    )
   }
 
   override predicate reverseReadExclude(Node n) { n.asExpr() = any(AwaitExpr ae).getExpr() }

--- a/csharp/ql/consistency-queries/DataFlowConsistency.ql
+++ b/csharp/ql/consistency-queries/DataFlowConsistency.ql
@@ -35,7 +35,7 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
   override predicate argHasPostUpdateExclude(ArgumentNode n) {
     n instanceof SummaryNode
     or
-    not exists(getAPostUpdateNodeForArg(n.asExpr()))
+    not exists(LocalFlow::getAPostUpdateNodeForArg(n.asExpr()))
     or
     n instanceof ImplicitCapturedArgumentNode
     or
@@ -46,7 +46,7 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
 
   override predicate postHasUniquePreExclude(PostUpdateNode n) {
     exists(ControlFlow::Nodes::ExprNode e, ControlFlow::Nodes::ExprNode arg |
-      e = getAPostUpdateNodeForArg(arg.getExpr()) and
+      e = LocalFlow::getAPostUpdateNodeForArg(arg.getExpr()) and
       e != arg and
       n = TExprPostUpdateNode(e)
     )
@@ -54,7 +54,7 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
 
   override predicate uniquePostUpdateExclude(Node n) {
     exists(ControlFlow::Nodes::ExprNode e, ControlFlow::Nodes::ExprNode arg |
-      e = getAPostUpdateNodeForArg(arg.getExpr()) and
+      e = LocalFlow::getAPostUpdateNodeForArg(arg.getExpr()) and
       e != arg and
       n.asExpr() = arg.getExpr()
     )

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -419,7 +419,8 @@ module LocalFlow {
     exists(Expr e | any(LocalExprStepConfiguration x).hasExprPath(_, result, e, cfn) |
       e instanceof ConditionalExpr or
       e instanceof Cast or
-      e instanceof NullCoalescingExpr
+      e instanceof NullCoalescingExpr or
+      e instanceof SwitchExpr
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -420,8 +420,9 @@ module LocalFlow {
   }
 
   /** Gets a node for which to construct a post-update node for argument `arg`. */
-  ControlFlow::Nodes::ExprNode getAPostUpdateNodeForArg(Argument arg) {
-    result = getALastEvalNode*(arg.getAControlFlowNode()) and
+  ControlFlow::Nodes::ExprNode getAPostUpdateNodeForArg(ControlFlow::Nodes::ExprNode arg) {
+    arg.getExpr() instanceof Argument and
+    result = getALastEvalNode*(arg) and
     exists(Expr e | result.getExpr() = e |
       exists(Type t | t = e.stripCasts().getType() |
         t instanceof RefType and
@@ -1946,7 +1947,7 @@ private module PostUpdateNodes {
       //
       // This ensures that we get flow out of the call into both leafs (1), while still
       // maintaining the invariant that the underlying expression is a pre-update node (2).
-      cfn = LocalFlow::getAPostUpdateNodeForArg(result.asExpr())
+      cfn = LocalFlow::getAPostUpdateNodeForArg(result.getControlFlowNode())
       or
       cfn = result.getControlFlowNode()
     }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -421,7 +421,8 @@ module LocalFlow {
       e instanceof Cast or
       e instanceof NullCoalescingExpr or
       e instanceof SwitchExpr or
-      e instanceof SuppressNullableWarningExpr
+      e instanceof SuppressNullableWarningExpr or
+      e instanceof AssignExpr
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -418,7 +418,8 @@ module LocalFlow {
   private ControlFlow::Nodes::ExprNode getALastEvalNode(ControlFlow::Nodes::ExprNode cfn) {
     exists(Expr e | any(LocalExprStepConfiguration x).hasExprPath(_, result, e, cfn) |
       e instanceof ConditionalExpr or
-      e instanceof Cast
+      e instanceof Cast or
+      e instanceof NullCoalescingExpr
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -416,7 +416,10 @@ module LocalFlow {
    * will be the value of `n`.
    */
   private ControlFlow::Nodes::ExprNode getALastEvalNode(ControlFlow::Nodes::ExprNode cfn) {
-    any(LocalExprStepConfiguration x).hasExprPath(_, result, any(ConditionalExpr ce), cfn)
+    exists(Expr e | any(LocalExprStepConfiguration x).hasExprPath(_, result, e, cfn) |
+      e instanceof ConditionalExpr or
+      e instanceof Cast
+    )
   }
 
   /** Gets a node for which to construct a post-update node for argument `arg`. */

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -420,7 +420,8 @@ module LocalFlow {
       e instanceof ConditionalExpr or
       e instanceof Cast or
       e instanceof NullCoalescingExpr or
-      e instanceof SwitchExpr
+      e instanceof SwitchExpr or
+      e instanceof SuppressNullableWarningExpr
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -197,7 +197,7 @@ private predicate relevantArgumentType(ControlFlow::Nodes::ExprNode cfn) {
 }
 
 /** Gets a node for which to construct a post-update node for argument `arg`. */
-private ControlFlow::Nodes::ExprNode getAPostUpdateNodeForArg(Argument arg) {
+ControlFlow::Nodes::ExprNode getAPostUpdateNodeForArg(Argument arg) {
   result = getALastEvalNode*(arg.getAControlFlowNode()) and
   relevantArgumentType(result) and
   not exists(getALastEvalNode(result))

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -423,13 +423,11 @@ module LocalFlow {
   ControlFlow::Nodes::ExprNode getAPostUpdateNodeForArg(ControlFlow::Nodes::ExprNode arg) {
     arg.getExpr() instanceof Argument and
     result = getALastEvalNode*(arg) and
-    exists(Expr e | result.getExpr() = e |
-      exists(Type t | t = e.stripCasts().getType() |
-        t instanceof RefType and
-        not t instanceof NullType
-        or
-        t = any(TypeParameter tp | not tp.isValueType())
-      )
+    exists(Expr e, Type t | result.getExpr() = e and t = e.stripCasts().getType() |
+      t instanceof RefType and
+      not t instanceof NullType
+      or
+      t = any(TypeParameter tp | not tp.isValueType())
     ) and
     not exists(getALastEvalNode(result))
   }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -177,6 +177,32 @@ predicate hasNodePath(ControlFlowReachabilityConfiguration conf, ExprNode n1, No
   )
 }
 
+/**
+ * Gets a node that may execute last in `n`, and which, when it executes last,
+ * will be the value of `n`.
+ */
+private ControlFlow::Nodes::ExprNode getALastEvalNode(ControlFlow::Nodes::ExprNode cfn) {
+  exists(ConditionalExpr e | cfn.getExpr() = e | result.getExpr() = [e.getThen(), e.getElse()])
+}
+
+private predicate relevantArgumentType(ControlFlow::Nodes::ExprNode cfn) {
+  exists(Expr e | cfn.getExpr() = e |
+    exists(Type t | t = e.stripCasts().getType() |
+      t instanceof RefType and
+      not t instanceof NullType
+      or
+      t = any(TypeParameter tp | not tp.isValueType())
+    )
+  )
+}
+
+/** Gets a node for which to construct a post-update node for argument `arg`. */
+private ControlFlow::Nodes::ExprNode getAPostUpdateNodeForArg(Argument arg) {
+  result = getALastEvalNode*(arg.getAControlFlowNode()) and
+  relevantArgumentType(result) and
+  not exists(getALastEvalNode(result))
+}
+
 /** Provides predicates related to local data flow. */
 module LocalFlow {
   private class LocalExprStepConfiguration extends ControlFlowReachabilityConfiguration {
@@ -719,14 +745,9 @@ private module Cached {
       cfn.getElement().(ObjectCreation).hasInitializer()
     } or
     TExprPostUpdateNode(ControlFlow::Nodes::ExprNode cfn) {
+      cfn = getAPostUpdateNodeForArg(_)
+      or
       exists(Expr e | e = cfn.getExpr() |
-        exists(Type t | t = e.(Argument).stripCasts().getType() |
-          t instanceof RefType and
-          not t instanceof NullType
-          or
-          t = any(TypeParameter tp | not tp.isValueType())
-        )
-        or
         fieldOrPropertyStore(_, _, _, e, true)
         or
         arrayStore(_, _, e, true)
@@ -1921,7 +1942,18 @@ private module PostUpdateNodes {
 
     ExprPostUpdateNode() { this = TExprPostUpdateNode(cfn) }
 
-    override ExprNode getPreUpdateNode() { cfn = result.getControlFlowNode() }
+    override ExprNode getPreUpdateNode() {
+      // For compund arguments, such as `m(if b then x else y)`, we want the leaf nodes
+      // `[post] x` and `[post] y` to have two pre-update nodes: (1) the compund argument,
+      // `if b then x else y`; and the (2) the underlying expressions; `x` and `y`,
+      // respectively.
+      //
+      // This ensures that we get flow out of the call into both leafs (1), while still
+      // maintaining the invariant that the underlying expression is a pre-update node (2).
+      cfn = getAPostUpdateNodeForArg(result.asExpr())
+      or
+      cfn = result.getControlFlowNode()
+    }
 
     override DataFlowCallable getEnclosingCallableImpl() {
       result.asCallable() = cfn.getEnclosingCallable()

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -62,6 +62,7 @@
 | GlobalDataFlow.cs:546:15:546:21 | access to field field |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field |
 | GlobalDataFlow.cs:553:15:553:22 | access to field field |
+| GlobalDataFlow.cs:561:15:561:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -61,6 +61,7 @@
 | GlobalDataFlow.cs:545:15:545:21 | access to field field |
 | GlobalDataFlow.cs:546:15:546:21 | access to field field |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field |
+| GlobalDataFlow.cs:553:15:553:22 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -54,15 +54,18 @@
 | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 |
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field |
-| GlobalDataFlow.cs:514:15:514:22 | access to field field |
-| GlobalDataFlow.cs:523:15:523:21 | access to field field |
-| GlobalDataFlow.cs:530:15:530:21 | access to field field |
-| GlobalDataFlow.cs:531:15:531:21 | access to field field |
-| GlobalDataFlow.cs:545:15:545:21 | access to field field |
-| GlobalDataFlow.cs:546:15:546:21 | access to field field |
-| GlobalDataFlow.cs:547:15:547:21 | access to field field |
-| GlobalDataFlow.cs:553:15:553:22 | access to field field |
-| GlobalDataFlow.cs:561:15:561:21 | access to field field |
+| GlobalDataFlow.cs:509:15:509:22 | access to field field |
+| GlobalDataFlow.cs:515:15:515:22 | access to field field |
+| GlobalDataFlow.cs:516:15:516:22 | access to field field |
+| GlobalDataFlow.cs:517:15:517:22 | access to field field |
+| GlobalDataFlow.cs:526:15:526:21 | access to field field |
+| GlobalDataFlow.cs:533:15:533:21 | access to field field |
+| GlobalDataFlow.cs:534:15:534:21 | access to field field |
+| GlobalDataFlow.cs:548:15:548:21 | access to field field |
+| GlobalDataFlow.cs:549:15:549:21 | access to field field |
+| GlobalDataFlow.cs:550:15:550:21 | access to field field |
+| GlobalDataFlow.cs:556:15:556:22 | access to field field |
+| GlobalDataFlow.cs:564:15:564:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -55,6 +55,7 @@
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field |
+| GlobalDataFlow.cs:523:15:523:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -56,6 +56,8 @@
 | GlobalDataFlow.cs:508:15:508:22 | access to field field |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field |
 | GlobalDataFlow.cs:523:15:523:21 | access to field field |
+| GlobalDataFlow.cs:530:15:530:21 | access to field field |
+| GlobalDataFlow.cs:531:15:531:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -53,6 +53,8 @@
 | GlobalDataFlow.cs:427:41:427:46 | access to local variable sink20 |
 | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 |
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
+| GlobalDataFlow.cs:508:15:508:22 | access to field field |
+| GlobalDataFlow.cs:514:15:514:22 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -58,6 +58,9 @@
 | GlobalDataFlow.cs:523:15:523:21 | access to field field |
 | GlobalDataFlow.cs:530:15:530:21 | access to field field |
 | GlobalDataFlow.cs:531:15:531:21 | access to field field |
+| GlobalDataFlow.cs:545:15:545:21 | access to field field |
+| GlobalDataFlow.cs:546:15:546:21 | access to field field |
+| GlobalDataFlow.cs:547:15:547:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:553:71:553:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:559:71:559:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -270,6 +270,7 @@ edges
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
@@ -287,11 +288,13 @@ edges
 | GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:21 | access to field field |
 | GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:21 | access to field field |
 | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:21 | access to field field |
-| GlobalDataFlow.cs:553:71:553:71 | e [element] : String | GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String |
-| GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String | GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
+| GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:22 | access to field field |
+| GlobalDataFlow.cs:559:71:559:71 | e [element] : String | GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String | GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String |
+| GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String | GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -573,11 +576,14 @@ nodes
 | GlobalDataFlow.cs:546:15:546:21 | access to field field | semmle.label | access to field field |
 | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | semmle.label | access to local variable z [field field] : String |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:553:71:553:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:558:44:558:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | semmle.label | access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:553:15:553:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:559:71:559:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:564:44:564:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -615,7 +621,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:553:71:553:71 | e [element] : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:559:71:559:71 | e [element] : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -623,7 +629,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
-| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
+| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -644,6 +650,7 @@ subpaths
 | GlobalDataFlow.cs:545:15:545:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:545:15:545:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:546:15:546:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:546:15:546:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:547:15:547:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:553:15:553:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:553:15:553:22 | access to field field | access to field field |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:537:71:537:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:553:71:553:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -267,6 +267,9 @@ edges
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
@@ -278,11 +281,17 @@ edges
 | GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String |
 | GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:21 | access to field field |
 | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:21 | access to field field |
-| GlobalDataFlow.cs:537:71:537:71 | e [element] : String | GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String | GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String |
-| GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String | GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String |
+| GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String |
+| GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:21 | access to field field |
+| GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:21 | access to field field |
+| GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:21 | access to field field |
+| GlobalDataFlow.cs:553:71:553:71 | e [element] : String | GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String |
+| GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String | GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -555,11 +564,20 @@ nodes
 | GlobalDataFlow.cs:530:15:530:21 | access to field field | semmle.label | access to field field |
 | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
 | GlobalDataFlow.cs:531:15:531:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:537:71:537:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:542:44:542:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String | semmle.label | [post] access to local variable z [field field] : String |
+| GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:545:15:545:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:546:15:546:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | semmle.label | access to local variable z [field field] : String |
+| GlobalDataFlow.cs:547:15:547:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:553:71:553:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:558:44:558:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -597,7 +615,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:537:71:537:71 | e [element] : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:553:71:553:71 | e [element] : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -605,7 +623,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
-| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String |
+| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -623,6 +641,9 @@ subpaths
 | GlobalDataFlow.cs:523:15:523:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:523:15:523:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:530:15:530:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:530:15:530:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:531:15:531:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:531:15:531:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:545:15:545:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:545:15:545:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:546:15:546:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:546:15:546:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:547:15:547:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:547:15:547:21 | access to field field | access to field field |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:496:71:496:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:520:71:520:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -262,11 +262,11 @@ edges
 | GlobalDataFlow.cs:486:21:486:21 | s : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | GlobalDataFlow.cs:486:21:486:21 | s : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
-| GlobalDataFlow.cs:496:71:496:71 | e [element] : String | GlobalDataFlow.cs:499:27:499:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:499:22:499:22 | SSA def(x) : String | GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String |
-| GlobalDataFlow.cs:499:27:499:27 | access to parameter e [element] : String | GlobalDataFlow.cs:499:22:499:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String | GlobalDataFlow.cs:501:44:501:47 | delegate call : String |
+| GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String |
+| GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -522,11 +522,11 @@ nodes
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | semmle.label | access to parameter s |
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:496:71:496:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:499:22:499:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:499:27:499:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:501:44:501:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:520:71:520:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:525:44:525:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -564,7 +564,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:496:71:496:71 | e [element] : String | GlobalDataFlow.cs:501:44:501:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -572,7 +572,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
-| GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:501:44:501:47 | delegate call : String |
+| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:567:71:567:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:570:71:570:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -263,41 +263,50 @@ edges
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | GlobalDataFlow.cs:486:21:486:21 | s : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:30:507:31 | [post] access to local variable x2 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:514:31:514:32 | [post] access to local variable y1 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:514:36:514:37 | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:514:42:514:43 | [post] access to local variable y3 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:525:33:525:33 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:532:20:532:20 | [post] access to parameter x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:532:25:532:25 | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:544:20:544:20 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:545:20:545:20 | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:546:18:546:18 | [post] access to local variable z [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:555:20:555:21 | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:563:24:563:24 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:507:30:507:31 | [post] access to local variable x2 [field field] : String | GlobalDataFlow.cs:509:15:509:16 | access to local variable x2 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
-| GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String |
-| GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:22 | access to field field |
-| GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:21 | access to field field |
-| GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String |
-| GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String |
-| GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:21 | access to field field |
-| GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:21 | access to field field |
-| GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String |
-| GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String |
-| GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:21 | access to field field |
-| GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:21 | access to field field |
-| GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:21 | access to field field |
-| GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String |
-| GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:22 | access to field field |
-| GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:561:15:561:21 | access to field field |
-| GlobalDataFlow.cs:567:71:567:71 | e [element] : String | GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String | GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String |
-| GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String | GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String |
+| GlobalDataFlow.cs:509:15:509:16 | access to local variable x2 [field field] : String | GlobalDataFlow.cs:509:15:509:22 | access to field field |
+| GlobalDataFlow.cs:514:31:514:32 | [post] access to local variable y1 [field field] : String | GlobalDataFlow.cs:515:15:515:16 | access to local variable y1 [field field] : String |
+| GlobalDataFlow.cs:514:36:514:37 | [post] access to local variable y2 [field field] : String | GlobalDataFlow.cs:516:15:516:16 | access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:42:514:43 | [post] access to local variable y3 [field field] : String | GlobalDataFlow.cs:517:15:517:16 | access to local variable y3 [field field] : String |
+| GlobalDataFlow.cs:515:15:515:16 | access to local variable y1 [field field] : String | GlobalDataFlow.cs:515:15:515:22 | access to field field |
+| GlobalDataFlow.cs:516:15:516:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:516:15:516:22 | access to field field |
+| GlobalDataFlow.cs:517:15:517:16 | access to local variable y3 [field field] : String | GlobalDataFlow.cs:517:15:517:22 | access to field field |
+| GlobalDataFlow.cs:525:33:525:33 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:526:15:526:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:526:15:526:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:526:15:526:21 | access to field field |
+| GlobalDataFlow.cs:532:20:532:20 | [post] access to parameter x [field field] : String | GlobalDataFlow.cs:533:15:533:15 | access to parameter x [field field] : String |
+| GlobalDataFlow.cs:532:25:532:25 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:534:15:534:15 | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:533:15:533:15 | access to parameter x [field field] : String | GlobalDataFlow.cs:533:15:533:21 | access to field field |
+| GlobalDataFlow.cs:534:15:534:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:534:15:534:21 | access to field field |
+| GlobalDataFlow.cs:544:20:544:20 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:548:15:548:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:545:20:545:20 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:549:15:549:15 | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:546:18:546:18 | [post] access to local variable z [field field] : String | GlobalDataFlow.cs:550:15:550:15 | access to local variable z [field field] : String |
+| GlobalDataFlow.cs:548:15:548:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:548:15:548:21 | access to field field |
+| GlobalDataFlow.cs:549:15:549:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:549:15:549:21 | access to field field |
+| GlobalDataFlow.cs:550:15:550:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:550:15:550:21 | access to field field |
+| GlobalDataFlow.cs:555:20:555:21 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:556:15:556:16 | access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:556:15:556:16 | access to parameter sc [field field] : String | GlobalDataFlow.cs:556:15:556:22 | access to field field |
+| GlobalDataFlow.cs:563:24:563:24 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:564:15:564:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:564:15:564:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:564:15:564:21 | access to field field |
+| GlobalDataFlow.cs:570:71:570:71 | e [element] : String | GlobalDataFlow.cs:573:27:573:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:573:22:573:22 | SSA def(x) : String | GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String |
+| GlobalDataFlow.cs:573:27:573:27 | access to parameter e [element] : String | GlobalDataFlow.cs:573:22:573:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String | GlobalDataFlow.cs:575:44:575:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -556,40 +565,49 @@ nodes
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | semmle.label | [post] access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:507:30:507:31 | [post] access to local variable x2 [field field] : String | semmle.label | [post] access to local variable x2 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | semmle.label | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | semmle.label | [post] access to local variable y2 [field field] : String |
-| GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | semmle.label | access to local variable y2 [field field] : String |
-| GlobalDataFlow.cs:514:15:514:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:523:15:523:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String | semmle.label | [post] access to parameter x [field field] : String |
-| GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
-| GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | semmle.label | access to parameter x [field field] : String |
-| GlobalDataFlow.cs:530:15:530:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
-| GlobalDataFlow.cs:531:15:531:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
-| GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String | semmle.label | [post] access to local variable z [field field] : String |
-| GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:545:15:545:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
-| GlobalDataFlow.cs:546:15:546:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | semmle.label | access to local variable z [field field] : String |
-| GlobalDataFlow.cs:547:15:547:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
-| GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | semmle.label | access to parameter sc [field field] : String |
-| GlobalDataFlow.cs:553:15:553:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:561:15:561:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:567:71:567:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:572:44:572:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:509:15:509:16 | access to local variable x2 [field field] : String | semmle.label | access to local variable x2 [field field] : String |
+| GlobalDataFlow.cs:509:15:509:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:514:31:514:32 | [post] access to local variable y1 [field field] : String | semmle.label | [post] access to local variable y1 [field field] : String |
+| GlobalDataFlow.cs:514:36:514:37 | [post] access to local variable y2 [field field] : String | semmle.label | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:42:514:43 | [post] access to local variable y3 [field field] : String | semmle.label | [post] access to local variable y3 [field field] : String |
+| GlobalDataFlow.cs:515:15:515:16 | access to local variable y1 [field field] : String | semmle.label | access to local variable y1 [field field] : String |
+| GlobalDataFlow.cs:515:15:515:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:516:15:516:16 | access to local variable y2 [field field] : String | semmle.label | access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:516:15:516:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:517:15:517:16 | access to local variable y3 [field field] : String | semmle.label | access to local variable y3 [field field] : String |
+| GlobalDataFlow.cs:517:15:517:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:525:33:525:33 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:526:15:526:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:526:15:526:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:532:20:532:20 | [post] access to parameter x [field field] : String | semmle.label | [post] access to parameter x [field field] : String |
+| GlobalDataFlow.cs:532:25:532:25 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:533:15:533:15 | access to parameter x [field field] : String | semmle.label | access to parameter x [field field] : String |
+| GlobalDataFlow.cs:533:15:533:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:534:15:534:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:534:15:534:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:544:20:544:20 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:545:20:545:20 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:546:18:546:18 | [post] access to local variable z [field field] : String | semmle.label | [post] access to local variable z [field field] : String |
+| GlobalDataFlow.cs:548:15:548:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:548:15:548:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:549:15:549:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:549:15:549:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:550:15:550:15 | access to local variable z [field field] : String | semmle.label | access to local variable z [field field] : String |
+| GlobalDataFlow.cs:550:15:550:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:555:20:555:21 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:556:15:556:16 | access to parameter sc [field field] : String | semmle.label | access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:556:15:556:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:563:24:563:24 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:564:15:564:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:564:15:564:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:570:71:570:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:573:22:573:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:573:27:573:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:575:44:575:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -627,7 +645,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:567:71:567:71 | e [element] : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:570:71:570:71 | e [element] : String | GlobalDataFlow.cs:575:44:575:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -635,7 +653,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
-| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String |
+| GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:575:44:575:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -649,15 +667,18 @@ subpaths
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | access to field SinkField0 |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:508:15:508:22 | access to field field | access to field field |
-| GlobalDataFlow.cs:514:15:514:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:514:15:514:22 | access to field field | access to field field |
-| GlobalDataFlow.cs:523:15:523:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:523:15:523:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:530:15:530:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:530:15:530:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:531:15:531:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:531:15:531:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:545:15:545:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:545:15:545:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:546:15:546:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:546:15:546:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:547:15:547:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:547:15:547:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:553:15:553:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:553:15:553:22 | access to field field | access to field field |
-| GlobalDataFlow.cs:561:15:561:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:561:15:561:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:509:15:509:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:509:15:509:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:515:15:515:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:515:15:515:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:516:15:516:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:516:15:516:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:517:15:517:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:517:15:517:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:526:15:526:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:526:15:526:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:533:15:533:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:533:15:533:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:534:15:534:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:534:15:534:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:548:15:548:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:548:15:548:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:549:15:549:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:549:15:549:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:550:15:550:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:550:15:550:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:556:15:556:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:556:15:556:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:564:15:564:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:564:15:564:21 | access to field field | access to field field |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:520:71:520:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:529:71:529:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -264,16 +264,19 @@ edges
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
 | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String |
 | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:22 | access to field field |
-| GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String |
-| GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String |
+| GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:21 | access to field field |
+| GlobalDataFlow.cs:529:71:529:71 | e [element] : String | GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String | GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String |
+| GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String | GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -537,11 +540,14 @@ nodes
 | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | semmle.label | [post] access to local variable y2 [field field] : String |
 | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | semmle.label | access to local variable y2 [field field] : String |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:520:71:520:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:525:44:525:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:523:15:523:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:529:71:529:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:534:44:534:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -579,7 +585,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:529:71:529:71 | e [element] : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -587,7 +593,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
-| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String |
+| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -602,6 +608,7 @@ subpaths
 | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | access to field SinkField0 |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:508:15:508:22 | access to field field | access to field field |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:514:15:514:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:523:15:523:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:523:15:523:21 | access to field field | access to field field |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -262,6 +262,13 @@ edges
 | GlobalDataFlow.cs:486:21:486:21 | s : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | GlobalDataFlow.cs:486:21:486:21 | s : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
+| GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:22 | access to field field |
 | GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String |
 | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String |
 | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String |
@@ -522,6 +529,14 @@ nodes
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | semmle.label | access to parameter s |
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | semmle.label | [post] access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | semmle.label | access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:508:15:508:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | semmle.label | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | semmle.label | access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:15:514:22 | access to field field | semmle.label | access to field field |
 | GlobalDataFlow.cs:520:71:520:71 | e [element] : String | semmle.label | e [element] : String |
 | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
 | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
@@ -585,6 +600,8 @@ subpaths
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | access to field SinkField0 |
+| GlobalDataFlow.cs:508:15:508:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:508:15:508:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:514:15:514:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:514:15:514:22 | access to field field | access to field field |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:529:71:529:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:537:71:537:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -265,6 +265,8 @@ edges
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
@@ -272,11 +274,15 @@ edges
 | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:22 | access to field field |
 | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String |
 | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:21 | access to field field |
-| GlobalDataFlow.cs:529:71:529:71 | e [element] : String | GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String | GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String |
-| GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String | GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String |
+| GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String |
+| GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:21 | access to field field |
+| GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:21 | access to field field |
+| GlobalDataFlow.cs:537:71:537:71 | e [element] : String | GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String | GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String |
+| GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String | GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -543,11 +549,17 @@ nodes
 | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
 | GlobalDataFlow.cs:523:15:523:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:529:71:529:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:534:44:534:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String | semmle.label | [post] access to parameter x [field field] : String |
+| GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | semmle.label | access to parameter x [field field] : String |
+| GlobalDataFlow.cs:530:15:530:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:531:15:531:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:537:71:537:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:542:44:542:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -585,7 +597,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:529:71:529:71 | e [element] : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:537:71:537:71 | e [element] : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -593,7 +605,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
-| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String |
+| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -609,6 +621,8 @@ subpaths
 | GlobalDataFlow.cs:508:15:508:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:508:15:508:22 | access to field field | access to field field |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:514:15:514:22 | access to field field | access to field field |
 | GlobalDataFlow.cs:523:15:523:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:523:15:523:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:530:15:530:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:530:15:530:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:531:15:531:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:531:15:531:21 | access to field field | access to field field |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:559:71:559:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:567:71:567:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -271,6 +271,7 @@ edges
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
@@ -290,11 +291,13 @@ edges
 | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:21 | access to field field |
 | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:22 | access to field field |
-| GlobalDataFlow.cs:559:71:559:71 | e [element] : String | GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String | GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String |
-| GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String | GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String |
+| GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:561:15:561:21 | access to field field |
+| GlobalDataFlow.cs:567:71:567:71 | e [element] : String | GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String | GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String |
+| GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String | GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -579,11 +582,14 @@ nodes
 | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | semmle.label | access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:553:15:553:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:559:71:559:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:564:44:564:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:561:15:561:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:567:71:567:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:572:44:572:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -621,7 +627,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:559:71:559:71 | e [element] : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:567:71:567:71 | e [element] : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -629,7 +635,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
-| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String |
+| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -651,6 +657,7 @@ subpaths
 | GlobalDataFlow.cs:546:15:546:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:546:15:546:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:547:15:547:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:553:15:553:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:553:15:553:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:561:15:561:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:561:15:561:21 | access to field field | access to field field |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
 | Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -164,7 +164,8 @@
 | GlobalDataFlow.cs:511:18:511:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:511:18:511:34 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:521:17:521:36 | object creation of type SubSimpleClass | normal | GlobalDataFlow.cs:521:17:521:36 | object creation of type SubSimpleClass |
-| GlobalDataFlow.cs:534:44:534:47 | delegate call | normal | GlobalDataFlow.cs:534:44:534:47 | delegate call |
+| GlobalDataFlow.cs:528:17:528:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:528:17:528:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:542:44:542:47 | delegate call | normal | GlobalDataFlow.cs:542:44:542:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> |
 | Splitting.cs:20:22:20:30 | call to method Return<String> | normal | Splitting.cs:20:22:20:30 | call to method Return<String> |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -160,16 +160,16 @@
 | GlobalDataFlow.cs:477:22:477:40 | call to method GetResult | normal | GlobalDataFlow.cs:477:22:477:40 | call to method GetResult |
 | GlobalDataFlow.cs:505:18:505:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:505:18:505:34 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:506:18:506:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:506:18:506:34 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:510:18:510:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:510:18:510:34 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:511:18:511:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:511:18:511:34 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:521:17:521:36 | object creation of type SubSimpleClass | normal | GlobalDataFlow.cs:521:17:521:36 | object creation of type SubSimpleClass |
-| GlobalDataFlow.cs:528:17:528:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:528:17:528:33 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:536:17:536:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:536:17:536:33 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:537:17:537:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:537:17:537:33 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:538:17:538:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:538:17:538:33 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:559:17:559:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:559:17:559:33 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:572:44:572:47 | delegate call | normal | GlobalDataFlow.cs:572:44:572:47 | delegate call |
+| GlobalDataFlow.cs:513:18:513:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:513:18:513:34 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:524:17:524:36 | object creation of type SubSimpleClass | normal | GlobalDataFlow.cs:524:17:524:36 | object creation of type SubSimpleClass |
+| GlobalDataFlow.cs:531:17:531:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:531:17:531:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:539:17:539:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:539:17:539:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:540:17:540:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:540:17:540:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:541:17:541:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:541:17:541:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:562:17:562:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:562:17:562:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:575:44:575:47 | delegate call | normal | GlobalDataFlow.cs:575:44:575:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> |
 | Splitting.cs:20:22:20:30 | call to method Return<String> | normal | Splitting.cs:20:22:20:30 | call to method Return<String> |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -163,7 +163,8 @@
 | GlobalDataFlow.cs:510:18:510:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:510:18:510:34 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:511:18:511:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:511:18:511:34 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:525:44:525:47 | delegate call | normal | GlobalDataFlow.cs:525:44:525:47 | delegate call |
+| GlobalDataFlow.cs:521:17:521:36 | object creation of type SubSimpleClass | normal | GlobalDataFlow.cs:521:17:521:36 | object creation of type SubSimpleClass |
+| GlobalDataFlow.cs:534:44:534:47 | delegate call | normal | GlobalDataFlow.cs:534:44:534:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> |
 | Splitting.cs:20:22:20:30 | call to method Return<String> | normal | Splitting.cs:20:22:20:30 | call to method Return<String> |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -165,7 +165,10 @@
 | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:521:17:521:36 | object creation of type SubSimpleClass | normal | GlobalDataFlow.cs:521:17:521:36 | object creation of type SubSimpleClass |
 | GlobalDataFlow.cs:528:17:528:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:528:17:528:33 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:542:44:542:47 | delegate call | normal | GlobalDataFlow.cs:542:44:542:47 | delegate call |
+| GlobalDataFlow.cs:536:17:536:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:536:17:536:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:537:17:537:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:537:17:537:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:538:17:538:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:538:17:538:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:558:44:558:47 | delegate call | normal | GlobalDataFlow.cs:558:44:558:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> |
 | Splitting.cs:20:22:20:30 | call to method Return<String> | normal | Splitting.cs:20:22:20:30 | call to method Return<String> |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -168,7 +168,7 @@
 | GlobalDataFlow.cs:536:17:536:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:536:17:536:33 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:537:17:537:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:537:17:537:33 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:538:17:538:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:538:17:538:33 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:558:44:558:47 | delegate call | normal | GlobalDataFlow.cs:558:44:558:47 | delegate call |
+| GlobalDataFlow.cs:564:44:564:47 | delegate call | normal | GlobalDataFlow.cs:564:44:564:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> |
 | Splitting.cs:20:22:20:30 | call to method Return<String> | normal | Splitting.cs:20:22:20:30 | call to method Return<String> |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -158,7 +158,12 @@
 | GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait | normal | GlobalDataFlow.cs:475:25:475:50 | call to method ConfigureAwait |
 | GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter | normal | GlobalDataFlow.cs:476:23:476:44 | call to method GetAwaiter |
 | GlobalDataFlow.cs:477:22:477:40 | call to method GetResult | normal | GlobalDataFlow.cs:477:22:477:40 | call to method GetResult |
-| GlobalDataFlow.cs:501:44:501:47 | delegate call | normal | GlobalDataFlow.cs:501:44:501:47 | delegate call |
+| GlobalDataFlow.cs:505:18:505:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:505:18:505:34 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:506:18:506:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:506:18:506:34 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:510:18:510:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:510:18:510:34 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:511:18:511:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:511:18:511:34 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:512:18:512:34 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:525:44:525:47 | delegate call | normal | GlobalDataFlow.cs:525:44:525:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> |
 | Splitting.cs:20:22:20:30 | call to method Return<String> | normal | Splitting.cs:20:22:20:30 | call to method Return<String> |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -168,7 +168,8 @@
 | GlobalDataFlow.cs:536:17:536:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:536:17:536:33 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:537:17:537:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:537:17:537:33 | object creation of type SimpleClass |
 | GlobalDataFlow.cs:538:17:538:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:538:17:538:33 | object creation of type SimpleClass |
-| GlobalDataFlow.cs:564:44:564:47 | delegate call | normal | GlobalDataFlow.cs:564:44:564:47 | delegate call |
+| GlobalDataFlow.cs:559:17:559:33 | object creation of type SimpleClass | normal | GlobalDataFlow.cs:559:17:559:33 | object creation of type SimpleClass |
+| GlobalDataFlow.cs:572:44:572:47 | delegate call | normal | GlobalDataFlow.cs:572:44:572:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> | normal | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> |
 | Splitting.cs:20:22:20:30 | call to method Return<String> | normal | Splitting.cs:20:22:20:30 | call to method Return<String> |

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -513,6 +513,15 @@ public class DataFlow
         TaintField(b2 ? (b3 ? y1 : y2) : y3);
         Check(y2.field);
     }
+
+    private class SubSimpleClass : SimpleClass { }
+
+    public void M7()
+    {
+        var x = new SubSimpleClass();
+        TaintField((SimpleClass)x);
+        Check(x.field);
+    }
 }
 
 static class IEnumerableExtensions

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -546,6 +546,12 @@ public class DataFlow
         Check(y.field);
         Check(z.field);
     }
+
+    public void M10(SimpleClass? sc)
+    {
+        TaintField(sc!);
+        Check(sc.field);
+    }
 }
 
 static class IEnumerableExtensions

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -552,6 +552,14 @@ public class DataFlow
         TaintField(sc!);
         Check(sc.field);
     }
+
+    public void M11()
+    {
+        SimpleClass y = null;
+        var x = new SimpleClass();
+        TaintField(y = x);
+        Check(x.field);
+    }
 }
 
 static class IEnumerableExtensions

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -530,6 +530,22 @@ public class DataFlow
         Check(x.field);
         Check(y.field);
     }
+
+    public void M9(string choice)
+    {
+        var x = new SimpleClass();
+        var y = new SimpleClass();
+        var z = new SimpleClass();
+        TaintField(choice switch
+        {
+            "x" => x,
+            "y" => y,
+            _ => z
+        });
+        Check(x.field);
+        Check(y.field);
+        Check(z.field);
+    }
 }
 
 static class IEnumerableExtensions

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -489,6 +489,30 @@ public class DataFlow
 
         Inner(_ => { }, b, "taint source");
     }
+
+    private class SimpleClass
+    {
+        public string field = "";
+    }
+
+    private void TaintField(SimpleClass sc)
+    {
+        sc.field = "taint source";
+    }
+
+    public void M6(bool b1, bool b2, bool b3)
+    {
+        var x1 = new SimpleClass();
+        var x2 = new SimpleClass();
+        TaintField(b1 ? x1 : x2);
+        Check(x1.field);
+
+        var y1 = new SimpleClass();
+        var y2 = new SimpleClass();
+        var y3 = new SimpleClass();
+        TaintField(b2 ? (b3 ? y1 : y2) : y3);
+        Check(y2.field);
+    }
 }
 
 static class IEnumerableExtensions

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -490,7 +490,7 @@ public class DataFlow
         Inner(_ => { }, b, "taint source");
     }
 
-    private class SimpleClass
+    public class SimpleClass
     {
         public string field = "";
     }
@@ -521,6 +521,14 @@ public class DataFlow
         var x = new SubSimpleClass();
         TaintField((SimpleClass)x);
         Check(x.field);
+    }
+
+    public void M8(SimpleClass x)
+    {
+        var y = new SimpleClass();
+        TaintField(x ?? y);
+        Check(x.field);
+        Check(y.field);
     }
 }
 

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -506,12 +506,15 @@ public class DataFlow
         var x2 = new SimpleClass();
         TaintField(b1 ? x1 : x2);
         Check(x1.field);
+        Check(x2.field);
 
         var y1 = new SimpleClass();
         var y2 = new SimpleClass();
         var y3 = new SimpleClass();
         TaintField(b2 ? (b3 ? y1 : y2) : y3);
+        Check(y1.field);
         Check(y2.field);
+        Check(y3.field);
     }
 
     private class SubSimpleClass : SimpleClass { }

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -68,6 +68,7 @@
 | GlobalDataFlow.cs:545:15:545:21 | access to field field |
 | GlobalDataFlow.cs:546:15:546:21 | access to field field |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field |
+| GlobalDataFlow.cs:553:15:553:22 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -69,6 +69,7 @@
 | GlobalDataFlow.cs:546:15:546:21 | access to field field |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field |
 | GlobalDataFlow.cs:553:15:553:22 | access to field field |
+| GlobalDataFlow.cs:561:15:561:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -65,6 +65,9 @@
 | GlobalDataFlow.cs:523:15:523:21 | access to field field |
 | GlobalDataFlow.cs:530:15:530:21 | access to field field |
 | GlobalDataFlow.cs:531:15:531:21 | access to field field |
+| GlobalDataFlow.cs:545:15:545:21 | access to field field |
+| GlobalDataFlow.cs:546:15:546:21 | access to field field |
+| GlobalDataFlow.cs:547:15:547:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -60,6 +60,8 @@
 | GlobalDataFlow.cs:466:15:466:20 | access to local variable sink44 |
 | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 |
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
+| GlobalDataFlow.cs:508:15:508:22 | access to field field |
+| GlobalDataFlow.cs:514:15:514:22 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -62,6 +62,7 @@
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field |
+| GlobalDataFlow.cs:523:15:523:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -63,6 +63,8 @@
 | GlobalDataFlow.cs:508:15:508:22 | access to field field |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field |
 | GlobalDataFlow.cs:523:15:523:21 | access to field field |
+| GlobalDataFlow.cs:530:15:530:21 | access to field field |
+| GlobalDataFlow.cs:531:15:531:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -61,15 +61,18 @@
 | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 |
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field |
-| GlobalDataFlow.cs:514:15:514:22 | access to field field |
-| GlobalDataFlow.cs:523:15:523:21 | access to field field |
-| GlobalDataFlow.cs:530:15:530:21 | access to field field |
-| GlobalDataFlow.cs:531:15:531:21 | access to field field |
-| GlobalDataFlow.cs:545:15:545:21 | access to field field |
-| GlobalDataFlow.cs:546:15:546:21 | access to field field |
-| GlobalDataFlow.cs:547:15:547:21 | access to field field |
-| GlobalDataFlow.cs:553:15:553:22 | access to field field |
-| GlobalDataFlow.cs:561:15:561:21 | access to field field |
+| GlobalDataFlow.cs:509:15:509:22 | access to field field |
+| GlobalDataFlow.cs:515:15:515:22 | access to field field |
+| GlobalDataFlow.cs:516:15:516:22 | access to field field |
+| GlobalDataFlow.cs:517:15:517:22 | access to field field |
+| GlobalDataFlow.cs:526:15:526:21 | access to field field |
+| GlobalDataFlow.cs:533:15:533:21 | access to field field |
+| GlobalDataFlow.cs:534:15:534:21 | access to field field |
+| GlobalDataFlow.cs:548:15:548:21 | access to field field |
+| GlobalDataFlow.cs:549:15:549:21 | access to field field |
+| GlobalDataFlow.cs:550:15:550:21 | access to field field |
+| GlobalDataFlow.cs:556:15:556:22 | access to field field |
+| GlobalDataFlow.cs:564:15:564:21 | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -288,6 +288,13 @@ edges
 | GlobalDataFlow.cs:486:21:486:21 | s : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | GlobalDataFlow.cs:486:21:486:21 | s : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
+| GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:22 | access to field field |
 | GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String |
 | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String |
 | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String |
@@ -576,6 +583,14 @@ nodes
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | semmle.label | access to parameter s |
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | semmle.label | [post] access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | semmle.label | access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:508:15:508:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | semmle.label | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | semmle.label | access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:15:514:22 | access to field field | semmle.label | access to field field |
 | GlobalDataFlow.cs:520:71:520:71 | e [element] : String | semmle.label | e [element] : String |
 | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
 | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
@@ -697,6 +712,8 @@ subpaths
 | GlobalDataFlow.cs:466:15:466:20 | access to local variable sink44 | GlobalDataFlow.cs:465:51:465:64 | "taint source" : String | GlobalDataFlow.cs:466:15:466:20 | access to local variable sink44 | access to local variable sink44 |
 | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | GlobalDataFlow.cs:474:35:474:48 | "taint source" : String | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | access to local variable sink45 |
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | access to parameter s |
+| GlobalDataFlow.cs:508:15:508:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:508:15:508:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:514:15:514:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:514:15:514:22 | access to field field | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:529:71:529:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:537:71:537:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -291,6 +291,8 @@ edges
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
@@ -298,11 +300,15 @@ edges
 | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:22 | access to field field |
 | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String |
 | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:21 | access to field field |
-| GlobalDataFlow.cs:529:71:529:71 | e [element] : String | GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String | GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String |
-| GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String | GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String |
+| GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String |
+| GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:21 | access to field field |
+| GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:21 | access to field field |
+| GlobalDataFlow.cs:537:71:537:71 | e [element] : String | GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String | GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String |
+| GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String | GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -597,11 +603,17 @@ nodes
 | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
 | GlobalDataFlow.cs:523:15:523:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:529:71:529:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:534:44:534:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String | semmle.label | [post] access to parameter x [field field] : String |
+| GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | semmle.label | access to parameter x [field field] : String |
+| GlobalDataFlow.cs:530:15:530:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:531:15:531:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:537:71:537:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:542:44:542:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -639,7 +651,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:529:71:529:71 | e [element] : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:537:71:537:71 | e [element] : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -648,7 +660,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:446:64:446:64 | s : String | GlobalDataFlow.cs:448:9:448:10 | [post] access to parameter sb [element] : String | GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String |
+| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -721,6 +733,8 @@ subpaths
 | GlobalDataFlow.cs:508:15:508:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:508:15:508:22 | access to field field | access to field field |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:514:15:514:22 | access to field field | access to field field |
 | GlobalDataFlow.cs:523:15:523:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:523:15:523:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:530:15:530:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:530:15:530:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:531:15:531:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:531:15:531:21 | access to field field | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:520:71:520:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:529:71:529:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -290,16 +290,19 @@ edges
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
 | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String |
 | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:22 | access to field field |
-| GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String |
-| GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String |
+| GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:21 | access to field field |
+| GlobalDataFlow.cs:529:71:529:71 | e [element] : String | GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String | GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String |
+| GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String | GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -591,11 +594,14 @@ nodes
 | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | semmle.label | [post] access to local variable y2 [field field] : String |
 | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | semmle.label | access to local variable y2 [field field] : String |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:520:71:520:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:525:44:525:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:523:15:523:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:529:71:529:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:532:22:532:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:532:27:532:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:534:44:534:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -633,7 +639,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:529:71:529:71 | e [element] : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -642,7 +648,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:446:64:446:64 | s : String | GlobalDataFlow.cs:448:9:448:10 | [post] access to parameter sb [element] : String | GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String |
+| GlobalDataFlow.cs:534:46:534:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:534:44:534:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -714,6 +720,7 @@ subpaths
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | access to parameter s |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:508:15:508:22 | access to field field | access to field field |
 | GlobalDataFlow.cs:514:15:514:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:514:15:514:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:523:15:523:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:523:15:523:21 | access to field field | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:537:71:537:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:553:71:553:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -293,6 +293,9 @@ edges
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
@@ -304,11 +307,17 @@ edges
 | GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String |
 | GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:21 | access to field field |
 | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:21 | access to field field |
-| GlobalDataFlow.cs:537:71:537:71 | e [element] : String | GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String | GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String |
-| GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String | GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String |
+| GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String |
+| GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:21 | access to field field |
+| GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:21 | access to field field |
+| GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:21 | access to field field |
+| GlobalDataFlow.cs:553:71:553:71 | e [element] : String | GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String |
+| GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String | GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -609,11 +618,20 @@ nodes
 | GlobalDataFlow.cs:530:15:530:21 | access to field field | semmle.label | access to field field |
 | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
 | GlobalDataFlow.cs:531:15:531:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:537:71:537:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:540:22:540:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:540:27:540:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:542:44:542:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String | semmle.label | [post] access to local variable z [field field] : String |
+| GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:545:15:545:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:546:15:546:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | semmle.label | access to local variable z [field field] : String |
+| GlobalDataFlow.cs:547:15:547:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:553:71:553:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:558:44:558:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -651,7 +669,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:537:71:537:71 | e [element] : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:553:71:553:71 | e [element] : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -660,7 +678,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:446:64:446:64 | s : String | GlobalDataFlow.cs:448:9:448:10 | [post] access to parameter sb [element] : String | GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:542:46:542:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:542:44:542:47 | delegate call : String |
+| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -735,6 +753,9 @@ subpaths
 | GlobalDataFlow.cs:523:15:523:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:523:15:523:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:530:15:530:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:530:15:530:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:531:15:531:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:531:15:531:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:545:15:545:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:545:15:545:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:546:15:546:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:546:15:546:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:547:15:547:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:547:15:547:21 | access to field field | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:567:71:567:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:570:71:570:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -289,41 +289,50 @@ edges
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | GlobalDataFlow.cs:486:21:486:21 | s : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String |
-| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:507:30:507:31 | [post] access to local variable x2 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:514:31:514:32 | [post] access to local variable y1 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:514:36:514:37 | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:514:42:514:43 | [post] access to local variable y3 [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:525:33:525:33 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:532:20:532:20 | [post] access to parameter x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:532:25:532:25 | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:544:20:544:20 | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:545:20:545:20 | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:546:18:546:18 | [post] access to local variable z [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:555:20:555:21 | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:563:24:563:24 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:507:30:507:31 | [post] access to local variable x2 [field field] : String | GlobalDataFlow.cs:509:15:509:16 | access to local variable x2 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
-| GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String |
-| GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:514:15:514:22 | access to field field |
-| GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:523:15:523:21 | access to field field |
-| GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String |
-| GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String |
-| GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | GlobalDataFlow.cs:530:15:530:21 | access to field field |
-| GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:531:15:531:21 | access to field field |
-| GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String |
-| GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String |
-| GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:21 | access to field field |
-| GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:21 | access to field field |
-| GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:21 | access to field field |
-| GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String |
-| GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:22 | access to field field |
-| GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:561:15:561:21 | access to field field |
-| GlobalDataFlow.cs:567:71:567:71 | e [element] : String | GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String | GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String |
-| GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String | GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String |
+| GlobalDataFlow.cs:509:15:509:16 | access to local variable x2 [field field] : String | GlobalDataFlow.cs:509:15:509:22 | access to field field |
+| GlobalDataFlow.cs:514:31:514:32 | [post] access to local variable y1 [field field] : String | GlobalDataFlow.cs:515:15:515:16 | access to local variable y1 [field field] : String |
+| GlobalDataFlow.cs:514:36:514:37 | [post] access to local variable y2 [field field] : String | GlobalDataFlow.cs:516:15:516:16 | access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:42:514:43 | [post] access to local variable y3 [field field] : String | GlobalDataFlow.cs:517:15:517:16 | access to local variable y3 [field field] : String |
+| GlobalDataFlow.cs:515:15:515:16 | access to local variable y1 [field field] : String | GlobalDataFlow.cs:515:15:515:22 | access to field field |
+| GlobalDataFlow.cs:516:15:516:16 | access to local variable y2 [field field] : String | GlobalDataFlow.cs:516:15:516:22 | access to field field |
+| GlobalDataFlow.cs:517:15:517:16 | access to local variable y3 [field field] : String | GlobalDataFlow.cs:517:15:517:22 | access to field field |
+| GlobalDataFlow.cs:525:33:525:33 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:526:15:526:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:526:15:526:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:526:15:526:21 | access to field field |
+| GlobalDataFlow.cs:532:20:532:20 | [post] access to parameter x [field field] : String | GlobalDataFlow.cs:533:15:533:15 | access to parameter x [field field] : String |
+| GlobalDataFlow.cs:532:25:532:25 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:534:15:534:15 | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:533:15:533:15 | access to parameter x [field field] : String | GlobalDataFlow.cs:533:15:533:21 | access to field field |
+| GlobalDataFlow.cs:534:15:534:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:534:15:534:21 | access to field field |
+| GlobalDataFlow.cs:544:20:544:20 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:548:15:548:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:545:20:545:20 | [post] access to local variable y [field field] : String | GlobalDataFlow.cs:549:15:549:15 | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:546:18:546:18 | [post] access to local variable z [field field] : String | GlobalDataFlow.cs:550:15:550:15 | access to local variable z [field field] : String |
+| GlobalDataFlow.cs:548:15:548:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:548:15:548:21 | access to field field |
+| GlobalDataFlow.cs:549:15:549:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:549:15:549:21 | access to field field |
+| GlobalDataFlow.cs:550:15:550:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:550:15:550:21 | access to field field |
+| GlobalDataFlow.cs:555:20:555:21 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:556:15:556:16 | access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:556:15:556:16 | access to parameter sc [field field] : String | GlobalDataFlow.cs:556:15:556:22 | access to field field |
+| GlobalDataFlow.cs:563:24:563:24 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:564:15:564:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:564:15:564:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:564:15:564:21 | access to field field |
+| GlobalDataFlow.cs:570:71:570:71 | e [element] : String | GlobalDataFlow.cs:573:27:573:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:573:22:573:22 | SSA def(x) : String | GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String |
+| GlobalDataFlow.cs:573:27:573:27 | access to parameter e [element] : String | GlobalDataFlow.cs:573:22:573:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String | GlobalDataFlow.cs:575:44:575:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -610,40 +619,49 @@ nodes
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | semmle.label | [post] access to local variable x1 [field field] : String |
+| GlobalDataFlow.cs:507:30:507:31 | [post] access to local variable x2 [field field] : String | semmle.label | [post] access to local variable x2 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | semmle.label | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:513:36:513:37 | [post] access to local variable y2 [field field] : String | semmle.label | [post] access to local variable y2 [field field] : String |
-| GlobalDataFlow.cs:514:15:514:16 | access to local variable y2 [field field] : String | semmle.label | access to local variable y2 [field field] : String |
-| GlobalDataFlow.cs:514:15:514:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:522:33:522:33 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:523:15:523:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:523:15:523:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:529:20:529:20 | [post] access to parameter x [field field] : String | semmle.label | [post] access to parameter x [field field] : String |
-| GlobalDataFlow.cs:529:25:529:25 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
-| GlobalDataFlow.cs:530:15:530:15 | access to parameter x [field field] : String | semmle.label | access to parameter x [field field] : String |
-| GlobalDataFlow.cs:530:15:530:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:531:15:531:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
-| GlobalDataFlow.cs:531:15:531:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
-| GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String | semmle.label | [post] access to local variable z [field field] : String |
-| GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:545:15:545:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
-| GlobalDataFlow.cs:546:15:546:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | semmle.label | access to local variable z [field field] : String |
-| GlobalDataFlow.cs:547:15:547:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
-| GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | semmle.label | access to parameter sc [field field] : String |
-| GlobalDataFlow.cs:553:15:553:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
-| GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
-| GlobalDataFlow.cs:561:15:561:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:567:71:567:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:572:44:572:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:509:15:509:16 | access to local variable x2 [field field] : String | semmle.label | access to local variable x2 [field field] : String |
+| GlobalDataFlow.cs:509:15:509:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:514:31:514:32 | [post] access to local variable y1 [field field] : String | semmle.label | [post] access to local variable y1 [field field] : String |
+| GlobalDataFlow.cs:514:36:514:37 | [post] access to local variable y2 [field field] : String | semmle.label | [post] access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:514:42:514:43 | [post] access to local variable y3 [field field] : String | semmle.label | [post] access to local variable y3 [field field] : String |
+| GlobalDataFlow.cs:515:15:515:16 | access to local variable y1 [field field] : String | semmle.label | access to local variable y1 [field field] : String |
+| GlobalDataFlow.cs:515:15:515:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:516:15:516:16 | access to local variable y2 [field field] : String | semmle.label | access to local variable y2 [field field] : String |
+| GlobalDataFlow.cs:516:15:516:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:517:15:517:16 | access to local variable y3 [field field] : String | semmle.label | access to local variable y3 [field field] : String |
+| GlobalDataFlow.cs:517:15:517:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:525:33:525:33 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:526:15:526:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:526:15:526:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:532:20:532:20 | [post] access to parameter x [field field] : String | semmle.label | [post] access to parameter x [field field] : String |
+| GlobalDataFlow.cs:532:25:532:25 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:533:15:533:15 | access to parameter x [field field] : String | semmle.label | access to parameter x [field field] : String |
+| GlobalDataFlow.cs:533:15:533:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:534:15:534:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:534:15:534:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:544:20:544:20 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:545:20:545:20 | [post] access to local variable y [field field] : String | semmle.label | [post] access to local variable y [field field] : String |
+| GlobalDataFlow.cs:546:18:546:18 | [post] access to local variable z [field field] : String | semmle.label | [post] access to local variable z [field field] : String |
+| GlobalDataFlow.cs:548:15:548:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:548:15:548:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:549:15:549:15 | access to local variable y [field field] : String | semmle.label | access to local variable y [field field] : String |
+| GlobalDataFlow.cs:549:15:549:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:550:15:550:15 | access to local variable z [field field] : String | semmle.label | access to local variable z [field field] : String |
+| GlobalDataFlow.cs:550:15:550:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:555:20:555:21 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:556:15:556:16 | access to parameter sc [field field] : String | semmle.label | access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:556:15:556:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:563:24:563:24 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:564:15:564:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:564:15:564:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:570:71:570:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:573:22:573:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:573:27:573:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:575:44:575:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -681,7 +699,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:567:71:567:71 | e [element] : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:570:71:570:71 | e [element] : String | GlobalDataFlow.cs:575:44:575:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -690,7 +708,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:446:64:446:64 | s : String | GlobalDataFlow.cs:448:9:448:10 | [post] access to parameter sb [element] : String | GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String |
+| GlobalDataFlow.cs:575:46:575:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:575:44:575:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -761,15 +779,18 @@ subpaths
 | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | GlobalDataFlow.cs:474:35:474:48 | "taint source" : String | GlobalDataFlow.cs:478:15:478:20 | access to local variable sink45 | access to local variable sink45 |
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | access to parameter s |
 | GlobalDataFlow.cs:508:15:508:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:508:15:508:22 | access to field field | access to field field |
-| GlobalDataFlow.cs:514:15:514:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:514:15:514:22 | access to field field | access to field field |
-| GlobalDataFlow.cs:523:15:523:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:523:15:523:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:530:15:530:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:530:15:530:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:531:15:531:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:531:15:531:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:545:15:545:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:545:15:545:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:546:15:546:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:546:15:546:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:547:15:547:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:547:15:547:21 | access to field field | access to field field |
-| GlobalDataFlow.cs:553:15:553:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:553:15:553:22 | access to field field | access to field field |
-| GlobalDataFlow.cs:561:15:561:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:561:15:561:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:509:15:509:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:509:15:509:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:515:15:515:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:515:15:515:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:516:15:516:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:516:15:516:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:517:15:517:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:517:15:517:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:526:15:526:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:526:15:526:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:533:15:533:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:533:15:533:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:534:15:534:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:534:15:534:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:548:15:548:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:548:15:548:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:549:15:549:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:549:15:549:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:550:15:550:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:550:15:550:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:556:15:556:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:556:15:556:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:564:15:564:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:564:15:564:21 | access to field field | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:559:71:559:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:567:71:567:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -297,6 +297,7 @@ edges
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
@@ -316,11 +317,13 @@ edges
 | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:21 | access to field field |
 | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:22 | access to field field |
-| GlobalDataFlow.cs:559:71:559:71 | e [element] : String | GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String | GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String |
-| GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String | GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String |
+| GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String | GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:561:15:561:21 | access to field field |
+| GlobalDataFlow.cs:567:71:567:71 | e [element] : String | GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String | GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String |
+| GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String | GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -633,11 +636,14 @@ nodes
 | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | semmle.label | access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:553:15:553:22 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:559:71:559:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:564:44:564:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:560:24:560:24 | [post] access to local variable x [field field] : String | semmle.label | [post] access to local variable x [field field] : String |
+| GlobalDataFlow.cs:561:15:561:15 | access to local variable x [field field] : String | semmle.label | access to local variable x [field field] : String |
+| GlobalDataFlow.cs:561:15:561:21 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:567:71:567:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:570:22:570:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:570:27:570:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:572:44:572:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -675,7 +681,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:559:71:559:71 | e [element] : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:567:71:567:71 | e [element] : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -684,7 +690,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:446:64:446:64 | s : String | GlobalDataFlow.cs:448:9:448:10 | [post] access to parameter sb [element] : String | GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String |
+| GlobalDataFlow.cs:572:46:572:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:572:44:572:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -763,6 +769,7 @@ subpaths
 | GlobalDataFlow.cs:546:15:546:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:546:15:546:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:547:15:547:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:553:15:553:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:553:15:553:22 | access to field field | access to field field |
+| GlobalDataFlow.cs:561:15:561:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:561:15:561:21 | access to field field | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:496:71:496:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:520:71:520:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -288,11 +288,11 @@ edges
 | GlobalDataFlow.cs:486:21:486:21 | s : String | GlobalDataFlow.cs:486:32:486:32 | access to parameter s |
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | GlobalDataFlow.cs:486:21:486:21 | s : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | GlobalDataFlow.cs:483:53:483:55 | arg : String |
-| GlobalDataFlow.cs:496:71:496:71 | e [element] : String | GlobalDataFlow.cs:499:27:499:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:499:22:499:22 | SSA def(x) : String | GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String |
-| GlobalDataFlow.cs:499:27:499:27 | access to parameter e [element] : String | GlobalDataFlow.cs:499:22:499:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String | GlobalDataFlow.cs:501:44:501:47 | delegate call : String |
+| GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String |
+| GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -576,11 +576,11 @@ nodes
 | GlobalDataFlow.cs:486:32:486:32 | access to parameter s | semmle.label | access to parameter s |
 | GlobalDataFlow.cs:487:15:487:17 | access to parameter arg : String | semmle.label | access to parameter arg : String |
 | GlobalDataFlow.cs:490:28:490:41 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:496:71:496:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:499:22:499:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:499:27:499:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:501:44:501:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:520:71:520:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:523:22:523:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:523:27:523:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:525:44:525:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -618,7 +618,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:496:71:496:71 | e [element] : String | GlobalDataFlow.cs:501:44:501:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:520:71:520:71 | e [element] : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -627,7 +627,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:446:64:446:64 | s : String | GlobalDataFlow.cs:448:9:448:10 | [post] access to parameter sb [element] : String | GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:501:46:501:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:501:44:501:47 | delegate call : String |
+| GlobalDataFlow.cs:525:46:525:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:525:44:525:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:22:81:93 | call to method First<String> : String | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String |
 | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:553:71:553:71 | e [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:559:71:559:71 | e [element] : String |
 | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String | GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String |
 | GlobalDataFlow.cs:81:59:81:63 | access to local variable sink3 : String | GlobalDataFlow.cs:81:57:81:65 | { ..., ... } [element] : String |
 | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String |
@@ -296,6 +296,7 @@ edges
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:541:20:541:20 | [post] access to local variable x [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:542:20:542:20 | [post] access to local variable y [field field] : String |
 | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:543:18:543:18 | [post] access to local variable z [field field] : String |
+| GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:500:9:500:10 | [post] access to parameter sc [field field] : String |
 | GlobalDataFlow.cs:507:25:507:26 | [post] access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String |
 | GlobalDataFlow.cs:508:15:508:16 | access to local variable x1 [field field] : String | GlobalDataFlow.cs:508:15:508:22 | access to field field |
@@ -313,11 +314,13 @@ edges
 | GlobalDataFlow.cs:545:15:545:15 | access to local variable x [field field] : String | GlobalDataFlow.cs:545:15:545:21 | access to field field |
 | GlobalDataFlow.cs:546:15:546:15 | access to local variable y [field field] : String | GlobalDataFlow.cs:546:15:546:21 | access to field field |
 | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | GlobalDataFlow.cs:547:15:547:21 | access to field field |
-| GlobalDataFlow.cs:553:71:553:71 | e [element] : String | GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String |
-| GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String | GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String |
-| GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String | GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String |
-| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
-| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
+| GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | GlobalDataFlow.cs:553:15:553:22 | access to field field |
+| GlobalDataFlow.cs:559:71:559:71 | e [element] : String | GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String |
+| GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String | GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String |
+| GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String | GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String |
+| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String |
+| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -627,11 +630,14 @@ nodes
 | GlobalDataFlow.cs:546:15:546:21 | access to field field | semmle.label | access to field field |
 | GlobalDataFlow.cs:547:15:547:15 | access to local variable z [field field] : String | semmle.label | access to local variable z [field field] : String |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field | semmle.label | access to field field |
-| GlobalDataFlow.cs:553:71:553:71 | e [element] : String | semmle.label | e [element] : String |
-| GlobalDataFlow.cs:556:22:556:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:556:27:556:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
-| GlobalDataFlow.cs:558:44:558:47 | delegate call : String | semmle.label | delegate call : String |
-| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | semmle.label | access to local variable x : String |
+| GlobalDataFlow.cs:552:20:552:21 | [post] access to parameter sc [field field] : String | semmle.label | [post] access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:553:15:553:16 | access to parameter sc [field field] : String | semmle.label | access to parameter sc [field field] : String |
+| GlobalDataFlow.cs:553:15:553:22 | access to field field | semmle.label | access to field field |
+| GlobalDataFlow.cs:559:71:559:71 | e [element] : String | semmle.label | e [element] : String |
+| GlobalDataFlow.cs:562:22:562:22 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:562:27:562:27 | access to parameter e [element] : String | semmle.label | access to parameter e [element] : String |
+| GlobalDataFlow.cs:564:44:564:47 | delegate call : String | semmle.label | delegate call : String |
+| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | semmle.label | access to local variable x : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String | semmle.label | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String | semmle.label | [b (line 3): true] call to method Return<String> : String |
@@ -669,7 +675,7 @@ subpaths
 | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:73:29:73:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:76:19:76:23 | access to local variable sink1 : String | GlobalDataFlow.cs:304:32:304:32 | x : String | GlobalDataFlow.cs:306:9:306:13 | SSA def(y) : String | GlobalDataFlow.cs:76:30:76:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:79:19:79:23 | access to local variable sink2 : String | GlobalDataFlow.cs:310:32:310:32 | x : String | GlobalDataFlow.cs:312:9:312:13 | SSA def(y) : String | GlobalDataFlow.cs:79:30:79:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:553:71:553:71 | e [element] : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
+| GlobalDataFlow.cs:81:23:81:65 | (...) ... [element] : String | GlobalDataFlow.cs:559:71:559:71 | e [element] : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String | GlobalDataFlow.cs:81:22:81:85 | call to method SelectEven<String,String> [element] : String |
 | GlobalDataFlow.cs:138:63:138:63 | access to parameter x : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String |
 | GlobalDataFlow.cs:139:29:139:33 | access to local variable sink3 : String | GlobalDataFlow.cs:138:40:138:40 | x : String | GlobalDataFlow.cs:138:45:138:64 | call to method ApplyFunc<String,String> : String | GlobalDataFlow.cs:139:21:139:34 | delegate call : String |
 | GlobalDataFlow.cs:147:39:147:43 | access to local variable sink4 : String | GlobalDataFlow.cs:387:46:387:46 | x : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String | GlobalDataFlow.cs:147:21:147:44 | call to method ApplyFunc<String,String> : String |
@@ -678,7 +684,7 @@ subpaths
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:298:26:298:26 | x : String | GlobalDataFlow.cs:301:16:301:41 | ... ? ... : ... : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:389:18:389:18 | access to parameter x : String | GlobalDataFlow.cs:300:27:300:28 | x0 : String | GlobalDataFlow.cs:300:33:300:34 | access to parameter x0 : String | GlobalDataFlow.cs:389:16:389:19 | delegate call : String |
 | GlobalDataFlow.cs:454:35:454:48 | "taint source" : String | GlobalDataFlow.cs:446:64:446:64 | s : String | GlobalDataFlow.cs:448:9:448:10 | [post] access to parameter sb [element] : String | GlobalDataFlow.cs:454:31:454:32 | [post] access to local variable sb [element] : String |
-| GlobalDataFlow.cs:558:46:558:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:558:44:558:47 | delegate call : String |
+| GlobalDataFlow.cs:564:46:564:46 | access to local variable x : String | GlobalDataFlow.cs:81:79:81:79 | x : String | GlobalDataFlow.cs:81:84:81:84 | access to parameter x : String | GlobalDataFlow.cs:564:44:564:47 | delegate call : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return<String> : String |
 | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return<String> : String |
 | Splitting.cs:20:29:20:29 | access to parameter s : String | Splitting.cs:16:26:16:26 | x : String | Splitting.cs:16:32:16:32 | access to parameter x : String | Splitting.cs:20:22:20:30 | call to method Return<String> : String |
@@ -756,6 +762,7 @@ subpaths
 | GlobalDataFlow.cs:545:15:545:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:545:15:545:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:546:15:546:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:546:15:546:21 | access to field field | access to field field |
 | GlobalDataFlow.cs:547:15:547:21 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:547:15:547:21 | access to field field | access to field field |
+| GlobalDataFlow.cs:553:15:553:22 | access to field field | GlobalDataFlow.cs:500:20:500:33 | "taint source" : String | GlobalDataFlow.cs:553:15:553:22 | access to field field | access to field field |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -760,6 +760,7 @@
 | Splitting.cs:39:15:39:15 | [b (line 32): true] access to parameter b | Splitting.cs:42:13:42:13 | [b (line 32): true] access to parameter b |
 | Splitting.cs:39:19:39:19 | [b (line 32): true] access to local variable x | Splitting.cs:39:15:39:25 | [b (line 32): true] ... ? ... : ... |
 | Splitting.cs:39:19:39:19 | [b (line 32): true] access to local variable x | Splitting.cs:40:23:40:23 | [b (line 32): true] access to local variable x |
+| Splitting.cs:39:19:39:19 | [post] [b (line 32): true] access to local variable x | Splitting.cs:40:23:40:23 | [b (line 32): true] access to local variable x |
 | Splitting.cs:39:23:39:25 | [b (line 32): false] "c" | Splitting.cs:39:15:39:25 | [b (line 32): false] ... ? ... : ... |
 | Splitting.cs:40:23:40:23 | [b (line 32): false] access to local variable x | Splitting.cs:40:15:40:23 | [b (line 32): false] (...) ... |
 | Splitting.cs:40:23:40:23 | [b (line 32): true] access to local variable x | Splitting.cs:40:15:40:23 | [b (line 32): true] (...) ... |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -889,6 +889,7 @@
 | Splitting.cs:39:15:39:15 | [b (line 32): true] access to parameter b | Splitting.cs:42:13:42:13 | [b (line 32): true] access to parameter b |
 | Splitting.cs:39:19:39:19 | [b (line 32): true] access to local variable x | Splitting.cs:39:15:39:25 | [b (line 32): true] ... ? ... : ... |
 | Splitting.cs:39:19:39:19 | [b (line 32): true] access to local variable x | Splitting.cs:40:23:40:23 | [b (line 32): true] access to local variable x |
+| Splitting.cs:39:19:39:19 | [post] [b (line 32): true] access to local variable x | Splitting.cs:40:23:40:23 | [b (line 32): true] access to local variable x |
 | Splitting.cs:39:23:39:25 | [b (line 32): false] "c" | Splitting.cs:39:15:39:25 | [b (line 32): false] ... ? ... : ... |
 | Splitting.cs:40:23:40:23 | [b (line 32): false] access to local variable x | Splitting.cs:40:15:40:23 | [b (line 32): false] (...) ... |
 | Splitting.cs:40:23:40:23 | [b (line 32): true] access to local variable x | Splitting.cs:40:15:40:23 | [b (line 32): true] (...) ... |


### PR DESCRIPTION
This is the C# version of: https://github.com/github/codeql/pull/10444
That is, we can now identify flow out through arguments where expressions are inlined.

Assume we have
```csharp
public class SimpleClass
{
    public string field = "";
}

public void TaintField(SimpleClass sc)
{
    sc.field = "taint source";
}
```
then flow out via `x` and `y` are tracked correctly in the following pseudo example.
```csharp
SimpleClass x = ...
SimpleClass y = ...
TaintField(b ? x : y);
Sink(x.field);
Sink(y.field);
``` 

Furthermore, we also track flow out of expressions like
```csharp
TaintField((SimpleClass)x) // Cast expressions
TaintField(x ?? y) // Null Coalescing expressions
TaintField(x!) // Suppress nullable warning expressions
TaintField(y = x) // Assignment expressions
TaintField(choice switch "x" => x ...)
```