### PR TITLE
Ruby: update `clap` to v4.0

### DIFF
--- a/ruby/extractor/Cargo.toml
+++ b/ruby/extractor/Cargo.toml
@@ -12,7 +12,7 @@ node-types = { path = "../node-types" }
 tree-sitter = "0.19"
 tree-sitter-embedded-template = { git = "https://github.com/tree-sitter/tree-sitter-embedded-template.git", rev = "1a538da253d73f896b9f6c0c7d79cda58791ac5c" }
 tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "ad1043283b1f9daf4aad381b6a81f18a5a27fe7e" }
-clap = "3.0"
+clap = "4.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 rayon = "1.5.0"

--- a/ruby/generator/Cargo.toml
+++ b/ruby/generator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0"
+clap = "4.0"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }


### PR DESCRIPTION
Combines https://github.com/github/codeql/pull/10614 and https://github.com/github/codeql/pull/10615