### PR TITLE
Add TypeModel.getAnApiNode

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -164,14 +164,27 @@ module ModelInput {
   class TypeModel extends Unit {
     /**
      * Gets a data-flow node that is a source of the type `package;type`.
+     *
+     * This must not depend on API graphs, but ensures that an API node is generated for
+     * the source.
      */
     DataFlow::Node getASource(string package, string type) { none() }
 
     /**
-     * Gets a data flow node that is a sink of the type `package;type`,
+     * Gets a data-flow node that is a sink of the type `package;type`,
      * usually because it is an argument passed to a parameter of that type.
+     *
+     * This must not depend on API graphs, but ensures that an API node is generated for
+     * the sink.
      */
     DataFlow::Node getASink(string package, string type) { none() }
+
+    /**
+     * Gets an API node that is a source or sink of the type `package;type`.
+     *
+     * Unlike `getASource` and `getASink`, this may depend on API graphs.
+     */
+    API::Node getAnApiNode(string package, string type) { none() }
   }
 
   /**
@@ -433,6 +446,8 @@ private API::Node getNodeFromType(string package, string type) {
   result = any(TypeModelUseEntry e).getNodeForType(package, type)
   or
   result = any(TypeModelDefEntry e).getNodeForType(package, type)
+  or
+  result = any(TypeModel t).getAnApiNode(package, type)
   or
   result = Specific::getExtraNodeFromType(package, type)
 }

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
@@ -164,14 +164,27 @@ module ModelInput {
   class TypeModel extends Unit {
     /**
      * Gets a data-flow node that is a source of the type `package;type`.
+     *
+     * This must not depend on API graphs, but ensures that an API node is generated for
+     * the source.
      */
     DataFlow::Node getASource(string package, string type) { none() }
 
     /**
-     * Gets a data flow node that is a sink of the type `package;type`,
+     * Gets a data-flow node that is a sink of the type `package;type`,
      * usually because it is an argument passed to a parameter of that type.
+     *
+     * This must not depend on API graphs, but ensures that an API node is generated for
+     * the sink.
      */
     DataFlow::Node getASink(string package, string type) { none() }
+
+    /**
+     * Gets an API node that is a source or sink of the type `package;type`.
+     *
+     * Unlike `getASource` and `getASink`, this may depend on API graphs.
+     */
+    API::Node getAnApiNode(string package, string type) { none() }
   }
 
   /**
@@ -433,6 +446,8 @@ private API::Node getNodeFromType(string package, string type) {
   result = any(TypeModelUseEntry e).getNodeForType(package, type)
   or
   result = any(TypeModelDefEntry e).getNodeForType(package, type)
+  or
+  result = any(TypeModel t).getAnApiNode(package, type)
   or
   result = Specific::getExtraNodeFromType(package, type)
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
@@ -164,14 +164,27 @@ module ModelInput {
   class TypeModel extends Unit {
     /**
      * Gets a data-flow node that is a source of the type `package;type`.
+     *
+     * This must not depend on API graphs, but ensures that an API node is generated for
+     * the source.
      */
     DataFlow::Node getASource(string package, string type) { none() }
 
     /**
-     * Gets a data flow node that is a sink of the type `package;type`,
+     * Gets a data-flow node that is a sink of the type `package;type`,
      * usually because it is an argument passed to a parameter of that type.
+     *
+     * This must not depend on API graphs, but ensures that an API node is generated for
+     * the sink.
      */
     DataFlow::Node getASink(string package, string type) { none() }
+
+    /**
+     * Gets an API node that is a source or sink of the type `package;type`.
+     *
+     * Unlike `getASource` and `getASink`, this may depend on API graphs.
+     */
+    API::Node getAnApiNode(string package, string type) { none() }
   }
 
   /**
@@ -433,6 +446,8 @@ private API::Node getNodeFromType(string package, string type) {
   result = any(TypeModelUseEntry e).getNodeForType(package, type)
   or
   result = any(TypeModelDefEntry e).getNodeForType(package, type)
+  or
+  result = any(TypeModel t).getAnApiNode(package, type)
   or
   result = Specific::getExtraNodeFromType(package, type)
 }

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -34,6 +34,10 @@ edges
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:128:26:128:32 | tainted |
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:130:23:130:29 | tainted |
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:130:23:130:29 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:133:19:133:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:133:19:133:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:134:19:134:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:134:19:134:25 | tainted |
 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
 | summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
@@ -186,6 +190,8 @@ edges
 | summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:125:21:125:27 | tainted |
 | summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:128:26:128:32 | tainted |
 | summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:130:23:130:29 | tainted |
+| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:133:19:133:25 | tainted |
+| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:134:19:134:25 | tainted |
 | summaries.rb:115:16:115:22 | tainted :  | summaries.rb:115:16:115:22 | [post] tainted :  |
 | summaries.rb:115:16:115:22 | tainted :  | summaries.rb:115:25:115:25 | [post] y :  |
 | summaries.rb:115:16:115:22 | tainted :  | summaries.rb:115:33:115:33 | [post] z :  |
@@ -387,6 +393,10 @@ nodes
 | summaries.rb:128:26:128:32 | tainted | semmle.label | tainted |
 | summaries.rb:130:23:130:29 | tainted | semmle.label | tainted |
 | summaries.rb:130:23:130:29 | tainted | semmle.label | tainted |
+| summaries.rb:133:19:133:25 | tainted | semmle.label | tainted |
+| summaries.rb:133:19:133:25 | tainted | semmle.label | tainted |
+| summaries.rb:134:19:134:25 | tainted | semmle.label | tainted |
+| summaries.rb:134:19:134:25 | tainted | semmle.label | tainted |
 subpaths
 invalidSpecComponent
 #select
@@ -474,6 +484,10 @@ invalidSpecComponent
 | summaries.rb:128:26:128:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:128:26:128:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
 | summaries.rb:130:23:130:29 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:130:23:130:29 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
 | summaries.rb:130:23:130:29 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:130:23:130:29 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:133:19:133:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:133:19:133:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:133:19:133:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:133:19:133:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:134:19:134:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:134:19:134:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:134:19:134:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:134:19:134:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
 warning
 | CSV type row should have 5 columns but has 2: test;TooFewColumns |
 | CSV type row should have 5 columns but has 8: test;TooManyColumns;;;Member[Foo].Instance;too;many;columns |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -3,6 +3,7 @@
  */
 
 import codeql.ruby.AST
+import codeql.ruby.ApiGraphs
 import codeql.ruby.dataflow.FlowSummary
 import codeql.ruby.TaintTracking
 import codeql.ruby.dataflow.internal.FlowSummaryImpl
@@ -111,6 +112,12 @@ private class TypeFromCodeQL extends ModelInput::TypeModel {
     package = "test" and
     type = "FooOrBar" and
     result.asExpr().getExpr().getConstantValue().getString() = "magic_string"
+  }
+
+  override API::Node getAnApiNode(string package, string type) {
+    package = "test" and
+    type = "FooOrBar" and
+    result = API::getTopLevelMember("Alias").getMember(["Foo", "Bar"])
   }
 }
 

--- a/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
+++ b/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
@@ -129,3 +129,8 @@ Foo.sinkAnyNamedArg(key: tainted) # $ hasValueFlow=tainted
 
 "magic_string".method(tainted) # $ hasValueFlow=tainted
 "magic_string2".method(tainted)
+
+Alias::Foo.method(tainted) # $ hasValueFlow=tainted
+Alias::Bar.method(tainted) # $ hasValueFlow=tainted
+Something::Foo.method(tainted)
+Alias::Something.method(tainted)


### PR DESCRIPTION
Adds `TypeModel.getAnApiNode`. This allows contributing to a type definition when we already have an API node at hand. 

The existing predicates, `getSource` and `getSink`, contribute entry points to ensure an API node is going to exist, but must these can not themselves depend on API graphs.