### PR TITLE
Swift: Add `ClassOrStructDecl` class

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/decl/ClassOrStructDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/ClassOrStructDecl.qll
@@ -1,0 +1,23 @@
+private import codeql.swift.elements.decl.ClassDecl
+private import codeql.swift.elements.decl.StructDecl
+private import codeql.swift.elements.decl.NominalTypeDecl
+
+/**
+ * A `class` or `struct` declaration. For example `MyStruct` or `MyClass` in the following example:
+ * ```swift
+ * struct MyStruct {
+ *   // ...
+ * }
+ *
+ * class MyClass {
+ *   // ...
+ * }
+ * ```
+ */
+class ClassOrStructDecl extends NominalTypeDecl {
+  ClassOrStructDecl() {
+    this instanceof ClassDecl
+    or
+    this instanceof StructDecl
+  }
+}

--- a/swift/ql/lib/swift.qll
+++ b/swift/ql/lib/swift.qll
@@ -4,3 +4,4 @@ import codeql.swift.elements
 import codeql.swift.elements.expr.ArithmeticOperation
 import codeql.swift.elements.expr.LogicalOperation
 import codeql.swift.elements.decl.MethodDecl
+import codeql.swift.elements.decl.ClassOrStructDecl


### PR DESCRIPTION
This PR adds a class that's defined as the union of `ClassDecl and `StructDecl`. This is motivated by us having used the wrong one of these on several occasions.

Hopefully, by instead relying on this union class, we'll be less likely to run into these issues.
