### PR TITLE
Swift: URL taint sources

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -79,6 +79,7 @@ private import internal.FlowSummaryImplSpecific
  */
 private module Frameworks {
   private import codeql.swift.frameworks.StandardLibrary.String
+  private import codeql.swift.frameworks.StandardLibrary.Url
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
@@ -1,0 +1,27 @@
+import swift
+private import codeql.swift.dataflow.FlowSources
+
+/**
+ * Model certain members of `URL` as sources of remote flow.
+ */
+class UrlRemoteFlowSource extends RemoteFlowSource {
+  UrlRemoteFlowSource() {
+    exists(StructDecl urlClass, ConcreteVarDecl memberDecl |
+      urlClass.getName() = "URL" and
+      (
+        urlClass.getAMember() = memberDecl and
+        memberDecl.getName() = ["resourceBytes", "lines"]
+        or
+        exists(StructDecl asyncBytesClass |
+          urlClass.getAMember() = asyncBytesClass and
+          asyncBytesClass.getName() = "AsyncBytes" and
+          asyncBytesClass.getAMember() = memberDecl and
+          memberDecl.getName() = "lines"
+        )
+      ) and
+      this.asExpr().(MemberRefExpr).getMember() = memberDecl
+    )
+  }
+
+  override string getSourceType() { result = "external" }
+}

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
@@ -2,7 +2,7 @@ import swift
 private import codeql.swift.dataflow.FlowSources
 
 /**
- * Model certain members of `URL` as sources of remote flow.
+ * A model for `URL` members that are sources of remote flow.
  */
 class UrlRemoteFlowSource extends RemoteFlowSource {
   UrlRemoteFlowSource() {

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -1,2 +1,5 @@
 | string.swift:27:21:27:21 | call to init(contentsOf:) | external |
 | string.swift:27:21:27:44 | call to init(contentsOf:) | external |
+| url.swift:53:15:53:19 | .resourceBytes | external |
+| url.swift:60:15:60:19 | .lines | external |
+| url.swift:67:16:67:22 | .lines | external |

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -1,0 +1,2 @@
+| string.swift:27:21:27:21 | call to init(contentsOf:) | external |
+| string.swift:27:21:27:44 | call to init(contentsOf:) | external |

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.ql
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.ql
@@ -1,0 +1,5 @@
+import swift
+import codeql.swift.dataflow.FlowSources
+
+from RemoteFlowSource source
+select source, concat(source.getSourceType(), ", ")

--- a/swift/ql/test/library-tests/dataflow/flowsources/string.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/string.swift
@@ -1,0 +1,31 @@
+
+// --- stubs ---
+
+struct URL
+{
+	init?(string: String) {}
+}
+
+extension String {
+	init(contentsOf: URL) throws {
+		var data = ""
+
+		// ...
+
+		self.init(data)
+	}
+}
+
+// --- tests ---
+
+func testStrings() {
+	do
+	{
+		let string1 = String()
+		let string2 = String(repeating: "abc", count: 10)
+		let url = URL(string: "http://example.com/")
+		let string3 = try String(contentsOf: url!) // SOURCE
+	} catch {
+		// ...
+	}
+}

--- a/swift/ql/test/library-tests/dataflow/flowsources/url.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/url.swift
@@ -1,0 +1,76 @@
+// --- stubs ---
+
+struct URL {
+	init?(string: String) {}
+
+	struct AsyncBytes : AsyncSequence, AsyncIteratorProtocol {
+		typealias Element = UInt8
+
+		func makeAsyncIterator() -> AsyncBytes {
+			return AsyncBytes()
+		}
+
+		mutating func next() async -> Element? { return nil }
+
+		var lines: AsyncLineSequence<Self> {
+			get {
+				return AsyncLineSequence<Self>()
+			}
+		}
+	}
+
+	var resourceBytes: URL.AsyncBytes {
+		get {
+			return AsyncBytes()
+		}
+	}
+
+	struct AsyncLineSequence<Base> : AsyncSequence, AsyncIteratorProtocol where Base : AsyncSequence, Base.Element == UInt8 {
+		typealias Element = String
+
+		func makeAsyncIterator() -> AsyncLineSequence<Base> {
+			return AsyncLineSequence<Base>()
+		}
+
+		mutating func next() async -> Element? { return nil }
+	}
+
+	var lines: AsyncLineSequence<URL.AsyncBytes> {
+		get {
+			return AsyncLineSequence<URL.AsyncBytes>()
+		}
+	}
+}
+
+func print(_ items: Any...) {}
+
+// --- tests ---
+
+func testURLs() async {
+	do
+	{
+		let url = URL(string: "http://example.com/")!
+		let bytes = url.resourceBytes // SOURCE
+
+		for try await byte in bytes
+		{
+			print(byte)
+		}
+
+		let lines = url.lines // SOURCE
+
+		for try await line in lines
+		{
+			print(line)
+		}
+
+		let lines2 = bytes.lines // SOURCE
+
+		for try await line in lines2
+		{
+			print(line)
+		}
+	} catch {
+		// ...
+	}
+}


### PR DESCRIPTION
Add `URL.resourceBytes`, `URL.lines` and `URL.resourceBytes.lines` as taint sources.

I haven't used Models-As-Data because it doesn't currently support member variables in Swift.  When that changes we should be able to simplify the model itself to three lines of CSV.