### PR TITLE
Python: subscript def nodes

### DIFF
--- a/python/ql/lib/change-notes/2022-10-04-api-subscript-nodes.md
+++ b/python/ql/lib/change-notes/2022-10-04-api-subscript-nodes.md
@@ -3,4 +3,4 @@ category: minorAnalysis
 ---
 * Fixed labels in the API graph pertaining to definitions of subscripts. Previously, these were labelled by `getMember` rather than `getASubscript`.
 * Added `API::SubscriptReadNode` and `API::SubscriptWriteNode` with convenience predicates to obtain the index and, in the case of a write, the written value.
-* Added convenience predicates to obtain a subscript at a specific index, when the index happens to be a statically known string.
+* Added convenience predicates `getMember("key")` to obtain a subscript at a specific index, when the index happens to be a statically known string.

--- a/python/ql/lib/change-notes/2022-10-04-api-subscript-nodes.md
+++ b/python/ql/lib/change-notes/2022-10-04-api-subscript-nodes.md
@@ -3,4 +3,4 @@ category: minorAnalysis
 ---
 * Fixed labels in the API graph pertaining to definitions of subscripts. Previously, these were labelled by `getMember` rather than `getASubscript`.
 * Added `API::SubscriptReadNode` and `API::SubscriptWriteNode` with convenience predicates to obtain the index and, in the case of a write, the written value.
-* Added convenience predicates `getMember("key")` to obtain a subscript at a specific index, when the index happens to be a statically known string.
+* Added convenience predicates `getSubscript("key")` to obtain a subscript at a specific index, when the index happens to be a statically known string.

--- a/python/ql/lib/change-notes/2022-10-04-api-subscript-nodes.md
+++ b/python/ql/lib/change-notes/2022-10-04-api-subscript-nodes.md
@@ -2,5 +2,6 @@
 category: minorAnalysis
 ---
 * Fixed labels in the API graph pertaining to definitions of subscripts. Previously, these were labelled by `getMember` rather than `getASubscript`.
-* Added `API::SubscriptReadNode` and `API::SubscriptWriteNode` with convenience predicates to obtain the index and, in the case of a write, the written value.
+* Added edges for indices of subscripts to the API graph. Now a subscripted API node will have an edge to the API node for the index expression. So if `foo` is matched by API node `A`, then `"key"` in `foo["key"]` will be matched by the API node `A.getIndex()`, which can be used to track the origin of the index.
+* Added `API::SubscriptReadNode` and `API::SubscriptWriteNode` with convenience predicates to obtain the index and, in the case of a write, the written value. This is useful to tie indices to matching subscript expressions.
 * Added convenience predicates `getSubscript("key")` to obtain a subscript at a specific index, when the index happens to be a statically known string.

--- a/python/ql/lib/change-notes/2022-10-04-api-subscript-nodes.md
+++ b/python/ql/lib/change-notes/2022-10-04-api-subscript-nodes.md
@@ -1,0 +1,6 @@
+---
+category: minorAnalysis
+---
+* Fixed labels in the API graph pertaining to definitions of subscripts. Previously, these were labelled by `getMember` rather than `getASubscript`.
+* Added `API::SubscriptReadNode` and `API::SubscriptWriteNode` with convenience predicates to obtain the index and, in the case of a write, the written value.
+* Added convenience predicates to obtain a subscript at a specific index, when the index happens to be a statically known string.

--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -506,6 +506,18 @@ module API {
 
   /**
    * A read of a subscript that is connected to the API graph.
+   *
+   * This can be used to reason about the index of subscripts.
+   * For the code
+   * ```python
+   * x = foo[bar]
+   * y = foo[baz]
+   * ```
+   * there wil be subscript edges from `foo` to both `foo[bar]` and `foo[baz]`,
+   * and there will be index edges from `foo` to both `bar` and `baz`.
+   * There will be a separate `SubscriptReadNode` for `foo[bar]` (and one for `foo[baz]`),
+   * and the member predicates `getObject` and `getIndex` will return nodes
+   * consistent with that particular read.
    */
   class SubscriptReadNode extends DataFlow::Node {
     API::Node subscripted;
@@ -525,7 +537,17 @@ module API {
   /**
    * A write to a subscript that is connected to the API graph.
    *
-   * The member predicate `getValue` is guaranteed to exist and be unique to this write.
+   * This can be used to reason about the index and written values of subscripts.
+   * For the code
+   * ```python
+   * foo[bar] = x
+   * foo[baz] = y
+   * ```
+   * there wil be subscript edges from `foo` to both `x` and `y`,
+   * and there will be index edges from `foo` to both `bar` and `baz`.
+   * There will be a separate `SubscriptWriteNode` for `x` (and one for `y`),
+   * and the member predicates `getObject`, `getIndex`, and `getValue` will return nodes
+   * consistent with that particular write.
    */
   class SubscriptWriteNode extends DataFlow::Node {
     API::Node subscripted;

--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -519,7 +519,7 @@ module API {
    * and the member predicates `getObject` and `getIndex` will return nodes
    * consistent with that particular read.
    */
-  class SubscriptReadNode extends DataFlow::Node {
+  private class SubscriptReadNode extends DataFlow::Node {
     API::Node object;
 
     SubscriptReadNode() { this = object.getASubscript().asSource() }
@@ -549,7 +549,7 @@ module API {
    * and the member predicates `getObject`, `getIndex`, and `getValue` will return nodes
    * consistent with that particular write.
    */
-  class SubscriptWriteNode extends DataFlow::Node {
+  private class SubscriptWriteNode extends DataFlow::Node {
     API::Node object;
 
     SubscriptWriteNode() { this = object.getASubscript().asSink() }

--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -252,7 +252,7 @@ module API {
     /**
      * Gets a node representing a subscript of this node at (string) index `key`.
      * This requires that the index can be statically determined.
-     * 
+     *
      * For example, the subscripts of `a` and `b` below would be found using
      * the index `foo`:
      * ```py
@@ -511,7 +511,7 @@ module API {
     /** Gets an API node for the object being subscripted. */
     API::Node getObject() { result = subscripted }
 
-    /** Gets the data flow node representing the index of this read, if any. */
+    /** Gets the data flow node representing the index of this read. */
     DataFlow::Node getIndex() {
       result.asCfgNode() = this.asCfgNode().(PY::SubscriptNode).getIndex()
     }
@@ -530,7 +530,7 @@ module API {
     /** Gets an API node for the object being subscripted. */
     API::Node getObject() { result = subscripted }
 
-    /** Gets the data flow node representing the index of this write, if any. */
+    /** Gets the data flow node representing the index of this write. */
     DataFlow::Node getIndex() {
       exists(PY::SubscriptNode subscriptNode |
         subscriptNode.(PY::DefinitionNode).getValue() = this.asCfgNode() and

--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -249,6 +249,10 @@ module API {
      */
     Node getASubscript() { result = this.getASuccessor(Label::subscript()) }
 
+    /**
+     * Gets a node representing a subscript of this node at index `key`.
+     * This requires that the index can be statically determined.
+     */
     Node getSubscript(string key) {
       (
         exists(SubscriptReadNode subscript | subscript = result.getInducingNode() |

--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -250,8 +250,16 @@ module API {
     Node getASubscript() { result = this.getASuccessor(Label::subscript()) }
 
     /**
-     * Gets a node representing a subscript of this node at index `key`.
+     * Gets a node representing a subscript of this node at (string) index `key`.
      * This requires that the index can be statically determined.
+     * 
+     * For example, the subscripts of `a` and `b` below would be found using
+     * the index `foo`:
+     * ```py
+     * a["foo"]
+     * x = "foo" if cond else "bar"
+     * b[x]
+     * ```
      */
     Node getSubscript(string key) {
       (
@@ -500,7 +508,7 @@ module API {
 
     SubscriptReadNode() { this = subscripted.getASubscript().asSource() }
 
-    /** Gets ans API node for the object being subscripted */
+    /** Gets an API node for the object being subscripted. */
     API::Node getObject() { result = subscripted }
 
     /** Gets the data flow node representing the index of this read, if any. */
@@ -519,7 +527,7 @@ module API {
 
     SubscriptWriteNode() { this = subscripted.getASubscript().asSink() }
 
-    /** Gets ans API node for the object being subscripted */
+    /** Gets an API node for the object being subscripted. */
     API::Node getObject() { result = subscripted }
 
     /** Gets the data flow node representing the index of this write, if any. */

--- a/python/ql/lib/semmle/python/ApiGraphs.qll
+++ b/python/ql/lib/semmle/python/ApiGraphs.qll
@@ -249,6 +249,20 @@ module API {
      */
     Node getASubscript() { result = this.getASuccessor(Label::subscript()) }
 
+    Node getSubscript(string key) {
+      (
+        exists(SubscriptReadNode subscript | subscript = result.getInducingNode() |
+          this = subscript.getObject() and
+          key = subscript.getIndex().getALocalSource().asExpr().(PY::StrConst).getText()
+        )
+        or
+        exists(SubscriptWriteNode subscript | subscript = result.getInducingNode() |
+          this = subscript.getObject() and
+          key = subscript.getIndex().getALocalSource().asExpr().(PY::StrConst).getText()
+        )
+      )
+    }
+
     /**
      * Gets a string representation of the lexicographically least among all shortest access paths
      * from the root to this node.

--- a/python/ql/lib/semmle/python/dataflow/new/internal/LocalSources.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/LocalSources.qll
@@ -104,7 +104,7 @@ class LocalSourceNode extends Node {
   /**
    * Gets a subscript of this node.
    */
-  Node getASubscript() { Cached::subscript(this, result) }
+  Node getSubscript(Node index) { Cached::subscript(this, result, index) }
 
   /**
    * Gets a call to the method `methodName` on this node.
@@ -249,13 +249,14 @@ private module Cached {
   }
 
   /**
-   * Holds if `node` flows to a sequence/mapping of which `subscript` is a subscript.
+   * Holds if `node` flows to a sequence/mapping of which `subscript` is a subscript with index/key `index`.
    */
   cached
-  predicate subscript(LocalSourceNode node, CfgNode subscript) {
+  predicate subscript(LocalSourceNode node, CfgNode subscript, CfgNode index) {
     exists(CfgNode seq, SubscriptNode subscriptNode | subscriptNode = subscript.getNode() |
       node.flowsTo(seq) and
-      seq.getNode() = subscriptNode.getObject()
+      seq.getNode() = subscriptNode.getObject() and
+      index.getNode() = subscriptNode.getIndex()
     )
   }
 }

--- a/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
@@ -616,24 +616,17 @@ module AiohttpWebModel {
    * A dict-like write to an item of the `cookies` attribute on a HTTP response, such as
    * `response.cookies[name] = value`.
    */
-  class AiohttpResponseCookieSubscriptWrite extends Http::Server::CookieWrite::Range {
-    DataFlow::Node index;
-    DataFlow::Node value;
-
+  class AiohttpResponseCookieSubscriptWrite extends API::SubscriptWriteNode,
+    Http::Server::CookieWrite::Range {
     AiohttpResponseCookieSubscriptWrite() {
-      exists(API::SubscriptWriteNode subscriptWrite |
-        subscriptWrite.getObject() = aiohttpResponseInstance().getMember("cookies") and
-        this = subscriptWrite and
-        index = subscriptWrite.getIndex() and
-        value = subscriptWrite.getValue().asSink()
-      )
+      this.getObject() = aiohttpResponseInstance().getMember("cookies")
     }
 
     override DataFlow::Node getHeaderArg() { none() }
 
-    override DataFlow::Node getNameArg() { result = index }
+    override DataFlow::Node getNameArg() { result = this.getIndex() }
 
-    override DataFlow::Node getValueArg() { result = value }
+    override DataFlow::Node getValueArg() { result = this.getValue().asSink() }
   }
 }
 

--- a/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
@@ -621,14 +621,12 @@ module AiohttpWebModel {
     DataFlow::Node value;
 
     AiohttpResponseCookieSubscriptWrite() {
-      exists(SubscriptNode subscript |
-        // To give `this` a value, we need to choose between either LHS or RHS,
-        // and just go with the LHS
-        this.asCfgNode() = subscript
-      |
-        subscript.getObject() =
-          aiohttpResponseInstance().getMember("cookies").getAValueReachableFromSource().asCfgNode() and
-        value.asCfgNode() = subscript.(DefinitionNode).getValue() and
+      // `value` defines a subscript
+      value = aiohttpResponseInstance().getMember("cookies").getASubscript().asSink() and
+      // recover the `SubscriptNode` to get the index (and to define `this`)
+      // this part assumes a specific syntax for defining the subscript
+      exists(SubscriptNode subscript | value.asCfgNode() = subscript.(DefinitionNode).getValue() |
+        this.asCfgNode() = subscript and
         index.asCfgNode() = subscript.getIndex()
       )
     }

--- a/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
@@ -621,13 +621,11 @@ module AiohttpWebModel {
     DataFlow::Node value;
 
     AiohttpResponseCookieSubscriptWrite() {
-      // `value` defines a subscript
-      value = aiohttpResponseInstance().getMember("cookies").getASubscript().asSink() and
-      // recover the `SubscriptNode` to get the index (and to define `this`)
-      // this part assumes a specific syntax for defining the subscript
-      exists(SubscriptNode subscript | value.asCfgNode() = subscript.(DefinitionNode).getValue() |
-        this.asCfgNode() = subscript and
-        index.asCfgNode() = subscript.getIndex()
+      exists(API::SubscriptWriteNode subscriptWrite |
+        subscriptWrite.getObject() = aiohttpResponseInstance().getMember("cookies") and
+        this = subscriptWrite and
+        index = subscriptWrite.getIndex() and
+        value = subscriptWrite.getValue().asSink()
       )
     }
 

--- a/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
@@ -624,7 +624,7 @@ module AiohttpWebModel {
 
     override DataFlow::Node getHeaderArg() { none() }
 
-    override DataFlow::Node getNameArg() { result = this.getIndex() }
+    override DataFlow::Node getNameArg() { result = this.getIndex().asSink() }
 
     override DataFlow::Node getValueArg() { result = this.getValue().asSink() }
   }

--- a/python/ql/src/experimental/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Django.qll
@@ -91,14 +91,10 @@ private module ExperimentalPrivateDjango {
             result = baseClassRef().getReturn().getAMember()
           }
 
-          /** Gets a reference to a header instance call with `__setitem__`. */
-          API::Node headerSetItem() {
-            result = headerInstance() and
-            result.asSource().(DataFlow::AttrRead).getAttributeName() = "__setitem__"
-          }
-
           class DjangoResponseSetItemCall extends DataFlow::CallCfgNode, HeaderDeclaration::Range {
-            DjangoResponseSetItemCall() { this = headerSetItem().getACall() }
+            DjangoResponseSetItemCall() {
+              this = baseClassRef().getReturn().getMember("__setitem__").getACall()
+            }
 
             override DataFlow::Node getNameArg() { result = this.getArg(0) }
 
@@ -109,8 +105,7 @@ private module ExperimentalPrivateDjango {
             DataFlow::Node headerInput;
 
             DjangoResponseDefinition() {
-              this.asCfgNode().(DefinitionNode) =
-                headerInstance().getAValueReachableFromSource().asCfgNode() and
+              headerInput = headerInstance().asSink() and
               headerInput.asCfgNode() = this.asCfgNode().(DefinitionNode).getValue()
             }
 

--- a/python/ql/src/experimental/semmle/python/libraries/SmtpLib.qll
+++ b/python/ql/src/experimental/semmle/python/libraries/SmtpLib.qll
@@ -102,33 +102,6 @@ module SmtpLib {
   }
 
   /**
-   * Gets a message subscript write by correlating subscript's object local source with
-   * `smtp`'s `sendmail` call 3rd argument's local source.
-   *
-   * Given the following example with `getSMTPSubscriptByIndex(any(SmtpLibSendMail s), "Subject")`:
-   *
-   * ```py
-   * message = MIMEMultipart("alternative")
-   * message["Subject"] = "multipart test"
-   * server.sendmail(sender_email, receiver_email, message.as_string())
-   * ```
-   *
-   * * `def` would be `message["Subject"]` (`DefinitionNode`)
-   * * `sub` would be `message["Subject"]` (`Subscript`)
-   * * `result` would be `"multipart test"`
-   */
-  private DataFlow::Node getSmtpSubscriptByIndex(DataFlow::CallCfgNode sendCall, string index) {
-    exists(DefinitionNode def, Subscript sub |
-      sub = def.getNode() and
-      DataFlow::exprNode(sub.getObject()).getALocalSource() =
-        [sendCall.getArg(2), sendCall.getArg(2).(DataFlow::MethodCallNode).getObject()]
-            .getALocalSource() and
-      sub.getIndex().(StrConst).getText() = index and
-      result.asCfgNode() = def.getValue()
-    )
-  }
-
-  /**
    * Gets a reference to `smtplib.SMTP_SSL().sendmail()`.
    *
    * Given the following example:
@@ -153,7 +126,7 @@ module SmtpLib {
    * * `getFrom()`'s result would be `sender_email`.
    * * `getSubject()`'s result would be `"multipart test"`.
    */
-  private class SmtpLibSendMail extends DataFlow::CallCfgNode, EmailSender::Range {
+  private class SmtpLibSendMail extends API::CallNode, EmailSender::Range {
     SmtpLibSendMail() {
       this = smtpConnectionInstance().getReturn().getMember("sendmail").getACall()
     }
@@ -163,15 +136,24 @@ module SmtpLib {
     override DataFlow::Node getHtmlBody() { result = getSmtpMessage(this, "html") }
 
     override DataFlow::Node getTo() {
-      result in [this.getArg(1), getSmtpSubscriptByIndex(this, "To")]
+      result = this.getParameter(1, "to_addrs").asSink()
+      or
+      result = this.getMsg().getSubscript("To").asSink()
     }
 
     override DataFlow::Node getFrom() {
-      result in [this.getArg(0), getSmtpSubscriptByIndex(this, "From")]
+      result = this.getParameter(0, "from_addr").asSink()
+      or
+      result = this.getMsg().getSubscript("From").asSink()
     }
 
-    override DataFlow::Node getSubject() {
-      result in [this.getArg(2), getSmtpSubscriptByIndex(this, "Subject")]
+    override DataFlow::Node getSubject() { result = this.getMsg().getSubscript("Subject").asSink() }
+
+    private API::Node getMsg() {
+      result.getAValueReachableFromSource() = this.getParameter(2, "msg").asSink()
+      or
+      result.getMember("as_string").getReturn().getAValueReachableFromSource() =
+        this.getParameter(2, "msg").asSink()
     }
   }
 }

--- a/python/ql/test/library-tests/ApiGraphs/py3/deftest1.py
+++ b/python/ql/test/library-tests/ApiGraphs/py3/deftest1.py
@@ -5,12 +5,12 @@ def callback(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("bar").
 
 foo.bar(callback) #$ def=moduleImport("mypkg").getMember("foo").getMember("bar").getParameter(0) use=moduleImport("mypkg").getMember("foo").getMember("bar").getReturn()
 
-def callback2(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("c").getParameter(0)
-    x.baz2() #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("c").getParameter(0).getMember("baz2").getReturn()
+def callback2(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getASubscript().getParameter(0)
+    x.baz2() #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getASubscript().getParameter(0).getMember("baz2").getReturn()
 
 mydict = {
-  "c": callback2, #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("c")
-  "other": "whatever" #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("other")
+  "c": callback2, #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getASubscript()
+  "other": "whatever" #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getASubscript()
 }
 
 foo.baz(mydict) #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0) use=moduleImport("mypkg").getMember("foo").getMember("baz").getReturn()
@@ -34,11 +34,11 @@ otherDict.fourth = callback4
 
 foo.quack(otherDict.fourth) #$ def=moduleImport("mypkg").getMember("foo").getMember("quack").getParameter(0) use=moduleImport("mypkg").getMember("foo").getMember("quack").getReturn()
 
-def namedCallback(myName, otherName): 
-    # Using named parameters: 
+def namedCallback(myName, otherName):
+    # Using named parameters:
     myName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getParameter(0).getKeywordParameter("myName").getReturn()
     otherName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getParameter(0).getKeywordParameter("otherName").getReturn()
-    # Using numbered parameters: 
+    # Using numbered parameters:
     myName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getParameter(0).getParameter(0).getReturn()
     otherName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getParameter(0).getParameter(1).getReturn()
 

--- a/python/ql/test/library-tests/ApiGraphs/py3/getSubscript.expected
+++ b/python/ql/test/library-tests/ApiGraphs/py3/getSubscript.expected
@@ -1,0 +1,6 @@
+| test_subscript.py:4:11:4:28 | Use moduleImport("mypkg").getMember("foo").getReturn().getASubscript() |
+| test_subscript.py:5:26:5:27 | Def moduleImport("mypkg").getMember("foo").getReturn().getASubscript() |
+| test_subscript.py:6:5:6:22 | Use moduleImport("mypkg").getMember("foo").getReturn().getASubscript() |
+| test_subscript.py:6:5:6:28 | Def moduleImport("mypkg").getMember("foo").getReturn().getASubscript() |
+| test_subscript.py:7:5:7:22 | Use moduleImport("mypkg").getMember("foo").getReturn().getASubscript() |
+| test_subscript.py:7:5:7:28 | Def moduleImport("mypkg").getMember("foo").getReturn().getASubscript() |

--- a/python/ql/test/library-tests/ApiGraphs/py3/getSubscript.ql
+++ b/python/ql/test/library-tests/ApiGraphs/py3/getSubscript.ql
@@ -1,0 +1,4 @@
+import python
+import semmle.python.ApiGraphs
+
+select API::moduleImport("mypkg").getMember("foo").getReturn().getSubscript(["bar", "baz", "qux"])

--- a/python/ql/test/library-tests/ApiGraphs/py3/test_subscript.py
+++ b/python/ql/test/library-tests/ApiGraphs/py3/test_subscript.py
@@ -1,0 +1,8 @@
+import mypkg
+
+def test_subscript():
+    bar = mypkg.foo()["bar"] #$ use=moduleImport("mypkg").getMember("foo").getReturn().getASubscript()
+    mypkg.foo()["baz"] = 42 #$ def=moduleImport("mypkg").getMember("foo").getReturn().getASubscript()
+    mypkg.foo()["qux"] += 42 #$ use=moduleImport("mypkg").getMember("foo").getReturn().getASubscript()
+    mypkg.foo()["qux"] += 42 #$ def=moduleImport("mypkg").getMember("foo").getReturn().getASubscript()
+    mypkg.foo()[mypkg.index] = mypkg.value #$ def=moduleImport("mypkg").getMember("foo").getReturn().getASubscript()


### PR DESCRIPTION
Follow on to #10539. Fix the def-nodes for subscripts.

I also experimented with recovering the index of a subscript (see [the commit](https://github.com/github/codeql/pull/10608/commits/2435ccf06e6f3640d5c091d06b7ad4a1c29e85a2)). I did it for the case where the subscript is being written to. This is the complicated case, because the actual `SubscriptNode` is _not_ an API node:
For
```python
  header["key"] = "value"
```
`header` would be an API use node and `"value"` would be an API def node with path `[path to header].getASubscript()`. (To get the data flow node, we can then use `asSink()` or `getAValueReachingSink()` as appropriate.)

Update: There is now a `SubscriptReadNode` and a `SubscriptWriteNode` to help with recovering the index and the written value.