### PR TITLE
QL: allow getURL as an acronym

### DIFF
--- a/ql/ql/src/codeql_ql/style/AcronymsShouldBeCamelCaseQuery.qll
+++ b/ql/ql/src/codeql_ql/style/AcronymsShouldBeCamelCaseQuery.qll
@@ -37,6 +37,7 @@ predicate shouldBePascalCased(string name, AstNode node, string kind) {
   not node.hasAnnotation("deprecated") and
   // allowed upper-case acronyms.
   not name.regexpMatch(".*(PEP|AES|DES|EOF).*") and
+  not name = "getURL" and // getURL is a language feature
   not (name.regexpMatch("T[A-Z]{3}[^A-Z].*") and node instanceof NewTypeBranch) and
   not (name.regexpMatch("T[A-Z]{3}[^A-Z].*") and node instanceof NewType) and
   not name.toUpperCase() = name // We are OK with fully-uppercase names.

--- a/ql/ql/src/qlpack.yml
+++ b/ql/ql/src/qlpack.yml
@@ -6,4 +6,4 @@ suites: codeql-suites
 defaultSuiteFile: codeql-suites/ql-code-scanning.qls
 extractor: ql
 dependencies:
-  codeql/typos: 0.0.1-dev
+  codeql/typos: 0.0.2-dev


### PR DESCRIPTION
`getURL` is a language feature, so it should be allowed as an upper-case acronym.  