### PR TITLE
C++: Make `OverrunWriteProductFlow` raise alerts on overflows

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
@@ -20,7 +20,8 @@ module ProductFlow {
      * `source1` and `source2` must belong to the same callable.
      */
     predicate isSourcePair(
-      DataFlow::Node source1, string state1, DataFlow::Node source2, string state2
+      DataFlow::Node source1, DataFlow::FlowState state1, DataFlow::Node source2,
+      DataFlow::FlowState state2
     ) {
       state1 = "" and
       state2 = "" and
@@ -89,6 +90,49 @@ module ProductFlow {
      */
     predicate isBarrierOut2(DataFlow::Node node) { none() }
 
+    /*
+     * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps in
+     * the first projection of the product dataflow graph.
+     */
+
+    predicate isAdditionalFlowStep1(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+    /**
+     * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps in
+     * the first projection of the product dataflow graph.
+     *
+     * This step is only applicable in `state1` and updates the flow state to `state2`.
+     */
+    predicate isAdditionalFlowStep1(
+      DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,
+      DataFlow::FlowState state2
+    ) {
+      state1 instanceof DataFlow::FlowStateEmpty and
+      state2 instanceof DataFlow::FlowStateEmpty and
+      this.isAdditionalFlowStep1(node1, node2)
+    }
+
+    /**
+     * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps in
+     * the second projection of the product dataflow graph.
+     */
+    predicate isAdditionalFlowStep2(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+    /**
+     * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps in
+     * the second projection of the product dataflow graph.
+     *
+     * This step is only applicable in `state1` and updates the flow state to `state2`.
+     */
+    predicate isAdditionalFlowStep2(
+      DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,
+      DataFlow::FlowState state2
+    ) {
+      state1 instanceof DataFlow::FlowStateEmpty and
+      state2 instanceof DataFlow::FlowStateEmpty and
+      this.isAdditionalFlowStep2(node1, node2)
+    }
+
     predicate hasFlowPath(
       DataFlow::PathNode source1, DataFlow2::PathNode source2, DataFlow::PathNode sink1,
       DataFlow2::PathNode sink2
@@ -103,45 +147,60 @@ module ProductFlow {
     class Conf1 extends DataFlow::Configuration {
       Conf1() { this = "Conf1" }
 
-      override predicate isSource(DataFlow::Node source, string state) {
+      override predicate isSource(DataFlow::Node source, DataFlow::FlowState state) {
         exists(Configuration conf | conf.isSourcePair(source, state, _, _))
       }
 
-      override predicate isSink(DataFlow::Node sink, string state) {
+      override predicate isSink(DataFlow::Node sink, DataFlow::FlowState state) {
         exists(Configuration conf | conf.isSinkPair(sink, state, _, _))
       }
 
-      override predicate isBarrier(DataFlow::Node node, string state) {
+      override predicate isBarrier(DataFlow::Node node, DataFlow::FlowState state) {
         exists(Configuration conf | conf.isBarrier1(node, state))
       }
 
       override predicate isBarrierOut(DataFlow::Node node) {
         exists(Configuration conf | conf.isBarrierOut1(node))
       }
+
+      override predicate isAdditionalFlowStep(
+        DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,
+        DataFlow::FlowState state2
+      ) {
+        exists(Configuration conf | conf.isAdditionalFlowStep1(node1, state1, node2, state2))
+      }
     }
 
     class Conf2 extends DataFlow2::Configuration {
       Conf2() { this = "Conf2" }
 
-      override predicate isSource(DataFlow::Node source, string state) {
-        exists(Configuration conf, DataFlow::Node source1 |
-          conf.isSourcePair(source1, _, source, state) and
-          any(Conf1 c).hasFlow(source1, _)
+      override predicate isSource(DataFlow::Node source, DataFlow::FlowState state) {
+        exists(Configuration conf, DataFlow::PathNode source1 |
+          conf.isSourcePair(source1.getNode(), source1.getState(), source, state) and
+          any(Conf1 c).hasFlowPath(source1, _)
         )
       }
 
-      override predicate isSink(DataFlow::Node sink, string state) {
-        exists(Configuration conf, DataFlow::Node sink1 |
-          conf.isSinkPair(sink1, _, sink, state) and any(Conf1 c).hasFlow(_, sink1)
+      override predicate isSink(DataFlow::Node sink, DataFlow::FlowState state) {
+        exists(Configuration conf, DataFlow::PathNode sink1 |
+          conf.isSinkPair(sink1.getNode(), sink1.getState(), sink, state) and
+          any(Conf1 c).hasFlowPath(_, sink1)
         )
       }
 
-      override predicate isBarrier(DataFlow::Node node, string state) {
+      override predicate isBarrier(DataFlow::Node node, DataFlow::FlowState state) {
         exists(Configuration conf | conf.isBarrier2(node, state))
       }
 
       override predicate isBarrierOut(DataFlow::Node node) {
         exists(Configuration conf | conf.isBarrierOut2(node))
+      }
+
+      override predicate isAdditionalFlowStep(
+        DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,
+        DataFlow::FlowState state2
+      ) {
+        exists(Configuration conf | conf.isAdditionalFlowStep2(node1, state1, node2, state2))
       }
     }
   }
@@ -150,7 +209,7 @@ module ProductFlow {
     Configuration conf, DataFlow::PathNode source1, DataFlow2::PathNode source2,
     DataFlow::PathNode node1, DataFlow2::PathNode node2
   ) {
-    conf.isSourcePair(node1.getNode(), _, node2.getNode(), _) and
+    conf.isSourcePair(node1.getNode(), node1.getState(), node2.getNode(), node2.getState()) and
     node1 = source1 and
     node2 = source2
     or
@@ -213,7 +272,7 @@ module ProductFlow {
   ) {
     exists(DataFlow::PathNode mid1, DataFlow2::PathNode mid2 |
       reachableInterprocEntry(conf, source1, source2, mid1, mid2) and
-      conf.isSinkPair(sink1.getNode(), _, sink2.getNode(), _) and
+      conf.isSinkPair(sink1.getNode(), sink1.getState(), sink2.getNode(), sink2.getState()) and
       localPathStep1*(mid1, sink1) and
       localPathStep2*(mid2, sink2)
     )

--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.cpp
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.cpp
@@ -1,0 +1,9 @@
+int f(char * s, unsigned size) {
+	char* buf = (char*)malloc(size);
+
+	strncpy(buf, s, size + 1); // wrong: copy may exceed size of buf
+
+	for (int i = 0; i <= size; i++) { // wrong: upper limit that is higher than size of buf
+		cout << buf[i];
+	}
+}

--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.qhelp
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.qhelp
@@ -1,0 +1,29 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>You must ensure that you do not exceed the size of an allocation during write and read operations.
+If an operation attempts to write to or access an element that is outside the range of the allocation then this results in a buffer overflow.
+Buffer overflows can lead to anything from a segmentation fault to a security vulnerability.
+</p>
+
+</overview>
+<recommendation>
+<p>
+Check the offsets and sizes used in the highlighted operations to ensure that a buffer overflow will not occur.
+</p>
+
+</recommendation>
+<example><sample src="OverrunWriteProductFlow.cpp" />
+
+
+
+</example>
+<references>
+
+<li>I. Gerg. <em>An Overview and Example of the Buffer-Overflow Exploit</em>. IANewsletter vol 7 no 4. 2005.</li>
+<li>M. Donaldson. <em>Inside the Buffer Overflow Attack: Mechanism, Method &amp; Prevention</em>. SANS Institute InfoSec Reading Room. 2002.</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -123,6 +123,21 @@ class StringSizeConfiguration extends ProductFlow::Configuration {
       delta > state2.toInt()
     )
   }
+
+  override predicate isAdditionalFlowStep2(
+    DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,
+    DataFlow::FlowState state2
+  ) {
+    exists(AddInstruction add, Operand op, int delta, int s1, int s2 |
+      s1 = [0 .. 32] and // An arbitrary bound because we need to bound `state`
+      state1 = s1.toString() and
+      state2 = s2.toString() and
+      add.hasOperands(node1.asOperand(), op) and
+      semBounded(op.getDef(), any(SemZeroBound zero), delta, true, _) and
+      node2.asInstruction() = add and
+      s1 = s2 + delta
+    )
+  }
 }
 
 from

--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -39,49 +39,27 @@ predicate bounded(Instruction i, Instruction b, int delta) {
   )
 }
 
-/**
- * Holds if the combination of `n` and `state` represents an appropriate
- * source for the expression `e` suitable for use-use flow.
- */
-private predicate hasSizeImpl(Expr e, DataFlow::Node n, string state) {
-  // The simple case: If the size is a variable access with no qualifier we can just use the
-  // dataflow node for that expression and no state.
-  exists(VariableAccess va |
-    va = e and
-    not va instanceof FieldAccess and
-    n.asConvertedExpr() = va.getFullyConverted() and
-    state = "0"
-  )
-  or
-  // If the size is a choice between two expressions we allow both to be nodes representing the size.
-  exists(ConditionalExpr cond | cond = e | hasSizeImpl([cond.getThen(), cond.getElse()], n, state))
-  or
-  // If the size is an expression plus a constant, we pick the dataflow node of the expression and
-  // remember the constant in the state.
-  exists(Expr const, Expr nonconst |
-    e.(AddExpr).hasOperands(const, nonconst) and
-    state = const.getValue() and
-    hasSizeImpl(nonconst, n, _)
-  )
-  or
-  exists(Expr const, Expr nonconst |
-    e.(SubExpr).hasOperands(const, nonconst) and
-    state = "-" + const.getValue() and
-    hasSizeImpl(nonconst, n, _)
-  )
-}
+VariableAccess getAVariableAccess(Expr e) { e.getAChild*() = result }
 
 /**
  * Holds if `(n, state)` pair represents the source of flow for the size
  * expression associated with `alloc`.
  */
 predicate hasSize(AllocationExpr alloc, DataFlow::Node n, string state) {
-  hasSizeImpl(alloc.getSizeExpr(), n, state)
+  exists(VariableAccess va, Expr size, int delta |
+    size = alloc.getSizeExpr() and
+    // Get the unique variable in a size expression like `x` in `malloc(x + 1)`.
+    va = unique( | | getAVariableAccess(size)) and
+    // Compute `delta` as the constant difference between `x` and `x + 1`.
+    bounded(any(Instruction instr | instr.getUnconvertedResultExpression() = size),
+      any(LoadInstruction load | load.getUnconvertedResultExpression() = va), delta) and
+    n.asConvertedExpr() = va.getFullyConverted() and
+    state = delta.toString()
+  )
 }
 
 predicate isSinkPairImpl(
-  CallInstruction c, DataFlow::Node bufSink, DataFlow::Node sizeSink, int delta, Expr eBuf,
-  Expr eSize
+  CallInstruction c, DataFlow::Node bufSink, DataFlow::Node sizeSink, int delta, Expr eBuf
 ) {
   exists(int bufIndex, int sizeIndex, Instruction sizeInstr, Instruction bufInstr |
     bufInstr = bufSink.asInstruction() and
@@ -89,9 +67,7 @@ predicate isSinkPairImpl(
     sizeInstr = sizeSink.asInstruction() and
     c.getStaticCallTarget().(ArrayFunction).hasArrayWithVariableSize(bufIndex, sizeIndex) and
     bounded(c.getArgument(sizeIndex), sizeInstr, delta) and
-    eSize = sizeInstr.getUnconvertedResultExpression() and
-    eBuf = bufInstr.getUnconvertedResultExpression() and
-    delta >= 1
+    eBuf = bufInstr.getUnconvertedResultExpression()
   )
 }
 
@@ -117,9 +93,9 @@ class StringSizeConfiguration extends ProductFlow::Configuration {
     DataFlow::FlowState state2
   ) {
     state1 instanceof DataFlow::FlowStateEmpty and
-    state2 = [0 .. 32].toString() and // An arbitrary bound because we need to bound `state2`
+    state2 = [-32 .. 32].toString() and // An arbitrary bound because we need to bound `state2`
     exists(int delta |
-      isSinkPairImpl(_, bufSink, sizeSink, delta, _, _) and
+      isSinkPairImpl(_, bufSink, sizeSink, delta, _) and
       delta > state2.toInt()
     )
   }
@@ -129,7 +105,7 @@ class StringSizeConfiguration extends ProductFlow::Configuration {
     DataFlow::FlowState state2
   ) {
     exists(AddInstruction add, Operand op, int delta, int s1, int s2 |
-      s1 = [0 .. 32] and // An arbitrary bound because we need to bound `state`
+      s1 = [-32 .. 32] and // An arbitrary bound because we need to bound `state`
       state1 = s1.toString() and
       state2 = s2.toString() and
       add.hasOperands(node1.asOperand(), op) and
@@ -142,13 +118,14 @@ class StringSizeConfiguration extends ProductFlow::Configuration {
 
 from
   StringSizeConfiguration conf, DataFlow::PathNode source1, DataFlow2::PathNode source2,
-  DataFlow::PathNode sink1, DataFlow2::PathNode sink2, int k, CallInstruction c,
-  DataFlow::Node sourceNode, Expr bound, Expr buffer, string element
+  DataFlow::PathNode sink1, DataFlow2::PathNode sink2, int overflow, int sinkState,
+  CallInstruction c, DataFlow::Node sourceNode, Expr buffer, string element
 where
   conf.hasFlowPath(source1, source2, sink1, sink2) and
-  k > sink2.getState().toInt() and
-  isSinkPairImpl(c, sink1.getNode(), sink2.getNode(), k, buffer, bound) and
+  sinkState = sink2.getState().toInt() and
+  isSinkPairImpl(c, sink1.getNode(), sink2.getNode(), overflow + sinkState, buffer) and
+  overflow > 0 and
   sourceNode = source1.getNode() and
-  if k = 1 then element = " element." else element = " elements."
+  if overflow = 1 then element = " element." else element = " elements."
 select c.getUnconvertedResultExpression(), source1, sink1,
-  "This write may overflow $@ by " + k + element, buffer, buffer.toString()
+  "This write may overflow $@ by " + overflow + element, buffer, buffer.toString()

--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -1,42 +1,139 @@
 /**
  * @name Overrunning write
- * @description TODO
+ * @description Exceeding the size of a static array during write or access operations
+ *              may result in a buffer overflow.
  * @kind path-problem
  * @problem.severity error
  * @id cpp/overrun-write
  * @tags reliability
  *       security
+ *       external/cwe/cwe-119
+ *       external/cwe/cwe-131
  */
 
 import cpp
 import experimental.semmle.code.cpp.dataflow.ProductFlow
 import semmle.code.cpp.ir.IR
-import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.models.interfaces.Allocation
 import semmle.code.cpp.models.interfaces.ArrayFunction
+import experimental.semmle.code.cpp.semantic.analysis.RangeAnalysis
+import experimental.semmle.code.cpp.semantic.SemanticBound
+import experimental.semmle.code.cpp.semantic.SemanticExprSpecific
 import DataFlow::PathGraph
+
+pragma[nomagic]
+Instruction getABoundIn(SemBound b, IRFunction func) {
+  result = b.getExpr(0) and
+  result.getEnclosingIRFunction() = func
+}
+
+/**
+ * Holds if `i <= b + delta`.
+ */
+pragma[nomagic]
+predicate bounded(Instruction i, Instruction b, int delta) {
+  exists(SemBound bound, IRFunction func |
+    semBounded(getSemanticExpr(i), bound, delta, true, _) and
+    b = getABoundIn(bound, func) and
+    i.getEnclosingIRFunction() = func
+  )
+}
+
+/**
+ * Holds if the combination of `n` and `state` represents an appropriate
+ * source for the expression `e` suitable for use-use flow.
+ */
+private predicate hasSizeImpl(Expr e, DataFlow::Node n, string state) {
+  // The simple case: If the size is a variable access with no qualifier we can just use the
+  // dataflow node for that expression and no state.
+  exists(VariableAccess va |
+    va = e and
+    not va instanceof FieldAccess and
+    n.asConvertedExpr() = va.getFullyConverted() and
+    state = "0"
+  )
+  or
+  // If the size is a choice between two expressions we allow both to be nodes representing the size.
+  exists(ConditionalExpr cond | cond = e | hasSizeImpl([cond.getThen(), cond.getElse()], n, state))
+  or
+  // If the size is an expression plus a constant, we pick the dataflow node of the expression and
+  // remember the constant in the state.
+  exists(Expr const, Expr nonconst |
+    e.(AddExpr).hasOperands(const, nonconst) and
+    state = const.getValue() and
+    hasSizeImpl(nonconst, n, _)
+  )
+  or
+  exists(Expr const, Expr nonconst |
+    e.(SubExpr).hasOperands(const, nonconst) and
+    state = "-" + const.getValue() and
+    hasSizeImpl(nonconst, n, _)
+  )
+}
+
+/**
+ * Holds if `(n, state)` pair represents the source of flow for the size
+ * expression associated with `alloc`.
+ */
+predicate hasSize(AllocationExpr alloc, DataFlow::Node n, string state) {
+  hasSizeImpl(alloc.getSizeExpr(), n, state)
+}
+
+predicate isSinkPairImpl(
+  CallInstruction c, DataFlow::Node bufSink, DataFlow::Node sizeSink, int delta, Expr eBuf,
+  Expr eSize
+) {
+  exists(int bufIndex, int sizeIndex, Instruction sizeInstr, Instruction bufInstr |
+    bufInstr = bufSink.asInstruction() and
+    c.getArgument(bufIndex) = bufInstr and
+    sizeInstr = sizeSink.asInstruction() and
+    c.getStaticCallTarget().(ArrayFunction).hasArrayWithVariableSize(bufIndex, sizeIndex) and
+    bounded(c.getArgument(sizeIndex), sizeInstr, delta) and
+    eSize = sizeInstr.getUnconvertedResultExpression() and
+    eBuf = bufInstr.getUnconvertedResultExpression() and
+    delta >= 1
+  )
+}
 
 class StringSizeConfiguration extends ProductFlow::Configuration {
   StringSizeConfiguration() { this = "StringSizeConfiguration" }
 
-  override predicate isSourcePair(DataFlow::Node bufSource, DataFlow::Node sizeSource) {
-    bufSource.asConvertedExpr().(AllocationExpr).getSizeExpr() = sizeSource.asConvertedExpr()
+  override predicate isSourcePair(
+    DataFlow::Node bufSource, DataFlow::FlowState state1, DataFlow::Node sizeSource,
+    DataFlow::FlowState state2
+  ) {
+    // In the case of an allocation like
+    // ```cpp
+    // malloc(size + 1);
+    // ```
+    // we use `state2` to remember that there was an offset (in this case an offset of `1`) added
+    // to the size of the allocation. This state is then checked in `isSinkPair`.
+    state1 instanceof DataFlow::FlowStateEmpty and
+    hasSize(bufSource.asConvertedExpr(), sizeSource, state2)
   }
 
-  override predicate isSinkPair(DataFlow::Node bufSink, DataFlow::Node sizeSink) {
-    exists(CallInstruction c, int bufIndex, int sizeIndex |
-      c.getStaticCallTarget().(ArrayFunction).hasArrayWithVariableSize(bufIndex, sizeIndex) and
-      c.getArgument(bufIndex) = bufSink.asInstruction() and
-      c.getArgument(sizeIndex) = sizeSink.asInstruction()
+  override predicate isSinkPair(
+    DataFlow::Node bufSink, DataFlow::FlowState state1, DataFlow::Node sizeSink,
+    DataFlow::FlowState state2
+  ) {
+    state1 instanceof DataFlow::FlowStateEmpty and
+    state2 = [0 .. 32].toString() and // An arbitrary bound because we need to bound `state2`
+    exists(int delta |
+      isSinkPairImpl(_, bufSink, sizeSink, delta, _, _) and
+      delta > state2.toInt()
     )
   }
 }
 
-// we don't actually check correctness yet. Right now the query just finds relevant source/sink pairs.
 from
   StringSizeConfiguration conf, DataFlow::PathNode source1, DataFlow2::PathNode source2,
-  DataFlow::PathNode sink1, DataFlow2::PathNode sink2
-where conf.hasFlowPath(source1, source2, sink1, sink2)
-// TODO: pull delta out and display it
-select sink1.getNode(), source1, sink1, "Overrunning write allocated at $@ bounded by $@.", source1,
-  source1.toString(), sink2, sink2.toString()
+  DataFlow::PathNode sink1, DataFlow2::PathNode sink2, int k, CallInstruction c,
+  DataFlow::Node sourceNode, Expr bound, Expr buffer, string element
+where
+  conf.hasFlowPath(source1, source2, sink1, sink2) and
+  k > sink2.getState().toInt() and
+  isSinkPairImpl(c, sink1.getNode(), sink2.getNode(), k, buffer, bound) and
+  sourceNode = source1.getNode() and
+  if k = 1 then element = " element." else element = " elements."
+select c.getUnconvertedResultExpression(), source1, sink1,
+  "This write may overflow $@ by " + k + element, buffer, buffer.toString()

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
@@ -43,6 +43,26 @@ edges
 | test.cpp:137:22:137:27 | FieldAddress indirection | test.cpp:137:22:137:27 | Load |
 | test.cpp:141:17:141:19 | Load indirection [string] | test.cpp:141:22:141:27 | FieldAddress indirection |
 | test.cpp:141:22:141:27 | FieldAddress indirection | test.cpp:141:22:141:27 | Load |
+| test.cpp:147:5:147:34 | Store | test.cpp:147:10:147:15 | Load indirection [post update] [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:152:13:152:15 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:156:13:156:15 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:195:17:195:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:199:17:199:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:203:17:203:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:207:17:207:19 | Load indirection [string] |
+| test.cpp:147:19:147:24 | call to malloc | test.cpp:147:5:147:34 | Store |
+| test.cpp:152:13:152:15 | Load indirection [string] | test.cpp:152:18:152:23 | FieldAddress indirection |
+| test.cpp:152:18:152:23 | FieldAddress indirection | test.cpp:152:18:152:23 | Load |
+| test.cpp:156:13:156:15 | Load indirection [string] | test.cpp:156:18:156:23 | FieldAddress indirection |
+| test.cpp:156:18:156:23 | FieldAddress indirection | test.cpp:156:18:156:23 | Load |
+| test.cpp:195:17:195:19 | Load indirection [string] | test.cpp:195:22:195:27 | FieldAddress indirection |
+| test.cpp:195:22:195:27 | FieldAddress indirection | test.cpp:195:22:195:27 | Load |
+| test.cpp:199:17:199:19 | Load indirection [string] | test.cpp:199:22:199:27 | FieldAddress indirection |
+| test.cpp:199:22:199:27 | FieldAddress indirection | test.cpp:199:22:199:27 | Load |
+| test.cpp:203:17:203:19 | Load indirection [string] | test.cpp:203:22:203:27 | FieldAddress indirection |
+| test.cpp:203:22:203:27 | FieldAddress indirection | test.cpp:203:22:203:27 | Load |
+| test.cpp:207:17:207:19 | Load indirection [string] | test.cpp:207:22:207:27 | FieldAddress indirection |
+| test.cpp:207:22:207:27 | FieldAddress indirection | test.cpp:207:22:207:27 | Load |
 nodes
 | test.cpp:16:11:16:21 | VariableAddress indirection [string] | semmle.label | VariableAddress indirection [string] |
 | test.cpp:18:5:18:30 | Store | semmle.label | Store |
@@ -90,6 +110,27 @@ nodes
 | test.cpp:141:17:141:19 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:141:22:141:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:141:22:141:27 | Load | semmle.label | Load |
+| test.cpp:147:5:147:34 | Store | semmle.label | Store |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | semmle.label | Load indirection [post update] [string] |
+| test.cpp:147:19:147:24 | call to malloc | semmle.label | call to malloc |
+| test.cpp:152:13:152:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:152:18:152:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:152:18:152:23 | Load | semmle.label | Load |
+| test.cpp:156:13:156:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:156:18:156:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:156:18:156:23 | Load | semmle.label | Load |
+| test.cpp:195:17:195:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:195:22:195:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:195:22:195:27 | Load | semmle.label | Load |
+| test.cpp:199:17:199:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:199:22:199:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:199:22:199:27 | Load | semmle.label | Load |
+| test.cpp:203:17:203:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:203:22:203:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:203:22:203:27 | Load | semmle.label | Load |
+| test.cpp:207:17:207:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:207:22:207:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:207:22:207:27 | Load | semmle.label | Load |
 subpaths
 #select
 | test.cpp:42:5:42:11 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:42:18:42:23 | Load | This write may overflow $@ by 1 element. | test.cpp:42:18:42:23 | string | string |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
@@ -95,3 +95,6 @@ subpaths
 | test.cpp:42:5:42:11 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:42:18:42:23 | Load | This write may overflow $@ by 1 element. | test.cpp:42:18:42:23 | string | string |
 | test.cpp:72:9:72:15 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:72:22:72:27 | Load | This write may overflow $@ by 1 element. | test.cpp:72:22:72:27 | string | string |
 | test.cpp:80:9:80:15 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:80:22:80:27 | Load | This write may overflow $@ by 2 elements. | test.cpp:80:22:80:27 | string | string |
+| test.cpp:99:5:99:11 | call to strncpy | test.cpp:90:19:90:24 | call to malloc | test.cpp:99:18:99:23 | Load | This write may overflow $@ by 1 element. | test.cpp:99:18:99:23 | string | string |
+| test.cpp:129:9:129:15 | call to strncpy | test.cpp:90:19:90:24 | call to malloc | test.cpp:129:22:129:27 | Load | This write may overflow $@ by 1 element. | test.cpp:129:22:129:27 | string | string |
+| test.cpp:137:9:137:15 | call to strncpy | test.cpp:90:19:90:24 | call to malloc | test.cpp:137:22:137:27 | Load | This write may overflow $@ by 2 elements. | test.cpp:137:22:137:27 | string | string |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
@@ -1,6 +1,7 @@
 edges
 | test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:24:21:24:31 | Call indirection [string] |
 | test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:34:21:34:31 | Call indirection [string] |
+| test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:39:21:39:31 | Call indirection [string] |
 | test.cpp:18:5:18:30 | Store | test.cpp:18:10:18:15 | Load indirection [post update] [string] |
 | test.cpp:18:10:18:15 | Load indirection [post update] [string] | test.cpp:16:11:16:21 | VariableAddress indirection [string] |
 | test.cpp:18:19:18:24 | call to malloc | test.cpp:18:5:18:30 | Store |
@@ -12,6 +13,94 @@ edges
 | test.cpp:30:18:30:23 | FieldAddress indirection | test.cpp:30:18:30:23 | Load |
 | test.cpp:34:21:34:31 | Call indirection [string] | test.cpp:35:21:35:23 | str indirection [string] |
 | test.cpp:35:21:35:23 | str indirection [string] | test.cpp:29:32:29:34 | str indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:41:13:41:15 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:42:13:42:15 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:44:13:44:15 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:45:13:45:15 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:48:17:48:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:52:17:52:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:56:17:56:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:60:17:60:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:64:17:64:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:68:17:68:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:72:17:72:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:76:17:76:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:80:17:80:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:84:17:84:19 | Load indirection [string] |
+| test.cpp:41:13:41:15 | Load indirection [string] | test.cpp:41:18:41:23 | FieldAddress indirection |
+| test.cpp:41:18:41:23 | FieldAddress indirection | test.cpp:41:18:41:23 | Load |
+| test.cpp:42:13:42:15 | Load indirection [string] | test.cpp:42:18:42:23 | FieldAddress indirection |
+| test.cpp:42:18:42:23 | FieldAddress indirection | test.cpp:42:18:42:23 | Load |
+| test.cpp:44:13:44:15 | Load indirection [string] | test.cpp:44:18:44:23 | FieldAddress indirection |
+| test.cpp:44:18:44:23 | FieldAddress indirection | test.cpp:44:18:44:23 | Load |
+| test.cpp:45:13:45:15 | Load indirection [string] | test.cpp:45:18:45:23 | FieldAddress indirection |
+| test.cpp:45:18:45:23 | FieldAddress indirection | test.cpp:45:18:45:23 | Load |
+| test.cpp:48:17:48:19 | Load indirection [string] | test.cpp:48:22:48:27 | FieldAddress indirection |
+| test.cpp:48:22:48:27 | FieldAddress indirection | test.cpp:48:22:48:27 | Load |
+| test.cpp:52:17:52:19 | Load indirection [string] | test.cpp:52:22:52:27 | FieldAddress indirection |
+| test.cpp:52:22:52:27 | FieldAddress indirection | test.cpp:52:22:52:27 | Load |
+| test.cpp:56:17:56:19 | Load indirection [string] | test.cpp:56:22:56:27 | FieldAddress indirection |
+| test.cpp:56:22:56:27 | FieldAddress indirection | test.cpp:56:22:56:27 | Load |
+| test.cpp:60:17:60:19 | Load indirection [string] | test.cpp:60:22:60:27 | FieldAddress indirection |
+| test.cpp:60:22:60:27 | FieldAddress indirection | test.cpp:60:22:60:27 | Load |
+| test.cpp:64:17:64:19 | Load indirection [string] | test.cpp:64:22:64:27 | FieldAddress indirection |
+| test.cpp:64:22:64:27 | FieldAddress indirection | test.cpp:64:22:64:27 | Load |
+| test.cpp:68:17:68:19 | Load indirection [string] | test.cpp:68:22:68:27 | FieldAddress indirection |
+| test.cpp:68:22:68:27 | FieldAddress indirection | test.cpp:68:22:68:27 | Load |
+| test.cpp:72:17:72:19 | Load indirection [string] | test.cpp:72:22:72:27 | FieldAddress indirection |
+| test.cpp:72:22:72:27 | FieldAddress indirection | test.cpp:72:22:72:27 | Load |
+| test.cpp:76:17:76:19 | Load indirection [string] | test.cpp:76:22:76:27 | FieldAddress indirection |
+| test.cpp:76:22:76:27 | FieldAddress indirection | test.cpp:76:22:76:27 | Load |
+| test.cpp:80:17:80:19 | Load indirection [string] | test.cpp:80:22:80:27 | FieldAddress indirection |
+| test.cpp:80:22:80:27 | FieldAddress indirection | test.cpp:80:22:80:27 | Load |
+| test.cpp:84:17:84:19 | Load indirection [string] | test.cpp:84:22:84:27 | FieldAddress indirection |
+| test.cpp:84:22:84:27 | FieldAddress indirection | test.cpp:84:22:84:27 | Load |
+| test.cpp:88:11:88:30 | VariableAddress indirection [string] | test.cpp:96:21:96:40 | Call indirection [string] |
+| test.cpp:90:5:90:34 | Store | test.cpp:90:10:90:15 | Load indirection [post update] [string] |
+| test.cpp:90:10:90:15 | Load indirection [post update] [string] | test.cpp:88:11:88:30 | VariableAddress indirection [string] |
+| test.cpp:90:19:90:24 | call to malloc | test.cpp:90:5:90:34 | Store |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:98:13:98:15 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:99:13:99:15 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:101:13:101:15 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:102:13:102:15 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:105:17:105:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:109:17:109:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:113:17:113:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:117:17:117:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:121:17:121:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:125:17:125:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:129:17:129:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:133:17:133:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:137:17:137:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:141:17:141:19 | Load indirection [string] |
+| test.cpp:98:13:98:15 | Load indirection [string] | test.cpp:98:18:98:23 | FieldAddress indirection |
+| test.cpp:98:18:98:23 | FieldAddress indirection | test.cpp:98:18:98:23 | Load |
+| test.cpp:99:13:99:15 | Load indirection [string] | test.cpp:99:18:99:23 | FieldAddress indirection |
+| test.cpp:99:18:99:23 | FieldAddress indirection | test.cpp:99:18:99:23 | Load |
+| test.cpp:101:13:101:15 | Load indirection [string] | test.cpp:101:18:101:23 | FieldAddress indirection |
+| test.cpp:101:18:101:23 | FieldAddress indirection | test.cpp:101:18:101:23 | Load |
+| test.cpp:102:13:102:15 | Load indirection [string] | test.cpp:102:18:102:23 | FieldAddress indirection |
+| test.cpp:102:18:102:23 | FieldAddress indirection | test.cpp:102:18:102:23 | Load |
+| test.cpp:105:17:105:19 | Load indirection [string] | test.cpp:105:22:105:27 | FieldAddress indirection |
+| test.cpp:105:22:105:27 | FieldAddress indirection | test.cpp:105:22:105:27 | Load |
+| test.cpp:109:17:109:19 | Load indirection [string] | test.cpp:109:22:109:27 | FieldAddress indirection |
+| test.cpp:109:22:109:27 | FieldAddress indirection | test.cpp:109:22:109:27 | Load |
+| test.cpp:113:17:113:19 | Load indirection [string] | test.cpp:113:22:113:27 | FieldAddress indirection |
+| test.cpp:113:22:113:27 | FieldAddress indirection | test.cpp:113:22:113:27 | Load |
+| test.cpp:117:17:117:19 | Load indirection [string] | test.cpp:117:22:117:27 | FieldAddress indirection |
+| test.cpp:117:22:117:27 | FieldAddress indirection | test.cpp:117:22:117:27 | Load |
+| test.cpp:121:17:121:19 | Load indirection [string] | test.cpp:121:22:121:27 | FieldAddress indirection |
+| test.cpp:121:22:121:27 | FieldAddress indirection | test.cpp:121:22:121:27 | Load |
+| test.cpp:125:17:125:19 | Load indirection [string] | test.cpp:125:22:125:27 | FieldAddress indirection |
+| test.cpp:125:22:125:27 | FieldAddress indirection | test.cpp:125:22:125:27 | Load |
+| test.cpp:129:17:129:19 | Load indirection [string] | test.cpp:129:22:129:27 | FieldAddress indirection |
+| test.cpp:129:22:129:27 | FieldAddress indirection | test.cpp:129:22:129:27 | Load |
+| test.cpp:133:17:133:19 | Load indirection [string] | test.cpp:133:22:133:27 | FieldAddress indirection |
+| test.cpp:133:22:133:27 | FieldAddress indirection | test.cpp:133:22:133:27 | Load |
+| test.cpp:137:17:137:19 | Load indirection [string] | test.cpp:137:22:137:27 | FieldAddress indirection |
+| test.cpp:137:22:137:27 | FieldAddress indirection | test.cpp:137:22:137:27 | Load |
+| test.cpp:141:17:141:19 | Load indirection [string] | test.cpp:141:22:141:27 | FieldAddress indirection |
+| test.cpp:141:22:141:27 | FieldAddress indirection | test.cpp:141:22:141:27 | Load |
 nodes
 | test.cpp:16:11:16:21 | VariableAddress indirection [string] | semmle.label | VariableAddress indirection [string] |
 | test.cpp:18:5:18:30 | Store | semmle.label | Store |
@@ -27,7 +116,98 @@ nodes
 | test.cpp:30:18:30:23 | Load | semmle.label | Load |
 | test.cpp:34:21:34:31 | Call indirection [string] | semmle.label | Call indirection [string] |
 | test.cpp:35:21:35:23 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | semmle.label | Call indirection [string] |
+| test.cpp:41:13:41:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:41:18:41:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:41:18:41:23 | Load | semmle.label | Load |
+| test.cpp:42:13:42:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:42:18:42:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:42:18:42:23 | Load | semmle.label | Load |
+| test.cpp:44:13:44:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:44:18:44:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:44:18:44:23 | Load | semmle.label | Load |
+| test.cpp:45:13:45:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:45:18:45:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:45:18:45:23 | Load | semmle.label | Load |
+| test.cpp:48:17:48:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:48:22:48:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:48:22:48:27 | Load | semmle.label | Load |
+| test.cpp:52:17:52:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:52:22:52:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:52:22:52:27 | Load | semmle.label | Load |
+| test.cpp:56:17:56:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:56:22:56:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:56:22:56:27 | Load | semmle.label | Load |
+| test.cpp:60:17:60:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:60:22:60:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:60:22:60:27 | Load | semmle.label | Load |
+| test.cpp:64:17:64:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:64:22:64:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:64:22:64:27 | Load | semmle.label | Load |
+| test.cpp:68:17:68:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:68:22:68:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:68:22:68:27 | Load | semmle.label | Load |
+| test.cpp:72:17:72:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:72:22:72:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:72:22:72:27 | Load | semmle.label | Load |
+| test.cpp:76:17:76:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:76:22:76:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:76:22:76:27 | Load | semmle.label | Load |
+| test.cpp:80:17:80:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:80:22:80:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:80:22:80:27 | Load | semmle.label | Load |
+| test.cpp:84:17:84:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:84:22:84:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:84:22:84:27 | Load | semmle.label | Load |
+| test.cpp:88:11:88:30 | VariableAddress indirection [string] | semmle.label | VariableAddress indirection [string] |
+| test.cpp:90:5:90:34 | Store | semmle.label | Store |
+| test.cpp:90:10:90:15 | Load indirection [post update] [string] | semmle.label | Load indirection [post update] [string] |
+| test.cpp:90:19:90:24 | call to malloc | semmle.label | call to malloc |
+| test.cpp:96:21:96:40 | Call indirection [string] | semmle.label | Call indirection [string] |
+| test.cpp:98:13:98:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:98:18:98:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:98:18:98:23 | Load | semmle.label | Load |
+| test.cpp:99:13:99:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:99:18:99:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:99:18:99:23 | Load | semmle.label | Load |
+| test.cpp:101:13:101:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:101:18:101:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:101:18:101:23 | Load | semmle.label | Load |
+| test.cpp:102:13:102:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:102:18:102:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:102:18:102:23 | Load | semmle.label | Load |
+| test.cpp:105:17:105:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:105:22:105:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:105:22:105:27 | Load | semmle.label | Load |
+| test.cpp:109:17:109:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:109:22:109:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:109:22:109:27 | Load | semmle.label | Load |
+| test.cpp:113:17:113:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:113:22:113:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:113:22:113:27 | Load | semmle.label | Load |
+| test.cpp:117:17:117:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:117:22:117:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:117:22:117:27 | Load | semmle.label | Load |
+| test.cpp:121:17:121:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:121:22:121:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:121:22:121:27 | Load | semmle.label | Load |
+| test.cpp:125:17:125:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:125:22:125:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:125:22:125:27 | Load | semmle.label | Load |
+| test.cpp:129:17:129:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:129:22:129:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:129:22:129:27 | Load | semmle.label | Load |
+| test.cpp:133:17:133:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:133:22:133:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:133:22:133:27 | Load | semmle.label | Load |
+| test.cpp:137:17:137:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:137:22:137:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:137:22:137:27 | Load | semmle.label | Load |
+| test.cpp:141:17:141:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:141:22:141:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:141:22:141:27 | Load | semmle.label | Load |
 subpaths
 #select
-| test.cpp:26:18:26:23 | Load | test.cpp:18:19:18:24 | call to malloc | test.cpp:26:18:26:23 | Load | Overrunning write allocated at $@ bounded by $@. | test.cpp:18:19:18:24 | call to malloc | call to malloc | test.cpp:26:31:26:39 | Convert | Convert |
-| test.cpp:30:18:30:23 | Load | test.cpp:18:19:18:24 | call to malloc | test.cpp:30:18:30:23 | Load | Overrunning write allocated at $@ bounded by $@. | test.cpp:18:19:18:24 | call to malloc | call to malloc | test.cpp:30:31:30:39 | Convert | Convert |
+| test.cpp:26:18:26:23 | Load | test.cpp:18:19:18:24 | call to malloc | test.cpp:26:18:26:23 | Load | Overrunning write allocated at $@ bounded by $@. | test.cpp:18:19:18:24 | call to malloc | call to malloc | test.cpp:26:36:26:39 | Load | Load |
+| test.cpp:30:18:30:23 | Load | test.cpp:18:19:18:24 | call to malloc | test.cpp:30:18:30:23 | Load | Overrunning write allocated at $@ bounded by $@. | test.cpp:18:19:18:24 | call to malloc | call to malloc | test.cpp:30:36:30:39 | Load | Load |
+| test.cpp:41:18:41:23 | Load | test.cpp:18:19:18:24 | call to malloc | test.cpp:41:18:41:23 | Load | Overrunning write allocated at $@ bounded by $@. | test.cpp:18:19:18:24 | call to malloc | call to malloc | test.cpp:41:36:41:39 | Load | Load |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
@@ -1,52 +1,18 @@
 edges
-| test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:24:21:24:31 | Call indirection [string] |
-| test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:34:21:34:31 | Call indirection [string] |
 | test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:39:21:39:31 | Call indirection [string] |
 | test.cpp:18:5:18:30 | Store | test.cpp:18:10:18:15 | Load indirection [post update] [string] |
 | test.cpp:18:10:18:15 | Load indirection [post update] [string] | test.cpp:16:11:16:21 | VariableAddress indirection [string] |
 | test.cpp:18:19:18:24 | call to malloc | test.cpp:18:5:18:30 | Store |
-| test.cpp:24:21:24:31 | Call indirection [string] | test.cpp:26:13:26:15 | Load indirection [string] |
-| test.cpp:26:13:26:15 | Load indirection [string] | test.cpp:26:18:26:23 | FieldAddress indirection |
-| test.cpp:26:18:26:23 | FieldAddress indirection | test.cpp:26:18:26:23 | Load |
-| test.cpp:29:32:29:34 | str indirection [string] | test.cpp:30:13:30:15 | Load indirection [string] |
-| test.cpp:30:13:30:15 | Load indirection [string] | test.cpp:30:18:30:23 | FieldAddress indirection |
-| test.cpp:30:18:30:23 | FieldAddress indirection | test.cpp:30:18:30:23 | Load |
-| test.cpp:34:21:34:31 | Call indirection [string] | test.cpp:35:21:35:23 | str indirection [string] |
-| test.cpp:35:21:35:23 | str indirection [string] | test.cpp:29:32:29:34 | str indirection [string] |
-| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:41:13:41:15 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:42:13:42:15 | Load indirection [string] |
-| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:44:13:44:15 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:45:13:45:15 | Load indirection [string] |
-| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:48:17:48:19 | Load indirection [string] |
-| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:52:17:52:19 | Load indirection [string] |
-| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:56:17:56:19 | Load indirection [string] |
-| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:60:17:60:19 | Load indirection [string] |
-| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:64:17:64:19 | Load indirection [string] |
-| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:68:17:68:19 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:72:17:72:19 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:76:17:76:19 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:80:17:80:19 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:84:17:84:19 | Load indirection [string] |
-| test.cpp:41:13:41:15 | Load indirection [string] | test.cpp:41:18:41:23 | FieldAddress indirection |
-| test.cpp:41:18:41:23 | FieldAddress indirection | test.cpp:41:18:41:23 | Load |
 | test.cpp:42:13:42:15 | Load indirection [string] | test.cpp:42:18:42:23 | FieldAddress indirection |
 | test.cpp:42:18:42:23 | FieldAddress indirection | test.cpp:42:18:42:23 | Load |
-| test.cpp:44:13:44:15 | Load indirection [string] | test.cpp:44:18:44:23 | FieldAddress indirection |
-| test.cpp:44:18:44:23 | FieldAddress indirection | test.cpp:44:18:44:23 | Load |
 | test.cpp:45:13:45:15 | Load indirection [string] | test.cpp:45:18:45:23 | FieldAddress indirection |
 | test.cpp:45:18:45:23 | FieldAddress indirection | test.cpp:45:18:45:23 | Load |
-| test.cpp:48:17:48:19 | Load indirection [string] | test.cpp:48:22:48:27 | FieldAddress indirection |
-| test.cpp:48:22:48:27 | FieldAddress indirection | test.cpp:48:22:48:27 | Load |
-| test.cpp:52:17:52:19 | Load indirection [string] | test.cpp:52:22:52:27 | FieldAddress indirection |
-| test.cpp:52:22:52:27 | FieldAddress indirection | test.cpp:52:22:52:27 | Load |
-| test.cpp:56:17:56:19 | Load indirection [string] | test.cpp:56:22:56:27 | FieldAddress indirection |
-| test.cpp:56:22:56:27 | FieldAddress indirection | test.cpp:56:22:56:27 | Load |
-| test.cpp:60:17:60:19 | Load indirection [string] | test.cpp:60:22:60:27 | FieldAddress indirection |
-| test.cpp:60:22:60:27 | FieldAddress indirection | test.cpp:60:22:60:27 | Load |
-| test.cpp:64:17:64:19 | Load indirection [string] | test.cpp:64:22:64:27 | FieldAddress indirection |
-| test.cpp:64:22:64:27 | FieldAddress indirection | test.cpp:64:22:64:27 | Load |
-| test.cpp:68:17:68:19 | Load indirection [string] | test.cpp:68:22:68:27 | FieldAddress indirection |
-| test.cpp:68:22:68:27 | FieldAddress indirection | test.cpp:68:22:68:27 | Load |
 | test.cpp:72:17:72:19 | Load indirection [string] | test.cpp:72:22:72:27 | FieldAddress indirection |
 | test.cpp:72:22:72:27 | FieldAddress indirection | test.cpp:72:22:72:27 | Load |
 | test.cpp:76:17:76:19 | Load indirection [string] | test.cpp:76:22:76:27 | FieldAddress indirection |
@@ -59,40 +25,16 @@ edges
 | test.cpp:90:5:90:34 | Store | test.cpp:90:10:90:15 | Load indirection [post update] [string] |
 | test.cpp:90:10:90:15 | Load indirection [post update] [string] | test.cpp:88:11:88:30 | VariableAddress indirection [string] |
 | test.cpp:90:19:90:24 | call to malloc | test.cpp:90:5:90:34 | Store |
-| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:98:13:98:15 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:99:13:99:15 | Load indirection [string] |
-| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:101:13:101:15 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:102:13:102:15 | Load indirection [string] |
-| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:105:17:105:19 | Load indirection [string] |
-| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:109:17:109:19 | Load indirection [string] |
-| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:113:17:113:19 | Load indirection [string] |
-| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:117:17:117:19 | Load indirection [string] |
-| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:121:17:121:19 | Load indirection [string] |
-| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:125:17:125:19 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:129:17:129:19 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:133:17:133:19 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:137:17:137:19 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:141:17:141:19 | Load indirection [string] |
-| test.cpp:98:13:98:15 | Load indirection [string] | test.cpp:98:18:98:23 | FieldAddress indirection |
-| test.cpp:98:18:98:23 | FieldAddress indirection | test.cpp:98:18:98:23 | Load |
 | test.cpp:99:13:99:15 | Load indirection [string] | test.cpp:99:18:99:23 | FieldAddress indirection |
 | test.cpp:99:18:99:23 | FieldAddress indirection | test.cpp:99:18:99:23 | Load |
-| test.cpp:101:13:101:15 | Load indirection [string] | test.cpp:101:18:101:23 | FieldAddress indirection |
-| test.cpp:101:18:101:23 | FieldAddress indirection | test.cpp:101:18:101:23 | Load |
 | test.cpp:102:13:102:15 | Load indirection [string] | test.cpp:102:18:102:23 | FieldAddress indirection |
 | test.cpp:102:18:102:23 | FieldAddress indirection | test.cpp:102:18:102:23 | Load |
-| test.cpp:105:17:105:19 | Load indirection [string] | test.cpp:105:22:105:27 | FieldAddress indirection |
-| test.cpp:105:22:105:27 | FieldAddress indirection | test.cpp:105:22:105:27 | Load |
-| test.cpp:109:17:109:19 | Load indirection [string] | test.cpp:109:22:109:27 | FieldAddress indirection |
-| test.cpp:109:22:109:27 | FieldAddress indirection | test.cpp:109:22:109:27 | Load |
-| test.cpp:113:17:113:19 | Load indirection [string] | test.cpp:113:22:113:27 | FieldAddress indirection |
-| test.cpp:113:22:113:27 | FieldAddress indirection | test.cpp:113:22:113:27 | Load |
-| test.cpp:117:17:117:19 | Load indirection [string] | test.cpp:117:22:117:27 | FieldAddress indirection |
-| test.cpp:117:22:117:27 | FieldAddress indirection | test.cpp:117:22:117:27 | Load |
-| test.cpp:121:17:121:19 | Load indirection [string] | test.cpp:121:22:121:27 | FieldAddress indirection |
-| test.cpp:121:22:121:27 | FieldAddress indirection | test.cpp:121:22:121:27 | Load |
-| test.cpp:125:17:125:19 | Load indirection [string] | test.cpp:125:22:125:27 | FieldAddress indirection |
-| test.cpp:125:22:125:27 | FieldAddress indirection | test.cpp:125:22:125:27 | Load |
 | test.cpp:129:17:129:19 | Load indirection [string] | test.cpp:129:22:129:27 | FieldAddress indirection |
 | test.cpp:129:22:129:27 | FieldAddress indirection | test.cpp:129:22:129:27 | Load |
 | test.cpp:133:17:133:19 | Load indirection [string] | test.cpp:133:22:133:27 | FieldAddress indirection |
@@ -106,47 +48,13 @@ nodes
 | test.cpp:18:5:18:30 | Store | semmle.label | Store |
 | test.cpp:18:10:18:15 | Load indirection [post update] [string] | semmle.label | Load indirection [post update] [string] |
 | test.cpp:18:19:18:24 | call to malloc | semmle.label | call to malloc |
-| test.cpp:24:21:24:31 | Call indirection [string] | semmle.label | Call indirection [string] |
-| test.cpp:26:13:26:15 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:26:18:26:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:26:18:26:23 | Load | semmle.label | Load |
-| test.cpp:29:32:29:34 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:30:13:30:15 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:30:18:30:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:30:18:30:23 | Load | semmle.label | Load |
-| test.cpp:34:21:34:31 | Call indirection [string] | semmle.label | Call indirection [string] |
-| test.cpp:35:21:35:23 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | semmle.label | Call indirection [string] |
-| test.cpp:41:13:41:15 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:41:18:41:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:41:18:41:23 | Load | semmle.label | Load |
 | test.cpp:42:13:42:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:42:18:42:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:42:18:42:23 | Load | semmle.label | Load |
-| test.cpp:44:13:44:15 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:44:18:44:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:44:18:44:23 | Load | semmle.label | Load |
 | test.cpp:45:13:45:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:45:18:45:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:45:18:45:23 | Load | semmle.label | Load |
-| test.cpp:48:17:48:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:48:22:48:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:48:22:48:27 | Load | semmle.label | Load |
-| test.cpp:52:17:52:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:52:22:52:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:52:22:52:27 | Load | semmle.label | Load |
-| test.cpp:56:17:56:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:56:22:56:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:56:22:56:27 | Load | semmle.label | Load |
-| test.cpp:60:17:60:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:60:22:60:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:60:22:60:27 | Load | semmle.label | Load |
-| test.cpp:64:17:64:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:64:22:64:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:64:22:64:27 | Load | semmle.label | Load |
-| test.cpp:68:17:68:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:68:22:68:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:68:22:68:27 | Load | semmle.label | Load |
 | test.cpp:72:17:72:19 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:72:22:72:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:72:22:72:27 | Load | semmle.label | Load |
@@ -164,36 +72,12 @@ nodes
 | test.cpp:90:10:90:15 | Load indirection [post update] [string] | semmle.label | Load indirection [post update] [string] |
 | test.cpp:90:19:90:24 | call to malloc | semmle.label | call to malloc |
 | test.cpp:96:21:96:40 | Call indirection [string] | semmle.label | Call indirection [string] |
-| test.cpp:98:13:98:15 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:98:18:98:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:98:18:98:23 | Load | semmle.label | Load |
 | test.cpp:99:13:99:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:99:18:99:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:99:18:99:23 | Load | semmle.label | Load |
-| test.cpp:101:13:101:15 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:101:18:101:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:101:18:101:23 | Load | semmle.label | Load |
 | test.cpp:102:13:102:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:102:18:102:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:102:18:102:23 | Load | semmle.label | Load |
-| test.cpp:105:17:105:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:105:22:105:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:105:22:105:27 | Load | semmle.label | Load |
-| test.cpp:109:17:109:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:109:22:109:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:109:22:109:27 | Load | semmle.label | Load |
-| test.cpp:113:17:113:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:113:22:113:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:113:22:113:27 | Load | semmle.label | Load |
-| test.cpp:117:17:117:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:117:22:117:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:117:22:117:27 | Load | semmle.label | Load |
-| test.cpp:121:17:121:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:121:22:121:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:121:22:121:27 | Load | semmle.label | Load |
-| test.cpp:125:17:125:19 | Load indirection [string] | semmle.label | Load indirection [string] |
-| test.cpp:125:22:125:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
-| test.cpp:125:22:125:27 | Load | semmle.label | Load |
 | test.cpp:129:17:129:19 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:129:22:129:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:129:22:129:27 | Load | semmle.label | Load |
@@ -208,6 +92,6 @@ nodes
 | test.cpp:141:22:141:27 | Load | semmle.label | Load |
 subpaths
 #select
-| test.cpp:26:18:26:23 | Load | test.cpp:18:19:18:24 | call to malloc | test.cpp:26:18:26:23 | Load | Overrunning write allocated at $@ bounded by $@. | test.cpp:18:19:18:24 | call to malloc | call to malloc | test.cpp:26:36:26:39 | Load | Load |
-| test.cpp:30:18:30:23 | Load | test.cpp:18:19:18:24 | call to malloc | test.cpp:30:18:30:23 | Load | Overrunning write allocated at $@ bounded by $@. | test.cpp:18:19:18:24 | call to malloc | call to malloc | test.cpp:30:36:30:39 | Load | Load |
-| test.cpp:41:18:41:23 | Load | test.cpp:18:19:18:24 | call to malloc | test.cpp:41:18:41:23 | Load | Overrunning write allocated at $@ bounded by $@. | test.cpp:18:19:18:24 | call to malloc | call to malloc | test.cpp:41:36:41:39 | Load | Load |
+| test.cpp:42:5:42:11 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:42:18:42:23 | Load | This write may overflow $@ by 1 element. | test.cpp:42:18:42:23 | string | string |
+| test.cpp:72:9:72:15 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:72:22:72:27 | Load | This write may overflow $@ by 1 element. | test.cpp:72:22:72:27 | string | string |
+| test.cpp:80:9:80:15 | call to strncpy | test.cpp:18:19:18:24 | call to malloc | test.cpp:80:22:80:27 | Load | This write may overflow $@ by 2 elements. | test.cpp:80:22:80:27 | string | string |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
@@ -1,18 +1,52 @@
 edges
+| test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:24:21:24:31 | Call indirection [string] |
+| test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:34:21:34:31 | Call indirection [string] |
 | test.cpp:16:11:16:21 | VariableAddress indirection [string] | test.cpp:39:21:39:31 | Call indirection [string] |
 | test.cpp:18:5:18:30 | Store | test.cpp:18:10:18:15 | Load indirection [post update] [string] |
 | test.cpp:18:10:18:15 | Load indirection [post update] [string] | test.cpp:16:11:16:21 | VariableAddress indirection [string] |
 | test.cpp:18:19:18:24 | call to malloc | test.cpp:18:5:18:30 | Store |
+| test.cpp:24:21:24:31 | Call indirection [string] | test.cpp:26:13:26:15 | Load indirection [string] |
+| test.cpp:26:13:26:15 | Load indirection [string] | test.cpp:26:18:26:23 | FieldAddress indirection |
+| test.cpp:26:18:26:23 | FieldAddress indirection | test.cpp:26:18:26:23 | Load |
+| test.cpp:29:32:29:34 | str indirection [string] | test.cpp:30:13:30:15 | Load indirection [string] |
+| test.cpp:30:13:30:15 | Load indirection [string] | test.cpp:30:18:30:23 | FieldAddress indirection |
+| test.cpp:30:18:30:23 | FieldAddress indirection | test.cpp:30:18:30:23 | Load |
+| test.cpp:34:21:34:31 | Call indirection [string] | test.cpp:35:21:35:23 | str indirection [string] |
+| test.cpp:35:21:35:23 | str indirection [string] | test.cpp:29:32:29:34 | str indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:41:13:41:15 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:42:13:42:15 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:44:13:44:15 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:45:13:45:15 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:48:17:48:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:52:17:52:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:56:17:56:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:60:17:60:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:64:17:64:19 | Load indirection [string] |
+| test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:68:17:68:19 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:72:17:72:19 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:76:17:76:19 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:80:17:80:19 | Load indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | test.cpp:84:17:84:19 | Load indirection [string] |
+| test.cpp:41:13:41:15 | Load indirection [string] | test.cpp:41:18:41:23 | FieldAddress indirection |
+| test.cpp:41:18:41:23 | FieldAddress indirection | test.cpp:41:18:41:23 | Load |
 | test.cpp:42:13:42:15 | Load indirection [string] | test.cpp:42:18:42:23 | FieldAddress indirection |
 | test.cpp:42:18:42:23 | FieldAddress indirection | test.cpp:42:18:42:23 | Load |
+| test.cpp:44:13:44:15 | Load indirection [string] | test.cpp:44:18:44:23 | FieldAddress indirection |
+| test.cpp:44:18:44:23 | FieldAddress indirection | test.cpp:44:18:44:23 | Load |
 | test.cpp:45:13:45:15 | Load indirection [string] | test.cpp:45:18:45:23 | FieldAddress indirection |
 | test.cpp:45:18:45:23 | FieldAddress indirection | test.cpp:45:18:45:23 | Load |
+| test.cpp:48:17:48:19 | Load indirection [string] | test.cpp:48:22:48:27 | FieldAddress indirection |
+| test.cpp:48:22:48:27 | FieldAddress indirection | test.cpp:48:22:48:27 | Load |
+| test.cpp:52:17:52:19 | Load indirection [string] | test.cpp:52:22:52:27 | FieldAddress indirection |
+| test.cpp:52:22:52:27 | FieldAddress indirection | test.cpp:52:22:52:27 | Load |
+| test.cpp:56:17:56:19 | Load indirection [string] | test.cpp:56:22:56:27 | FieldAddress indirection |
+| test.cpp:56:22:56:27 | FieldAddress indirection | test.cpp:56:22:56:27 | Load |
+| test.cpp:60:17:60:19 | Load indirection [string] | test.cpp:60:22:60:27 | FieldAddress indirection |
+| test.cpp:60:22:60:27 | FieldAddress indirection | test.cpp:60:22:60:27 | Load |
+| test.cpp:64:17:64:19 | Load indirection [string] | test.cpp:64:22:64:27 | FieldAddress indirection |
+| test.cpp:64:22:64:27 | FieldAddress indirection | test.cpp:64:22:64:27 | Load |
+| test.cpp:68:17:68:19 | Load indirection [string] | test.cpp:68:22:68:27 | FieldAddress indirection |
+| test.cpp:68:22:68:27 | FieldAddress indirection | test.cpp:68:22:68:27 | Load |
 | test.cpp:72:17:72:19 | Load indirection [string] | test.cpp:72:22:72:27 | FieldAddress indirection |
 | test.cpp:72:22:72:27 | FieldAddress indirection | test.cpp:72:22:72:27 | Load |
 | test.cpp:76:17:76:19 | Load indirection [string] | test.cpp:76:22:76:27 | FieldAddress indirection |
@@ -25,16 +59,40 @@ edges
 | test.cpp:90:5:90:34 | Store | test.cpp:90:10:90:15 | Load indirection [post update] [string] |
 | test.cpp:90:10:90:15 | Load indirection [post update] [string] | test.cpp:88:11:88:30 | VariableAddress indirection [string] |
 | test.cpp:90:19:90:24 | call to malloc | test.cpp:90:5:90:34 | Store |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:98:13:98:15 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:99:13:99:15 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:101:13:101:15 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:102:13:102:15 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:105:17:105:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:109:17:109:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:113:17:113:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:117:17:117:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:121:17:121:19 | Load indirection [string] |
+| test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:125:17:125:19 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:129:17:129:19 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:133:17:133:19 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:137:17:137:19 | Load indirection [string] |
 | test.cpp:96:21:96:40 | Call indirection [string] | test.cpp:141:17:141:19 | Load indirection [string] |
+| test.cpp:98:13:98:15 | Load indirection [string] | test.cpp:98:18:98:23 | FieldAddress indirection |
+| test.cpp:98:18:98:23 | FieldAddress indirection | test.cpp:98:18:98:23 | Load |
 | test.cpp:99:13:99:15 | Load indirection [string] | test.cpp:99:18:99:23 | FieldAddress indirection |
 | test.cpp:99:18:99:23 | FieldAddress indirection | test.cpp:99:18:99:23 | Load |
+| test.cpp:101:13:101:15 | Load indirection [string] | test.cpp:101:18:101:23 | FieldAddress indirection |
+| test.cpp:101:18:101:23 | FieldAddress indirection | test.cpp:101:18:101:23 | Load |
 | test.cpp:102:13:102:15 | Load indirection [string] | test.cpp:102:18:102:23 | FieldAddress indirection |
 | test.cpp:102:18:102:23 | FieldAddress indirection | test.cpp:102:18:102:23 | Load |
+| test.cpp:105:17:105:19 | Load indirection [string] | test.cpp:105:22:105:27 | FieldAddress indirection |
+| test.cpp:105:22:105:27 | FieldAddress indirection | test.cpp:105:22:105:27 | Load |
+| test.cpp:109:17:109:19 | Load indirection [string] | test.cpp:109:22:109:27 | FieldAddress indirection |
+| test.cpp:109:22:109:27 | FieldAddress indirection | test.cpp:109:22:109:27 | Load |
+| test.cpp:113:17:113:19 | Load indirection [string] | test.cpp:113:22:113:27 | FieldAddress indirection |
+| test.cpp:113:22:113:27 | FieldAddress indirection | test.cpp:113:22:113:27 | Load |
+| test.cpp:117:17:117:19 | Load indirection [string] | test.cpp:117:22:117:27 | FieldAddress indirection |
+| test.cpp:117:22:117:27 | FieldAddress indirection | test.cpp:117:22:117:27 | Load |
+| test.cpp:121:17:121:19 | Load indirection [string] | test.cpp:121:22:121:27 | FieldAddress indirection |
+| test.cpp:121:22:121:27 | FieldAddress indirection | test.cpp:121:22:121:27 | Load |
+| test.cpp:125:17:125:19 | Load indirection [string] | test.cpp:125:22:125:27 | FieldAddress indirection |
+| test.cpp:125:22:125:27 | FieldAddress indirection | test.cpp:125:22:125:27 | Load |
 | test.cpp:129:17:129:19 | Load indirection [string] | test.cpp:129:22:129:27 | FieldAddress indirection |
 | test.cpp:129:22:129:27 | FieldAddress indirection | test.cpp:129:22:129:27 | Load |
 | test.cpp:133:17:133:19 | Load indirection [string] | test.cpp:133:22:133:27 | FieldAddress indirection |
@@ -44,17 +102,56 @@ edges
 | test.cpp:141:17:141:19 | Load indirection [string] | test.cpp:141:22:141:27 | FieldAddress indirection |
 | test.cpp:141:22:141:27 | FieldAddress indirection | test.cpp:141:22:141:27 | Load |
 | test.cpp:147:5:147:34 | Store | test.cpp:147:10:147:15 | Load indirection [post update] [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:150:13:150:15 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:151:13:151:15 | Load indirection [string] |
 | test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:152:13:152:15 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:154:13:154:15 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:155:13:155:15 | Load indirection [string] |
 | test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:156:13:156:15 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:159:17:159:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:163:17:163:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:167:17:167:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:171:17:171:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:175:17:175:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:179:17:179:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:183:17:183:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:187:17:187:19 | Load indirection [string] |
+| test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:191:17:191:19 | Load indirection [string] |
 | test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:195:17:195:19 | Load indirection [string] |
 | test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:199:17:199:19 | Load indirection [string] |
 | test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:203:17:203:19 | Load indirection [string] |
 | test.cpp:147:10:147:15 | Load indirection [post update] [string] | test.cpp:207:17:207:19 | Load indirection [string] |
 | test.cpp:147:19:147:24 | call to malloc | test.cpp:147:5:147:34 | Store |
+| test.cpp:150:13:150:15 | Load indirection [string] | test.cpp:150:18:150:23 | FieldAddress indirection |
+| test.cpp:150:18:150:23 | FieldAddress indirection | test.cpp:150:18:150:23 | Load |
+| test.cpp:151:13:151:15 | Load indirection [string] | test.cpp:151:18:151:23 | FieldAddress indirection |
+| test.cpp:151:18:151:23 | FieldAddress indirection | test.cpp:151:18:151:23 | Load |
 | test.cpp:152:13:152:15 | Load indirection [string] | test.cpp:152:18:152:23 | FieldAddress indirection |
 | test.cpp:152:18:152:23 | FieldAddress indirection | test.cpp:152:18:152:23 | Load |
+| test.cpp:154:13:154:15 | Load indirection [string] | test.cpp:154:18:154:23 | FieldAddress indirection |
+| test.cpp:154:18:154:23 | FieldAddress indirection | test.cpp:154:18:154:23 | Load |
+| test.cpp:155:13:155:15 | Load indirection [string] | test.cpp:155:18:155:23 | FieldAddress indirection |
+| test.cpp:155:18:155:23 | FieldAddress indirection | test.cpp:155:18:155:23 | Load |
 | test.cpp:156:13:156:15 | Load indirection [string] | test.cpp:156:18:156:23 | FieldAddress indirection |
 | test.cpp:156:18:156:23 | FieldAddress indirection | test.cpp:156:18:156:23 | Load |
+| test.cpp:159:17:159:19 | Load indirection [string] | test.cpp:159:22:159:27 | FieldAddress indirection |
+| test.cpp:159:22:159:27 | FieldAddress indirection | test.cpp:159:22:159:27 | Load |
+| test.cpp:163:17:163:19 | Load indirection [string] | test.cpp:163:22:163:27 | FieldAddress indirection |
+| test.cpp:163:22:163:27 | FieldAddress indirection | test.cpp:163:22:163:27 | Load |
+| test.cpp:167:17:167:19 | Load indirection [string] | test.cpp:167:22:167:27 | FieldAddress indirection |
+| test.cpp:167:22:167:27 | FieldAddress indirection | test.cpp:167:22:167:27 | Load |
+| test.cpp:171:17:171:19 | Load indirection [string] | test.cpp:171:22:171:27 | FieldAddress indirection |
+| test.cpp:171:22:171:27 | FieldAddress indirection | test.cpp:171:22:171:27 | Load |
+| test.cpp:175:17:175:19 | Load indirection [string] | test.cpp:175:22:175:27 | FieldAddress indirection |
+| test.cpp:175:22:175:27 | FieldAddress indirection | test.cpp:175:22:175:27 | Load |
+| test.cpp:179:17:179:19 | Load indirection [string] | test.cpp:179:22:179:27 | FieldAddress indirection |
+| test.cpp:179:22:179:27 | FieldAddress indirection | test.cpp:179:22:179:27 | Load |
+| test.cpp:183:17:183:19 | Load indirection [string] | test.cpp:183:22:183:27 | FieldAddress indirection |
+| test.cpp:183:22:183:27 | FieldAddress indirection | test.cpp:183:22:183:27 | Load |
+| test.cpp:187:17:187:19 | Load indirection [string] | test.cpp:187:22:187:27 | FieldAddress indirection |
+| test.cpp:187:22:187:27 | FieldAddress indirection | test.cpp:187:22:187:27 | Load |
+| test.cpp:191:17:191:19 | Load indirection [string] | test.cpp:191:22:191:27 | FieldAddress indirection |
+| test.cpp:191:22:191:27 | FieldAddress indirection | test.cpp:191:22:191:27 | Load |
 | test.cpp:195:17:195:19 | Load indirection [string] | test.cpp:195:22:195:27 | FieldAddress indirection |
 | test.cpp:195:22:195:27 | FieldAddress indirection | test.cpp:195:22:195:27 | Load |
 | test.cpp:199:17:199:19 | Load indirection [string] | test.cpp:199:22:199:27 | FieldAddress indirection |
@@ -68,13 +165,47 @@ nodes
 | test.cpp:18:5:18:30 | Store | semmle.label | Store |
 | test.cpp:18:10:18:15 | Load indirection [post update] [string] | semmle.label | Load indirection [post update] [string] |
 | test.cpp:18:19:18:24 | call to malloc | semmle.label | call to malloc |
+| test.cpp:24:21:24:31 | Call indirection [string] | semmle.label | Call indirection [string] |
+| test.cpp:26:13:26:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:26:18:26:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:26:18:26:23 | Load | semmle.label | Load |
+| test.cpp:29:32:29:34 | str indirection [string] | semmle.label | str indirection [string] |
+| test.cpp:30:13:30:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:30:18:30:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:30:18:30:23 | Load | semmle.label | Load |
+| test.cpp:34:21:34:31 | Call indirection [string] | semmle.label | Call indirection [string] |
+| test.cpp:35:21:35:23 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:39:21:39:31 | Call indirection [string] | semmle.label | Call indirection [string] |
+| test.cpp:41:13:41:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:41:18:41:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:41:18:41:23 | Load | semmle.label | Load |
 | test.cpp:42:13:42:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:42:18:42:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:42:18:42:23 | Load | semmle.label | Load |
+| test.cpp:44:13:44:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:44:18:44:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:44:18:44:23 | Load | semmle.label | Load |
 | test.cpp:45:13:45:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:45:18:45:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:45:18:45:23 | Load | semmle.label | Load |
+| test.cpp:48:17:48:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:48:22:48:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:48:22:48:27 | Load | semmle.label | Load |
+| test.cpp:52:17:52:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:52:22:52:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:52:22:52:27 | Load | semmle.label | Load |
+| test.cpp:56:17:56:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:56:22:56:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:56:22:56:27 | Load | semmle.label | Load |
+| test.cpp:60:17:60:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:60:22:60:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:60:22:60:27 | Load | semmle.label | Load |
+| test.cpp:64:17:64:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:64:22:64:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:64:22:64:27 | Load | semmle.label | Load |
+| test.cpp:68:17:68:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:68:22:68:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:68:22:68:27 | Load | semmle.label | Load |
 | test.cpp:72:17:72:19 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:72:22:72:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:72:22:72:27 | Load | semmle.label | Load |
@@ -92,12 +223,36 @@ nodes
 | test.cpp:90:10:90:15 | Load indirection [post update] [string] | semmle.label | Load indirection [post update] [string] |
 | test.cpp:90:19:90:24 | call to malloc | semmle.label | call to malloc |
 | test.cpp:96:21:96:40 | Call indirection [string] | semmle.label | Call indirection [string] |
+| test.cpp:98:13:98:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:98:18:98:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:98:18:98:23 | Load | semmle.label | Load |
 | test.cpp:99:13:99:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:99:18:99:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:99:18:99:23 | Load | semmle.label | Load |
+| test.cpp:101:13:101:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:101:18:101:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:101:18:101:23 | Load | semmle.label | Load |
 | test.cpp:102:13:102:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:102:18:102:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:102:18:102:23 | Load | semmle.label | Load |
+| test.cpp:105:17:105:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:105:22:105:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:105:22:105:27 | Load | semmle.label | Load |
+| test.cpp:109:17:109:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:109:22:109:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:109:22:109:27 | Load | semmle.label | Load |
+| test.cpp:113:17:113:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:113:22:113:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:113:22:113:27 | Load | semmle.label | Load |
+| test.cpp:117:17:117:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:117:22:117:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:117:22:117:27 | Load | semmle.label | Load |
+| test.cpp:121:17:121:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:121:22:121:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:121:22:121:27 | Load | semmle.label | Load |
+| test.cpp:125:17:125:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:125:22:125:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:125:22:125:27 | Load | semmle.label | Load |
 | test.cpp:129:17:129:19 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:129:22:129:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:129:22:129:27 | Load | semmle.label | Load |
@@ -113,12 +268,51 @@ nodes
 | test.cpp:147:5:147:34 | Store | semmle.label | Store |
 | test.cpp:147:10:147:15 | Load indirection [post update] [string] | semmle.label | Load indirection [post update] [string] |
 | test.cpp:147:19:147:24 | call to malloc | semmle.label | call to malloc |
+| test.cpp:150:13:150:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:150:18:150:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:150:18:150:23 | Load | semmle.label | Load |
+| test.cpp:151:13:151:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:151:18:151:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:151:18:151:23 | Load | semmle.label | Load |
 | test.cpp:152:13:152:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:152:18:152:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:152:18:152:23 | Load | semmle.label | Load |
+| test.cpp:154:13:154:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:154:18:154:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:154:18:154:23 | Load | semmle.label | Load |
+| test.cpp:155:13:155:15 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:155:18:155:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:155:18:155:23 | Load | semmle.label | Load |
 | test.cpp:156:13:156:15 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:156:18:156:23 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:156:18:156:23 | Load | semmle.label | Load |
+| test.cpp:159:17:159:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:159:22:159:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:159:22:159:27 | Load | semmle.label | Load |
+| test.cpp:163:17:163:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:163:22:163:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:163:22:163:27 | Load | semmle.label | Load |
+| test.cpp:167:17:167:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:167:22:167:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:167:22:167:27 | Load | semmle.label | Load |
+| test.cpp:171:17:171:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:171:22:171:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:171:22:171:27 | Load | semmle.label | Load |
+| test.cpp:175:17:175:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:175:22:175:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:175:22:175:27 | Load | semmle.label | Load |
+| test.cpp:179:17:179:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:179:22:179:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:179:22:179:27 | Load | semmle.label | Load |
+| test.cpp:183:17:183:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:183:22:183:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:183:22:183:27 | Load | semmle.label | Load |
+| test.cpp:187:17:187:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:187:22:187:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:187:22:187:27 | Load | semmle.label | Load |
+| test.cpp:191:17:191:19 | Load indirection [string] | semmle.label | Load indirection [string] |
+| test.cpp:191:22:191:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
+| test.cpp:191:22:191:27 | Load | semmle.label | Load |
 | test.cpp:195:17:195:19 | Load indirection [string] | semmle.label | Load indirection [string] |
 | test.cpp:195:22:195:27 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | test.cpp:195:22:195:27 | Load | semmle.label | Load |
@@ -139,3 +333,12 @@ subpaths
 | test.cpp:99:5:99:11 | call to strncpy | test.cpp:90:19:90:24 | call to malloc | test.cpp:99:18:99:23 | Load | This write may overflow $@ by 1 element. | test.cpp:99:18:99:23 | string | string |
 | test.cpp:129:9:129:15 | call to strncpy | test.cpp:90:19:90:24 | call to malloc | test.cpp:129:22:129:27 | Load | This write may overflow $@ by 1 element. | test.cpp:129:22:129:27 | string | string |
 | test.cpp:137:9:137:15 | call to strncpy | test.cpp:90:19:90:24 | call to malloc | test.cpp:137:22:137:27 | Load | This write may overflow $@ by 2 elements. | test.cpp:137:22:137:27 | string | string |
+| test.cpp:152:5:152:11 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:152:18:152:23 | Load | This write may overflow $@ by 1 element. | test.cpp:152:18:152:23 | string | string |
+| test.cpp:154:5:154:11 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:154:18:154:23 | Load | This write may overflow $@ by 1 element. | test.cpp:154:18:154:23 | string | string |
+| test.cpp:156:5:156:11 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:156:18:156:23 | Load | This write may overflow $@ by 2 elements. | test.cpp:156:18:156:23 | string | string |
+| test.cpp:175:9:175:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:175:22:175:27 | Load | This write may overflow $@ by 1 element. | test.cpp:175:22:175:27 | string | string |
+| test.cpp:187:9:187:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:187:22:187:27 | Load | This write may overflow $@ by 1 element. | test.cpp:187:22:187:27 | string | string |
+| test.cpp:195:9:195:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:195:22:195:27 | Load | This write may overflow $@ by 1 element. | test.cpp:195:22:195:27 | string | string |
+| test.cpp:199:9:199:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:199:22:199:27 | Load | This write may overflow $@ by 2 elements. | test.cpp:199:22:199:27 | string | string |
+| test.cpp:203:9:203:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:203:22:203:27 | Load | This write may overflow $@ by 2 elements. | test.cpp:203:22:203:27 | string | string |
+| test.cpp:207:9:207:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:207:22:207:27 | Load | This write may overflow $@ by 3 elements. | test.cpp:207:22:207:27 | string | string |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
@@ -96,7 +96,7 @@ void test4(unsigned size, char *buf, unsigned anotherSize) {
     string_t *str = mk_string_t_plus_one(size);
 
     strncpy(str->string, buf, str->size); // GOOD
-    strncpy(str->string, buf, str->size + 1); // BAD [NOT DETECTED]
+    strncpy(str->string, buf, str->size + 1); // BAD
 
     strncpy(str->string, buf, size); // GOOD
     strncpy(str->string, buf, size + 1); // GOOD
@@ -126,7 +126,7 @@ void test4(unsigned size, char *buf, unsigned anotherSize) {
     }
 
     if(anotherSize <= str->size + 1) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize <= size + 1) {
@@ -134,7 +134,7 @@ void test4(unsigned size, char *buf, unsigned anotherSize) {
     }
 
     if(anotherSize <= str->size + 2) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize <= size + 2) {

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
@@ -23,11 +23,11 @@ string_t *mk_string_t(int size) {
 void test1(int size, char *buf) {
     string_t *str = mk_string_t(size);
 
-    strncpy(str->string, buf, str->size); // GOOD [FALSE POSITIVE]
+    strncpy(str->string, buf, str->size); // GOOD
 }
 
 void strncpy_wrapper(string_t *str, char *buf) {
-    strncpy(str->string, buf, str->size); // GOOD [FALSE POSITIVE]
+    strncpy(str->string, buf, str->size); // GOOD
 }
 
 void test2(int size, char *buf) {
@@ -38,8 +38,8 @@ void test2(int size, char *buf) {
 void test3(unsigned size, char *buf, unsigned anotherSize) {
     string_t *str = mk_string_t(size);
 
-    strncpy(str->string, buf, str->size); // GOOD [FALSE POSITIVE]
-    strncpy(str->string, buf, str->size + 1); // BAD [NOT DETECTED]
+    strncpy(str->string, buf, str->size); // GOOD
+    strncpy(str->string, buf, str->size + 1); // BAD
 
     strncpy(str->string, buf, size); // GOOD
     strncpy(str->string, buf, size + 1); // BAD [NOT DETECTED]
@@ -69,7 +69,7 @@ void test3(unsigned size, char *buf, unsigned anotherSize) {
     }
 
     if(anotherSize <= str->size + 1) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize <= size + 1) {
@@ -77,7 +77,7 @@ void test3(unsigned size, char *buf, unsigned anotherSize) {
     }
 
     if(anotherSize <= str->size + 2) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize <= size + 2) {

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
@@ -1,5 +1,5 @@
 
-typedef unsigned long long size_t;
+typedef unsigned size_t;
 int sprintf(char *s, const char *format, ...);
 int snprintf(char *s, size_t n, const char *format, ...);
 int scanf(const char *format, ...);
@@ -10,7 +10,7 @@ char *strncpy(char *dst, const char *src, size_t n);
 typedef struct
 {
 	char *string;
-	int size;
+	unsigned size;
 } string_t;
 
 string_t *mk_string_t(int size) {
@@ -23,15 +23,122 @@ string_t *mk_string_t(int size) {
 void test1(int size, char *buf) {
     string_t *str = mk_string_t(size);
 
-    strncpy(str->string, buf, str->size);
+    strncpy(str->string, buf, str->size); // GOOD [FALSE POSITIVE]
 }
 
 void strncpy_wrapper(string_t *str, char *buf) {
-    strncpy(str->string, buf, str->size);
+    strncpy(str->string, buf, str->size); // GOOD [FALSE POSITIVE]
 }
 
 void test2(int size, char *buf) {
     string_t *str = mk_string_t(size);
     strncpy_wrapper(str, buf);
+}
+
+void test3(unsigned size, char *buf, unsigned anotherSize) {
+    string_t *str = mk_string_t(size);
+
+    strncpy(str->string, buf, str->size); // GOOD [FALSE POSITIVE]
+    strncpy(str->string, buf, str->size + 1); // BAD [NOT DETECTED]
+
+    strncpy(str->string, buf, size); // GOOD
+    strncpy(str->string, buf, size + 1); // BAD [NOT DETECTED]
+
+    if(anotherSize < str->size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= str->size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < str->size + 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < size + 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= str->size + 1) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= size + 1) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= str->size + 2) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= size + 2) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+}
+
+string_t *mk_string_t_plus_one(int size) {
+    string_t *str = (string_t *) malloc(sizeof(string_t));
+    str->string = malloc(size + 1);
+    str->size = size + 1;
+    return str;
+}
+
+void test4(unsigned size, char *buf, unsigned anotherSize) {
+    string_t *str = mk_string_t_plus_one(size);
+
+    strncpy(str->string, buf, str->size); // GOOD
+    strncpy(str->string, buf, str->size + 1); // BAD [NOT DETECTED]
+
+    strncpy(str->string, buf, size); // GOOD
+    strncpy(str->string, buf, size + 1); // GOOD
+
+    if(anotherSize < str->size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= str->size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < str->size + 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < size + 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= str->size + 1) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= size + 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= str->size + 2) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= size + 2) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
 }
 

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
@@ -142,3 +142,69 @@ void test4(unsigned size, char *buf, unsigned anotherSize) {
     }
 }
 
+void test5(unsigned size, char *buf, unsigned anotherSize) {
+    string_t *str = (string_t *) malloc(sizeof(string_t));
+    str->string = malloc(size - 1);
+    str->size = size - 1;
+
+    strncpy(str->string, buf, str->size); // GOOD
+    strncpy(str->string, buf, str->size - 1); // GOOD
+    strncpy(str->string, buf, str->size + 1); // BAD [NOT DETECTED]
+
+    strncpy(str->string, buf, size); // BAD [NOT DETECTED]
+    strncpy(str->string, buf, size - 1); // GOOD
+    strncpy(str->string, buf, size + 1); // BAD [NOT DETECTED]
+
+    if(anotherSize < str->size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= str->size) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= str->size - 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= size) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= size - 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < str->size + 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize < size + 1) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize < size - 1) {
+        strncpy(str->string, buf, anotherSize); // GOOD
+    }
+
+    if(anotherSize <= str->size + 1) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= size + 1) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= str->size + 2) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+
+    if(anotherSize <= size + 2) {
+        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+    }
+}
+

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
@@ -149,11 +149,11 @@ void test5(unsigned size, char *buf, unsigned anotherSize) {
 
     strncpy(str->string, buf, str->size); // GOOD
     strncpy(str->string, buf, str->size - 1); // GOOD
-    strncpy(str->string, buf, str->size + 1); // BAD [NOT DETECTED]
+    strncpy(str->string, buf, str->size + 1); // BAD
 
-    strncpy(str->string, buf, size); // BAD [NOT DETECTED]
+    strncpy(str->string, buf, size); // BAD
     strncpy(str->string, buf, size - 1); // GOOD
-    strncpy(str->string, buf, size + 1); // BAD [NOT DETECTED]
+    strncpy(str->string, buf, size + 1); // BAD
 
     if(anotherSize < str->size) {
         strncpy(str->string, buf, anotherSize); // GOOD
@@ -172,7 +172,7 @@ void test5(unsigned size, char *buf, unsigned anotherSize) {
     }
 
     if(anotherSize <= size) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize <= size - 1) {
@@ -184,7 +184,7 @@ void test5(unsigned size, char *buf, unsigned anotherSize) {
     }
 
     if(anotherSize < size + 1) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize < size - 1) {
@@ -192,19 +192,19 @@ void test5(unsigned size, char *buf, unsigned anotherSize) {
     }
 
     if(anotherSize <= str->size + 1) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize <= size + 1) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize <= str->size + 2) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 
     if(anotherSize <= size + 2) {
-        strncpy(str->string, buf, anotherSize); // BAD [NOT DETECTED]
+        strncpy(str->string, buf, anotherSize); // BAD
     }
 }
 


### PR DESCRIPTION
We merged https://github.com/github/codeql/pull/10398 before we really finished off the `OverrunWriteProductFlow.ql` query. In particular:
- Its tests weren't all annotated.
- It was highlighting any flow from an `(allocation, size)` pair to an `ArrayFunction` operation regardless of whether the operation was dangerous or not.
- It was missing metadata and qhelp.

This PR fixed all of those rings. Commit-by-commit review is encouraged:

- https://github.com/github/codeql/commit/51758aa928113d810acf72269b07f2d1c0cf3770 adds more tests and adds annotations.
- https://github.com/github/codeql/commit/ccbbb5754e78b809133b69d6f18657ad696d9d08 does the majority of the work of this PR: it turns the query into a query that's finding vulnerabilities instead of being a testing query for the product-dataflow library.
- https://github.com/github/codeql/commit/769ff5c6f3fea89635daa98a8e376ef075b65207 adds an `isAdditionalFlowStep` predicate to the product-dataflow library to fix some missing flow results.
- https://github.com/github/codeql/commit/4ab676774e3b634368ede30e5cb2dc1a443ee84a adds qhelp to the new query. This is mostly a copy/paste from https://github.com/github/codeql/blob/main/cpp/ql/src/Critical/OverflowStatic.qhelp, except that I've edited the parts that specifically mentions `static` buffers (since this new query deals with any kind of buffers).