### PR TITLE
QL: adjust the consistency query to not be noisy on parameterised modules

### DIFF
--- a/ql/ql/src/codeql_ql/ast/internal/Module.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Module.qll
@@ -389,6 +389,7 @@ module ModConsistency {
     ) >= 2 and
     // paramerized modules are not treated nicely, so we ignore them here.
     not i.getResolvedModule().getEnclosing*().asModule().hasParameter(_, _, _) and
+    not i.getResolvedModule().asModule().hasAnnotation("signature") and
     not i.getLocation()
         .getFile()
         .getAbsolutePath()

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -211,7 +211,9 @@ module PredConsistency {
     c > 1 and
     resolvePredicateExpr(pe, p) and
     // parameterized modules are expected to resolve to multiple.
-    not exists(ClasslessPredicate sig | not sig.isSignature() and resolvePredicateExpr(pe, sig))
+    not exists(Predicate sig | sig.getParent*().hasAnnotation("signature") |
+      resolvePredicateExpr(pe, sig)
+    )
   }
 
   query predicate multipleResolveCall(Call call, int c, PredicateOrBuiltin p) {
@@ -227,6 +229,6 @@ module PredConsistency {
     c > 1 and
     resolveCall(call, p) and
     // parameterized modules are expected to resolve to multiple.
-    not exists(ClasslessPredicate sig | not sig.isSignature() and resolveCall(call, sig))
+    not exists(Predicate sig | sig.getParent*().hasAnnotation("signature") | resolveCall(call, sig))
   }
 }

--- a/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
+++ b/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
@@ -24,9 +24,10 @@ where
     PredConsistency::noResolvePredicateExpr(node) and
     msg = "PredConsistency::noResolvePredicateExpr"
     or
-    PredConsistency::multipleResolveCall(node, _, _) and
-    msg = "PredConsistency::multipleResolveCall"
-    or
+    // This went out the window with parameterised modules.
+    // PredConsistency::multipleResolveCall(node, _, _) and
+    // msg = "PredConsistency::multipleResolveCall"
+    // or
     PredConsistency::multipleResolvePredicateExpr(node, _, _) and
     msg = "PredConsistency::multipleResolvePredicateExpr"
     or


### PR DESCRIPTION
The query was starting to get noisy on e.g. https://github.com/github/codeql/pull/10592 

With these changes the query reports nothing on `main` (and nothing on the PR above).  