### PR TITLE
Ruby: Account for `protected` methods in call graph

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -314,15 +314,20 @@ private module Cached {
         exists(Module tp |
           instanceMethodCall(call, tp, method) and
           result = lookupMethod(tp, method) and
-          if result.(Method).isPrivate()
-          then
-            call.getReceiver().getExpr() instanceof SelfVariableAccess and
-            // For now, we restrict the scope of top-level declarations to their file.
-            // This may remove some plausible targets, but also removes a lot of
-            // implausible targets
-            if result.getEnclosingModule() instanceof Toplevel
-            then result.getFile() = call.getFile()
+          (
+            if result.(Method).isPrivate()
+            then
+              call.getReceiver().getExpr() instanceof SelfVariableAccess and
+              // For now, we restrict the scope of top-level declarations to their file.
+              // This may remove some plausible targets, but also removes a lot of
+              // implausible targets
+              if result.getEnclosingModule() instanceof Toplevel
+              then result.getFile() = call.getFile()
+              else any()
             else any()
+          ) and
+          if result.(Method).isProtected()
+          then result = lookupMethod(call.getExpr().getEnclosingModule().getModule(), method)
           else any()
         )
         or

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -97,6 +97,9 @@ calls.rb:
 
 #  477| ExtendSingletonMethod
 
+#  487| ProtectedMethods
+#-----| super -> Object
+
 hello.rb:
 #    1| EnglishWords
 

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -49,56 +49,62 @@ calls.rb:
 #  105| Module
 #-----| super -> Object
 
-#  112| Object
+#  115| Object
 #-----| super -> BasicObject
 #-----| include -> Kernel
 #-----| prepend -> A
 
-#  117| Hash
+#  120| Hash
 #-----| super -> Object
 
-#  122| Array
+#  125| Array
 #-----| super -> Object
 
-#  162| S
+#  165| S
 #-----| super -> Object
 
-#  168| A
+#  171| A
 #-----| super -> S
 #-----| super -> B
 #-----| prepend -> A::B
 
-#  173| B
+#  176| B
 #-----| super -> S
 
-#  187| Singletons
+#  190| Singletons
 #-----| super -> Object
 
-#  307| SelfNew
+#  310| SelfNew
 #-----| super -> Object
 
-#  322| C1
+#  325| C1
 #-----| super -> Object
 
-#  328| C2
+#  331| C2
 #-----| super -> C1
 
-#  334| C3
+#  337| C3
 #-----| super -> C2
 
-#  374| SingletonOverride1
+#  377| SingletonOverride1
 #-----| super -> Object
 
-#  399| SingletonOverride2
+#  402| SingletonOverride2
 #-----| super -> SingletonOverride1
 
-#  414| ConditionalInstanceMethods
+#  417| ConditionalInstanceMethods
 #-----| super -> Object
 
-#  477| ExtendSingletonMethod
+#  480| ExtendSingletonMethod
 
-#  487| ProtectedMethods
+#  490| ProtectedMethodInModule
+
+#  496| ProtectedMethods
 #-----| super -> Object
+#-----| include -> ProtectedMethodInModule
+
+#  515| ProtectedMethodsSub
+#-----| super -> ProtectedMethods
 
 hello.rb:
 #    1| EnglishWords

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -188,7 +188,6 @@ getTarget
 | calls.rb:494:9:494:28 | call to new | calls.rb:114:5:114:16 | new |
 | calls.rb:494:9:494:32 | call to foo | calls.rb:488:15:490:7 | foo |
 | calls.rb:498:1:498:20 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:498:1:498:24 | call to foo | calls.rb:488:15:490:7 | foo |
 | calls.rb:499:1:499:20 | call to new | calls.rb:114:5:114:16 | new |
 | calls.rb:499:1:499:24 | call to bar | calls.rb:492:5:495:7 | bar |
 | hello.rb:12:5:12:24 | call to include | calls.rb:107:5:107:20 | include |
@@ -294,6 +293,7 @@ unresolvedCall
 | calls.rb:482:5:482:15 | call to extend |
 | calls.rb:485:1:485:31 | call to singleton |
 | calls.rb:488:5:490:7 | call to protected |
+| calls.rb:498:1:498:24 | call to foo |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -172,11 +172,25 @@ getTarget
 | calls.rb:447:1:447:30 | call to new | calls.rb:114:5:114:16 | new |
 | calls.rb:448:1:448:30 | call to new | calls.rb:114:5:114:16 | new |
 | calls.rb:449:1:449:30 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:451:27:469:3 | call to new | calls.rb:114:5:114:16 | new |
 | calls.rb:454:13:454:22 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:458:5:462:7 | call to new | calls.rb:114:5:114:16 | new |
 | calls.rb:458:5:462:11 | call to new | calls.rb:114:5:114:16 | new |
 | calls.rb:460:13:460:22 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:466:13:466:27 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:471:1:471:27 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:472:1:472:27 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:473:1:473:27 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:474:1:474:27 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:475:1:475:27 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:489:9:489:35 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:493:9:493:11 | call to foo | calls.rb:488:15:490:7 | foo |
+| calls.rb:494:9:494:28 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:494:9:494:32 | call to foo | calls.rb:488:15:490:7 | foo |
+| calls.rb:498:1:498:20 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:498:1:498:24 | call to foo | calls.rb:488:15:490:7 | foo |
+| calls.rb:499:1:499:20 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:499:1:499:24 | call to bar | calls.rb:492:5:495:7 | bar |
 | hello.rb:12:5:12:24 | call to include | calls.rb:107:5:107:20 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
@@ -265,27 +279,21 @@ unresolvedCall
 | calls.rb:447:1:447:33 | call to m3 |
 | calls.rb:448:1:448:33 | call to m4 |
 | calls.rb:449:1:449:33 | call to m5 |
-| calls.rb:450:1:450:4 | call to exit |
-| calls.rb:451:27:469:3 | call to new |
 | calls.rb:452:5:452:11 | call to [] |
 | calls.rb:452:5:456:7 | call to each |
 | calls.rb:458:5:462:15 | call to bar |
 | calls.rb:464:5:464:11 | call to [] |
 | calls.rb:464:5:468:7 | call to each |
 | calls.rb:465:9:467:11 | call to define_method |
-| calls.rb:471:1:471:27 | call to new |
 | calls.rb:471:1:471:31 | call to foo |
-| calls.rb:472:1:472:27 | call to new |
 | calls.rb:472:1:472:31 | call to bar |
-| calls.rb:473:1:473:27 | call to new |
 | calls.rb:473:1:473:33 | call to baz_0 |
-| calls.rb:474:1:474:27 | call to new |
 | calls.rb:474:1:474:33 | call to baz_1 |
-| calls.rb:475:1:475:27 | call to new |
 | calls.rb:475:1:475:33 | call to baz_2 |
 | calls.rb:479:9:479:46 | call to puts |
 | calls.rb:482:5:482:15 | call to extend |
 | calls.rb:485:1:485:31 | call to singleton |
+| calls.rb:488:5:490:7 | call to protected |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |
@@ -385,6 +393,7 @@ publicMethod
 | calls.rb:427:13:429:15 | m4 |
 | calls.rb:437:13:439:15 | m5 |
 | calls.rb:478:5:480:7 | singleton |
+| calls.rb:492:5:495:7 | bar |
 | hello.rb:2:5:4:7 | hello |
 | hello.rb:5:5:7:7 | world |
 | hello.rb:13:5:15:7 | message |
@@ -401,5 +410,6 @@ publicMethod
 | private.rb:66:3:67:5 | public |
 | private.rb:91:3:93:5 | call_m1 |
 protectedMethod
+| calls.rb:488:15:490:7 | foo |
 | private.rb:32:3:33:5 | protected1 |
 | private.rb:35:3:36:5 | protected2 |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -12,185 +12,197 @@ getTarget
 | calls.rb:32:5:32:15 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
 | calls.rb:33:5:33:20 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
 | calls.rb:37:1:37:13 | call to singleton_m | calls.rb:25:5:27:7 | singleton_m |
-| calls.rb:44:5:44:13 | call to include | calls.rb:107:5:107:20 | include |
+| calls.rb:44:5:44:13 | call to include | calls.rb:108:5:110:7 | include |
 | calls.rb:52:9:52:18 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
 | calls.rb:53:9:53:23 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
-| calls.rb:60:5:60:9 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:60:5:60:9 | call to new | calls.rb:117:5:117:16 | new |
 | calls.rb:61:1:61:5 | call to baz | calls.rb:51:5:57:7 | baz |
 | calls.rb:63:1:63:12 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
 | calls.rb:67:9:67:13 | call to super | calls.rb:51:5:57:7 | baz |
-| calls.rb:71:5:71:9 | call to new | calls.rb:114:5:114:16 | new |
+| calls.rb:71:5:71:9 | call to new | calls.rb:117:5:117:16 | new |
 | calls.rb:72:1:72:5 | call to baz | calls.rb:66:5:68:7 | baz |
 | calls.rb:74:1:74:12 | call to instance_m | calls.rb:22:5:24:7 | instance_m |
 | calls.rb:77:5:77:16 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
 | calls.rb:78:5:78:16 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
 | calls.rb:82:5:82:11 | yield ... | calls.rb:88:16:88:29 | { ... } |
-| calls.rb:82:5:82:11 | yield ... | calls.rb:159:10:159:28 | { ... } |
-| calls.rb:86:11:86:18 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:87:5:87:10 | ...[...] | calls.rb:119:5:119:31 | [] |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:162:10:162:28 | { ... } |
+| calls.rb:86:11:86:18 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:87:5:87:10 | ...[...] | calls.rb:122:5:122:31 | [] |
 | calls.rb:88:5:88:29 | call to call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:88:22:88:27 | ...[...] | calls.rb:119:5:119:31 | [] |
-| calls.rb:113:5:113:18 | call to include | calls.rb:107:5:107:20 | include |
-| calls.rb:130:15:130:25 | call to length | calls.rb:126:3:126:17 | length |
-| calls.rb:131:9:131:24 | yield ... | calls.rb:147:23:147:62 | { ... } |
-| calls.rb:131:9:131:24 | yield ... | calls.rb:149:17:149:35 | { ... } |
-| calls.rb:131:9:131:24 | yield ... | calls.rb:151:17:151:40 | { ... } |
-| calls.rb:131:9:131:24 | yield ... | calls.rb:153:18:153:37 | { ... } |
-| calls.rb:131:18:131:24 | ...[...] | calls.rb:124:3:124:29 | [] |
-| calls.rb:138:5:138:20 | yield ... | calls.rb:141:7:141:30 | { ... } |
-| calls.rb:141:1:141:30 | call to funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:141:13:141:29 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:141:18:141:29 | call to capitalize | calls.rb:97:5:97:23 | capitalize |
-| calls.rb:143:1:143:14 | call to capitalize | calls.rb:97:5:97:23 | capitalize |
-| calls.rb:144:1:144:12 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
-| calls.rb:145:1:145:5 | call to abs | calls.rb:93:5:93:16 | abs |
-| calls.rb:147:1:147:62 | call to foreach | calls.rb:128:3:134:5 | foreach |
-| calls.rb:147:32:147:61 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:149:1:149:35 | call to foreach | calls.rb:128:3:134:5 | foreach |
-| calls.rb:149:23:149:34 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
-| calls.rb:151:1:151:40 | call to foreach | calls.rb:128:3:134:5 | foreach |
-| calls.rb:151:23:151:39 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:153:1:153:37 | call to foreach | calls.rb:128:3:134:5 | foreach |
-| calls.rb:153:27:153:36 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:156:5:156:17 | call to call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:159:1:159:28 | call to indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:159:16:159:27 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
-| calls.rb:164:9:164:17 | call to to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:164:9:164:17 | call to to_s | calls.rb:174:5:175:7 | to_s |
-| calls.rb:178:1:178:5 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:178:1:178:14 | call to s_method | calls.rb:163:5:165:7 | s_method |
-| calls.rb:179:1:179:5 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:179:1:179:14 | call to s_method | calls.rb:163:5:165:7 | s_method |
-| calls.rb:180:1:180:5 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:180:1:180:14 | call to s_method | calls.rb:163:5:165:7 | s_method |
-| calls.rb:185:1:185:15 | call to private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:189:9:189:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:190:9:190:24 | call to singleton_b | calls.rb:193:5:196:7 | singleton_b |
-| calls.rb:194:9:194:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:195:9:195:24 | call to singleton_c | calls.rb:198:5:200:7 | singleton_c |
-| calls.rb:199:9:199:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:203:9:203:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:204:9:204:24 | call to singleton_a | calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:209:13:209:30 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:211:9:211:19 | call to singleton_e | calls.rb:208:9:210:11 | singleton_e |
-| calls.rb:216:13:216:30 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:233:1:235:3 | singleton_g |
-| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:240:1:242:3 | singleton_g |
-| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:248:5:250:7 | singleton_g |
-| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:264:1:266:3 | singleton_g |
-| calls.rb:225:1:225:22 | call to singleton_a | calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:226:1:226:22 | call to singleton_f | calls.rb:215:9:217:11 | singleton_f |
-| calls.rb:228:6:228:19 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:230:1:230:11 | call to instance | calls.rb:207:5:212:7 | instance |
-| calls.rb:231:1:231:14 | call to singleton_e | calls.rb:208:9:210:11 | singleton_e |
-| calls.rb:234:5:234:24 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:237:1:237:14 | call to singleton_g | calls.rb:233:1:235:3 | singleton_g |
-| calls.rb:238:1:238:19 | call to call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:241:5:241:24 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:244:1:244:14 | call to singleton_g | calls.rb:240:1:242:3 | singleton_g |
-| calls.rb:245:1:245:19 | call to call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:249:9:249:28 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:253:1:253:14 | call to singleton_g | calls.rb:248:5:250:7 | singleton_g |
-| calls.rb:254:1:254:19 | call to call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:256:6:256:19 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:260:1:260:8 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:262:1:262:16 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:265:5:265:22 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:268:1:268:22 | call to singleton_g | calls.rb:264:1:266:3 | singleton_g |
-| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:248:5:250:7 | singleton_g |
-| calls.rb:270:1:270:19 | call to call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:272:6:272:19 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:276:5:276:12 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:276:5:276:21 | call to instance | calls.rb:207:5:212:7 | instance |
-| calls.rb:279:9:279:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:278:5:280:7 | singleton_h |
-| calls.rb:285:1:285:17 | call to create | calls.rb:275:1:283:3 | create |
-| calls.rb:286:1:286:22 | call to singleton_h | calls.rb:278:5:280:7 | singleton_h |
-| calls.rb:292:9:292:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:296:1:296:13 | call to singleton_i | calls.rb:291:5:293:7 | singleton_i |
-| calls.rb:297:1:297:22 | call to singleton_i | calls.rb:291:5:293:7 | singleton_i |
-| calls.rb:301:9:301:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:305:1:305:22 | call to singleton_j | calls.rb:300:5:302:7 | singleton_j |
-| calls.rb:309:9:309:31 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:310:9:310:11 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:314:9:314:11 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:314:9:314:20 | call to instance | calls.rb:308:5:311:7 | instance |
-| calls.rb:317:5:317:7 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:317:5:317:16 | call to instance | calls.rb:308:5:311:7 | instance |
-| calls.rb:320:1:320:17 | call to singleton | calls.rb:313:5:315:7 | singleton |
-| calls.rb:324:9:324:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:330:9:330:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:336:9:336:26 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:343:9:343:18 | call to instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:345:9:345:18 | call to instance | calls.rb:329:5:331:7 | instance |
-| calls.rb:345:9:345:18 | call to instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:347:9:347:18 | call to instance | calls.rb:323:5:325:7 | instance |
-| calls.rb:347:9:347:18 | call to instance | calls.rb:329:5:331:7 | instance |
-| calls.rb:347:9:347:18 | call to instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:352:20:352:29 | call to instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:353:26:353:36 | call to instance | calls.rb:329:5:331:7 | instance |
-| calls.rb:353:26:353:36 | call to instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:354:26:354:36 | call to instance | calls.rb:323:5:325:7 | instance |
-| calls.rb:354:26:354:36 | call to instance | calls.rb:329:5:331:7 | instance |
-| calls.rb:354:26:354:36 | call to instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:358:6:358:11 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:359:1:359:11 | call to instance | calls.rb:323:5:325:7 | instance |
-| calls.rb:360:1:360:25 | call to pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:360:19:360:24 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:361:1:361:25 | call to pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:361:19:361:24 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:362:1:362:25 | call to pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:362:19:362:24 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:366:9:366:28 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:370:6:370:11 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:371:1:371:16 | call to add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:372:1:372:11 | call to instance | calls.rb:323:5:325:7 | instance |
-| calls.rb:372:1:372:11 | call to instance | calls.rb:365:5:367:7 | instance |
-| calls.rb:377:13:377:48 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:381:13:381:22 | call to singleton1 | calls.rb:376:9:378:11 | singleton1 |
-| calls.rb:381:13:381:22 | call to singleton1 | calls.rb:401:9:403:11 | singleton1 |
-| calls.rb:386:9:386:44 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:390:9:390:18 | call to singleton2 | calls.rb:385:5:387:7 | singleton2 |
-| calls.rb:390:9:390:18 | call to singleton2 | calls.rb:406:5:408:7 | singleton2 |
-| calls.rb:393:5:393:14 | call to singleton2 | calls.rb:385:5:387:7 | singleton2 |
-| calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:380:9:382:11 | call_singleton1 |
-| calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:389:5:391:7 | call_singleton2 |
-| calls.rb:402:13:402:48 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:407:9:407:44 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:417:13:417:48 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:422:9:422:44 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:425:13:425:48 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:428:17:428:52 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:436:9:440:11 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:436:9:440:15 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:438:17:438:40 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:444:1:444:30 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:444:1:444:33 | call to m1 | calls.rb:416:9:418:11 | m1 |
-| calls.rb:445:1:445:30 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:446:1:446:30 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:446:1:446:33 | call to m2 | calls.rb:421:5:433:7 | m2 |
-| calls.rb:447:1:447:30 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:448:1:448:30 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:449:1:449:30 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:451:27:469:3 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:454:13:454:22 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:458:5:462:7 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:458:5:462:11 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:460:13:460:22 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:466:13:466:27 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:471:1:471:27 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:472:1:472:27 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:473:1:473:27 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:474:1:474:27 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:475:1:475:27 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:489:9:489:35 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:493:9:493:11 | call to foo | calls.rb:488:15:490:7 | foo |
-| calls.rb:494:9:494:28 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:494:9:494:32 | call to foo | calls.rb:488:15:490:7 | foo |
-| calls.rb:498:1:498:20 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:499:1:499:20 | call to new | calls.rb:114:5:114:16 | new |
-| calls.rb:499:1:499:24 | call to bar | calls.rb:492:5:495:7 | bar |
-| hello.rb:12:5:12:24 | call to include | calls.rb:107:5:107:20 | include |
+| calls.rb:88:22:88:27 | ...[...] | calls.rb:122:5:122:31 | [] |
+| calls.rb:116:5:116:18 | call to include | calls.rb:108:5:110:7 | include |
+| calls.rb:133:15:133:25 | call to length | calls.rb:129:3:129:17 | length |
+| calls.rb:134:9:134:24 | yield ... | calls.rb:150:23:150:62 | { ... } |
+| calls.rb:134:9:134:24 | yield ... | calls.rb:152:17:152:35 | { ... } |
+| calls.rb:134:9:134:24 | yield ... | calls.rb:154:17:154:40 | { ... } |
+| calls.rb:134:9:134:24 | yield ... | calls.rb:156:18:156:37 | { ... } |
+| calls.rb:134:18:134:24 | ...[...] | calls.rb:127:3:127:29 | [] |
+| calls.rb:141:5:141:20 | yield ... | calls.rb:144:7:144:30 | { ... } |
+| calls.rb:144:1:144:30 | call to funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:144:13:144:29 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:144:18:144:29 | call to capitalize | calls.rb:97:5:97:23 | capitalize |
+| calls.rb:146:1:146:14 | call to capitalize | calls.rb:97:5:97:23 | capitalize |
+| calls.rb:147:1:147:12 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:148:1:148:5 | call to abs | calls.rb:93:5:93:16 | abs |
+| calls.rb:150:1:150:62 | call to foreach | calls.rb:131:3:137:5 | foreach |
+| calls.rb:150:32:150:61 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:152:1:152:35 | call to foreach | calls.rb:131:3:137:5 | foreach |
+| calls.rb:152:23:152:34 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:154:1:154:40 | call to foreach | calls.rb:131:3:137:5 | foreach |
+| calls.rb:154:23:154:39 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:156:1:156:37 | call to foreach | calls.rb:131:3:137:5 | foreach |
+| calls.rb:156:27:156:36 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:159:5:159:17 | call to call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:162:1:162:28 | call to indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:162:16:162:27 | call to bit_length | calls.rb:92:5:92:23 | bit_length |
+| calls.rb:167:9:167:17 | call to to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:167:9:167:17 | call to to_s | calls.rb:177:5:178:7 | to_s |
+| calls.rb:181:1:181:5 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:181:1:181:14 | call to s_method | calls.rb:166:5:168:7 | s_method |
+| calls.rb:182:1:182:5 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:182:1:182:14 | call to s_method | calls.rb:166:5:168:7 | s_method |
+| calls.rb:183:1:183:5 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:183:1:183:14 | call to s_method | calls.rb:166:5:168:7 | s_method |
+| calls.rb:188:1:188:15 | call to private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:192:9:192:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:193:9:193:24 | call to singleton_b | calls.rb:196:5:199:7 | singleton_b |
+| calls.rb:197:9:197:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:198:9:198:24 | call to singleton_c | calls.rb:201:5:203:7 | singleton_c |
+| calls.rb:202:9:202:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:206:9:206:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:207:9:207:24 | call to singleton_a | calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:212:13:212:30 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:214:9:214:19 | call to singleton_e | calls.rb:211:9:213:11 | singleton_e |
+| calls.rb:219:13:219:30 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:224:9:224:24 | call to singleton_g | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:224:9:224:24 | call to singleton_g | calls.rb:243:1:245:3 | singleton_g |
+| calls.rb:224:9:224:24 | call to singleton_g | calls.rb:251:5:253:7 | singleton_g |
+| calls.rb:224:9:224:24 | call to singleton_g | calls.rb:267:1:269:3 | singleton_g |
+| calls.rb:228:1:228:22 | call to singleton_a | calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:229:1:229:22 | call to singleton_f | calls.rb:218:9:220:11 | singleton_f |
+| calls.rb:231:6:231:19 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:233:1:233:11 | call to instance | calls.rb:210:5:215:7 | instance |
+| calls.rb:234:1:234:14 | call to singleton_e | calls.rb:211:9:213:11 | singleton_e |
+| calls.rb:237:5:237:24 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:240:1:240:14 | call to singleton_g | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:241:1:241:19 | call to call_singleton_g | calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:244:5:244:24 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:247:1:247:14 | call to singleton_g | calls.rb:243:1:245:3 | singleton_g |
+| calls.rb:248:1:248:19 | call to call_singleton_g | calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:252:9:252:28 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:256:1:256:14 | call to singleton_g | calls.rb:251:5:253:7 | singleton_g |
+| calls.rb:257:1:257:19 | call to call_singleton_g | calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:259:6:259:19 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:263:1:263:8 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:265:1:265:16 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:268:5:268:22 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:271:1:271:22 | call to singleton_g | calls.rb:267:1:269:3 | singleton_g |
+| calls.rb:272:1:272:14 | call to singleton_g | calls.rb:251:5:253:7 | singleton_g |
+| calls.rb:273:1:273:19 | call to call_singleton_g | calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:275:6:275:19 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:279:5:279:12 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:279:5:279:21 | call to instance | calls.rb:210:5:215:7 | instance |
+| calls.rb:282:9:282:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:285:5:285:20 | call to singleton_h | calls.rb:281:5:283:7 | singleton_h |
+| calls.rb:288:1:288:17 | call to create | calls.rb:278:1:286:3 | create |
+| calls.rb:289:1:289:22 | call to singleton_h | calls.rb:281:5:283:7 | singleton_h |
+| calls.rb:295:9:295:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:299:1:299:13 | call to singleton_i | calls.rb:294:5:296:7 | singleton_i |
+| calls.rb:300:1:300:22 | call to singleton_i | calls.rb:294:5:296:7 | singleton_i |
+| calls.rb:304:9:304:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:308:1:308:22 | call to singleton_j | calls.rb:303:5:305:7 | singleton_j |
+| calls.rb:312:9:312:31 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:313:9:313:11 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:317:9:317:11 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:317:9:317:20 | call to instance | calls.rb:311:5:314:7 | instance |
+| calls.rb:320:5:320:7 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:320:5:320:16 | call to instance | calls.rb:311:5:314:7 | instance |
+| calls.rb:323:1:323:17 | call to singleton | calls.rb:316:5:318:7 | singleton |
+| calls.rb:327:9:327:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:333:9:333:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:339:9:339:26 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:346:9:346:18 | call to instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:348:9:348:18 | call to instance | calls.rb:332:5:334:7 | instance |
+| calls.rb:348:9:348:18 | call to instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:350:9:350:18 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:350:9:350:18 | call to instance | calls.rb:332:5:334:7 | instance |
+| calls.rb:350:9:350:18 | call to instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:355:20:355:29 | call to instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:356:26:356:36 | call to instance | calls.rb:332:5:334:7 | instance |
+| calls.rb:356:26:356:36 | call to instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:357:26:357:36 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:357:26:357:36 | call to instance | calls.rb:332:5:334:7 | instance |
+| calls.rb:357:26:357:36 | call to instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:361:6:361:11 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:362:1:362:11 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:363:1:363:25 | call to pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:363:19:363:24 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:364:1:364:25 | call to pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:364:19:364:24 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:365:1:365:25 | call to pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:365:19:365:24 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:369:9:369:28 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:373:6:373:11 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:374:1:374:16 | call to add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:375:1:375:11 | call to instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:375:1:375:11 | call to instance | calls.rb:368:5:370:7 | instance |
+| calls.rb:380:13:380:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:384:13:384:22 | call to singleton1 | calls.rb:379:9:381:11 | singleton1 |
+| calls.rb:384:13:384:22 | call to singleton1 | calls.rb:404:9:406:11 | singleton1 |
+| calls.rb:389:9:389:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:393:9:393:18 | call to singleton2 | calls.rb:388:5:390:7 | singleton2 |
+| calls.rb:393:9:393:18 | call to singleton2 | calls.rb:409:5:411:7 | singleton2 |
+| calls.rb:396:5:396:14 | call to singleton2 | calls.rb:388:5:390:7 | singleton2 |
+| calls.rb:399:1:399:34 | call to call_singleton1 | calls.rb:383:9:385:11 | call_singleton1 |
+| calls.rb:400:1:400:34 | call to call_singleton2 | calls.rb:392:5:394:7 | call_singleton2 |
+| calls.rb:405:13:405:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:410:9:410:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:420:13:420:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:425:9:425:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:428:13:428:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:431:17:431:52 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:439:9:443:11 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:439:9:443:15 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:441:17:441:40 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:447:1:447:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:447:1:447:33 | call to m1 | calls.rb:419:9:421:11 | m1 |
+| calls.rb:448:1:448:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:449:1:449:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:449:1:449:33 | call to m2 | calls.rb:424:5:436:7 | m2 |
+| calls.rb:450:1:450:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:451:1:451:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:452:1:452:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:454:27:472:3 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:457:13:457:22 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:461:5:465:7 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:461:5:465:11 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:463:13:463:22 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:469:13:469:27 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:474:1:474:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:475:1:475:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:476:1:476:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:477:1:477:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:478:1:478:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:497:5:497:35 | call to include | calls.rb:108:5:110:7 | include |
+| calls.rb:500:9:500:35 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:504:9:504:11 | call to foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:505:9:505:11 | call to bar | calls.rb:499:15:501:7 | bar |
+| calls.rb:506:9:506:28 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:506:9:506:32 | call to foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:507:9:507:28 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:507:9:507:32 | call to bar | calls.rb:499:15:501:7 | bar |
+| calls.rb:511:1:511:20 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:512:1:512:20 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:513:1:513:20 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:513:1:513:24 | call to baz | calls.rb:503:5:508:7 | baz |
+| calls.rb:517:9:517:11 | call to foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:518:9:518:31 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:518:9:518:35 | call to foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:522:1:522:23 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:523:1:523:23 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:524:1:524:23 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:524:1:524:27 | call to baz | calls.rb:516:5:519:7 | baz |
+| hello.rb:12:5:12:24 | call to include | calls.rb:108:5:110:7 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
 | hello.rb:20:30:20:34 | call to world | hello.rb:5:5:7:7 | world |
@@ -199,41 +211,41 @@ getTarget
 | modules.rb:33:3:33:25 | call to puts | calls.rb:102:5:102:30 | puts |
 | modules.rb:44:3:44:19 | call to puts | calls.rb:102:5:102:30 | puts |
 | modules.rb:55:3:55:30 | call to puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:89:3:89:16 | call to include | calls.rb:107:5:107:20 | include |
-| modules.rb:90:3:90:38 | call to module_eval | calls.rb:106:5:106:24 | module_eval |
-| modules.rb:90:24:90:36 | call to prepend | calls.rb:108:5:108:20 | prepend |
-| modules.rb:96:3:96:14 | call to include | calls.rb:107:5:107:20 | include |
-| modules.rb:102:3:102:16 | call to prepend | calls.rb:108:5:108:20 | prepend |
-| modules.rb:126:6:126:11 | call to new | calls.rb:114:5:114:16 | new |
-| modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:108:5:108:20 | prepend |
-| private.rb:2:3:3:5 | call to private | calls.rb:109:5:109:20 | private |
-| private.rb:10:3:10:19 | call to private | calls.rb:109:5:109:20 | private |
-| private.rb:12:3:12:9 | call to private | calls.rb:109:5:109:20 | private |
-| private.rb:43:3:43:19 | call to private | calls.rb:109:5:109:20 | private |
-| private.rb:45:3:45:9 | call to private | calls.rb:109:5:109:20 | private |
-| private.rb:54:1:54:5 | call to new | calls.rb:114:5:114:16 | new |
-| private.rb:55:1:55:5 | call to new | calls.rb:114:5:114:16 | new |
-| private.rb:56:1:56:5 | call to new | calls.rb:114:5:114:16 | new |
-| private.rb:57:1:57:5 | call to new | calls.rb:114:5:114:16 | new |
-| private.rb:58:1:58:5 | call to new | calls.rb:114:5:114:16 | new |
+| modules.rb:89:3:89:16 | call to include | calls.rb:108:5:110:7 | include |
+| modules.rb:90:3:90:38 | call to module_eval | calls.rb:107:5:107:24 | module_eval |
+| modules.rb:90:24:90:36 | call to prepend | calls.rb:111:5:111:20 | prepend |
+| modules.rb:96:3:96:14 | call to include | calls.rb:108:5:110:7 | include |
+| modules.rb:102:3:102:16 | call to prepend | calls.rb:111:5:111:20 | prepend |
+| modules.rb:126:6:126:11 | call to new | calls.rb:117:5:117:16 | new |
+| modules_rec.rb:8:3:8:11 | call to prepend | calls.rb:111:5:111:20 | prepend |
+| private.rb:2:3:3:5 | call to private | calls.rb:112:5:112:20 | private |
+| private.rb:10:3:10:19 | call to private | calls.rb:112:5:112:20 | private |
+| private.rb:12:3:12:9 | call to private | calls.rb:112:5:112:20 | private |
+| private.rb:43:3:43:19 | call to private | calls.rb:112:5:112:20 | private |
+| private.rb:45:3:45:9 | call to private | calls.rb:112:5:112:20 | private |
+| private.rb:54:1:54:5 | call to new | calls.rb:117:5:117:16 | new |
+| private.rb:55:1:55:5 | call to new | calls.rb:117:5:117:16 | new |
+| private.rb:56:1:56:5 | call to new | calls.rb:117:5:117:16 | new |
+| private.rb:57:1:57:5 | call to new | calls.rb:117:5:117:16 | new |
+| private.rb:58:1:58:5 | call to new | calls.rb:117:5:117:16 | new |
 | private.rb:58:1:58:12 | call to public | private.rb:5:3:6:5 | public |
 | private.rb:60:1:60:15 | call to private_on_main | private.rb:51:1:52:3 | private_on_main |
-| private.rb:63:3:64:5 | call to private | calls.rb:109:5:109:20 | private |
-| private.rb:71:3:71:19 | call to private | calls.rb:109:5:109:20 | private |
-| private.rb:73:3:73:9 | call to private | calls.rb:109:5:109:20 | private |
-| private.rb:83:3:85:5 | call to private | calls.rb:109:5:109:20 | private |
+| private.rb:63:3:64:5 | call to private | calls.rb:112:5:112:20 | private |
+| private.rb:71:3:71:19 | call to private | calls.rb:112:5:112:20 | private |
+| private.rb:73:3:73:9 | call to private | calls.rb:112:5:112:20 | private |
+| private.rb:83:3:85:5 | call to private | calls.rb:112:5:112:20 | private |
 | private.rb:84:7:84:32 | call to puts | calls.rb:102:5:102:30 | puts |
-| private.rb:87:3:89:5 | call to private | calls.rb:109:5:109:20 | private |
+| private.rb:87:3:89:5 | call to private | calls.rb:112:5:112:20 | private |
 | private.rb:88:7:88:32 | call to puts | calls.rb:102:5:102:30 | puts |
 | private.rb:92:7:92:8 | call to m1 | private.rb:83:11:85:5 | m1 |
 | private.rb:92:7:92:8 | call to m1 | private.rb:97:11:101:5 | m1 |
-| private.rb:97:3:101:5 | call to private | calls.rb:109:5:109:20 | private |
+| private.rb:97:3:101:5 | call to private | calls.rb:112:5:112:20 | private |
 | private.rb:98:7:98:32 | call to puts | calls.rb:102:5:102:30 | puts |
 | private.rb:99:7:99:8 | call to m2 | private.rb:87:11:89:5 | m2 |
-| private.rb:100:7:100:26 | call to new | calls.rb:114:5:114:16 | new |
-| private.rb:104:1:104:20 | call to new | calls.rb:114:5:114:16 | new |
+| private.rb:100:7:100:26 | call to new | calls.rb:117:5:117:16 | new |
+| private.rb:104:1:104:20 | call to new | calls.rb:117:5:117:16 | new |
 | private.rb:104:1:104:28 | call to call_m1 | private.rb:91:3:93:5 | call_m1 |
-| private.rb:105:1:105:20 | call to new | calls.rb:114:5:114:16 | new |
+| private.rb:105:1:105:20 | call to new | calls.rb:117:5:117:16 | new |
 unresolvedCall
 | calls.rb:26:9:26:18 | call to instance_m |
 | calls.rb:29:5:29:14 | call to instance_m |
@@ -249,51 +261,57 @@ unresolvedCall
 | calls.rb:62:1:62:13 | call to singleton_m |
 | calls.rb:73:1:73:13 | call to singleton_m |
 | calls.rb:102:17:102:26 | call to old_puts |
-| calls.rb:119:15:119:27 | call to old_lookup |
-| calls.rb:124:13:124:25 | call to old_lookup |
-| calls.rb:130:11:130:25 | ... < ... |
-| calls.rb:132:11:132:12 | ... + ... |
-| calls.rb:147:1:147:13 | call to [] |
-| calls.rb:147:48:147:59 | call to capitalize |
-| calls.rb:149:1:149:7 | call to [] |
-| calls.rb:151:1:151:7 | call to [] |
-| calls.rb:151:28:151:39 | call to capitalize |
-| calls.rb:153:1:153:8 | call to [] |
-| calls.rb:153:4:153:5 | - ... |
-| calls.rb:153:32:153:36 | call to abs |
-| calls.rb:257:1:257:14 | call to singleton_e |
-| calls.rb:258:1:258:14 | call to singleton_g |
-| calls.rb:271:1:271:14 | call to singleton_g |
-| calls.rb:273:1:273:14 | call to singleton_g |
-| calls.rb:310:9:310:20 | call to instance |
-| calls.rb:411:1:411:34 | call to call_singleton1 |
-| calls.rb:412:1:412:34 | call to call_singleton2 |
-| calls.rb:415:8:415:13 | call to rand |
-| calls.rb:415:8:415:17 | ... > ... |
-| calls.rb:432:9:432:10 | call to m3 |
-| calls.rb:435:8:435:13 | call to rand |
-| calls.rb:435:8:435:17 | ... > ... |
-| calls.rb:436:9:440:18 | call to m5 |
-| calls.rb:445:1:445:33 | call to m3 |
-| calls.rb:447:1:447:33 | call to m3 |
-| calls.rb:448:1:448:33 | call to m4 |
-| calls.rb:449:1:449:33 | call to m5 |
-| calls.rb:452:5:452:11 | call to [] |
-| calls.rb:452:5:456:7 | call to each |
-| calls.rb:458:5:462:15 | call to bar |
-| calls.rb:464:5:464:11 | call to [] |
-| calls.rb:464:5:468:7 | call to each |
-| calls.rb:465:9:467:11 | call to define_method |
-| calls.rb:471:1:471:31 | call to foo |
-| calls.rb:472:1:472:31 | call to bar |
-| calls.rb:473:1:473:33 | call to baz_0 |
-| calls.rb:474:1:474:33 | call to baz_1 |
-| calls.rb:475:1:475:33 | call to baz_2 |
-| calls.rb:479:9:479:46 | call to puts |
-| calls.rb:482:5:482:15 | call to extend |
-| calls.rb:485:1:485:31 | call to singleton |
-| calls.rb:488:5:490:7 | call to protected |
-| calls.rb:498:1:498:24 | call to foo |
+| calls.rb:109:9:109:21 | call to old_include |
+| calls.rb:122:15:122:27 | call to old_lookup |
+| calls.rb:127:13:127:25 | call to old_lookup |
+| calls.rb:133:11:133:25 | ... < ... |
+| calls.rb:135:11:135:12 | ... + ... |
+| calls.rb:150:1:150:13 | call to [] |
+| calls.rb:150:48:150:59 | call to capitalize |
+| calls.rb:152:1:152:7 | call to [] |
+| calls.rb:154:1:154:7 | call to [] |
+| calls.rb:154:28:154:39 | call to capitalize |
+| calls.rb:156:1:156:8 | call to [] |
+| calls.rb:156:4:156:5 | - ... |
+| calls.rb:156:32:156:36 | call to abs |
+| calls.rb:260:1:260:14 | call to singleton_e |
+| calls.rb:261:1:261:14 | call to singleton_g |
+| calls.rb:274:1:274:14 | call to singleton_g |
+| calls.rb:276:1:276:14 | call to singleton_g |
+| calls.rb:313:9:313:20 | call to instance |
+| calls.rb:414:1:414:34 | call to call_singleton1 |
+| calls.rb:415:1:415:34 | call to call_singleton2 |
+| calls.rb:418:8:418:13 | call to rand |
+| calls.rb:418:8:418:17 | ... > ... |
+| calls.rb:435:9:435:10 | call to m3 |
+| calls.rb:438:8:438:13 | call to rand |
+| calls.rb:438:8:438:17 | ... > ... |
+| calls.rb:439:9:443:18 | call to m5 |
+| calls.rb:448:1:448:33 | call to m3 |
+| calls.rb:450:1:450:33 | call to m3 |
+| calls.rb:451:1:451:33 | call to m4 |
+| calls.rb:452:1:452:33 | call to m5 |
+| calls.rb:455:5:455:11 | call to [] |
+| calls.rb:455:5:459:7 | call to each |
+| calls.rb:461:5:465:15 | call to bar |
+| calls.rb:467:5:467:11 | call to [] |
+| calls.rb:467:5:471:7 | call to each |
+| calls.rb:468:9:470:11 | call to define_method |
+| calls.rb:474:1:474:31 | call to foo |
+| calls.rb:475:1:475:31 | call to bar |
+| calls.rb:476:1:476:33 | call to baz_0 |
+| calls.rb:477:1:477:33 | call to baz_1 |
+| calls.rb:478:1:478:33 | call to baz_2 |
+| calls.rb:482:9:482:46 | call to puts |
+| calls.rb:485:5:485:15 | call to extend |
+| calls.rb:488:1:488:31 | call to singleton |
+| calls.rb:491:5:493:7 | call to protected |
+| calls.rb:492:9:492:42 | call to puts |
+| calls.rb:499:5:501:7 | call to protected |
+| calls.rb:511:1:511:24 | call to foo |
+| calls.rb:512:1:512:24 | call to bar |
+| calls.rb:522:1:522:27 | call to foo |
+| calls.rb:523:1:523:27 | call to bar |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |
@@ -313,14 +331,14 @@ privateMethod
 | calls.rb:76:1:79:3 | optional_arg |
 | calls.rb:81:1:83:3 | call_block |
 | calls.rb:85:1:89:3 | foo |
-| calls.rb:137:1:139:3 | funny |
-| calls.rb:155:1:157:3 | indirect |
-| calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:275:1:283:3 | create |
-| calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:453:9:455:11 | foo |
-| calls.rb:459:9:461:11 | bar |
+| calls.rb:140:1:142:3 | funny |
+| calls.rb:158:1:160:3 | indirect |
+| calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:278:1:286:3 | create |
+| calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:456:9:458:11 | foo |
+| calls.rb:462:9:464:11 | bar |
 | private.rb:2:11:3:5 | private1 |
 | private.rb:8:3:9:5 | private2 |
 | private.rb:14:3:15:5 | private3 |
@@ -348,52 +366,53 @@ publicMethod
 | calls.rb:93:5:93:16 | abs |
 | calls.rb:97:5:97:23 | capitalize |
 | calls.rb:102:5:102:30 | puts |
-| calls.rb:106:5:106:24 | module_eval |
-| calls.rb:107:5:107:20 | include |
-| calls.rb:108:5:108:20 | prepend |
-| calls.rb:109:5:109:20 | private |
-| calls.rb:114:5:114:16 | new |
-| calls.rb:119:5:119:31 | [] |
-| calls.rb:124:3:124:29 | [] |
-| calls.rb:126:3:126:17 | length |
-| calls.rb:128:3:134:5 | foreach |
-| calls.rb:163:5:165:7 | s_method |
-| calls.rb:169:5:170:7 | to_s |
-| calls.rb:174:5:175:7 | to_s |
-| calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:193:5:196:7 | singleton_b |
-| calls.rb:198:5:200:7 | singleton_c |
-| calls.rb:202:5:205:7 | singleton_d |
-| calls.rb:207:5:212:7 | instance |
-| calls.rb:208:9:210:11 | singleton_e |
-| calls.rb:215:9:217:11 | singleton_f |
-| calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:233:1:235:3 | singleton_g |
-| calls.rb:240:1:242:3 | singleton_g |
-| calls.rb:248:5:250:7 | singleton_g |
-| calls.rb:264:1:266:3 | singleton_g |
-| calls.rb:278:5:280:7 | singleton_h |
-| calls.rb:291:5:293:7 | singleton_i |
-| calls.rb:300:5:302:7 | singleton_j |
-| calls.rb:308:5:311:7 | instance |
-| calls.rb:313:5:315:7 | singleton |
-| calls.rb:323:5:325:7 | instance |
-| calls.rb:329:5:331:7 | instance |
-| calls.rb:335:5:337:7 | instance |
-| calls.rb:365:5:367:7 | instance |
-| calls.rb:376:9:378:11 | singleton1 |
-| calls.rb:380:9:382:11 | call_singleton1 |
-| calls.rb:385:5:387:7 | singleton2 |
-| calls.rb:389:5:391:7 | call_singleton2 |
-| calls.rb:401:9:403:11 | singleton1 |
-| calls.rb:406:5:408:7 | singleton2 |
-| calls.rb:416:9:418:11 | m1 |
-| calls.rb:421:5:433:7 | m2 |
-| calls.rb:424:9:430:11 | m3 |
-| calls.rb:427:13:429:15 | m4 |
-| calls.rb:437:13:439:15 | m5 |
-| calls.rb:478:5:480:7 | singleton |
-| calls.rb:492:5:495:7 | bar |
+| calls.rb:107:5:107:24 | module_eval |
+| calls.rb:108:5:110:7 | include |
+| calls.rb:111:5:111:20 | prepend |
+| calls.rb:112:5:112:20 | private |
+| calls.rb:117:5:117:16 | new |
+| calls.rb:122:5:122:31 | [] |
+| calls.rb:127:3:127:29 | [] |
+| calls.rb:129:3:129:17 | length |
+| calls.rb:131:3:137:5 | foreach |
+| calls.rb:166:5:168:7 | s_method |
+| calls.rb:172:5:173:7 | to_s |
+| calls.rb:177:5:178:7 | to_s |
+| calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:196:5:199:7 | singleton_b |
+| calls.rb:201:5:203:7 | singleton_c |
+| calls.rb:205:5:208:7 | singleton_d |
+| calls.rb:210:5:215:7 | instance |
+| calls.rb:211:9:213:11 | singleton_e |
+| calls.rb:218:9:220:11 | singleton_f |
+| calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:243:1:245:3 | singleton_g |
+| calls.rb:251:5:253:7 | singleton_g |
+| calls.rb:267:1:269:3 | singleton_g |
+| calls.rb:281:5:283:7 | singleton_h |
+| calls.rb:294:5:296:7 | singleton_i |
+| calls.rb:303:5:305:7 | singleton_j |
+| calls.rb:311:5:314:7 | instance |
+| calls.rb:316:5:318:7 | singleton |
+| calls.rb:326:5:328:7 | instance |
+| calls.rb:332:5:334:7 | instance |
+| calls.rb:338:5:340:7 | instance |
+| calls.rb:368:5:370:7 | instance |
+| calls.rb:379:9:381:11 | singleton1 |
+| calls.rb:383:9:385:11 | call_singleton1 |
+| calls.rb:388:5:390:7 | singleton2 |
+| calls.rb:392:5:394:7 | call_singleton2 |
+| calls.rb:404:9:406:11 | singleton1 |
+| calls.rb:409:5:411:7 | singleton2 |
+| calls.rb:419:9:421:11 | m1 |
+| calls.rb:424:5:436:7 | m2 |
+| calls.rb:427:9:433:11 | m3 |
+| calls.rb:430:13:432:15 | m4 |
+| calls.rb:440:13:442:15 | m5 |
+| calls.rb:481:5:483:7 | singleton |
+| calls.rb:503:5:508:7 | baz |
+| calls.rb:516:5:519:7 | baz |
 | hello.rb:2:5:4:7 | hello |
 | hello.rb:5:5:7:7 | world |
 | hello.rb:13:5:15:7 | message |
@@ -410,6 +429,7 @@ publicMethod
 | private.rb:66:3:67:5 | public |
 | private.rb:91:3:93:5 | call_m1 |
 protectedMethod
-| calls.rb:488:15:490:7 | foo |
+| calls.rb:491:15:493:7 | foo |
+| calls.rb:499:15:501:7 | bar |
 | private.rb:32:3:33:5 | protected1 |
 | private.rb:35:3:36:5 | protected2 |

--- a/ruby/ql/test/library-tests/modules/calls.rb
+++ b/ruby/ql/test/library-tests/modules/calls.rb
@@ -103,8 +103,11 @@ module Kernel
 end
 
 class Module
+    alias :old_include :include
     def module_eval; end
-    def include; end
+    def include x
+        old_include x
+    end
     def prepend; end
     def private; end
 end
@@ -484,16 +487,38 @@ end
 
 ExtendSingletonMethod.singleton # currently unable to resolve
 
-class ProtectedMethods
+module ProtectedMethodInModule
     protected def foo
-        puts "ProtectedMethods#foo"
+        puts "ProtectedMethodInModule#foo"
+    end
+end
+
+class ProtectedMethods
+    include ProtectedMethodInModule
+
+    protected def bar
+        puts "ProtectedMethods#bar"
     end
 
-    def bar
+    def baz
         foo
+        bar
         ProtectedMethods.new.foo
+        ProtectedMethods.new.bar
     end
 end
 
 ProtectedMethods.new.foo # NoMethodError
-ProtectedMethods.new.bar
+ProtectedMethods.new.bar # NoMethodError
+ProtectedMethods.new.baz
+
+class ProtectedMethodsSub < ProtectedMethods
+    def baz
+        foo
+        ProtectedMethodsSub.new.foo
+    end
+end
+
+ProtectedMethodsSub.new.foo # NoMethodError
+ProtectedMethodsSub.new.bar # NoMethodError
+ProtectedMethodsSub.new.baz

--- a/ruby/ql/test/library-tests/modules/calls.rb
+++ b/ruby/ql/test/library-tests/modules/calls.rb
@@ -447,7 +447,7 @@ ConditionalInstanceMethods.new.m2
 ConditionalInstanceMethods.new.m3 # currently unable to resolve
 ConditionalInstanceMethods.new.m4 # currently unable to resolve
 ConditionalInstanceMethods.new.m5 # NoMethodError
-exit
+
 EsotericInstanceMethods = Class.new do
     [0,1,2].each do
         def foo
@@ -483,3 +483,17 @@ module ExtendSingletonMethod
 end
 
 ExtendSingletonMethod.singleton # currently unable to resolve
+
+class ProtectedMethods
+    protected def foo
+        puts "ProtectedMethods#foo"
+    end
+
+    def bar
+        foo
+        ProtectedMethods.new.foo
+    end
+end
+
+ProtectedMethods.new.foo # NoMethodError
+ProtectedMethods.new.bar

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -6,41 +6,43 @@ getMethod
 | calls.rb:91:1:94:3 | Integer | bit_length | calls.rb:92:5:92:23 | bit_length |
 | calls.rb:96:1:98:3 | String | capitalize | calls.rb:97:5:97:23 | capitalize |
 | calls.rb:100:1:103:3 | Kernel | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:105:1:110:3 | Module | include | calls.rb:107:5:107:20 | include |
-| calls.rb:105:1:110:3 | Module | module_eval | calls.rb:106:5:106:24 | module_eval |
-| calls.rb:105:1:110:3 | Module | prepend | calls.rb:108:5:108:20 | prepend |
-| calls.rb:105:1:110:3 | Module | private | calls.rb:109:5:109:20 | private |
-| calls.rb:112:1:115:3 | Object | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:112:1:115:3 | Object | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:112:1:115:3 | Object | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:112:1:115:3 | Object | create | calls.rb:275:1:283:3 | create |
-| calls.rb:112:1:115:3 | Object | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:112:1:115:3 | Object | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:112:1:115:3 | Object | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:112:1:115:3 | Object | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:112:1:115:3 | Object | new | calls.rb:114:5:114:16 | new |
-| calls.rb:112:1:115:3 | Object | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:112:1:115:3 | Object | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:112:1:115:3 | Object | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:112:1:115:3 | Object | private_on_main | private.rb:51:1:52:3 | private_on_main |
-| calls.rb:117:1:120:3 | Hash | [] | calls.rb:119:5:119:31 | [] |
-| calls.rb:122:1:135:3 | Array | [] | calls.rb:124:3:124:29 | [] |
-| calls.rb:122:1:135:3 | Array | foreach | calls.rb:128:3:134:5 | foreach |
-| calls.rb:122:1:135:3 | Array | length | calls.rb:126:3:126:17 | length |
-| calls.rb:162:1:166:3 | S | s_method | calls.rb:163:5:165:7 | s_method |
-| calls.rb:168:1:171:3 | A | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:173:1:176:3 | B | to_s | calls.rb:174:5:175:7 | to_s |
-| calls.rb:187:1:223:3 | Singletons | call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:187:1:223:3 | Singletons | instance | calls.rb:207:5:212:7 | instance |
-| calls.rb:307:1:318:3 | SelfNew | instance | calls.rb:308:5:311:7 | instance |
-| calls.rb:322:1:326:3 | C1 | instance | calls.rb:323:5:325:7 | instance |
-| calls.rb:328:1:332:3 | C2 | instance | calls.rb:329:5:331:7 | instance |
-| calls.rb:334:1:338:3 | C3 | instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | m1 | calls.rb:416:9:418:11 | m1 |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | m2 | calls.rb:421:5:433:7 | m2 |
-| calls.rb:477:1:483:3 | ExtendSingletonMethod | singleton | calls.rb:478:5:480:7 | singleton |
-| calls.rb:487:1:496:3 | ProtectedMethods | bar | calls.rb:492:5:495:7 | bar |
-| calls.rb:487:1:496:3 | ProtectedMethods | foo | calls.rb:488:15:490:7 | foo |
+| calls.rb:105:1:113:3 | Module | include | calls.rb:108:5:110:7 | include |
+| calls.rb:105:1:113:3 | Module | module_eval | calls.rb:107:5:107:24 | module_eval |
+| calls.rb:105:1:113:3 | Module | prepend | calls.rb:111:5:111:20 | prepend |
+| calls.rb:105:1:113:3 | Module | private | calls.rb:112:5:112:20 | private |
+| calls.rb:115:1:118:3 | Object | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:115:1:118:3 | Object | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:115:1:118:3 | Object | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:115:1:118:3 | Object | create | calls.rb:278:1:286:3 | create |
+| calls.rb:115:1:118:3 | Object | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:115:1:118:3 | Object | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:115:1:118:3 | Object | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:115:1:118:3 | Object | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:115:1:118:3 | Object | new | calls.rb:117:5:117:16 | new |
+| calls.rb:115:1:118:3 | Object | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:115:1:118:3 | Object | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:115:1:118:3 | Object | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:115:1:118:3 | Object | private_on_main | private.rb:51:1:52:3 | private_on_main |
+| calls.rb:120:1:123:3 | Hash | [] | calls.rb:122:5:122:31 | [] |
+| calls.rb:125:1:138:3 | Array | [] | calls.rb:127:3:127:29 | [] |
+| calls.rb:125:1:138:3 | Array | foreach | calls.rb:131:3:137:5 | foreach |
+| calls.rb:125:1:138:3 | Array | length | calls.rb:129:3:129:17 | length |
+| calls.rb:165:1:169:3 | S | s_method | calls.rb:166:5:168:7 | s_method |
+| calls.rb:171:1:174:3 | A | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:176:1:179:3 | B | to_s | calls.rb:177:5:178:7 | to_s |
+| calls.rb:190:1:226:3 | Singletons | call_singleton_g | calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:190:1:226:3 | Singletons | instance | calls.rb:210:5:215:7 | instance |
+| calls.rb:310:1:321:3 | SelfNew | instance | calls.rb:311:5:314:7 | instance |
+| calls.rb:325:1:329:3 | C1 | instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:331:1:335:3 | C2 | instance | calls.rb:332:5:334:7 | instance |
+| calls.rb:337:1:341:3 | C3 | instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | m1 | calls.rb:419:9:421:11 | m1 |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | m2 | calls.rb:424:5:436:7 | m2 |
+| calls.rb:480:1:486:3 | ExtendSingletonMethod | singleton | calls.rb:481:5:483:7 | singleton |
+| calls.rb:490:1:494:3 | ProtectedMethodInModule | foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:496:1:509:3 | ProtectedMethods | bar | calls.rb:499:15:501:7 | bar |
+| calls.rb:496:1:509:3 | ProtectedMethods | baz | calls.rb:503:5:508:7 | baz |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | baz | calls.rb:516:5:519:7 | baz |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
@@ -71,386 +73,403 @@ getMethod
 | private.rb:96:1:102:3 | PrivateOverride2 | m1 | private.rb:97:11:101:5 | m1 |
 lookupMethod
 | calls.rb:21:1:34:3 | M | instance_m | calls.rb:22:5:24:7 | instance_m |
-| calls.rb:43:1:58:3 | C | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:43:1:58:3 | C | add_singleton | calls.rb:367:1:371:3 | add_singleton |
 | calls.rb:43:1:58:3 | C | baz | calls.rb:51:5:57:7 | baz |
 | calls.rb:43:1:58:3 | C | call_block | calls.rb:81:1:83:3 | call_block |
 | calls.rb:43:1:58:3 | C | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:43:1:58:3 | C | create | calls.rb:275:1:283:3 | create |
+| calls.rb:43:1:58:3 | C | create | calls.rb:278:1:286:3 | create |
 | calls.rb:43:1:58:3 | C | foo | calls.rb:1:1:3:3 | foo |
 | calls.rb:43:1:58:3 | C | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:43:1:58:3 | C | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:43:1:58:3 | C | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:43:1:58:3 | C | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:43:1:58:3 | C | indirect | calls.rb:158:1:160:3 | indirect |
 | calls.rb:43:1:58:3 | C | instance_m | calls.rb:22:5:24:7 | instance_m |
-| calls.rb:43:1:58:3 | C | new | calls.rb:114:5:114:16 | new |
+| calls.rb:43:1:58:3 | C | new | calls.rb:117:5:117:16 | new |
 | calls.rb:43:1:58:3 | C | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:43:1:58:3 | C | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:43:1:58:3 | C | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:43:1:58:3 | C | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:43:1:58:3 | C | private_on_main | calls.rb:185:1:186:3 | private_on_main |
 | calls.rb:43:1:58:3 | C | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:43:1:58:3 | C | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:65:1:69:3 | D | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:43:1:58:3 | C | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:65:1:69:3 | D | add_singleton | calls.rb:367:1:371:3 | add_singleton |
 | calls.rb:65:1:69:3 | D | baz | calls.rb:66:5:68:7 | baz |
 | calls.rb:65:1:69:3 | D | call_block | calls.rb:81:1:83:3 | call_block |
 | calls.rb:65:1:69:3 | D | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:65:1:69:3 | D | create | calls.rb:275:1:283:3 | create |
+| calls.rb:65:1:69:3 | D | create | calls.rb:278:1:286:3 | create |
 | calls.rb:65:1:69:3 | D | foo | calls.rb:1:1:3:3 | foo |
 | calls.rb:65:1:69:3 | D | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:65:1:69:3 | D | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:65:1:69:3 | D | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:65:1:69:3 | D | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:65:1:69:3 | D | indirect | calls.rb:158:1:160:3 | indirect |
 | calls.rb:65:1:69:3 | D | instance_m | calls.rb:22:5:24:7 | instance_m |
-| calls.rb:65:1:69:3 | D | new | calls.rb:114:5:114:16 | new |
+| calls.rb:65:1:69:3 | D | new | calls.rb:117:5:117:16 | new |
 | calls.rb:65:1:69:3 | D | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:65:1:69:3 | D | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:65:1:69:3 | D | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:65:1:69:3 | D | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:65:1:69:3 | D | private_on_main | calls.rb:185:1:186:3 | private_on_main |
 | calls.rb:65:1:69:3 | D | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:65:1:69:3 | D | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:65:1:69:3 | D | to_s | calls.rb:172:5:173:7 | to_s |
 | calls.rb:91:1:94:3 | Integer | abs | calls.rb:93:5:93:16 | abs |
 | calls.rb:91:1:94:3 | Integer | bit_length | calls.rb:92:5:92:23 | bit_length |
-| calls.rb:91:1:94:3 | Integer | new | calls.rb:114:5:114:16 | new |
+| calls.rb:91:1:94:3 | Integer | new | calls.rb:117:5:117:16 | new |
 | calls.rb:91:1:94:3 | Integer | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:91:1:94:3 | Integer | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:96:1:98:3 | String | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:91:1:94:3 | Integer | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:96:1:98:3 | String | add_singleton | calls.rb:367:1:371:3 | add_singleton |
 | calls.rb:96:1:98:3 | String | call_block | calls.rb:81:1:83:3 | call_block |
 | calls.rb:96:1:98:3 | String | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
 | calls.rb:96:1:98:3 | String | capitalize | calls.rb:97:5:97:23 | capitalize |
-| calls.rb:96:1:98:3 | String | create | calls.rb:275:1:283:3 | create |
+| calls.rb:96:1:98:3 | String | create | calls.rb:278:1:286:3 | create |
 | calls.rb:96:1:98:3 | String | foo | calls.rb:1:1:3:3 | foo |
 | calls.rb:96:1:98:3 | String | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:96:1:98:3 | String | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:96:1:98:3 | String | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:96:1:98:3 | String | new | calls.rb:114:5:114:16 | new |
+| calls.rb:96:1:98:3 | String | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:96:1:98:3 | String | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:96:1:98:3 | String | new | calls.rb:117:5:117:16 | new |
 | calls.rb:96:1:98:3 | String | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:96:1:98:3 | String | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:96:1:98:3 | String | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:96:1:98:3 | String | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:96:1:98:3 | String | private_on_main | calls.rb:185:1:186:3 | private_on_main |
 | calls.rb:96:1:98:3 | String | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:96:1:98:3 | String | to_s | calls.rb:169:5:170:7 | to_s |
+| calls.rb:96:1:98:3 | String | to_s | calls.rb:172:5:173:7 | to_s |
 | calls.rb:100:1:103:3 | Kernel | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:105:1:110:3 | Module | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:105:1:110:3 | Module | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:105:1:110:3 | Module | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:105:1:110:3 | Module | create | calls.rb:275:1:283:3 | create |
-| calls.rb:105:1:110:3 | Module | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:105:1:110:3 | Module | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:105:1:110:3 | Module | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:105:1:110:3 | Module | include | calls.rb:107:5:107:20 | include |
-| calls.rb:105:1:110:3 | Module | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:105:1:110:3 | Module | module_eval | calls.rb:106:5:106:24 | module_eval |
-| calls.rb:105:1:110:3 | Module | new | calls.rb:114:5:114:16 | new |
-| calls.rb:105:1:110:3 | Module | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:105:1:110:3 | Module | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:105:1:110:3 | Module | prepend | calls.rb:108:5:108:20 | prepend |
-| calls.rb:105:1:110:3 | Module | private | calls.rb:109:5:109:20 | private |
-| calls.rb:105:1:110:3 | Module | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:105:1:110:3 | Module | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:105:1:110:3 | Module | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:112:1:115:3 | Object | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:112:1:115:3 | Object | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:112:1:115:3 | Object | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:112:1:115:3 | Object | create | calls.rb:275:1:283:3 | create |
-| calls.rb:112:1:115:3 | Object | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:112:1:115:3 | Object | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:112:1:115:3 | Object | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:112:1:115:3 | Object | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:112:1:115:3 | Object | new | calls.rb:114:5:114:16 | new |
-| calls.rb:112:1:115:3 | Object | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:112:1:115:3 | Object | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:112:1:115:3 | Object | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:112:1:115:3 | Object | private_on_main | private.rb:51:1:52:3 | private_on_main |
-| calls.rb:112:1:115:3 | Object | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:112:1:115:3 | Object | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:117:1:120:3 | Hash | [] | calls.rb:119:5:119:31 | [] |
-| calls.rb:117:1:120:3 | Hash | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:117:1:120:3 | Hash | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:117:1:120:3 | Hash | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:117:1:120:3 | Hash | create | calls.rb:275:1:283:3 | create |
-| calls.rb:117:1:120:3 | Hash | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:117:1:120:3 | Hash | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:117:1:120:3 | Hash | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:117:1:120:3 | Hash | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:117:1:120:3 | Hash | new | calls.rb:114:5:114:16 | new |
-| calls.rb:117:1:120:3 | Hash | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:117:1:120:3 | Hash | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:117:1:120:3 | Hash | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:117:1:120:3 | Hash | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:117:1:120:3 | Hash | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:122:1:135:3 | Array | [] | calls.rb:124:3:124:29 | [] |
-| calls.rb:122:1:135:3 | Array | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:122:1:135:3 | Array | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:122:1:135:3 | Array | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:122:1:135:3 | Array | create | calls.rb:275:1:283:3 | create |
-| calls.rb:122:1:135:3 | Array | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:122:1:135:3 | Array | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:122:1:135:3 | Array | foreach | calls.rb:128:3:134:5 | foreach |
-| calls.rb:122:1:135:3 | Array | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:122:1:135:3 | Array | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:122:1:135:3 | Array | length | calls.rb:126:3:126:17 | length |
-| calls.rb:122:1:135:3 | Array | new | calls.rb:114:5:114:16 | new |
-| calls.rb:122:1:135:3 | Array | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:122:1:135:3 | Array | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:122:1:135:3 | Array | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:122:1:135:3 | Array | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:122:1:135:3 | Array | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:162:1:166:3 | S | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:162:1:166:3 | S | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:162:1:166:3 | S | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:162:1:166:3 | S | create | calls.rb:275:1:283:3 | create |
-| calls.rb:162:1:166:3 | S | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:162:1:166:3 | S | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:162:1:166:3 | S | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:162:1:166:3 | S | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:162:1:166:3 | S | new | calls.rb:114:5:114:16 | new |
-| calls.rb:162:1:166:3 | S | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:162:1:166:3 | S | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:162:1:166:3 | S | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:162:1:166:3 | S | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:162:1:166:3 | S | s_method | calls.rb:163:5:165:7 | s_method |
-| calls.rb:162:1:166:3 | S | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:168:1:171:3 | A | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:168:1:171:3 | A | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:168:1:171:3 | A | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:168:1:171:3 | A | create | calls.rb:275:1:283:3 | create |
-| calls.rb:168:1:171:3 | A | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:168:1:171:3 | A | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:168:1:171:3 | A | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:168:1:171:3 | A | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:168:1:171:3 | A | new | calls.rb:114:5:114:16 | new |
-| calls.rb:168:1:171:3 | A | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:168:1:171:3 | A | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:168:1:171:3 | A | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:168:1:171:3 | A | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:168:1:171:3 | A | s_method | calls.rb:163:5:165:7 | s_method |
-| calls.rb:168:1:171:3 | A | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:173:1:176:3 | B | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:173:1:176:3 | B | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:173:1:176:3 | B | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:173:1:176:3 | B | create | calls.rb:275:1:283:3 | create |
-| calls.rb:173:1:176:3 | B | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:173:1:176:3 | B | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:173:1:176:3 | B | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:173:1:176:3 | B | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:173:1:176:3 | B | new | calls.rb:114:5:114:16 | new |
-| calls.rb:173:1:176:3 | B | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:173:1:176:3 | B | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:173:1:176:3 | B | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:173:1:176:3 | B | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:173:1:176:3 | B | s_method | calls.rb:163:5:165:7 | s_method |
-| calls.rb:173:1:176:3 | B | to_s | calls.rb:174:5:175:7 | to_s |
-| calls.rb:187:1:223:3 | Singletons | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:187:1:223:3 | Singletons | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:187:1:223:3 | Singletons | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:187:1:223:3 | Singletons | call_singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:187:1:223:3 | Singletons | create | calls.rb:275:1:283:3 | create |
-| calls.rb:187:1:223:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:187:1:223:3 | Singletons | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:187:1:223:3 | Singletons | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:187:1:223:3 | Singletons | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:187:1:223:3 | Singletons | instance | calls.rb:207:5:212:7 | instance |
-| calls.rb:187:1:223:3 | Singletons | new | calls.rb:114:5:114:16 | new |
-| calls.rb:187:1:223:3 | Singletons | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:187:1:223:3 | Singletons | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:187:1:223:3 | Singletons | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:187:1:223:3 | Singletons | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:187:1:223:3 | Singletons | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:307:1:318:3 | SelfNew | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:307:1:318:3 | SelfNew | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:307:1:318:3 | SelfNew | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:307:1:318:3 | SelfNew | create | calls.rb:275:1:283:3 | create |
-| calls.rb:307:1:318:3 | SelfNew | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:307:1:318:3 | SelfNew | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:307:1:318:3 | SelfNew | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:307:1:318:3 | SelfNew | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:307:1:318:3 | SelfNew | instance | calls.rb:308:5:311:7 | instance |
-| calls.rb:307:1:318:3 | SelfNew | new | calls.rb:114:5:114:16 | new |
-| calls.rb:307:1:318:3 | SelfNew | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:307:1:318:3 | SelfNew | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:307:1:318:3 | SelfNew | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:307:1:318:3 | SelfNew | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:307:1:318:3 | SelfNew | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:322:1:326:3 | C1 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:322:1:326:3 | C1 | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:322:1:326:3 | C1 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:322:1:326:3 | C1 | create | calls.rb:275:1:283:3 | create |
-| calls.rb:322:1:326:3 | C1 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:322:1:326:3 | C1 | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:322:1:326:3 | C1 | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:322:1:326:3 | C1 | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:322:1:326:3 | C1 | instance | calls.rb:323:5:325:7 | instance |
-| calls.rb:322:1:326:3 | C1 | new | calls.rb:114:5:114:16 | new |
-| calls.rb:322:1:326:3 | C1 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:322:1:326:3 | C1 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:322:1:326:3 | C1 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:322:1:326:3 | C1 | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:322:1:326:3 | C1 | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:328:1:332:3 | C2 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:328:1:332:3 | C2 | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:328:1:332:3 | C2 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:328:1:332:3 | C2 | create | calls.rb:275:1:283:3 | create |
-| calls.rb:328:1:332:3 | C2 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:328:1:332:3 | C2 | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:328:1:332:3 | C2 | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:328:1:332:3 | C2 | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:328:1:332:3 | C2 | instance | calls.rb:329:5:331:7 | instance |
-| calls.rb:328:1:332:3 | C2 | new | calls.rb:114:5:114:16 | new |
-| calls.rb:328:1:332:3 | C2 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:328:1:332:3 | C2 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:328:1:332:3 | C2 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:328:1:332:3 | C2 | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:328:1:332:3 | C2 | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:334:1:338:3 | C3 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:334:1:338:3 | C3 | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:334:1:338:3 | C3 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:334:1:338:3 | C3 | create | calls.rb:275:1:283:3 | create |
-| calls.rb:334:1:338:3 | C3 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:334:1:338:3 | C3 | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:334:1:338:3 | C3 | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:334:1:338:3 | C3 | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:334:1:338:3 | C3 | instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:334:1:338:3 | C3 | new | calls.rb:114:5:114:16 | new |
-| calls.rb:334:1:338:3 | C3 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:334:1:338:3 | C3 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:334:1:338:3 | C3 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:334:1:338:3 | C3 | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:334:1:338:3 | C3 | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:374:1:394:3 | SingletonOverride1 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:374:1:394:3 | SingletonOverride1 | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:374:1:394:3 | SingletonOverride1 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:374:1:394:3 | SingletonOverride1 | create | calls.rb:275:1:283:3 | create |
-| calls.rb:374:1:394:3 | SingletonOverride1 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:374:1:394:3 | SingletonOverride1 | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:374:1:394:3 | SingletonOverride1 | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:374:1:394:3 | SingletonOverride1 | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:374:1:394:3 | SingletonOverride1 | new | calls.rb:114:5:114:16 | new |
-| calls.rb:374:1:394:3 | SingletonOverride1 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:374:1:394:3 | SingletonOverride1 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:374:1:394:3 | SingletonOverride1 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:374:1:394:3 | SingletonOverride1 | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:374:1:394:3 | SingletonOverride1 | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:399:1:409:3 | SingletonOverride2 | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:399:1:409:3 | SingletonOverride2 | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:399:1:409:3 | SingletonOverride2 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:399:1:409:3 | SingletonOverride2 | create | calls.rb:275:1:283:3 | create |
-| calls.rb:399:1:409:3 | SingletonOverride2 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:399:1:409:3 | SingletonOverride2 | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:399:1:409:3 | SingletonOverride2 | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:399:1:409:3 | SingletonOverride2 | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:399:1:409:3 | SingletonOverride2 | new | calls.rb:114:5:114:16 | new |
-| calls.rb:399:1:409:3 | SingletonOverride2 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:399:1:409:3 | SingletonOverride2 | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:399:1:409:3 | SingletonOverride2 | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:399:1:409:3 | SingletonOverride2 | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:399:1:409:3 | SingletonOverride2 | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | create | calls.rb:275:1:283:3 | create |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | m1 | calls.rb:416:9:418:11 | m1 |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | m2 | calls.rb:421:5:433:7 | m2 |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | new | calls.rb:114:5:114:16 | new |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | to_s | calls.rb:169:5:170:7 | to_s |
-| calls.rb:477:1:483:3 | ExtendSingletonMethod | singleton | calls.rb:478:5:480:7 | singleton |
-| calls.rb:487:1:496:3 | ProtectedMethods | add_singleton | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:487:1:496:3 | ProtectedMethods | bar | calls.rb:492:5:495:7 | bar |
-| calls.rb:487:1:496:3 | ProtectedMethods | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:487:1:496:3 | ProtectedMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:487:1:496:3 | ProtectedMethods | create | calls.rb:275:1:283:3 | create |
-| calls.rb:487:1:496:3 | ProtectedMethods | foo | calls.rb:488:15:490:7 | foo |
-| calls.rb:487:1:496:3 | ProtectedMethods | funny | calls.rb:137:1:139:3 | funny |
-| calls.rb:487:1:496:3 | ProtectedMethods | indirect | calls.rb:155:1:157:3 | indirect |
-| calls.rb:487:1:496:3 | ProtectedMethods | new | calls.rb:114:5:114:16 | new |
-| calls.rb:487:1:496:3 | ProtectedMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:487:1:496:3 | ProtectedMethods | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:487:1:496:3 | ProtectedMethods | private_on_main | calls.rb:182:1:183:3 | private_on_main |
-| calls.rb:487:1:496:3 | ProtectedMethods | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:487:1:496:3 | ProtectedMethods | to_s | calls.rb:169:5:170:7 | to_s |
-| file://:0:0:0:0 | Class | include | calls.rb:107:5:107:20 | include |
-| file://:0:0:0:0 | Class | module_eval | calls.rb:106:5:106:24 | module_eval |
-| file://:0:0:0:0 | Class | new | calls.rb:114:5:114:16 | new |
-| file://:0:0:0:0 | Class | prepend | calls.rb:108:5:108:20 | prepend |
-| file://:0:0:0:0 | Class | private | calls.rb:109:5:109:20 | private |
+| calls.rb:105:1:113:3 | Module | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:105:1:113:3 | Module | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:105:1:113:3 | Module | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:105:1:113:3 | Module | create | calls.rb:278:1:286:3 | create |
+| calls.rb:105:1:113:3 | Module | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:105:1:113:3 | Module | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:105:1:113:3 | Module | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:105:1:113:3 | Module | include | calls.rb:108:5:110:7 | include |
+| calls.rb:105:1:113:3 | Module | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:105:1:113:3 | Module | module_eval | calls.rb:107:5:107:24 | module_eval |
+| calls.rb:105:1:113:3 | Module | new | calls.rb:117:5:117:16 | new |
+| calls.rb:105:1:113:3 | Module | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:105:1:113:3 | Module | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:105:1:113:3 | Module | prepend | calls.rb:111:5:111:20 | prepend |
+| calls.rb:105:1:113:3 | Module | private | calls.rb:112:5:112:20 | private |
+| calls.rb:105:1:113:3 | Module | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:105:1:113:3 | Module | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:105:1:113:3 | Module | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:115:1:118:3 | Object | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:115:1:118:3 | Object | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:115:1:118:3 | Object | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:115:1:118:3 | Object | create | calls.rb:278:1:286:3 | create |
+| calls.rb:115:1:118:3 | Object | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:115:1:118:3 | Object | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:115:1:118:3 | Object | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:115:1:118:3 | Object | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:115:1:118:3 | Object | new | calls.rb:117:5:117:16 | new |
+| calls.rb:115:1:118:3 | Object | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:115:1:118:3 | Object | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:115:1:118:3 | Object | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:115:1:118:3 | Object | private_on_main | private.rb:51:1:52:3 | private_on_main |
+| calls.rb:115:1:118:3 | Object | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:115:1:118:3 | Object | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:120:1:123:3 | Hash | [] | calls.rb:122:5:122:31 | [] |
+| calls.rb:120:1:123:3 | Hash | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:120:1:123:3 | Hash | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:120:1:123:3 | Hash | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:120:1:123:3 | Hash | create | calls.rb:278:1:286:3 | create |
+| calls.rb:120:1:123:3 | Hash | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:120:1:123:3 | Hash | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:120:1:123:3 | Hash | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:120:1:123:3 | Hash | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:120:1:123:3 | Hash | new | calls.rb:117:5:117:16 | new |
+| calls.rb:120:1:123:3 | Hash | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:120:1:123:3 | Hash | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:120:1:123:3 | Hash | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:120:1:123:3 | Hash | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:120:1:123:3 | Hash | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:125:1:138:3 | Array | [] | calls.rb:127:3:127:29 | [] |
+| calls.rb:125:1:138:3 | Array | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:125:1:138:3 | Array | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:125:1:138:3 | Array | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:125:1:138:3 | Array | create | calls.rb:278:1:286:3 | create |
+| calls.rb:125:1:138:3 | Array | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:125:1:138:3 | Array | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:125:1:138:3 | Array | foreach | calls.rb:131:3:137:5 | foreach |
+| calls.rb:125:1:138:3 | Array | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:125:1:138:3 | Array | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:125:1:138:3 | Array | length | calls.rb:129:3:129:17 | length |
+| calls.rb:125:1:138:3 | Array | new | calls.rb:117:5:117:16 | new |
+| calls.rb:125:1:138:3 | Array | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:125:1:138:3 | Array | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:125:1:138:3 | Array | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:125:1:138:3 | Array | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:125:1:138:3 | Array | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:165:1:169:3 | S | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:165:1:169:3 | S | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:165:1:169:3 | S | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:165:1:169:3 | S | create | calls.rb:278:1:286:3 | create |
+| calls.rb:165:1:169:3 | S | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:165:1:169:3 | S | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:165:1:169:3 | S | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:165:1:169:3 | S | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:165:1:169:3 | S | new | calls.rb:117:5:117:16 | new |
+| calls.rb:165:1:169:3 | S | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:165:1:169:3 | S | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:165:1:169:3 | S | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:165:1:169:3 | S | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:165:1:169:3 | S | s_method | calls.rb:166:5:168:7 | s_method |
+| calls.rb:165:1:169:3 | S | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:171:1:174:3 | A | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:171:1:174:3 | A | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:171:1:174:3 | A | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:171:1:174:3 | A | create | calls.rb:278:1:286:3 | create |
+| calls.rb:171:1:174:3 | A | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:171:1:174:3 | A | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:171:1:174:3 | A | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:171:1:174:3 | A | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:171:1:174:3 | A | new | calls.rb:117:5:117:16 | new |
+| calls.rb:171:1:174:3 | A | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:171:1:174:3 | A | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:171:1:174:3 | A | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:171:1:174:3 | A | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:171:1:174:3 | A | s_method | calls.rb:166:5:168:7 | s_method |
+| calls.rb:171:1:174:3 | A | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:176:1:179:3 | B | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:176:1:179:3 | B | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:176:1:179:3 | B | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:176:1:179:3 | B | create | calls.rb:278:1:286:3 | create |
+| calls.rb:176:1:179:3 | B | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:176:1:179:3 | B | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:176:1:179:3 | B | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:176:1:179:3 | B | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:176:1:179:3 | B | new | calls.rb:117:5:117:16 | new |
+| calls.rb:176:1:179:3 | B | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:176:1:179:3 | B | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:176:1:179:3 | B | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:176:1:179:3 | B | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:176:1:179:3 | B | s_method | calls.rb:166:5:168:7 | s_method |
+| calls.rb:176:1:179:3 | B | to_s | calls.rb:177:5:178:7 | to_s |
+| calls.rb:190:1:226:3 | Singletons | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:190:1:226:3 | Singletons | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:190:1:226:3 | Singletons | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:190:1:226:3 | Singletons | call_singleton_g | calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:190:1:226:3 | Singletons | create | calls.rb:278:1:286:3 | create |
+| calls.rb:190:1:226:3 | Singletons | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:190:1:226:3 | Singletons | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:190:1:226:3 | Singletons | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:190:1:226:3 | Singletons | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:190:1:226:3 | Singletons | instance | calls.rb:210:5:215:7 | instance |
+| calls.rb:190:1:226:3 | Singletons | new | calls.rb:117:5:117:16 | new |
+| calls.rb:190:1:226:3 | Singletons | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:190:1:226:3 | Singletons | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:190:1:226:3 | Singletons | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:190:1:226:3 | Singletons | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:190:1:226:3 | Singletons | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:310:1:321:3 | SelfNew | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:310:1:321:3 | SelfNew | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:310:1:321:3 | SelfNew | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:310:1:321:3 | SelfNew | create | calls.rb:278:1:286:3 | create |
+| calls.rb:310:1:321:3 | SelfNew | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:310:1:321:3 | SelfNew | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:310:1:321:3 | SelfNew | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:310:1:321:3 | SelfNew | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:310:1:321:3 | SelfNew | instance | calls.rb:311:5:314:7 | instance |
+| calls.rb:310:1:321:3 | SelfNew | new | calls.rb:117:5:117:16 | new |
+| calls.rb:310:1:321:3 | SelfNew | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:310:1:321:3 | SelfNew | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:310:1:321:3 | SelfNew | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:310:1:321:3 | SelfNew | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:310:1:321:3 | SelfNew | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:325:1:329:3 | C1 | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:325:1:329:3 | C1 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:325:1:329:3 | C1 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:325:1:329:3 | C1 | create | calls.rb:278:1:286:3 | create |
+| calls.rb:325:1:329:3 | C1 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:325:1:329:3 | C1 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:325:1:329:3 | C1 | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:325:1:329:3 | C1 | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:325:1:329:3 | C1 | instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:325:1:329:3 | C1 | new | calls.rb:117:5:117:16 | new |
+| calls.rb:325:1:329:3 | C1 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:325:1:329:3 | C1 | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:325:1:329:3 | C1 | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:325:1:329:3 | C1 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:325:1:329:3 | C1 | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:331:1:335:3 | C2 | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:331:1:335:3 | C2 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:331:1:335:3 | C2 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:331:1:335:3 | C2 | create | calls.rb:278:1:286:3 | create |
+| calls.rb:331:1:335:3 | C2 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:331:1:335:3 | C2 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:331:1:335:3 | C2 | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:331:1:335:3 | C2 | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:331:1:335:3 | C2 | instance | calls.rb:332:5:334:7 | instance |
+| calls.rb:331:1:335:3 | C2 | new | calls.rb:117:5:117:16 | new |
+| calls.rb:331:1:335:3 | C2 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:331:1:335:3 | C2 | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:331:1:335:3 | C2 | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:331:1:335:3 | C2 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:331:1:335:3 | C2 | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:337:1:341:3 | C3 | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:337:1:341:3 | C3 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:337:1:341:3 | C3 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:337:1:341:3 | C3 | create | calls.rb:278:1:286:3 | create |
+| calls.rb:337:1:341:3 | C3 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:337:1:341:3 | C3 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:337:1:341:3 | C3 | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:337:1:341:3 | C3 | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:337:1:341:3 | C3 | instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:337:1:341:3 | C3 | new | calls.rb:117:5:117:16 | new |
+| calls.rb:337:1:341:3 | C3 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:337:1:341:3 | C3 | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:337:1:341:3 | C3 | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:337:1:341:3 | C3 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:337:1:341:3 | C3 | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:377:1:397:3 | SingletonOverride1 | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:377:1:397:3 | SingletonOverride1 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:377:1:397:3 | SingletonOverride1 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:377:1:397:3 | SingletonOverride1 | create | calls.rb:278:1:286:3 | create |
+| calls.rb:377:1:397:3 | SingletonOverride1 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:377:1:397:3 | SingletonOverride1 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:377:1:397:3 | SingletonOverride1 | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:377:1:397:3 | SingletonOverride1 | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:377:1:397:3 | SingletonOverride1 | new | calls.rb:117:5:117:16 | new |
+| calls.rb:377:1:397:3 | SingletonOverride1 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:377:1:397:3 | SingletonOverride1 | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:377:1:397:3 | SingletonOverride1 | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:377:1:397:3 | SingletonOverride1 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:377:1:397:3 | SingletonOverride1 | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:402:1:412:3 | SingletonOverride2 | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:402:1:412:3 | SingletonOverride2 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:402:1:412:3 | SingletonOverride2 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:402:1:412:3 | SingletonOverride2 | create | calls.rb:278:1:286:3 | create |
+| calls.rb:402:1:412:3 | SingletonOverride2 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:402:1:412:3 | SingletonOverride2 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:402:1:412:3 | SingletonOverride2 | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:402:1:412:3 | SingletonOverride2 | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:402:1:412:3 | SingletonOverride2 | new | calls.rb:117:5:117:16 | new |
+| calls.rb:402:1:412:3 | SingletonOverride2 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:402:1:412:3 | SingletonOverride2 | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:402:1:412:3 | SingletonOverride2 | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:402:1:412:3 | SingletonOverride2 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:402:1:412:3 | SingletonOverride2 | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | create | calls.rb:278:1:286:3 | create |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | m1 | calls.rb:419:9:421:11 | m1 |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | m2 | calls.rb:424:5:436:7 | m2 |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | new | calls.rb:117:5:117:16 | new |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:480:1:486:3 | ExtendSingletonMethod | singleton | calls.rb:481:5:483:7 | singleton |
+| calls.rb:490:1:494:3 | ProtectedMethodInModule | foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:496:1:509:3 | ProtectedMethods | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:496:1:509:3 | ProtectedMethods | bar | calls.rb:499:15:501:7 | bar |
+| calls.rb:496:1:509:3 | ProtectedMethods | baz | calls.rb:503:5:508:7 | baz |
+| calls.rb:496:1:509:3 | ProtectedMethods | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:496:1:509:3 | ProtectedMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:496:1:509:3 | ProtectedMethods | create | calls.rb:278:1:286:3 | create |
+| calls.rb:496:1:509:3 | ProtectedMethods | foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:496:1:509:3 | ProtectedMethods | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:496:1:509:3 | ProtectedMethods | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:496:1:509:3 | ProtectedMethods | new | calls.rb:117:5:117:16 | new |
+| calls.rb:496:1:509:3 | ProtectedMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:496:1:509:3 | ProtectedMethods | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:496:1:509:3 | ProtectedMethods | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:496:1:509:3 | ProtectedMethods | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:496:1:509:3 | ProtectedMethods | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | bar | calls.rb:499:15:501:7 | bar |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | baz | calls.rb:516:5:519:7 | baz |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | create | calls.rb:278:1:286:3 | create |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | new | calls.rb:117:5:117:16 | new |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | to_s | calls.rb:172:5:173:7 | to_s |
+| file://:0:0:0:0 | Class | include | calls.rb:108:5:110:7 | include |
+| file://:0:0:0:0 | Class | module_eval | calls.rb:107:5:107:24 | module_eval |
+| file://:0:0:0:0 | Class | new | calls.rb:117:5:117:16 | new |
+| file://:0:0:0:0 | Class | prepend | calls.rb:111:5:111:20 | prepend |
+| file://:0:0:0:0 | Class | private | calls.rb:112:5:112:20 | private |
 | file://:0:0:0:0 | Class | puts | calls.rb:102:5:102:30 | puts |
-| file://:0:0:0:0 | Class | to_s | calls.rb:169:5:170:7 | to_s |
-| file://:0:0:0:0 | Complex | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Class | to_s | calls.rb:172:5:173:7 | to_s |
+| file://:0:0:0:0 | Complex | new | calls.rb:117:5:117:16 | new |
 | file://:0:0:0:0 | Complex | puts | calls.rb:102:5:102:30 | puts |
-| file://:0:0:0:0 | Complex | to_s | calls.rb:169:5:170:7 | to_s |
-| file://:0:0:0:0 | FalseClass | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Complex | to_s | calls.rb:172:5:173:7 | to_s |
+| file://:0:0:0:0 | FalseClass | new | calls.rb:117:5:117:16 | new |
 | file://:0:0:0:0 | FalseClass | puts | calls.rb:102:5:102:30 | puts |
-| file://:0:0:0:0 | FalseClass | to_s | calls.rb:169:5:170:7 | to_s |
-| file://:0:0:0:0 | Float | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | FalseClass | to_s | calls.rb:172:5:173:7 | to_s |
+| file://:0:0:0:0 | Float | new | calls.rb:117:5:117:16 | new |
 | file://:0:0:0:0 | Float | puts | calls.rb:102:5:102:30 | puts |
-| file://:0:0:0:0 | Float | to_s | calls.rb:169:5:170:7 | to_s |
-| file://:0:0:0:0 | NilClass | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Float | to_s | calls.rb:172:5:173:7 | to_s |
+| file://:0:0:0:0 | NilClass | new | calls.rb:117:5:117:16 | new |
 | file://:0:0:0:0 | NilClass | puts | calls.rb:102:5:102:30 | puts |
-| file://:0:0:0:0 | NilClass | to_s | calls.rb:169:5:170:7 | to_s |
-| file://:0:0:0:0 | Numeric | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | NilClass | to_s | calls.rb:172:5:173:7 | to_s |
+| file://:0:0:0:0 | Numeric | new | calls.rb:117:5:117:16 | new |
 | file://:0:0:0:0 | Numeric | puts | calls.rb:102:5:102:30 | puts |
-| file://:0:0:0:0 | Numeric | to_s | calls.rb:169:5:170:7 | to_s |
-| file://:0:0:0:0 | Rational | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Numeric | to_s | calls.rb:172:5:173:7 | to_s |
+| file://:0:0:0:0 | Rational | new | calls.rb:117:5:117:16 | new |
 | file://:0:0:0:0 | Rational | puts | calls.rb:102:5:102:30 | puts |
-| file://:0:0:0:0 | Rational | to_s | calls.rb:169:5:170:7 | to_s |
-| file://:0:0:0:0 | TrueClass | new | calls.rb:114:5:114:16 | new |
+| file://:0:0:0:0 | Rational | to_s | calls.rb:172:5:173:7 | to_s |
+| file://:0:0:0:0 | TrueClass | new | calls.rb:117:5:117:16 | new |
 | file://:0:0:0:0 | TrueClass | puts | calls.rb:102:5:102:30 | puts |
-| file://:0:0:0:0 | TrueClass | to_s | calls.rb:169:5:170:7 | to_s |
+| file://:0:0:0:0 | TrueClass | to_s | calls.rb:172:5:173:7 | to_s |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
-| hello.rb:11:1:16:3 | Greeting | new | calls.rb:114:5:114:16 | new |
+| hello.rb:11:1:16:3 | Greeting | new | calls.rb:117:5:117:16 | new |
 | hello.rb:11:1:16:3 | Greeting | puts | calls.rb:102:5:102:30 | puts |
-| hello.rb:11:1:16:3 | Greeting | to_s | calls.rb:169:5:170:7 | to_s |
+| hello.rb:11:1:16:3 | Greeting | to_s | calls.rb:172:5:173:7 | to_s |
 | hello.rb:11:1:16:3 | Greeting | world | hello.rb:5:5:7:7 | world |
 | hello.rb:18:1:22:3 | HelloWorld | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:18:1:22:3 | HelloWorld | message | hello.rb:19:5:21:7 | message |
-| hello.rb:18:1:22:3 | HelloWorld | new | calls.rb:114:5:114:16 | new |
+| hello.rb:18:1:22:3 | HelloWorld | new | calls.rb:117:5:117:16 | new |
 | hello.rb:18:1:22:3 | HelloWorld | puts | calls.rb:102:5:102:30 | puts |
-| hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:169:5:170:7 | to_s |
+| hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:172:5:173:7 | to_s |
 | hello.rb:18:1:22:3 | HelloWorld | world | hello.rb:5:5:7:7 | world |
 | modules.rb:4:1:24:3 | Foo | method_in_another_definition_of_foo | modules.rb:27:3:28:5 | method_in_another_definition_of_foo |
 | modules.rb:4:1:24:3 | Foo | method_in_foo | modules.rb:16:3:17:5 | method_in_foo |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_another_definition_of_foo_bar | modules.rb:52:3:53:5 | method_in_another_definition_of_foo_bar |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_foo_bar | modules.rb:9:5:10:7 | method_in_foo_bar |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | new | calls.rb:117:5:117:16 | new |
 | modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | to_s | calls.rb:169:5:170:7 | to_s |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | new | calls.rb:114:5:114:16 | new |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | to_s | calls.rb:172:5:173:7 | to_s |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | new | calls.rb:117:5:117:16 | new |
 | modules.rb:19:3:20:5 | Foo::ClassInFoo | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | to_s | calls.rb:169:5:170:7 | to_s |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | new | calls.rb:114:5:114:16 | new |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | to_s | calls.rb:172:5:173:7 | to_s |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | new | calls.rb:117:5:117:16 | new |
 | modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | to_s | calls.rb:169:5:170:7 | to_s |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | to_s | calls.rb:172:5:173:7 | to_s |
 | modules.rb:37:1:46:3 | Bar | method_a | modules.rb:38:3:39:5 | method_a |
 | modules.rb:37:1:46:3 | Bar | method_b | modules.rb:41:3:42:5 | method_b |
-| modules.rb:37:1:46:3 | Bar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:37:1:46:3 | Bar | new | calls.rb:117:5:117:16 | new |
 | modules.rb:37:1:46:3 | Bar | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:37:1:46:3 | Bar | to_s | calls.rb:169:5:170:7 | to_s |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:37:1:46:3 | Bar | to_s | calls.rb:172:5:173:7 | to_s |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | new | calls.rb:117:5:117:16 | new |
 | modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | to_s | calls.rb:169:5:170:7 | to_s |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | to_s | calls.rb:172:5:173:7 | to_s |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | new | calls.rb:117:5:117:16 | new |
 | modules.rb:66:5:67:7 | Test::Foo1::Bar | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | to_s | calls.rb:169:5:170:7 | to_s |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | new | calls.rb:114:5:114:16 | new |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | to_s | calls.rb:172:5:173:7 | to_s |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | new | calls.rb:117:5:117:16 | new |
 | modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | to_s | calls.rb:169:5:170:7 | to_s |
-| modules.rb:112:1:113:3 | YY | new | calls.rb:114:5:114:16 | new |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | to_s | calls.rb:172:5:173:7 | to_s |
+| modules.rb:112:1:113:3 | YY | new | calls.rb:117:5:117:16 | new |
 | modules.rb:112:1:113:3 | YY | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:112:1:113:3 | YY | to_s | calls.rb:169:5:170:7 | to_s |
-| modules.rb:116:7:117:9 | XX::YY | new | calls.rb:114:5:114:16 | new |
+| modules.rb:112:1:113:3 | YY | to_s | calls.rb:172:5:173:7 | to_s |
+| modules.rb:116:7:117:9 | XX::YY | new | calls.rb:117:5:117:16 | new |
 | modules.rb:116:7:117:9 | XX::YY | puts | calls.rb:102:5:102:30 | puts |
-| modules.rb:116:7:117:9 | XX::YY | to_s | calls.rb:169:5:170:7 | to_s |
-| modules_rec.rb:1:1:2:3 | B::A | new | calls.rb:114:5:114:16 | new |
+| modules.rb:116:7:117:9 | XX::YY | to_s | calls.rb:172:5:173:7 | to_s |
+| modules_rec.rb:1:1:2:3 | B::A | new | calls.rb:117:5:117:16 | new |
 | modules_rec.rb:1:1:2:3 | B::A | puts | calls.rb:102:5:102:30 | puts |
-| modules_rec.rb:1:1:2:3 | B::A | to_s | calls.rb:169:5:170:7 | to_s |
-| modules_rec.rb:4:1:5:3 | A::B | new | calls.rb:114:5:114:16 | new |
+| modules_rec.rb:1:1:2:3 | B::A | to_s | calls.rb:172:5:173:7 | to_s |
+| modules_rec.rb:4:1:5:3 | A::B | new | calls.rb:117:5:117:16 | new |
 | modules_rec.rb:4:1:5:3 | A::B | puts | calls.rb:102:5:102:30 | puts |
-| modules_rec.rb:4:1:5:3 | A::B | to_s | calls.rb:169:5:170:7 | to_s |
-| private.rb:1:1:49:3 | E | new | calls.rb:114:5:114:16 | new |
+| modules_rec.rb:4:1:5:3 | A::B | to_s | calls.rb:172:5:173:7 | to_s |
+| private.rb:1:1:49:3 | E | new | calls.rb:117:5:117:16 | new |
 | private.rb:1:1:49:3 | E | private1 | private.rb:2:11:3:5 | private1 |
 | private.rb:1:1:49:3 | E | private2 | private.rb:8:3:9:5 | private2 |
 | private.rb:1:1:49:3 | E | private3 | private.rb:14:3:15:5 | private3 |
@@ -462,7 +481,7 @@ lookupMethod
 | private.rb:1:1:49:3 | E | protected2 | private.rb:35:3:36:5 | protected2 |
 | private.rb:1:1:49:3 | E | public | private.rb:5:3:6:5 | public |
 | private.rb:1:1:49:3 | E | puts | calls.rb:102:5:102:30 | puts |
-| private.rb:1:1:49:3 | E | to_s | calls.rb:169:5:170:7 | to_s |
+| private.rb:1:1:49:3 | E | to_s | calls.rb:172:5:173:7 | to_s |
 | private.rb:62:1:80:3 | F | private1 | private.rb:63:11:64:5 | private1 |
 | private.rb:62:1:80:3 | F | private2 | private.rb:69:3:70:5 | private2 |
 | private.rb:62:1:80:3 | F | private3 | private.rb:75:3:76:5 | private3 |
@@ -471,17 +490,17 @@ lookupMethod
 | private.rb:82:1:94:3 | PrivateOverride1 | call_m1 | private.rb:91:3:93:5 | call_m1 |
 | private.rb:82:1:94:3 | PrivateOverride1 | m1 | private.rb:83:11:85:5 | m1 |
 | private.rb:82:1:94:3 | PrivateOverride1 | m2 | private.rb:87:11:89:5 | m2 |
-| private.rb:82:1:94:3 | PrivateOverride1 | new | calls.rb:114:5:114:16 | new |
+| private.rb:82:1:94:3 | PrivateOverride1 | new | calls.rb:117:5:117:16 | new |
 | private.rb:82:1:94:3 | PrivateOverride1 | private_on_main | private.rb:51:1:52:3 | private_on_main |
 | private.rb:82:1:94:3 | PrivateOverride1 | puts | calls.rb:102:5:102:30 | puts |
-| private.rb:82:1:94:3 | PrivateOverride1 | to_s | calls.rb:169:5:170:7 | to_s |
+| private.rb:82:1:94:3 | PrivateOverride1 | to_s | calls.rb:172:5:173:7 | to_s |
 | private.rb:96:1:102:3 | PrivateOverride2 | call_m1 | private.rb:91:3:93:5 | call_m1 |
 | private.rb:96:1:102:3 | PrivateOverride2 | m1 | private.rb:97:11:101:5 | m1 |
 | private.rb:96:1:102:3 | PrivateOverride2 | m2 | private.rb:87:11:89:5 | m2 |
-| private.rb:96:1:102:3 | PrivateOverride2 | new | calls.rb:114:5:114:16 | new |
+| private.rb:96:1:102:3 | PrivateOverride2 | new | calls.rb:117:5:117:16 | new |
 | private.rb:96:1:102:3 | PrivateOverride2 | private_on_main | private.rb:51:1:52:3 | private_on_main |
 | private.rb:96:1:102:3 | PrivateOverride2 | puts | calls.rb:102:5:102:30 | puts |
-| private.rb:96:1:102:3 | PrivateOverride2 | to_s | calls.rb:169:5:170:7 | to_s |
+| private.rb:96:1:102:3 | PrivateOverride2 | to_s | calls.rb:172:5:173:7 | to_s |
 enclosingMethod
 | calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:3:3 | foo |
 | calls.rb:2:5:2:14 | self | calls.rb:1:1:3:3 | foo |
@@ -542,258 +561,277 @@ enclosingMethod
 | calls.rb:102:17:102:26 | call to old_puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:102:17:102:26 | self | calls.rb:102:5:102:30 | puts |
 | calls.rb:102:26:102:26 | x | calls.rb:102:5:102:30 | puts |
-| calls.rb:119:12:119:12 | x | calls.rb:119:5:119:31 | [] |
-| calls.rb:119:12:119:12 | x | calls.rb:119:5:119:31 | [] |
-| calls.rb:119:15:119:27 | call to old_lookup | calls.rb:119:5:119:31 | [] |
-| calls.rb:119:15:119:27 | self | calls.rb:119:5:119:31 | [] |
-| calls.rb:119:26:119:26 | x | calls.rb:119:5:119:31 | [] |
-| calls.rb:124:10:124:10 | x | calls.rb:124:3:124:29 | [] |
-| calls.rb:124:10:124:10 | x | calls.rb:124:3:124:29 | [] |
-| calls.rb:124:13:124:25 | call to old_lookup | calls.rb:124:3:124:29 | [] |
-| calls.rb:124:13:124:25 | self | calls.rb:124:3:124:29 | [] |
-| calls.rb:124:24:124:24 | x | calls.rb:124:3:124:29 | [] |
-| calls.rb:128:15:128:19 | &body | calls.rb:128:3:134:5 | foreach |
-| calls.rb:128:16:128:19 | body | calls.rb:128:3:134:5 | foreach |
-| calls.rb:129:5:129:5 | x | calls.rb:128:3:134:5 | foreach |
-| calls.rb:129:5:129:9 | ... = ... | calls.rb:128:3:134:5 | foreach |
-| calls.rb:129:9:129:9 | 0 | calls.rb:128:3:134:5 | foreach |
-| calls.rb:130:5:133:7 | while ... | calls.rb:128:3:134:5 | foreach |
-| calls.rb:130:11:130:11 | x | calls.rb:128:3:134:5 | foreach |
-| calls.rb:130:11:130:25 | ... < ... | calls.rb:128:3:134:5 | foreach |
-| calls.rb:130:15:130:18 | self | calls.rb:128:3:134:5 | foreach |
-| calls.rb:130:15:130:25 | call to length | calls.rb:128:3:134:5 | foreach |
-| calls.rb:130:26:133:7 | do ... | calls.rb:128:3:134:5 | foreach |
-| calls.rb:131:9:131:24 | yield ... | calls.rb:128:3:134:5 | foreach |
-| calls.rb:131:15:131:15 | x | calls.rb:128:3:134:5 | foreach |
-| calls.rb:131:18:131:21 | self | calls.rb:128:3:134:5 | foreach |
-| calls.rb:131:18:131:24 | ...[...] | calls.rb:128:3:134:5 | foreach |
-| calls.rb:131:23:131:23 | x | calls.rb:128:3:134:5 | foreach |
-| calls.rb:132:9:132:9 | x | calls.rb:128:3:134:5 | foreach |
-| calls.rb:132:9:132:9 | x | calls.rb:128:3:134:5 | foreach |
-| calls.rb:132:9:132:14 | ... += ... | calls.rb:128:3:134:5 | foreach |
-| calls.rb:132:9:132:14 | ... = ... | calls.rb:128:3:134:5 | foreach |
-| calls.rb:132:11:132:12 | ... + ... | calls.rb:128:3:134:5 | foreach |
-| calls.rb:132:14:132:14 | 1 | calls.rb:128:3:134:5 | foreach |
-| calls.rb:138:5:138:20 | yield ... | calls.rb:137:1:139:3 | funny |
-| calls.rb:138:11:138:20 | "prefix: " | calls.rb:137:1:139:3 | funny |
-| calls.rb:138:12:138:19 | prefix:  | calls.rb:137:1:139:3 | funny |
-| calls.rb:155:14:155:15 | &b | calls.rb:155:1:157:3 | indirect |
-| calls.rb:155:15:155:15 | b | calls.rb:155:1:157:3 | indirect |
-| calls.rb:156:5:156:17 | call to call_block | calls.rb:155:1:157:3 | indirect |
-| calls.rb:156:5:156:17 | self | calls.rb:155:1:157:3 | indirect |
-| calls.rb:156:16:156:17 | &... | calls.rb:155:1:157:3 | indirect |
-| calls.rb:156:17:156:17 | b | calls.rb:155:1:157:3 | indirect |
-| calls.rb:164:9:164:12 | self | calls.rb:163:5:165:7 | s_method |
-| calls.rb:164:9:164:17 | call to to_s | calls.rb:163:5:165:7 | s_method |
-| calls.rb:189:9:189:26 | call to puts | calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:189:9:189:26 | self | calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:189:14:189:26 | "singleton_a" | calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:189:15:189:25 | singleton_a | calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:190:9:190:12 | self | calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:190:9:190:24 | call to singleton_b | calls.rb:188:5:191:7 | singleton_a |
-| calls.rb:194:9:194:26 | call to puts | calls.rb:193:5:196:7 | singleton_b |
-| calls.rb:194:9:194:26 | self | calls.rb:193:5:196:7 | singleton_b |
-| calls.rb:194:14:194:26 | "singleton_b" | calls.rb:193:5:196:7 | singleton_b |
-| calls.rb:194:15:194:25 | singleton_b | calls.rb:193:5:196:7 | singleton_b |
-| calls.rb:195:9:195:12 | self | calls.rb:193:5:196:7 | singleton_b |
-| calls.rb:195:9:195:24 | call to singleton_c | calls.rb:193:5:196:7 | singleton_b |
-| calls.rb:199:9:199:26 | call to puts | calls.rb:198:5:200:7 | singleton_c |
-| calls.rb:199:9:199:26 | self | calls.rb:198:5:200:7 | singleton_c |
-| calls.rb:199:14:199:26 | "singleton_c" | calls.rb:198:5:200:7 | singleton_c |
-| calls.rb:199:15:199:25 | singleton_c | calls.rb:198:5:200:7 | singleton_c |
-| calls.rb:203:9:203:26 | call to puts | calls.rb:202:5:205:7 | singleton_d |
-| calls.rb:203:9:203:26 | self | calls.rb:202:5:205:7 | singleton_d |
-| calls.rb:203:14:203:26 | "singleton_d" | calls.rb:202:5:205:7 | singleton_d |
-| calls.rb:203:15:203:25 | singleton_d | calls.rb:202:5:205:7 | singleton_d |
-| calls.rb:204:9:204:12 | self | calls.rb:202:5:205:7 | singleton_d |
-| calls.rb:204:9:204:24 | call to singleton_a | calls.rb:202:5:205:7 | singleton_d |
-| calls.rb:208:9:210:11 | singleton_e | calls.rb:207:5:212:7 | instance |
-| calls.rb:208:13:208:16 | self | calls.rb:207:5:212:7 | instance |
-| calls.rb:209:13:209:30 | call to puts | calls.rb:208:9:210:11 | singleton_e |
-| calls.rb:209:13:209:30 | self | calls.rb:208:9:210:11 | singleton_e |
-| calls.rb:209:18:209:30 | "singleton_e" | calls.rb:208:9:210:11 | singleton_e |
-| calls.rb:209:19:209:29 | singleton_e | calls.rb:208:9:210:11 | singleton_e |
-| calls.rb:211:9:211:19 | call to singleton_e | calls.rb:207:5:212:7 | instance |
-| calls.rb:211:9:211:19 | self | calls.rb:207:5:212:7 | instance |
-| calls.rb:216:13:216:30 | call to puts | calls.rb:215:9:217:11 | singleton_f |
-| calls.rb:216:13:216:30 | self | calls.rb:215:9:217:11 | singleton_f |
-| calls.rb:216:18:216:30 | "singleton_f" | calls.rb:215:9:217:11 | singleton_f |
-| calls.rb:216:19:216:29 | singleton_f | calls.rb:215:9:217:11 | singleton_f |
-| calls.rb:221:9:221:12 | self | calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:220:5:222:7 | call_singleton_g |
-| calls.rb:234:5:234:24 | call to puts | calls.rb:233:1:235:3 | singleton_g |
-| calls.rb:234:5:234:24 | self | calls.rb:233:1:235:3 | singleton_g |
-| calls.rb:234:10:234:24 | "singleton_g_1" | calls.rb:233:1:235:3 | singleton_g |
-| calls.rb:234:11:234:23 | singleton_g_1 | calls.rb:233:1:235:3 | singleton_g |
-| calls.rb:241:5:241:24 | call to puts | calls.rb:240:1:242:3 | singleton_g |
-| calls.rb:241:5:241:24 | self | calls.rb:240:1:242:3 | singleton_g |
-| calls.rb:241:10:241:24 | "singleton_g_2" | calls.rb:240:1:242:3 | singleton_g |
-| calls.rb:241:11:241:23 | singleton_g_2 | calls.rb:240:1:242:3 | singleton_g |
-| calls.rb:249:9:249:28 | call to puts | calls.rb:248:5:250:7 | singleton_g |
-| calls.rb:249:9:249:28 | self | calls.rb:248:5:250:7 | singleton_g |
-| calls.rb:249:14:249:28 | "singleton_g_3" | calls.rb:248:5:250:7 | singleton_g |
-| calls.rb:249:15:249:27 | singleton_g_3 | calls.rb:248:5:250:7 | singleton_g |
-| calls.rb:265:5:265:22 | call to puts | calls.rb:264:1:266:3 | singleton_g |
-| calls.rb:265:5:265:22 | self | calls.rb:264:1:266:3 | singleton_g |
-| calls.rb:265:10:265:22 | "singleton_g" | calls.rb:264:1:266:3 | singleton_g |
-| calls.rb:265:11:265:21 | singleton_g | calls.rb:264:1:266:3 | singleton_g |
-| calls.rb:275:12:275:15 | type | calls.rb:275:1:283:3 | create |
-| calls.rb:275:12:275:15 | type | calls.rb:275:1:283:3 | create |
-| calls.rb:276:5:276:8 | type | calls.rb:275:1:283:3 | create |
-| calls.rb:276:5:276:12 | call to new | calls.rb:275:1:283:3 | create |
-| calls.rb:276:5:276:21 | call to instance | calls.rb:275:1:283:3 | create |
-| calls.rb:278:5:280:7 | singleton_h | calls.rb:275:1:283:3 | create |
-| calls.rb:278:9:278:12 | type | calls.rb:275:1:283:3 | create |
-| calls.rb:279:9:279:26 | call to puts | calls.rb:278:5:280:7 | singleton_h |
-| calls.rb:279:9:279:26 | self | calls.rb:278:5:280:7 | singleton_h |
-| calls.rb:279:14:279:26 | "singleton_h" | calls.rb:278:5:280:7 | singleton_h |
-| calls.rb:279:15:279:25 | singleton_h | calls.rb:278:5:280:7 | singleton_h |
-| calls.rb:282:5:282:8 | type | calls.rb:275:1:283:3 | create |
-| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:275:1:283:3 | create |
-| calls.rb:292:9:292:26 | call to puts | calls.rb:291:5:293:7 | singleton_i |
-| calls.rb:292:9:292:26 | self | calls.rb:291:5:293:7 | singleton_i |
-| calls.rb:292:14:292:26 | "singleton_i" | calls.rb:291:5:293:7 | singleton_i |
-| calls.rb:292:15:292:25 | singleton_i | calls.rb:291:5:293:7 | singleton_i |
-| calls.rb:301:9:301:26 | call to puts | calls.rb:300:5:302:7 | singleton_j |
-| calls.rb:301:9:301:26 | self | calls.rb:300:5:302:7 | singleton_j |
-| calls.rb:301:14:301:26 | "singleton_j" | calls.rb:300:5:302:7 | singleton_j |
-| calls.rb:301:15:301:25 | singleton_j | calls.rb:300:5:302:7 | singleton_j |
-| calls.rb:309:9:309:31 | call to puts | calls.rb:308:5:311:7 | instance |
-| calls.rb:309:9:309:31 | self | calls.rb:308:5:311:7 | instance |
-| calls.rb:309:14:309:31 | "SelfNew#instance" | calls.rb:308:5:311:7 | instance |
-| calls.rb:309:15:309:30 | SelfNew#instance | calls.rb:308:5:311:7 | instance |
-| calls.rb:310:9:310:11 | call to new | calls.rb:308:5:311:7 | instance |
-| calls.rb:310:9:310:11 | self | calls.rb:308:5:311:7 | instance |
-| calls.rb:310:9:310:20 | call to instance | calls.rb:308:5:311:7 | instance |
-| calls.rb:314:9:314:11 | call to new | calls.rb:313:5:315:7 | singleton |
-| calls.rb:314:9:314:11 | self | calls.rb:313:5:315:7 | singleton |
-| calls.rb:314:9:314:20 | call to instance | calls.rb:313:5:315:7 | singleton |
-| calls.rb:324:9:324:26 | call to puts | calls.rb:323:5:325:7 | instance |
-| calls.rb:324:9:324:26 | self | calls.rb:323:5:325:7 | instance |
-| calls.rb:324:14:324:26 | "C1#instance" | calls.rb:323:5:325:7 | instance |
-| calls.rb:324:15:324:25 | C1#instance | calls.rb:323:5:325:7 | instance |
-| calls.rb:330:9:330:26 | call to puts | calls.rb:329:5:331:7 | instance |
-| calls.rb:330:9:330:26 | self | calls.rb:329:5:331:7 | instance |
-| calls.rb:330:14:330:26 | "C2#instance" | calls.rb:329:5:331:7 | instance |
-| calls.rb:330:15:330:25 | C2#instance | calls.rb:329:5:331:7 | instance |
-| calls.rb:336:9:336:26 | call to puts | calls.rb:335:5:337:7 | instance |
-| calls.rb:336:9:336:26 | self | calls.rb:335:5:337:7 | instance |
-| calls.rb:336:14:336:26 | "C3#instance" | calls.rb:335:5:337:7 | instance |
-| calls.rb:336:15:336:25 | C3#instance | calls.rb:335:5:337:7 | instance |
-| calls.rb:340:22:340:22 | x | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:340:22:340:22 | x | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:341:5:349:7 | case ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:341:10:341:10 | x | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:342:5:343:18 | when ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:342:10:342:11 | C3 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:342:12:343:18 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:343:9:343:9 | x | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:343:9:343:18 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:344:5:345:18 | when ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:344:10:344:11 | C2 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:344:12:345:18 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:345:9:345:9 | x | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:345:9:345:18 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:346:5:347:18 | when ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:346:10:346:11 | C1 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:346:12:347:18 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:347:9:347:9 | x | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:347:9:347:18 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:348:5:348:8 | else ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:351:5:355:7 | case ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:351:10:351:10 | x | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:352:9:352:29 | in ... then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:352:12:352:13 | C3 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:352:15:352:29 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:352:20:352:20 | x | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:352:20:352:29 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:353:9:353:36 | in ... then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:353:12:353:13 | C2 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:353:12:353:19 | ... => ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:353:18:353:19 | c2 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:353:21:353:36 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:353:26:353:27 | c2 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:353:26:353:36 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:354:9:354:36 | in ... then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:354:12:354:13 | C1 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:354:12:354:19 | ... => ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:354:18:354:19 | c1 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:354:21:354:36 | then ... | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:354:26:354:27 | c1 | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:354:26:354:36 | call to instance | calls.rb:340:1:356:3 | pattern_dispatch |
-| calls.rb:364:19:364:19 | x | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:364:19:364:19 | x | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:365:5:367:7 | instance | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:365:9:365:9 | x | calls.rb:364:1:368:3 | add_singleton |
-| calls.rb:366:9:366:28 | call to puts | calls.rb:365:5:367:7 | instance |
-| calls.rb:366:9:366:28 | self | calls.rb:365:5:367:7 | instance |
-| calls.rb:366:14:366:28 | "instance_on x" | calls.rb:365:5:367:7 | instance |
-| calls.rb:366:15:366:27 | instance_on x | calls.rb:365:5:367:7 | instance |
-| calls.rb:377:13:377:48 | call to puts | calls.rb:376:9:378:11 | singleton1 |
-| calls.rb:377:13:377:48 | self | calls.rb:376:9:378:11 | singleton1 |
-| calls.rb:377:18:377:48 | "SingletonOverride1#singleton1" | calls.rb:376:9:378:11 | singleton1 |
-| calls.rb:377:19:377:47 | SingletonOverride1#singleton1 | calls.rb:376:9:378:11 | singleton1 |
-| calls.rb:381:13:381:22 | call to singleton1 | calls.rb:380:9:382:11 | call_singleton1 |
-| calls.rb:381:13:381:22 | self | calls.rb:380:9:382:11 | call_singleton1 |
-| calls.rb:386:9:386:44 | call to puts | calls.rb:385:5:387:7 | singleton2 |
-| calls.rb:386:9:386:44 | self | calls.rb:385:5:387:7 | singleton2 |
-| calls.rb:386:14:386:44 | "SingletonOverride1#singleton2" | calls.rb:385:5:387:7 | singleton2 |
-| calls.rb:386:15:386:43 | SingletonOverride1#singleton2 | calls.rb:385:5:387:7 | singleton2 |
-| calls.rb:390:9:390:18 | call to singleton2 | calls.rb:389:5:391:7 | call_singleton2 |
-| calls.rb:390:9:390:18 | self | calls.rb:389:5:391:7 | call_singleton2 |
-| calls.rb:402:13:402:48 | call to puts | calls.rb:401:9:403:11 | singleton1 |
-| calls.rb:402:13:402:48 | self | calls.rb:401:9:403:11 | singleton1 |
-| calls.rb:402:18:402:48 | "SingletonOverride2#singleton1" | calls.rb:401:9:403:11 | singleton1 |
-| calls.rb:402:19:402:47 | SingletonOverride2#singleton1 | calls.rb:401:9:403:11 | singleton1 |
-| calls.rb:407:9:407:44 | call to puts | calls.rb:406:5:408:7 | singleton2 |
-| calls.rb:407:9:407:44 | self | calls.rb:406:5:408:7 | singleton2 |
-| calls.rb:407:14:407:44 | "SingletonOverride2#singleton2" | calls.rb:406:5:408:7 | singleton2 |
-| calls.rb:407:15:407:43 | SingletonOverride2#singleton2 | calls.rb:406:5:408:7 | singleton2 |
-| calls.rb:417:13:417:48 | call to puts | calls.rb:416:9:418:11 | m1 |
-| calls.rb:417:13:417:48 | self | calls.rb:416:9:418:11 | m1 |
-| calls.rb:417:18:417:48 | "ConditionalInstanceMethods#m1" | calls.rb:416:9:418:11 | m1 |
-| calls.rb:417:19:417:47 | ConditionalInstanceMethods#m1 | calls.rb:416:9:418:11 | m1 |
-| calls.rb:422:9:422:44 | call to puts | calls.rb:421:5:433:7 | m2 |
-| calls.rb:422:9:422:44 | self | calls.rb:421:5:433:7 | m2 |
-| calls.rb:422:14:422:44 | "ConditionalInstanceMethods#m2" | calls.rb:421:5:433:7 | m2 |
-| calls.rb:422:15:422:43 | ConditionalInstanceMethods#m2 | calls.rb:421:5:433:7 | m2 |
-| calls.rb:424:9:430:11 | m3 | calls.rb:421:5:433:7 | m2 |
-| calls.rb:425:13:425:48 | call to puts | calls.rb:424:9:430:11 | m3 |
-| calls.rb:425:13:425:48 | self | calls.rb:424:9:430:11 | m3 |
-| calls.rb:425:18:425:48 | "ConditionalInstanceMethods#m3" | calls.rb:424:9:430:11 | m3 |
-| calls.rb:425:19:425:47 | ConditionalInstanceMethods#m3 | calls.rb:424:9:430:11 | m3 |
-| calls.rb:427:13:429:15 | m4 | calls.rb:424:9:430:11 | m3 |
-| calls.rb:428:17:428:52 | call to puts | calls.rb:427:13:429:15 | m4 |
-| calls.rb:428:17:428:52 | self | calls.rb:427:13:429:15 | m4 |
-| calls.rb:428:22:428:52 | "ConditionalInstanceMethods#m4" | calls.rb:427:13:429:15 | m4 |
-| calls.rb:428:23:428:51 | ConditionalInstanceMethods#m4 | calls.rb:427:13:429:15 | m4 |
-| calls.rb:432:9:432:10 | call to m3 | calls.rb:421:5:433:7 | m2 |
-| calls.rb:432:9:432:10 | self | calls.rb:421:5:433:7 | m2 |
-| calls.rb:438:17:438:40 | call to puts | calls.rb:437:13:439:15 | m5 |
-| calls.rb:438:17:438:40 | self | calls.rb:437:13:439:15 | m5 |
-| calls.rb:438:22:438:40 | "AnonymousClass#m5" | calls.rb:437:13:439:15 | m5 |
-| calls.rb:438:23:438:39 | AnonymousClass#m5 | calls.rb:437:13:439:15 | m5 |
-| calls.rb:454:13:454:22 | call to puts | calls.rb:453:9:455:11 | foo |
-| calls.rb:454:13:454:22 | self | calls.rb:453:9:455:11 | foo |
-| calls.rb:454:18:454:22 | "foo" | calls.rb:453:9:455:11 | foo |
-| calls.rb:454:19:454:21 | foo | calls.rb:453:9:455:11 | foo |
-| calls.rb:460:13:460:22 | call to puts | calls.rb:459:9:461:11 | bar |
-| calls.rb:460:13:460:22 | self | calls.rb:459:9:461:11 | bar |
-| calls.rb:460:18:460:22 | "bar" | calls.rb:459:9:461:11 | bar |
-| calls.rb:460:19:460:21 | bar | calls.rb:459:9:461:11 | bar |
-| calls.rb:479:9:479:46 | call to puts | calls.rb:478:5:480:7 | singleton |
-| calls.rb:479:9:479:46 | self | calls.rb:478:5:480:7 | singleton |
-| calls.rb:479:14:479:46 | "ExtendSingletonMethod#singleton" | calls.rb:478:5:480:7 | singleton |
-| calls.rb:479:15:479:45 | ExtendSingletonMethod#singleton | calls.rb:478:5:480:7 | singleton |
-| calls.rb:489:9:489:35 | call to puts | calls.rb:488:15:490:7 | foo |
-| calls.rb:489:9:489:35 | self | calls.rb:488:15:490:7 | foo |
-| calls.rb:489:14:489:35 | "ProtectedMethods#foo" | calls.rb:488:15:490:7 | foo |
-| calls.rb:489:15:489:34 | ProtectedMethods#foo | calls.rb:488:15:490:7 | foo |
-| calls.rb:493:9:493:11 | call to foo | calls.rb:492:5:495:7 | bar |
-| calls.rb:493:9:493:11 | self | calls.rb:492:5:495:7 | bar |
-| calls.rb:494:9:494:24 | ProtectedMethods | calls.rb:492:5:495:7 | bar |
-| calls.rb:494:9:494:28 | call to new | calls.rb:492:5:495:7 | bar |
-| calls.rb:494:9:494:32 | call to foo | calls.rb:492:5:495:7 | bar |
+| calls.rb:108:17:108:17 | x | calls.rb:108:5:110:7 | include |
+| calls.rb:108:17:108:17 | x | calls.rb:108:5:110:7 | include |
+| calls.rb:109:9:109:21 | call to old_include | calls.rb:108:5:110:7 | include |
+| calls.rb:109:9:109:21 | self | calls.rb:108:5:110:7 | include |
+| calls.rb:109:21:109:21 | x | calls.rb:108:5:110:7 | include |
+| calls.rb:122:12:122:12 | x | calls.rb:122:5:122:31 | [] |
+| calls.rb:122:12:122:12 | x | calls.rb:122:5:122:31 | [] |
+| calls.rb:122:15:122:27 | call to old_lookup | calls.rb:122:5:122:31 | [] |
+| calls.rb:122:15:122:27 | self | calls.rb:122:5:122:31 | [] |
+| calls.rb:122:26:122:26 | x | calls.rb:122:5:122:31 | [] |
+| calls.rb:127:10:127:10 | x | calls.rb:127:3:127:29 | [] |
+| calls.rb:127:10:127:10 | x | calls.rb:127:3:127:29 | [] |
+| calls.rb:127:13:127:25 | call to old_lookup | calls.rb:127:3:127:29 | [] |
+| calls.rb:127:13:127:25 | self | calls.rb:127:3:127:29 | [] |
+| calls.rb:127:24:127:24 | x | calls.rb:127:3:127:29 | [] |
+| calls.rb:131:15:131:19 | &body | calls.rb:131:3:137:5 | foreach |
+| calls.rb:131:16:131:19 | body | calls.rb:131:3:137:5 | foreach |
+| calls.rb:132:5:132:5 | x | calls.rb:131:3:137:5 | foreach |
+| calls.rb:132:5:132:9 | ... = ... | calls.rb:131:3:137:5 | foreach |
+| calls.rb:132:9:132:9 | 0 | calls.rb:131:3:137:5 | foreach |
+| calls.rb:133:5:136:7 | while ... | calls.rb:131:3:137:5 | foreach |
+| calls.rb:133:11:133:11 | x | calls.rb:131:3:137:5 | foreach |
+| calls.rb:133:11:133:25 | ... < ... | calls.rb:131:3:137:5 | foreach |
+| calls.rb:133:15:133:18 | self | calls.rb:131:3:137:5 | foreach |
+| calls.rb:133:15:133:25 | call to length | calls.rb:131:3:137:5 | foreach |
+| calls.rb:133:26:136:7 | do ... | calls.rb:131:3:137:5 | foreach |
+| calls.rb:134:9:134:24 | yield ... | calls.rb:131:3:137:5 | foreach |
+| calls.rb:134:15:134:15 | x | calls.rb:131:3:137:5 | foreach |
+| calls.rb:134:18:134:21 | self | calls.rb:131:3:137:5 | foreach |
+| calls.rb:134:18:134:24 | ...[...] | calls.rb:131:3:137:5 | foreach |
+| calls.rb:134:23:134:23 | x | calls.rb:131:3:137:5 | foreach |
+| calls.rb:135:9:135:9 | x | calls.rb:131:3:137:5 | foreach |
+| calls.rb:135:9:135:9 | x | calls.rb:131:3:137:5 | foreach |
+| calls.rb:135:9:135:14 | ... += ... | calls.rb:131:3:137:5 | foreach |
+| calls.rb:135:9:135:14 | ... = ... | calls.rb:131:3:137:5 | foreach |
+| calls.rb:135:11:135:12 | ... + ... | calls.rb:131:3:137:5 | foreach |
+| calls.rb:135:14:135:14 | 1 | calls.rb:131:3:137:5 | foreach |
+| calls.rb:141:5:141:20 | yield ... | calls.rb:140:1:142:3 | funny |
+| calls.rb:141:11:141:20 | "prefix: " | calls.rb:140:1:142:3 | funny |
+| calls.rb:141:12:141:19 | prefix:  | calls.rb:140:1:142:3 | funny |
+| calls.rb:158:14:158:15 | &b | calls.rb:158:1:160:3 | indirect |
+| calls.rb:158:15:158:15 | b | calls.rb:158:1:160:3 | indirect |
+| calls.rb:159:5:159:17 | call to call_block | calls.rb:158:1:160:3 | indirect |
+| calls.rb:159:5:159:17 | self | calls.rb:158:1:160:3 | indirect |
+| calls.rb:159:16:159:17 | &... | calls.rb:158:1:160:3 | indirect |
+| calls.rb:159:17:159:17 | b | calls.rb:158:1:160:3 | indirect |
+| calls.rb:167:9:167:12 | self | calls.rb:166:5:168:7 | s_method |
+| calls.rb:167:9:167:17 | call to to_s | calls.rb:166:5:168:7 | s_method |
+| calls.rb:192:9:192:26 | call to puts | calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:192:9:192:26 | self | calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:192:14:192:26 | "singleton_a" | calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:192:15:192:25 | singleton_a | calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:193:9:193:12 | self | calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:193:9:193:24 | call to singleton_b | calls.rb:191:5:194:7 | singleton_a |
+| calls.rb:197:9:197:26 | call to puts | calls.rb:196:5:199:7 | singleton_b |
+| calls.rb:197:9:197:26 | self | calls.rb:196:5:199:7 | singleton_b |
+| calls.rb:197:14:197:26 | "singleton_b" | calls.rb:196:5:199:7 | singleton_b |
+| calls.rb:197:15:197:25 | singleton_b | calls.rb:196:5:199:7 | singleton_b |
+| calls.rb:198:9:198:12 | self | calls.rb:196:5:199:7 | singleton_b |
+| calls.rb:198:9:198:24 | call to singleton_c | calls.rb:196:5:199:7 | singleton_b |
+| calls.rb:202:9:202:26 | call to puts | calls.rb:201:5:203:7 | singleton_c |
+| calls.rb:202:9:202:26 | self | calls.rb:201:5:203:7 | singleton_c |
+| calls.rb:202:14:202:26 | "singleton_c" | calls.rb:201:5:203:7 | singleton_c |
+| calls.rb:202:15:202:25 | singleton_c | calls.rb:201:5:203:7 | singleton_c |
+| calls.rb:206:9:206:26 | call to puts | calls.rb:205:5:208:7 | singleton_d |
+| calls.rb:206:9:206:26 | self | calls.rb:205:5:208:7 | singleton_d |
+| calls.rb:206:14:206:26 | "singleton_d" | calls.rb:205:5:208:7 | singleton_d |
+| calls.rb:206:15:206:25 | singleton_d | calls.rb:205:5:208:7 | singleton_d |
+| calls.rb:207:9:207:12 | self | calls.rb:205:5:208:7 | singleton_d |
+| calls.rb:207:9:207:24 | call to singleton_a | calls.rb:205:5:208:7 | singleton_d |
+| calls.rb:211:9:213:11 | singleton_e | calls.rb:210:5:215:7 | instance |
+| calls.rb:211:13:211:16 | self | calls.rb:210:5:215:7 | instance |
+| calls.rb:212:13:212:30 | call to puts | calls.rb:211:9:213:11 | singleton_e |
+| calls.rb:212:13:212:30 | self | calls.rb:211:9:213:11 | singleton_e |
+| calls.rb:212:18:212:30 | "singleton_e" | calls.rb:211:9:213:11 | singleton_e |
+| calls.rb:212:19:212:29 | singleton_e | calls.rb:211:9:213:11 | singleton_e |
+| calls.rb:214:9:214:19 | call to singleton_e | calls.rb:210:5:215:7 | instance |
+| calls.rb:214:9:214:19 | self | calls.rb:210:5:215:7 | instance |
+| calls.rb:219:13:219:30 | call to puts | calls.rb:218:9:220:11 | singleton_f |
+| calls.rb:219:13:219:30 | self | calls.rb:218:9:220:11 | singleton_f |
+| calls.rb:219:18:219:30 | "singleton_f" | calls.rb:218:9:220:11 | singleton_f |
+| calls.rb:219:19:219:29 | singleton_f | calls.rb:218:9:220:11 | singleton_f |
+| calls.rb:224:9:224:12 | self | calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:224:9:224:24 | call to singleton_g | calls.rb:223:5:225:7 | call_singleton_g |
+| calls.rb:237:5:237:24 | call to puts | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:237:5:237:24 | self | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:237:10:237:24 | "singleton_g_1" | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:237:11:237:23 | singleton_g_1 | calls.rb:236:1:238:3 | singleton_g |
+| calls.rb:244:5:244:24 | call to puts | calls.rb:243:1:245:3 | singleton_g |
+| calls.rb:244:5:244:24 | self | calls.rb:243:1:245:3 | singleton_g |
+| calls.rb:244:10:244:24 | "singleton_g_2" | calls.rb:243:1:245:3 | singleton_g |
+| calls.rb:244:11:244:23 | singleton_g_2 | calls.rb:243:1:245:3 | singleton_g |
+| calls.rb:252:9:252:28 | call to puts | calls.rb:251:5:253:7 | singleton_g |
+| calls.rb:252:9:252:28 | self | calls.rb:251:5:253:7 | singleton_g |
+| calls.rb:252:14:252:28 | "singleton_g_3" | calls.rb:251:5:253:7 | singleton_g |
+| calls.rb:252:15:252:27 | singleton_g_3 | calls.rb:251:5:253:7 | singleton_g |
+| calls.rb:268:5:268:22 | call to puts | calls.rb:267:1:269:3 | singleton_g |
+| calls.rb:268:5:268:22 | self | calls.rb:267:1:269:3 | singleton_g |
+| calls.rb:268:10:268:22 | "singleton_g" | calls.rb:267:1:269:3 | singleton_g |
+| calls.rb:268:11:268:21 | singleton_g | calls.rb:267:1:269:3 | singleton_g |
+| calls.rb:278:12:278:15 | type | calls.rb:278:1:286:3 | create |
+| calls.rb:278:12:278:15 | type | calls.rb:278:1:286:3 | create |
+| calls.rb:279:5:279:8 | type | calls.rb:278:1:286:3 | create |
+| calls.rb:279:5:279:12 | call to new | calls.rb:278:1:286:3 | create |
+| calls.rb:279:5:279:21 | call to instance | calls.rb:278:1:286:3 | create |
+| calls.rb:281:5:283:7 | singleton_h | calls.rb:278:1:286:3 | create |
+| calls.rb:281:9:281:12 | type | calls.rb:278:1:286:3 | create |
+| calls.rb:282:9:282:26 | call to puts | calls.rb:281:5:283:7 | singleton_h |
+| calls.rb:282:9:282:26 | self | calls.rb:281:5:283:7 | singleton_h |
+| calls.rb:282:14:282:26 | "singleton_h" | calls.rb:281:5:283:7 | singleton_h |
+| calls.rb:282:15:282:25 | singleton_h | calls.rb:281:5:283:7 | singleton_h |
+| calls.rb:285:5:285:8 | type | calls.rb:278:1:286:3 | create |
+| calls.rb:285:5:285:20 | call to singleton_h | calls.rb:278:1:286:3 | create |
+| calls.rb:295:9:295:26 | call to puts | calls.rb:294:5:296:7 | singleton_i |
+| calls.rb:295:9:295:26 | self | calls.rb:294:5:296:7 | singleton_i |
+| calls.rb:295:14:295:26 | "singleton_i" | calls.rb:294:5:296:7 | singleton_i |
+| calls.rb:295:15:295:25 | singleton_i | calls.rb:294:5:296:7 | singleton_i |
+| calls.rb:304:9:304:26 | call to puts | calls.rb:303:5:305:7 | singleton_j |
+| calls.rb:304:9:304:26 | self | calls.rb:303:5:305:7 | singleton_j |
+| calls.rb:304:14:304:26 | "singleton_j" | calls.rb:303:5:305:7 | singleton_j |
+| calls.rb:304:15:304:25 | singleton_j | calls.rb:303:5:305:7 | singleton_j |
+| calls.rb:312:9:312:31 | call to puts | calls.rb:311:5:314:7 | instance |
+| calls.rb:312:9:312:31 | self | calls.rb:311:5:314:7 | instance |
+| calls.rb:312:14:312:31 | "SelfNew#instance" | calls.rb:311:5:314:7 | instance |
+| calls.rb:312:15:312:30 | SelfNew#instance | calls.rb:311:5:314:7 | instance |
+| calls.rb:313:9:313:11 | call to new | calls.rb:311:5:314:7 | instance |
+| calls.rb:313:9:313:11 | self | calls.rb:311:5:314:7 | instance |
+| calls.rb:313:9:313:20 | call to instance | calls.rb:311:5:314:7 | instance |
+| calls.rb:317:9:317:11 | call to new | calls.rb:316:5:318:7 | singleton |
+| calls.rb:317:9:317:11 | self | calls.rb:316:5:318:7 | singleton |
+| calls.rb:317:9:317:20 | call to instance | calls.rb:316:5:318:7 | singleton |
+| calls.rb:327:9:327:26 | call to puts | calls.rb:326:5:328:7 | instance |
+| calls.rb:327:9:327:26 | self | calls.rb:326:5:328:7 | instance |
+| calls.rb:327:14:327:26 | "C1#instance" | calls.rb:326:5:328:7 | instance |
+| calls.rb:327:15:327:25 | C1#instance | calls.rb:326:5:328:7 | instance |
+| calls.rb:333:9:333:26 | call to puts | calls.rb:332:5:334:7 | instance |
+| calls.rb:333:9:333:26 | self | calls.rb:332:5:334:7 | instance |
+| calls.rb:333:14:333:26 | "C2#instance" | calls.rb:332:5:334:7 | instance |
+| calls.rb:333:15:333:25 | C2#instance | calls.rb:332:5:334:7 | instance |
+| calls.rb:339:9:339:26 | call to puts | calls.rb:338:5:340:7 | instance |
+| calls.rb:339:9:339:26 | self | calls.rb:338:5:340:7 | instance |
+| calls.rb:339:14:339:26 | "C3#instance" | calls.rb:338:5:340:7 | instance |
+| calls.rb:339:15:339:25 | C3#instance | calls.rb:338:5:340:7 | instance |
+| calls.rb:343:22:343:22 | x | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:343:22:343:22 | x | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:344:5:352:7 | case ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:344:10:344:10 | x | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:345:5:346:18 | when ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:345:10:345:11 | C3 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:345:12:346:18 | then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:346:9:346:9 | x | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:346:9:346:18 | call to instance | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:347:5:348:18 | when ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:347:10:347:11 | C2 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:347:12:348:18 | then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:348:9:348:9 | x | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:348:9:348:18 | call to instance | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:349:5:350:18 | when ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:349:10:349:11 | C1 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:349:12:350:18 | then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:350:9:350:9 | x | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:350:9:350:18 | call to instance | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:351:5:351:8 | else ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:354:5:358:7 | case ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:354:10:354:10 | x | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:355:9:355:29 | in ... then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:355:12:355:13 | C3 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:355:15:355:29 | then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:355:20:355:20 | x | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:355:20:355:29 | call to instance | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:356:9:356:36 | in ... then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:356:12:356:13 | C2 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:356:12:356:19 | ... => ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:356:18:356:19 | c2 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:356:21:356:36 | then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:356:26:356:27 | c2 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:356:26:356:36 | call to instance | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:357:9:357:36 | in ... then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:357:12:357:13 | C1 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:357:12:357:19 | ... => ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:357:18:357:19 | c1 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:357:21:357:36 | then ... | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:357:26:357:27 | c1 | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:357:26:357:36 | call to instance | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:367:19:367:19 | x | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:367:19:367:19 | x | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:368:5:370:7 | instance | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:368:9:368:9 | x | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:369:9:369:28 | call to puts | calls.rb:368:5:370:7 | instance |
+| calls.rb:369:9:369:28 | self | calls.rb:368:5:370:7 | instance |
+| calls.rb:369:14:369:28 | "instance_on x" | calls.rb:368:5:370:7 | instance |
+| calls.rb:369:15:369:27 | instance_on x | calls.rb:368:5:370:7 | instance |
+| calls.rb:380:13:380:48 | call to puts | calls.rb:379:9:381:11 | singleton1 |
+| calls.rb:380:13:380:48 | self | calls.rb:379:9:381:11 | singleton1 |
+| calls.rb:380:18:380:48 | "SingletonOverride1#singleton1" | calls.rb:379:9:381:11 | singleton1 |
+| calls.rb:380:19:380:47 | SingletonOverride1#singleton1 | calls.rb:379:9:381:11 | singleton1 |
+| calls.rb:384:13:384:22 | call to singleton1 | calls.rb:383:9:385:11 | call_singleton1 |
+| calls.rb:384:13:384:22 | self | calls.rb:383:9:385:11 | call_singleton1 |
+| calls.rb:389:9:389:44 | call to puts | calls.rb:388:5:390:7 | singleton2 |
+| calls.rb:389:9:389:44 | self | calls.rb:388:5:390:7 | singleton2 |
+| calls.rb:389:14:389:44 | "SingletonOverride1#singleton2" | calls.rb:388:5:390:7 | singleton2 |
+| calls.rb:389:15:389:43 | SingletonOverride1#singleton2 | calls.rb:388:5:390:7 | singleton2 |
+| calls.rb:393:9:393:18 | call to singleton2 | calls.rb:392:5:394:7 | call_singleton2 |
+| calls.rb:393:9:393:18 | self | calls.rb:392:5:394:7 | call_singleton2 |
+| calls.rb:405:13:405:48 | call to puts | calls.rb:404:9:406:11 | singleton1 |
+| calls.rb:405:13:405:48 | self | calls.rb:404:9:406:11 | singleton1 |
+| calls.rb:405:18:405:48 | "SingletonOverride2#singleton1" | calls.rb:404:9:406:11 | singleton1 |
+| calls.rb:405:19:405:47 | SingletonOverride2#singleton1 | calls.rb:404:9:406:11 | singleton1 |
+| calls.rb:410:9:410:44 | call to puts | calls.rb:409:5:411:7 | singleton2 |
+| calls.rb:410:9:410:44 | self | calls.rb:409:5:411:7 | singleton2 |
+| calls.rb:410:14:410:44 | "SingletonOverride2#singleton2" | calls.rb:409:5:411:7 | singleton2 |
+| calls.rb:410:15:410:43 | SingletonOverride2#singleton2 | calls.rb:409:5:411:7 | singleton2 |
+| calls.rb:420:13:420:48 | call to puts | calls.rb:419:9:421:11 | m1 |
+| calls.rb:420:13:420:48 | self | calls.rb:419:9:421:11 | m1 |
+| calls.rb:420:18:420:48 | "ConditionalInstanceMethods#m1" | calls.rb:419:9:421:11 | m1 |
+| calls.rb:420:19:420:47 | ConditionalInstanceMethods#m1 | calls.rb:419:9:421:11 | m1 |
+| calls.rb:425:9:425:44 | call to puts | calls.rb:424:5:436:7 | m2 |
+| calls.rb:425:9:425:44 | self | calls.rb:424:5:436:7 | m2 |
+| calls.rb:425:14:425:44 | "ConditionalInstanceMethods#m2" | calls.rb:424:5:436:7 | m2 |
+| calls.rb:425:15:425:43 | ConditionalInstanceMethods#m2 | calls.rb:424:5:436:7 | m2 |
+| calls.rb:427:9:433:11 | m3 | calls.rb:424:5:436:7 | m2 |
+| calls.rb:428:13:428:48 | call to puts | calls.rb:427:9:433:11 | m3 |
+| calls.rb:428:13:428:48 | self | calls.rb:427:9:433:11 | m3 |
+| calls.rb:428:18:428:48 | "ConditionalInstanceMethods#m3" | calls.rb:427:9:433:11 | m3 |
+| calls.rb:428:19:428:47 | ConditionalInstanceMethods#m3 | calls.rb:427:9:433:11 | m3 |
+| calls.rb:430:13:432:15 | m4 | calls.rb:427:9:433:11 | m3 |
+| calls.rb:431:17:431:52 | call to puts | calls.rb:430:13:432:15 | m4 |
+| calls.rb:431:17:431:52 | self | calls.rb:430:13:432:15 | m4 |
+| calls.rb:431:22:431:52 | "ConditionalInstanceMethods#m4" | calls.rb:430:13:432:15 | m4 |
+| calls.rb:431:23:431:51 | ConditionalInstanceMethods#m4 | calls.rb:430:13:432:15 | m4 |
+| calls.rb:435:9:435:10 | call to m3 | calls.rb:424:5:436:7 | m2 |
+| calls.rb:435:9:435:10 | self | calls.rb:424:5:436:7 | m2 |
+| calls.rb:441:17:441:40 | call to puts | calls.rb:440:13:442:15 | m5 |
+| calls.rb:441:17:441:40 | self | calls.rb:440:13:442:15 | m5 |
+| calls.rb:441:22:441:40 | "AnonymousClass#m5" | calls.rb:440:13:442:15 | m5 |
+| calls.rb:441:23:441:39 | AnonymousClass#m5 | calls.rb:440:13:442:15 | m5 |
+| calls.rb:457:13:457:22 | call to puts | calls.rb:456:9:458:11 | foo |
+| calls.rb:457:13:457:22 | self | calls.rb:456:9:458:11 | foo |
+| calls.rb:457:18:457:22 | "foo" | calls.rb:456:9:458:11 | foo |
+| calls.rb:457:19:457:21 | foo | calls.rb:456:9:458:11 | foo |
+| calls.rb:463:13:463:22 | call to puts | calls.rb:462:9:464:11 | bar |
+| calls.rb:463:13:463:22 | self | calls.rb:462:9:464:11 | bar |
+| calls.rb:463:18:463:22 | "bar" | calls.rb:462:9:464:11 | bar |
+| calls.rb:463:19:463:21 | bar | calls.rb:462:9:464:11 | bar |
+| calls.rb:482:9:482:46 | call to puts | calls.rb:481:5:483:7 | singleton |
+| calls.rb:482:9:482:46 | self | calls.rb:481:5:483:7 | singleton |
+| calls.rb:482:14:482:46 | "ExtendSingletonMethod#singleton" | calls.rb:481:5:483:7 | singleton |
+| calls.rb:482:15:482:45 | ExtendSingletonMethod#singleton | calls.rb:481:5:483:7 | singleton |
+| calls.rb:492:9:492:42 | call to puts | calls.rb:491:15:493:7 | foo |
+| calls.rb:492:9:492:42 | self | calls.rb:491:15:493:7 | foo |
+| calls.rb:492:14:492:42 | "ProtectedMethodInModule#foo" | calls.rb:491:15:493:7 | foo |
+| calls.rb:492:15:492:41 | ProtectedMethodInModule#foo | calls.rb:491:15:493:7 | foo |
+| calls.rb:500:9:500:35 | call to puts | calls.rb:499:15:501:7 | bar |
+| calls.rb:500:9:500:35 | self | calls.rb:499:15:501:7 | bar |
+| calls.rb:500:14:500:35 | "ProtectedMethods#bar" | calls.rb:499:15:501:7 | bar |
+| calls.rb:500:15:500:34 | ProtectedMethods#bar | calls.rb:499:15:501:7 | bar |
+| calls.rb:504:9:504:11 | call to foo | calls.rb:503:5:508:7 | baz |
+| calls.rb:504:9:504:11 | self | calls.rb:503:5:508:7 | baz |
+| calls.rb:505:9:505:11 | call to bar | calls.rb:503:5:508:7 | baz |
+| calls.rb:505:9:505:11 | self | calls.rb:503:5:508:7 | baz |
+| calls.rb:506:9:506:24 | ProtectedMethods | calls.rb:503:5:508:7 | baz |
+| calls.rb:506:9:506:28 | call to new | calls.rb:503:5:508:7 | baz |
+| calls.rb:506:9:506:32 | call to foo | calls.rb:503:5:508:7 | baz |
+| calls.rb:507:9:507:24 | ProtectedMethods | calls.rb:503:5:508:7 | baz |
+| calls.rb:507:9:507:28 | call to new | calls.rb:503:5:508:7 | baz |
+| calls.rb:507:9:507:32 | call to bar | calls.rb:503:5:508:7 | baz |
+| calls.rb:517:9:517:11 | call to foo | calls.rb:516:5:519:7 | baz |
+| calls.rb:517:9:517:11 | self | calls.rb:516:5:519:7 | baz |
+| calls.rb:518:9:518:27 | ProtectedMethodsSub | calls.rb:516:5:519:7 | baz |
+| calls.rb:518:9:518:31 | call to new | calls.rb:516:5:519:7 | baz |
+| calls.rb:518:9:518:35 | call to foo | calls.rb:516:5:519:7 | baz |
 | hello.rb:3:9:3:22 | return | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:16:3:22 | "hello" | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:17:3:21 | hello | hello.rb:2:5:4:7 | hello |

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -39,6 +39,8 @@ getMethod
 | calls.rb:414:1:442:3 | ConditionalInstanceMethods | m1 | calls.rb:416:9:418:11 | m1 |
 | calls.rb:414:1:442:3 | ConditionalInstanceMethods | m2 | calls.rb:421:5:433:7 | m2 |
 | calls.rb:477:1:483:3 | ExtendSingletonMethod | singleton | calls.rb:478:5:480:7 | singleton |
+| calls.rb:487:1:496:3 | ProtectedMethods | bar | calls.rb:492:5:495:7 | bar |
+| calls.rb:487:1:496:3 | ProtectedMethods | foo | calls.rb:488:15:490:7 | foo |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
@@ -353,6 +355,20 @@ lookupMethod
 | calls.rb:414:1:442:3 | ConditionalInstanceMethods | puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:414:1:442:3 | ConditionalInstanceMethods | to_s | calls.rb:169:5:170:7 | to_s |
 | calls.rb:477:1:483:3 | ExtendSingletonMethod | singleton | calls.rb:478:5:480:7 | singleton |
+| calls.rb:487:1:496:3 | ProtectedMethods | add_singleton | calls.rb:364:1:368:3 | add_singleton |
+| calls.rb:487:1:496:3 | ProtectedMethods | bar | calls.rb:492:5:495:7 | bar |
+| calls.rb:487:1:496:3 | ProtectedMethods | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:487:1:496:3 | ProtectedMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:487:1:496:3 | ProtectedMethods | create | calls.rb:275:1:283:3 | create |
+| calls.rb:487:1:496:3 | ProtectedMethods | foo | calls.rb:488:15:490:7 | foo |
+| calls.rb:487:1:496:3 | ProtectedMethods | funny | calls.rb:137:1:139:3 | funny |
+| calls.rb:487:1:496:3 | ProtectedMethods | indirect | calls.rb:155:1:157:3 | indirect |
+| calls.rb:487:1:496:3 | ProtectedMethods | new | calls.rb:114:5:114:16 | new |
+| calls.rb:487:1:496:3 | ProtectedMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:487:1:496:3 | ProtectedMethods | pattern_dispatch | calls.rb:340:1:356:3 | pattern_dispatch |
+| calls.rb:487:1:496:3 | ProtectedMethods | private_on_main | calls.rb:182:1:183:3 | private_on_main |
+| calls.rb:487:1:496:3 | ProtectedMethods | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:487:1:496:3 | ProtectedMethods | to_s | calls.rb:169:5:170:7 | to_s |
 | file://:0:0:0:0 | Class | include | calls.rb:107:5:107:20 | include |
 | file://:0:0:0:0 | Class | module_eval | calls.rb:106:5:106:24 | module_eval |
 | file://:0:0:0:0 | Class | new | calls.rb:114:5:114:16 | new |
@@ -769,6 +785,15 @@ enclosingMethod
 | calls.rb:479:9:479:46 | self | calls.rb:478:5:480:7 | singleton |
 | calls.rb:479:14:479:46 | "ExtendSingletonMethod#singleton" | calls.rb:478:5:480:7 | singleton |
 | calls.rb:479:15:479:45 | ExtendSingletonMethod#singleton | calls.rb:478:5:480:7 | singleton |
+| calls.rb:489:9:489:35 | call to puts | calls.rb:488:15:490:7 | foo |
+| calls.rb:489:9:489:35 | self | calls.rb:488:15:490:7 | foo |
+| calls.rb:489:14:489:35 | "ProtectedMethods#foo" | calls.rb:488:15:490:7 | foo |
+| calls.rb:489:15:489:34 | ProtectedMethods#foo | calls.rb:488:15:490:7 | foo |
+| calls.rb:493:9:493:11 | call to foo | calls.rb:492:5:495:7 | bar |
+| calls.rb:493:9:493:11 | self | calls.rb:492:5:495:7 | bar |
+| calls.rb:494:9:494:24 | ProtectedMethods | calls.rb:492:5:495:7 | bar |
+| calls.rb:494:9:494:28 | call to new | calls.rb:492:5:495:7 | bar |
+| calls.rb:494:9:494:32 | call to foo | calls.rb:492:5:495:7 | bar |
 | hello.rb:3:9:3:22 | return | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:16:3:22 | "hello" | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:17:3:21 | hello | hello.rb:2:5:4:7 | hello |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -5,23 +5,25 @@ getModule
 | calls.rb:91:1:94:3 | Integer |
 | calls.rb:96:1:98:3 | String |
 | calls.rb:100:1:103:3 | Kernel |
-| calls.rb:105:1:110:3 | Module |
-| calls.rb:112:1:115:3 | Object |
-| calls.rb:117:1:120:3 | Hash |
-| calls.rb:122:1:135:3 | Array |
-| calls.rb:162:1:166:3 | S |
-| calls.rb:168:1:171:3 | A |
-| calls.rb:173:1:176:3 | B |
-| calls.rb:187:1:223:3 | Singletons |
-| calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:322:1:326:3 | C1 |
-| calls.rb:328:1:332:3 | C2 |
-| calls.rb:334:1:338:3 | C3 |
-| calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:105:1:113:3 | Module |
+| calls.rb:115:1:118:3 | Object |
+| calls.rb:120:1:123:3 | Hash |
+| calls.rb:125:1:138:3 | Array |
+| calls.rb:165:1:169:3 | S |
+| calls.rb:171:1:174:3 | A |
+| calls.rb:176:1:179:3 | B |
+| calls.rb:190:1:226:3 | Singletons |
+| calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:325:1:329:3 | C1 |
+| calls.rb:331:1:335:3 | C2 |
+| calls.rb:337:1:341:3 | C3 |
+| calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub |
 | file://:0:0:0:0 | BasicObject |
 | file://:0:0:0:0 | Class |
 | file://:0:0:0:0 | Complex |
@@ -79,29 +81,31 @@ getADeclaration
 | calls.rb:91:1:94:3 | Integer | calls.rb:91:1:94:3 | Integer |
 | calls.rb:96:1:98:3 | String | calls.rb:96:1:98:3 | String |
 | calls.rb:100:1:103:3 | Kernel | calls.rb:100:1:103:3 | Kernel |
-| calls.rb:105:1:110:3 | Module | calls.rb:105:1:110:3 | Module |
-| calls.rb:112:1:115:3 | Object | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:112:1:115:3 | Object | calls.rb:112:1:115:3 | Object |
-| calls.rb:112:1:115:3 | Object | hello.rb:1:1:22:3 | hello.rb |
-| calls.rb:112:1:115:3 | Object | modules.rb:1:1:129:4 | modules.rb |
-| calls.rb:112:1:115:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
-| calls.rb:112:1:115:3 | Object | private.rb:1:1:105:40 | private.rb |
-| calls.rb:117:1:120:3 | Hash | calls.rb:117:1:120:3 | Hash |
-| calls.rb:122:1:135:3 | Array | calls.rb:122:1:135:3 | Array |
-| calls.rb:162:1:166:3 | S | calls.rb:162:1:166:3 | S |
-| calls.rb:168:1:171:3 | A | calls.rb:168:1:171:3 | A |
-| calls.rb:168:1:171:3 | A | modules_rec.rb:7:1:9:3 | A |
-| calls.rb:173:1:176:3 | B | calls.rb:173:1:176:3 | B |
-| calls.rb:187:1:223:3 | Singletons | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:307:1:318:3 | SelfNew | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:322:1:326:3 | C1 | calls.rb:322:1:326:3 | C1 |
-| calls.rb:328:1:332:3 | C2 | calls.rb:328:1:332:3 | C2 |
-| calls.rb:334:1:338:3 | C3 | calls.rb:334:1:338:3 | C3 |
-| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:477:1:483:3 | ExtendSingletonMethod | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:487:1:496:3 | ProtectedMethods | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:105:1:113:3 | Module | calls.rb:105:1:113:3 | Module |
+| calls.rb:115:1:118:3 | Object | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:115:1:118:3 | Object | calls.rb:115:1:118:3 | Object |
+| calls.rb:115:1:118:3 | Object | hello.rb:1:1:22:3 | hello.rb |
+| calls.rb:115:1:118:3 | Object | modules.rb:1:1:129:4 | modules.rb |
+| calls.rb:115:1:118:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
+| calls.rb:115:1:118:3 | Object | private.rb:1:1:105:40 | private.rb |
+| calls.rb:120:1:123:3 | Hash | calls.rb:120:1:123:3 | Hash |
+| calls.rb:125:1:138:3 | Array | calls.rb:125:1:138:3 | Array |
+| calls.rb:165:1:169:3 | S | calls.rb:165:1:169:3 | S |
+| calls.rb:171:1:174:3 | A | calls.rb:171:1:174:3 | A |
+| calls.rb:171:1:174:3 | A | modules_rec.rb:7:1:9:3 | A |
+| calls.rb:176:1:179:3 | B | calls.rb:176:1:179:3 | B |
+| calls.rb:190:1:226:3 | Singletons | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:310:1:321:3 | SelfNew | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:325:1:329:3 | C1 | calls.rb:325:1:329:3 | C1 |
+| calls.rb:331:1:335:3 | C2 | calls.rb:331:1:335:3 | C2 |
+| calls.rb:337:1:341:3 | C3 | calls.rb:337:1:341:3 | C3 |
+| calls.rb:377:1:397:3 | SingletonOverride1 | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:402:1:412:3 | SingletonOverride2 | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:480:1:486:3 | ExtendSingletonMethod | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:490:1:494:3 | ProtectedMethodInModule | calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:496:1:509:3 | ProtectedMethods | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | calls.rb:515:1:520:3 | ProtectedMethodsSub |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
@@ -145,58 +149,60 @@ getADeclaration
 | private.rb:82:1:94:3 | PrivateOverride1 | private.rb:82:1:94:3 | PrivateOverride1 |
 | private.rb:96:1:102:3 | PrivateOverride2 | private.rb:96:1:102:3 | PrivateOverride2 |
 getSuperClass
-| calls.rb:43:1:58:3 | C | calls.rb:112:1:115:3 | Object |
+| calls.rb:43:1:58:3 | C | calls.rb:115:1:118:3 | Object |
 | calls.rb:65:1:69:3 | D | calls.rb:43:1:58:3 | C |
 | calls.rb:91:1:94:3 | Integer | file://:0:0:0:0 | Numeric |
-| calls.rb:96:1:98:3 | String | calls.rb:112:1:115:3 | Object |
-| calls.rb:105:1:110:3 | Module | calls.rb:112:1:115:3 | Object |
-| calls.rb:112:1:115:3 | Object | file://:0:0:0:0 | BasicObject |
-| calls.rb:117:1:120:3 | Hash | calls.rb:112:1:115:3 | Object |
-| calls.rb:122:1:135:3 | Array | calls.rb:112:1:115:3 | Object |
-| calls.rb:162:1:166:3 | S | calls.rb:112:1:115:3 | Object |
-| calls.rb:168:1:171:3 | A | calls.rb:162:1:166:3 | S |
-| calls.rb:168:1:171:3 | A | calls.rb:173:1:176:3 | B |
-| calls.rb:173:1:176:3 | B | calls.rb:162:1:166:3 | S |
-| calls.rb:187:1:223:3 | Singletons | calls.rb:112:1:115:3 | Object |
-| calls.rb:307:1:318:3 | SelfNew | calls.rb:112:1:115:3 | Object |
-| calls.rb:322:1:326:3 | C1 | calls.rb:112:1:115:3 | Object |
-| calls.rb:328:1:332:3 | C2 | calls.rb:322:1:326:3 | C1 |
-| calls.rb:334:1:338:3 | C3 | calls.rb:328:1:332:3 | C2 |
-| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:112:1:115:3 | Object |
-| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:112:1:115:3 | Object |
-| calls.rb:487:1:496:3 | ProtectedMethods | calls.rb:112:1:115:3 | Object |
-| file://:0:0:0:0 | Class | calls.rb:105:1:110:3 | Module |
+| calls.rb:96:1:98:3 | String | calls.rb:115:1:118:3 | Object |
+| calls.rb:105:1:113:3 | Module | calls.rb:115:1:118:3 | Object |
+| calls.rb:115:1:118:3 | Object | file://:0:0:0:0 | BasicObject |
+| calls.rb:120:1:123:3 | Hash | calls.rb:115:1:118:3 | Object |
+| calls.rb:125:1:138:3 | Array | calls.rb:115:1:118:3 | Object |
+| calls.rb:165:1:169:3 | S | calls.rb:115:1:118:3 | Object |
+| calls.rb:171:1:174:3 | A | calls.rb:165:1:169:3 | S |
+| calls.rb:171:1:174:3 | A | calls.rb:176:1:179:3 | B |
+| calls.rb:176:1:179:3 | B | calls.rb:165:1:169:3 | S |
+| calls.rb:190:1:226:3 | Singletons | calls.rb:115:1:118:3 | Object |
+| calls.rb:310:1:321:3 | SelfNew | calls.rb:115:1:118:3 | Object |
+| calls.rb:325:1:329:3 | C1 | calls.rb:115:1:118:3 | Object |
+| calls.rb:331:1:335:3 | C2 | calls.rb:325:1:329:3 | C1 |
+| calls.rb:337:1:341:3 | C3 | calls.rb:331:1:335:3 | C2 |
+| calls.rb:377:1:397:3 | SingletonOverride1 | calls.rb:115:1:118:3 | Object |
+| calls.rb:402:1:412:3 | SingletonOverride2 | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | calls.rb:115:1:118:3 | Object |
+| calls.rb:496:1:509:3 | ProtectedMethods | calls.rb:115:1:118:3 | Object |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | calls.rb:496:1:509:3 | ProtectedMethods |
+| file://:0:0:0:0 | Class | calls.rb:105:1:113:3 | Module |
 | file://:0:0:0:0 | Complex | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | FalseClass | calls.rb:112:1:115:3 | Object |
+| file://:0:0:0:0 | FalseClass | calls.rb:115:1:118:3 | Object |
 | file://:0:0:0:0 | Float | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | NilClass | calls.rb:112:1:115:3 | Object |
-| file://:0:0:0:0 | Numeric | calls.rb:112:1:115:3 | Object |
+| file://:0:0:0:0 | NilClass | calls.rb:115:1:118:3 | Object |
+| file://:0:0:0:0 | Numeric | calls.rb:115:1:118:3 | Object |
 | file://:0:0:0:0 | Rational | file://:0:0:0:0 | Numeric |
-| file://:0:0:0:0 | TrueClass | calls.rb:112:1:115:3 | Object |
-| hello.rb:11:1:16:3 | Greeting | calls.rb:112:1:115:3 | Object |
+| file://:0:0:0:0 | TrueClass | calls.rb:115:1:118:3 | Object |
+| hello.rb:11:1:16:3 | Greeting | calls.rb:115:1:118:3 | Object |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:11:1:16:3 | Greeting |
-| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:112:1:115:3 | Object |
-| modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:112:1:115:3 | Object |
-| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:112:1:115:3 | Object |
-| modules.rb:37:1:46:3 | Bar | calls.rb:112:1:115:3 | Object |
-| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | calls.rb:112:1:115:3 | Object |
-| modules.rb:66:5:67:7 | Test::Foo1::Bar | calls.rb:112:1:115:3 | Object |
-| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | calls.rb:112:1:115:3 | Object |
-| modules.rb:112:1:113:3 | YY | calls.rb:112:1:115:3 | Object |
+| modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:115:1:118:3 | Object |
+| modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:115:1:118:3 | Object |
+| modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:115:1:118:3 | Object |
+| modules.rb:37:1:46:3 | Bar | calls.rb:115:1:118:3 | Object |
+| modules.rb:49:3:50:5 | Foo::Bar::ClassInAnotherDefinitionOfFooBar | calls.rb:115:1:118:3 | Object |
+| modules.rb:66:5:67:7 | Test::Foo1::Bar | calls.rb:115:1:118:3 | Object |
+| modules.rb:72:5:73:7 | Test::Foo2::Foo2::Bar | calls.rb:115:1:118:3 | Object |
+| modules.rb:112:1:113:3 | YY | calls.rb:115:1:118:3 | Object |
 | modules.rb:116:7:117:9 | XX::YY | modules.rb:112:1:113:3 | YY |
-| modules_rec.rb:1:1:2:3 | B::A | calls.rb:112:1:115:3 | Object |
-| modules_rec.rb:4:1:5:3 | A::B | calls.rb:112:1:115:3 | Object |
-| private.rb:1:1:49:3 | E | calls.rb:112:1:115:3 | Object |
-| private.rb:82:1:94:3 | PrivateOverride1 | calls.rb:112:1:115:3 | Object |
+| modules_rec.rb:1:1:2:3 | B::A | calls.rb:115:1:118:3 | Object |
+| modules_rec.rb:4:1:5:3 | A::B | calls.rb:115:1:118:3 | Object |
+| private.rb:1:1:49:3 | E | calls.rb:115:1:118:3 | Object |
+| private.rb:82:1:94:3 | PrivateOverride1 | calls.rb:115:1:118:3 | Object |
 | private.rb:96:1:102:3 | PrivateOverride2 | private.rb:82:1:94:3 | PrivateOverride1 |
 getAPrependedModule
-| calls.rb:112:1:115:3 | Object | calls.rb:168:1:171:3 | A |
-| calls.rb:168:1:171:3 | A | modules_rec.rb:4:1:5:3 | A::B |
+| calls.rb:115:1:118:3 | Object | calls.rb:171:1:174:3 | A |
+| calls.rb:171:1:174:3 | A | modules_rec.rb:4:1:5:3 | A::B |
 | modules.rb:101:1:105:3 | PrependTest | modules.rb:63:1:81:3 | Test |
 getAnIncludedModule
 | calls.rb:43:1:58:3 | C | calls.rb:21:1:34:3 | M |
-| calls.rb:112:1:115:3 | Object | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:115:1:118:3 | Object | calls.rb:100:1:103:3 | Kernel |
+| calls.rb:496:1:509:3 | ProtectedMethods | calls.rb:490:1:494:3 | ProtectedMethodInModule |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:1:1:8:3 | EnglishWords |
 | modules.rb:88:1:93:3 | IncludeTest | modules.rb:63:1:81:3 | Test |
 | modules.rb:95:1:99:3 | IncludeTest2 | modules.rb:63:1:81:3 | Test |
@@ -208,64 +214,72 @@ resolveConstantReadAccess
 | calls.rb:65:11:65:11 | C | C |
 | calls.rb:71:5:71:5 | D | D |
 | calls.rb:86:11:86:14 | Hash | Hash |
-| calls.rb:112:16:112:21 | Module | Module |
-| calls.rb:113:13:113:18 | Kernel | Kernel |
-| calls.rb:147:1:147:13 | Array | Array |
-| calls.rb:149:1:149:7 | Array | Array |
-| calls.rb:151:1:151:7 | Array | Array |
-| calls.rb:153:1:153:8 | Array | Array |
-| calls.rb:168:11:168:11 | S | S |
-| calls.rb:173:11:173:11 | S | S |
-| calls.rb:178:1:178:1 | S | S |
-| calls.rb:179:1:179:1 | A | A |
-| calls.rb:180:1:180:1 | B | B |
-| calls.rb:225:1:225:10 | Singletons | Singletons |
-| calls.rb:226:1:226:10 | Singletons | Singletons |
-| calls.rb:228:6:228:15 | Singletons | Singletons |
-| calls.rb:256:6:256:15 | Singletons | Singletons |
-| calls.rb:264:5:264:14 | Singletons | Singletons |
-| calls.rb:268:1:268:10 | Singletons | Singletons |
-| calls.rb:272:6:272:15 | Singletons | Singletons |
-| calls.rb:285:8:285:17 | Singletons | Singletons |
-| calls.rb:286:1:286:10 | Singletons | Singletons |
-| calls.rb:288:5:288:14 | Singletons | Singletons |
-| calls.rb:297:1:297:10 | Singletons | Singletons |
-| calls.rb:299:10:299:19 | Singletons | Singletons |
-| calls.rb:305:1:305:10 | Singletons | Singletons |
-| calls.rb:320:1:320:7 | SelfNew | SelfNew |
-| calls.rb:328:12:328:13 | C1 | C1 |
-| calls.rb:334:12:334:13 | C2 | C2 |
-| calls.rb:342:10:342:11 | C3 | C3 |
-| calls.rb:344:10:344:11 | C2 | C2 |
-| calls.rb:346:10:346:11 | C1 | C1 |
-| calls.rb:352:12:352:13 | C3 | C3 |
-| calls.rb:353:12:353:13 | C2 | C2 |
-| calls.rb:354:12:354:13 | C1 | C1 |
-| calls.rb:358:6:358:7 | C1 | C1 |
-| calls.rb:360:19:360:20 | C1 | C1 |
-| calls.rb:361:19:361:20 | C2 | C2 |
-| calls.rb:362:19:362:20 | C3 | C3 |
-| calls.rb:370:6:370:7 | C1 | C1 |
-| calls.rb:396:1:396:18 | SingletonOverride1 | SingletonOverride1 |
-| calls.rb:397:1:397:18 | SingletonOverride1 | SingletonOverride1 |
-| calls.rb:399:28:399:45 | SingletonOverride1 | SingletonOverride1 |
-| calls.rb:411:1:411:18 | SingletonOverride2 | SingletonOverride2 |
-| calls.rb:412:1:412:18 | SingletonOverride2 | SingletonOverride2 |
-| calls.rb:436:9:436:13 | Class | Class |
-| calls.rb:444:1:444:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:445:1:445:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:446:1:446:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:115:16:115:21 | Module | Module |
+| calls.rb:116:13:116:18 | Kernel | Kernel |
+| calls.rb:150:1:150:13 | Array | Array |
+| calls.rb:152:1:152:7 | Array | Array |
+| calls.rb:154:1:154:7 | Array | Array |
+| calls.rb:156:1:156:8 | Array | Array |
+| calls.rb:171:11:171:11 | S | S |
+| calls.rb:176:11:176:11 | S | S |
+| calls.rb:181:1:181:1 | S | S |
+| calls.rb:182:1:182:1 | A | A |
+| calls.rb:183:1:183:1 | B | B |
+| calls.rb:228:1:228:10 | Singletons | Singletons |
+| calls.rb:229:1:229:10 | Singletons | Singletons |
+| calls.rb:231:6:231:15 | Singletons | Singletons |
+| calls.rb:259:6:259:15 | Singletons | Singletons |
+| calls.rb:267:5:267:14 | Singletons | Singletons |
+| calls.rb:271:1:271:10 | Singletons | Singletons |
+| calls.rb:275:6:275:15 | Singletons | Singletons |
+| calls.rb:288:8:288:17 | Singletons | Singletons |
+| calls.rb:289:1:289:10 | Singletons | Singletons |
+| calls.rb:291:5:291:14 | Singletons | Singletons |
+| calls.rb:300:1:300:10 | Singletons | Singletons |
+| calls.rb:302:10:302:19 | Singletons | Singletons |
+| calls.rb:308:1:308:10 | Singletons | Singletons |
+| calls.rb:323:1:323:7 | SelfNew | SelfNew |
+| calls.rb:331:12:331:13 | C1 | C1 |
+| calls.rb:337:12:337:13 | C2 | C2 |
+| calls.rb:345:10:345:11 | C3 | C3 |
+| calls.rb:347:10:347:11 | C2 | C2 |
+| calls.rb:349:10:349:11 | C1 | C1 |
+| calls.rb:355:12:355:13 | C3 | C3 |
+| calls.rb:356:12:356:13 | C2 | C2 |
+| calls.rb:357:12:357:13 | C1 | C1 |
+| calls.rb:361:6:361:7 | C1 | C1 |
+| calls.rb:363:19:363:20 | C1 | C1 |
+| calls.rb:364:19:364:20 | C2 | C2 |
+| calls.rb:365:19:365:20 | C3 | C3 |
+| calls.rb:373:6:373:7 | C1 | C1 |
+| calls.rb:399:1:399:18 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:400:1:400:18 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:402:28:402:45 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:414:1:414:18 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:415:1:415:18 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:439:9:439:13 | Class | Class |
 | calls.rb:447:1:447:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
 | calls.rb:448:1:448:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
 | calls.rb:449:1:449:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:451:27:451:31 | Class | Class |
-| calls.rb:452:5:452:11 | Array | Array |
-| calls.rb:458:5:458:9 | Class | Class |
-| calls.rb:464:5:464:11 | Array | Array |
-| calls.rb:485:1:485:21 | ExtendSingletonMethod | ExtendSingletonMethod |
-| calls.rb:494:9:494:24 | ProtectedMethods | ProtectedMethods |
-| calls.rb:498:1:498:16 | ProtectedMethods | ProtectedMethods |
-| calls.rb:499:1:499:16 | ProtectedMethods | ProtectedMethods |
+| calls.rb:450:1:450:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:451:1:451:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:452:1:452:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:454:27:454:31 | Class | Class |
+| calls.rb:455:5:455:11 | Array | Array |
+| calls.rb:461:5:461:9 | Class | Class |
+| calls.rb:467:5:467:11 | Array | Array |
+| calls.rb:488:1:488:21 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:497:13:497:35 | ProtectedMethodInModule | ProtectedMethodInModule |
+| calls.rb:506:9:506:24 | ProtectedMethods | ProtectedMethods |
+| calls.rb:507:9:507:24 | ProtectedMethods | ProtectedMethods |
+| calls.rb:511:1:511:16 | ProtectedMethods | ProtectedMethods |
+| calls.rb:512:1:512:16 | ProtectedMethods | ProtectedMethods |
+| calls.rb:513:1:513:16 | ProtectedMethods | ProtectedMethods |
+| calls.rb:515:29:515:44 | ProtectedMethods | ProtectedMethods |
+| calls.rb:518:9:518:27 | ProtectedMethodsSub | ProtectedMethodsSub |
+| calls.rb:522:1:522:19 | ProtectedMethodsSub | ProtectedMethodsSub |
+| calls.rb:523:1:523:19 | ProtectedMethodsSub | ProtectedMethodsSub |
+| calls.rb:524:1:524:19 | ProtectedMethodsSub | ProtectedMethodsSub |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
 | modules.rb:48:8:48:10 | Foo | Foo |
@@ -308,24 +322,26 @@ resolveConstantWriteAccess
 | calls.rb:91:1:94:3 | Integer | Integer |
 | calls.rb:96:1:98:3 | String | String |
 | calls.rb:100:1:103:3 | Kernel | Kernel |
-| calls.rb:105:1:110:3 | Module | Module |
-| calls.rb:112:1:115:3 | Object | Object |
-| calls.rb:117:1:120:3 | Hash | Hash |
-| calls.rb:122:1:135:3 | Array | Array |
-| calls.rb:162:1:166:3 | S | S |
-| calls.rb:168:1:171:3 | A | A |
-| calls.rb:173:1:176:3 | B | B |
-| calls.rb:187:1:223:3 | Singletons | Singletons |
-| calls.rb:307:1:318:3 | SelfNew | SelfNew |
-| calls.rb:322:1:326:3 | C1 | C1 |
-| calls.rb:328:1:332:3 | C2 | C2 |
-| calls.rb:334:1:338:3 | C3 | C3 |
-| calls.rb:374:1:394:3 | SingletonOverride1 | SingletonOverride1 |
-| calls.rb:399:1:409:3 | SingletonOverride2 | SingletonOverride2 |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:451:1:451:23 | EsotericInstanceMethods | EsotericInstanceMethods |
-| calls.rb:477:1:483:3 | ExtendSingletonMethod | ExtendSingletonMethod |
-| calls.rb:487:1:496:3 | ProtectedMethods | ProtectedMethods |
+| calls.rb:105:1:113:3 | Module | Module |
+| calls.rb:115:1:118:3 | Object | Object |
+| calls.rb:120:1:123:3 | Hash | Hash |
+| calls.rb:125:1:138:3 | Array | Array |
+| calls.rb:165:1:169:3 | S | S |
+| calls.rb:171:1:174:3 | A | A |
+| calls.rb:176:1:179:3 | B | B |
+| calls.rb:190:1:226:3 | Singletons | Singletons |
+| calls.rb:310:1:321:3 | SelfNew | SelfNew |
+| calls.rb:325:1:329:3 | C1 | C1 |
+| calls.rb:331:1:335:3 | C2 | C2 |
+| calls.rb:337:1:341:3 | C3 | C3 |
+| calls.rb:377:1:397:3 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:402:1:412:3 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:454:1:454:23 | EsotericInstanceMethods | EsotericInstanceMethods |
+| calls.rb:480:1:486:3 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:490:1:494:3 | ProtectedMethodInModule | ProtectedMethodInModule |
+| calls.rb:496:1:509:3 | ProtectedMethods | ProtectedMethods |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | ProtectedMethodsSub |
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |
@@ -380,32 +396,32 @@ resolveConstantWriteAccess
 | private.rb:82:1:94:3 | PrivateOverride1 | PrivateOverride1 |
 | private.rb:96:1:102:3 | PrivateOverride2 | PrivateOverride2 |
 enclosingModule
-| calls.rb:1:1:3:3 | foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:2:5:2:14 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:2:11:2:13 | foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:5:1:5:3 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:7:1:9:3 | bar | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:7:5:7:8 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:8:5:8:15 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:11:1:11:4 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:13:1:15:3 | bar | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:13:5:13:8 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:14:5:14:15 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:17:1:17:4 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:19:1:19:4 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:21:1:34:3 | M | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:1:1:3:3 | foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:5:1:5:3 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:7:1:9:3 | bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:7:5:7:8 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:8:5:8:15 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:11:1:11:4 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:13:1:15:3 | bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:13:5:13:8 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:14:5:14:15 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:17:1:17:4 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:19:1:19:4 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:21:1:34:3 | M | calls.rb:1:1:524:28 | calls.rb |
 | calls.rb:22:5:24:7 | instance_m | calls.rb:21:1:34:3 | M |
 | calls.rb:23:9:23:19 | call to singleton_m | calls.rb:21:1:34:3 | M |
 | calls.rb:23:9:23:19 | self | calls.rb:21:1:34:3 | M |
@@ -421,14 +437,14 @@ enclosingModule
 | calls.rb:32:5:32:15 | self | calls.rb:21:1:34:3 | M |
 | calls.rb:33:5:33:8 | self | calls.rb:21:1:34:3 | M |
 | calls.rb:33:5:33:20 | call to singleton_m | calls.rb:21:1:34:3 | M |
-| calls.rb:36:1:36:1 | M | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:37:1:37:1 | M | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:40:5:40:14 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:43:1:58:3 | C | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:36:1:36:1 | M | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:37:1:37:1 | M | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:40:5:40:14 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:43:1:58:3 | C | calls.rb:1:1:524:28 | calls.rb |
 | calls.rb:44:5:44:13 | call to include | calls.rb:43:1:58:3 | C |
 | calls.rb:44:5:44:13 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:44:13:44:13 | M | calls.rb:43:1:58:3 | C |
@@ -449,66 +465,66 @@ enclosingModule
 | calls.rb:55:9:55:19 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:56:9:56:12 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:56:9:56:24 | call to singleton_m | calls.rb:43:1:58:3 | C |
-| calls.rb:60:1:60:1 | c | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:60:5:60:5 | C | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:61:1:61:1 | c | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:62:1:62:1 | c | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:63:1:63:1 | c | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:65:1:69:3 | D | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:65:11:65:11 | C | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:60:1:60:1 | c | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:60:5:60:5 | C | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:61:1:61:1 | c | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:62:1:62:1 | c | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:63:1:63:1 | c | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:65:1:69:3 | D | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:65:11:65:11 | C | calls.rb:1:1:524:28 | calls.rb |
 | calls.rb:66:5:68:7 | baz | calls.rb:65:1:69:3 | D |
 | calls.rb:67:9:67:13 | call to super | calls.rb:65:1:69:3 | D |
-| calls.rb:71:1:71:1 | d | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:71:5:71:5 | D | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:72:1:72:1 | d | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:73:1:73:1 | d | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:74:1:74:1 | d | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:76:18:76:18 | a | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:76:18:76:18 | a | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:76:25:76:25 | b | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:76:25:76:25 | b | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:77:5:77:5 | a | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:78:5:78:5 | b | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:85:1:89:3 | foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:86:5:86:7 | var | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:87:5:87:7 | var | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:88:5:88:29 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:88:19:88:19 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:88:19:88:19 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:88:22:88:24 | var | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:88:26:88:26 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:71:1:71:1 | d | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:71:5:71:5 | D | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:72:1:72:1 | d | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:73:1:73:1 | d | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:74:1:74:1 | d | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:77:5:77:5 | a | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:78:5:78:5 | b | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:85:1:89:3 | foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:86:5:86:7 | var | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:87:5:87:7 | var | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:88:5:88:29 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:88:22:88:24 | var | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:88:26:88:26 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:524:28 | calls.rb |
 | calls.rb:92:5:92:23 | bit_length | calls.rb:91:1:94:3 | Integer |
 | calls.rb:93:5:93:16 | abs | calls.rb:91:1:94:3 | Integer |
-| calls.rb:96:1:98:3 | String | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:96:1:98:3 | String | calls.rb:1:1:524:28 | calls.rb |
 | calls.rb:97:5:97:23 | capitalize | calls.rb:96:1:98:3 | String |
-| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:524:28 | calls.rb |
 | calls.rb:101:5:101:25 | alias ... | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:101:11:101:19 | :old_puts | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:101:11:101:19 | old_puts | calls.rb:100:1:103:3 | Kernel |
@@ -520,683 +536,729 @@ enclosingModule
 | calls.rb:102:17:102:26 | call to old_puts | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:102:17:102:26 | self | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:102:26:102:26 | x | calls.rb:100:1:103:3 | Kernel |
-| calls.rb:105:1:110:3 | Module | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:106:5:106:24 | module_eval | calls.rb:105:1:110:3 | Module |
-| calls.rb:107:5:107:20 | include | calls.rb:105:1:110:3 | Module |
-| calls.rb:108:5:108:20 | prepend | calls.rb:105:1:110:3 | Module |
-| calls.rb:109:5:109:20 | private | calls.rb:105:1:110:3 | Module |
-| calls.rb:112:1:115:3 | Object | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:112:16:112:21 | Module | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:113:5:113:18 | call to include | calls.rb:112:1:115:3 | Object |
-| calls.rb:113:5:113:18 | self | calls.rb:112:1:115:3 | Object |
-| calls.rb:113:13:113:18 | Kernel | calls.rb:112:1:115:3 | Object |
-| calls.rb:114:5:114:16 | new | calls.rb:112:1:115:3 | Object |
-| calls.rb:117:1:120:3 | Hash | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:118:5:118:25 | alias ... | calls.rb:117:1:120:3 | Hash |
-| calls.rb:118:11:118:21 | :old_lookup | calls.rb:117:1:120:3 | Hash |
-| calls.rb:118:11:118:21 | old_lookup | calls.rb:117:1:120:3 | Hash |
-| calls.rb:118:23:118:25 | :[] | calls.rb:117:1:120:3 | Hash |
-| calls.rb:118:23:118:25 | [] | calls.rb:117:1:120:3 | Hash |
-| calls.rb:119:5:119:31 | [] | calls.rb:117:1:120:3 | Hash |
-| calls.rb:119:12:119:12 | x | calls.rb:117:1:120:3 | Hash |
-| calls.rb:119:12:119:12 | x | calls.rb:117:1:120:3 | Hash |
-| calls.rb:119:15:119:27 | call to old_lookup | calls.rb:117:1:120:3 | Hash |
-| calls.rb:119:15:119:27 | self | calls.rb:117:1:120:3 | Hash |
-| calls.rb:119:26:119:26 | x | calls.rb:117:1:120:3 | Hash |
-| calls.rb:122:1:135:3 | Array | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:123:3:123:23 | alias ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:123:9:123:19 | :old_lookup | calls.rb:122:1:135:3 | Array |
-| calls.rb:123:9:123:19 | old_lookup | calls.rb:122:1:135:3 | Array |
-| calls.rb:123:21:123:23 | :[] | calls.rb:122:1:135:3 | Array |
-| calls.rb:123:21:123:23 | [] | calls.rb:122:1:135:3 | Array |
-| calls.rb:124:3:124:29 | [] | calls.rb:122:1:135:3 | Array |
-| calls.rb:124:10:124:10 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:124:10:124:10 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:124:13:124:25 | call to old_lookup | calls.rb:122:1:135:3 | Array |
-| calls.rb:124:13:124:25 | self | calls.rb:122:1:135:3 | Array |
-| calls.rb:124:24:124:24 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:126:3:126:17 | length | calls.rb:122:1:135:3 | Array |
-| calls.rb:128:3:134:5 | foreach | calls.rb:122:1:135:3 | Array |
-| calls.rb:128:15:128:19 | &body | calls.rb:122:1:135:3 | Array |
-| calls.rb:128:16:128:19 | body | calls.rb:122:1:135:3 | Array |
-| calls.rb:129:5:129:5 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:129:5:129:9 | ... = ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:129:9:129:9 | 0 | calls.rb:122:1:135:3 | Array |
-| calls.rb:130:5:133:7 | while ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:130:11:130:11 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:130:11:130:25 | ... < ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:130:15:130:18 | self | calls.rb:122:1:135:3 | Array |
-| calls.rb:130:15:130:25 | call to length | calls.rb:122:1:135:3 | Array |
-| calls.rb:130:26:133:7 | do ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:131:9:131:24 | yield ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:131:15:131:15 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:131:18:131:21 | self | calls.rb:122:1:135:3 | Array |
-| calls.rb:131:18:131:24 | ...[...] | calls.rb:122:1:135:3 | Array |
-| calls.rb:131:23:131:23 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:132:9:132:9 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:132:9:132:9 | x | calls.rb:122:1:135:3 | Array |
-| calls.rb:132:9:132:14 | ... += ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:132:9:132:14 | ... = ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:132:11:132:12 | ... + ... | calls.rb:122:1:135:3 | Array |
-| calls.rb:132:14:132:14 | 1 | calls.rb:122:1:135:3 | Array |
-| calls.rb:137:1:139:3 | funny | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:138:5:138:20 | yield ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:138:11:138:20 | "prefix: " | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:138:12:138:19 | prefix:  | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:1:141:30 | call to funny | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:1:141:30 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:7:141:30 | { ... } | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:10:141:10 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:10:141:10 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:13:141:29 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:13:141:29 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:18:141:18 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:141:18:141:29 | call to capitalize | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:143:1:143:3 | "a" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:143:1:143:14 | call to capitalize | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:143:2:143:2 | a | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:144:1:144:1 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:144:1:144:12 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:145:1:145:1 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:145:1:145:5 | call to abs | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:1:147:13 | Array | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:1:147:13 | [...] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:1:147:13 | call to [] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:1:147:62 | call to foreach | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:2:147:4 | "a" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:3:147:3 | a | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:6:147:8 | "b" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:7:147:7 | b | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:10:147:12 | "c" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:11:147:11 | c | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:23:147:62 | { ... } | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:26:147:26 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:26:147:26 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:29:147:29 | v | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:29:147:29 | v | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:32:147:61 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:32:147:61 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:37:147:61 | "#{...} -> #{...}" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:38:147:41 | #{...} | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:40:147:40 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:42:147:45 |  ->  | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:46:147:60 | #{...} | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:48:147:48 | v | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:147:48:147:59 | call to capitalize | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:1:149:7 | Array | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:1:149:7 | [...] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:1:149:7 | call to [] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:1:149:35 | call to foreach | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:2:149:2 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:4:149:4 | 2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:6:149:6 | 3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:17:149:35 | { ... } | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:20:149:20 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:20:149:20 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:23:149:23 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:149:23:149:34 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:1:151:7 | Array | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:1:151:7 | [...] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:1:151:7 | call to [] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:1:151:40 | call to foreach | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:2:151:2 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:4:151:4 | 2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:6:151:6 | 3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:17:151:40 | { ... } | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:20:151:20 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:20:151:20 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:23:151:39 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:23:151:39 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:28:151:28 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:151:28:151:39 | call to capitalize | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:1:153:8 | Array | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:1:153:8 | [...] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:1:153:8 | call to [] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:1:153:37 | call to foreach | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:2:153:2 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:4:153:5 | - ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:5:153:5 | 2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:7:153:7 | 3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:18:153:37 | { ... } | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:21:153:21 | _ | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:21:153:21 | _ | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:24:153:24 | v | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:24:153:24 | v | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:27:153:36 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:27:153:36 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:32:153:32 | v | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:153:32:153:36 | call to abs | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:155:1:157:3 | indirect | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:155:14:155:15 | &b | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:155:15:155:15 | b | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:156:5:156:17 | call to call_block | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:156:5:156:17 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:156:16:156:17 | &... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:156:17:156:17 | b | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:159:1:159:28 | call to indirect | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:159:1:159:28 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:159:10:159:28 | { ... } | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:159:13:159:13 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:159:13:159:13 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:159:16:159:16 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:159:16:159:27 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:162:1:166:3 | S | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:163:5:165:7 | s_method | calls.rb:162:1:166:3 | S |
-| calls.rb:164:9:164:12 | self | calls.rb:162:1:166:3 | S |
-| calls.rb:164:9:164:17 | call to to_s | calls.rb:162:1:166:3 | S |
-| calls.rb:168:1:171:3 | A | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:168:11:168:11 | S | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:169:5:170:7 | to_s | calls.rb:168:1:171:3 | A |
-| calls.rb:173:1:176:3 | B | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:173:11:173:11 | S | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:174:5:175:7 | to_s | calls.rb:173:1:176:3 | B |
-| calls.rb:178:1:178:1 | S | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:178:1:178:5 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:178:1:178:14 | call to s_method | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:179:1:179:1 | A | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:179:1:179:5 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:179:1:179:14 | call to s_method | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:180:1:180:1 | B | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:180:1:180:5 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:180:1:180:14 | call to s_method | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:182:1:183:3 | private_on_main | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:185:1:185:15 | call to private_on_main | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:185:1:185:15 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:187:1:223:3 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:188:5:191:7 | singleton_a | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:188:9:188:12 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:189:9:189:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:189:9:189:26 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:189:14:189:26 | "singleton_a" | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:189:15:189:25 | singleton_a | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:190:9:190:12 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:190:9:190:24 | call to singleton_b | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:193:5:196:7 | singleton_b | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:193:9:193:12 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:194:9:194:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:194:9:194:26 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:194:14:194:26 | "singleton_b" | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:194:15:194:25 | singleton_b | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:195:9:195:12 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:195:9:195:24 | call to singleton_c | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:198:5:200:7 | singleton_c | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:198:9:198:12 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:199:9:199:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:199:9:199:26 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:199:14:199:26 | "singleton_c" | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:199:15:199:25 | singleton_c | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:202:5:205:7 | singleton_d | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:202:9:202:12 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:203:9:203:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:203:9:203:26 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:203:14:203:26 | "singleton_d" | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:203:15:203:25 | singleton_d | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:204:9:204:12 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:204:9:204:24 | call to singleton_a | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:207:5:212:7 | instance | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:208:9:210:11 | singleton_e | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:208:13:208:16 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:209:13:209:30 | call to puts | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:209:13:209:30 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:209:18:209:30 | "singleton_e" | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:209:19:209:29 | singleton_e | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:211:9:211:19 | call to singleton_e | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:211:9:211:19 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:214:5:218:7 | class << ... | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:214:14:214:17 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:215:9:217:11 | singleton_f | calls.rb:214:5:218:7 | class << ... |
-| calls.rb:216:13:216:30 | call to puts | calls.rb:214:5:218:7 | class << ... |
-| calls.rb:216:13:216:30 | self | calls.rb:214:5:218:7 | class << ... |
-| calls.rb:216:18:216:30 | "singleton_f" | calls.rb:214:5:218:7 | class << ... |
-| calls.rb:216:19:216:29 | singleton_f | calls.rb:214:5:218:7 | class << ... |
-| calls.rb:220:5:222:7 | call_singleton_g | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:221:9:221:12 | self | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:221:9:221:24 | call to singleton_g | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:225:1:225:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:225:1:225:22 | call to singleton_a | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:226:1:226:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:226:1:226:22 | call to singleton_f | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:228:1:228:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:228:1:228:19 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:228:6:228:15 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:228:6:228:19 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:230:1:230:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:230:1:230:11 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:231:1:231:14 | call to singleton_e | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:233:1:235:3 | singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:233:5:233:6 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:234:5:234:24 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:234:5:234:24 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:234:10:234:24 | "singleton_g_1" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:234:11:234:23 | singleton_g_1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:237:1:237:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:237:1:237:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:238:1:238:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:238:1:238:19 | call to call_singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:240:1:242:3 | singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:240:5:240:6 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:241:5:241:24 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:241:5:241:24 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:241:10:241:24 | "singleton_g_2" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:241:11:241:23 | singleton_g_2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:244:1:244:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:244:1:244:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:245:1:245:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:245:1:245:19 | call to call_singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:247:1:251:3 | class << ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:247:10:247:11 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:248:5:250:7 | singleton_g | calls.rb:247:1:251:3 | class << ... |
-| calls.rb:249:9:249:28 | call to puts | calls.rb:247:1:251:3 | class << ... |
-| calls.rb:249:9:249:28 | self | calls.rb:247:1:251:3 | class << ... |
-| calls.rb:249:14:249:28 | "singleton_g_3" | calls.rb:247:1:251:3 | class << ... |
-| calls.rb:249:15:249:27 | singleton_g_3 | calls.rb:247:1:251:3 | class << ... |
-| calls.rb:253:1:253:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:253:1:253:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:254:1:254:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:254:1:254:19 | call to call_singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:256:1:256:2 | c2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:256:1:256:19 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:256:6:256:15 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:256:6:256:19 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:257:1:257:2 | c2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:257:1:257:14 | call to singleton_e | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:258:1:258:2 | c2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:258:1:258:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:260:1:260:4 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:260:1:260:8 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:262:1:262:16 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:262:1:262:16 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:262:6:262:16 | "top-level" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:262:7:262:15 | top-level | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:264:1:266:3 | singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:264:5:264:14 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:265:5:265:22 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:265:5:265:22 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:265:10:265:22 | "singleton_g" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:265:11:265:21 | singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:268:1:268:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:268:1:268:22 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:269:1:269:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:270:1:270:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:270:1:270:19 | call to call_singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:271:1:271:2 | c2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:271:1:271:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:272:1:272:2 | c3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:272:1:272:19 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:272:6:272:15 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:272:6:272:19 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:273:1:273:2 | c3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:273:1:273:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:275:1:283:3 | create | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:275:12:275:15 | type | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:275:12:275:15 | type | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:276:5:276:8 | type | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:276:5:276:12 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:276:5:276:21 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:278:5:280:7 | singleton_h | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:278:9:278:12 | type | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:279:9:279:26 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:279:9:279:26 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:279:14:279:26 | "singleton_h" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:279:15:279:25 | singleton_h | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:282:5:282:8 | type | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:285:1:285:17 | call to create | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:285:1:285:17 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:285:8:285:17 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:286:1:286:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:286:1:286:22 | call to singleton_h | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:288:1:288:1 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:288:1:288:14 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:288:5:288:14 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:290:1:294:3 | class << ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:290:10:290:10 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:291:5:293:7 | singleton_i | calls.rb:290:1:294:3 | class << ... |
-| calls.rb:292:9:292:26 | call to puts | calls.rb:290:1:294:3 | class << ... |
-| calls.rb:292:9:292:26 | self | calls.rb:290:1:294:3 | class << ... |
-| calls.rb:292:14:292:26 | "singleton_i" | calls.rb:290:1:294:3 | class << ... |
-| calls.rb:292:15:292:25 | singleton_i | calls.rb:290:1:294:3 | class << ... |
-| calls.rb:296:1:296:1 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:296:1:296:13 | call to singleton_i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:297:1:297:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:297:1:297:22 | call to singleton_i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:299:1:303:3 | class << ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:299:10:299:19 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:300:5:302:7 | singleton_j | calls.rb:299:1:303:3 | class << ... |
-| calls.rb:301:9:301:26 | call to puts | calls.rb:299:1:303:3 | class << ... |
-| calls.rb:301:9:301:26 | self | calls.rb:299:1:303:3 | class << ... |
-| calls.rb:301:14:301:26 | "singleton_j" | calls.rb:299:1:303:3 | class << ... |
-| calls.rb:301:15:301:25 | singleton_j | calls.rb:299:1:303:3 | class << ... |
-| calls.rb:305:1:305:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:305:1:305:22 | call to singleton_j | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:307:1:318:3 | SelfNew | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:308:5:311:7 | instance | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:309:9:309:31 | call to puts | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:309:9:309:31 | self | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:309:14:309:31 | "SelfNew#instance" | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:309:15:309:30 | SelfNew#instance | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:310:9:310:11 | call to new | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:310:9:310:11 | self | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:310:9:310:20 | call to instance | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:313:5:315:7 | singleton | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:313:9:313:12 | self | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:314:9:314:11 | call to new | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:314:9:314:11 | self | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:314:9:314:20 | call to instance | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:317:5:317:7 | call to new | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:317:5:317:7 | self | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:317:5:317:16 | call to instance | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:320:1:320:7 | SelfNew | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:320:1:320:17 | call to singleton | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:322:1:326:3 | C1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:323:5:325:7 | instance | calls.rb:322:1:326:3 | C1 |
-| calls.rb:324:9:324:26 | call to puts | calls.rb:322:1:326:3 | C1 |
-| calls.rb:324:9:324:26 | self | calls.rb:322:1:326:3 | C1 |
-| calls.rb:324:14:324:26 | "C1#instance" | calls.rb:322:1:326:3 | C1 |
-| calls.rb:324:15:324:25 | C1#instance | calls.rb:322:1:326:3 | C1 |
-| calls.rb:328:1:332:3 | C2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:328:12:328:13 | C1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:329:5:331:7 | instance | calls.rb:328:1:332:3 | C2 |
-| calls.rb:330:9:330:26 | call to puts | calls.rb:328:1:332:3 | C2 |
-| calls.rb:330:9:330:26 | self | calls.rb:328:1:332:3 | C2 |
-| calls.rb:330:14:330:26 | "C2#instance" | calls.rb:328:1:332:3 | C2 |
-| calls.rb:330:15:330:25 | C2#instance | calls.rb:328:1:332:3 | C2 |
-| calls.rb:334:1:338:3 | C3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:334:12:334:13 | C2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:335:5:337:7 | instance | calls.rb:334:1:338:3 | C3 |
-| calls.rb:336:9:336:26 | call to puts | calls.rb:334:1:338:3 | C3 |
-| calls.rb:336:9:336:26 | self | calls.rb:334:1:338:3 | C3 |
-| calls.rb:336:14:336:26 | "C3#instance" | calls.rb:334:1:338:3 | C3 |
-| calls.rb:336:15:336:25 | C3#instance | calls.rb:334:1:338:3 | C3 |
-| calls.rb:340:1:356:3 | pattern_dispatch | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:340:22:340:22 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:340:22:340:22 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:341:5:349:7 | case ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:341:10:341:10 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:342:5:343:18 | when ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:342:10:342:11 | C3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:342:12:343:18 | then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:343:9:343:9 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:343:9:343:18 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:344:5:345:18 | when ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:344:10:344:11 | C2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:344:12:345:18 | then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:345:9:345:9 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:345:9:345:18 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:346:5:347:18 | when ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:346:10:346:11 | C1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:346:12:347:18 | then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:347:9:347:9 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:347:9:347:18 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:348:5:348:8 | else ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:351:5:355:7 | case ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:351:10:351:10 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:352:9:352:29 | in ... then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:352:12:352:13 | C3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:352:15:352:29 | then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:352:20:352:20 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:352:20:352:29 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:353:9:353:36 | in ... then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:353:12:353:13 | C2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:353:12:353:19 | ... => ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:353:18:353:19 | c2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:353:21:353:36 | then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:353:26:353:27 | c2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:353:26:353:36 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:354:9:354:36 | in ... then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:354:12:354:13 | C1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:354:12:354:19 | ... => ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:354:18:354:19 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:354:21:354:36 | then ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:354:26:354:27 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:354:26:354:36 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:358:1:358:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:358:1:358:11 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:358:6:358:7 | C1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:358:6:358:11 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:359:1:359:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:359:1:359:11 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:360:1:360:25 | call to pattern_dispatch | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:360:1:360:25 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:360:18:360:25 | ( ... ) | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:360:19:360:20 | C1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:360:19:360:24 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:361:1:361:25 | call to pattern_dispatch | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:361:1:361:25 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:361:18:361:25 | ( ... ) | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:361:19:361:20 | C2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:361:19:361:24 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:362:1:362:25 | call to pattern_dispatch | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:362:1:362:25 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:362:18:362:25 | ( ... ) | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:362:19:362:20 | C3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:362:19:362:24 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:364:1:368:3 | add_singleton | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:364:19:364:19 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:364:19:364:19 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:365:5:367:7 | instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:365:9:365:9 | x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:366:9:366:28 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:366:9:366:28 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:366:14:366:28 | "instance_on x" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:366:15:366:27 | instance_on x | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:370:1:370:2 | c3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:370:1:370:11 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:370:6:370:7 | C1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:370:6:370:11 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:371:1:371:16 | call to add_singleton | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:371:1:371:16 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:371:15:371:16 | c3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:372:1:372:2 | c3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:372:1:372:11 | call to instance | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:375:5:383:7 | class << ... | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:375:14:375:17 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:376:9:378:11 | singleton1 | calls.rb:375:5:383:7 | class << ... |
-| calls.rb:377:13:377:48 | call to puts | calls.rb:375:5:383:7 | class << ... |
-| calls.rb:377:13:377:48 | self | calls.rb:375:5:383:7 | class << ... |
-| calls.rb:377:18:377:48 | "SingletonOverride1#singleton1" | calls.rb:375:5:383:7 | class << ... |
-| calls.rb:377:19:377:47 | SingletonOverride1#singleton1 | calls.rb:375:5:383:7 | class << ... |
-| calls.rb:380:9:382:11 | call_singleton1 | calls.rb:375:5:383:7 | class << ... |
-| calls.rb:381:13:381:22 | call to singleton1 | calls.rb:375:5:383:7 | class << ... |
-| calls.rb:381:13:381:22 | self | calls.rb:375:5:383:7 | class << ... |
-| calls.rb:385:5:387:7 | singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:385:9:385:12 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:386:9:386:44 | call to puts | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:386:9:386:44 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:386:14:386:44 | "SingletonOverride1#singleton2" | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:386:15:386:43 | SingletonOverride1#singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:389:5:391:7 | call_singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:389:9:389:12 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:390:9:390:18 | call to singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:390:9:390:18 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:393:5:393:14 | call to singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:393:5:393:14 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:396:1:396:18 | SingletonOverride1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:397:1:397:18 | SingletonOverride1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:399:28:399:45 | SingletonOverride1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:400:5:404:7 | class << ... | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:400:14:400:17 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:401:9:403:11 | singleton1 | calls.rb:400:5:404:7 | class << ... |
-| calls.rb:402:13:402:48 | call to puts | calls.rb:400:5:404:7 | class << ... |
-| calls.rb:402:13:402:48 | self | calls.rb:400:5:404:7 | class << ... |
-| calls.rb:402:18:402:48 | "SingletonOverride2#singleton1" | calls.rb:400:5:404:7 | class << ... |
-| calls.rb:402:19:402:47 | SingletonOverride2#singleton1 | calls.rb:400:5:404:7 | class << ... |
-| calls.rb:406:5:408:7 | singleton2 | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:406:9:406:12 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:407:9:407:44 | call to puts | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:407:9:407:44 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:407:14:407:44 | "SingletonOverride2#singleton2" | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:407:15:407:43 | SingletonOverride2#singleton2 | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:411:1:411:18 | SingletonOverride2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:411:1:411:34 | call to call_singleton1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:412:1:412:18 | SingletonOverride2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:412:1:412:34 | call to call_singleton2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:415:5:419:7 | if ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:415:8:415:13 | call to rand | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:415:8:415:13 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:415:8:415:17 | ... > ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:415:17:415:17 | 0 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:415:19:418:11 | then ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:416:9:418:11 | m1 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:417:13:417:48 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:417:13:417:48 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:417:18:417:48 | "ConditionalInstanceMethods#m1" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:417:19:417:47 | ConditionalInstanceMethods#m1 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:421:5:433:7 | m2 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:422:9:422:44 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:422:9:422:44 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:422:14:422:44 | "ConditionalInstanceMethods#m2" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:422:15:422:43 | ConditionalInstanceMethods#m2 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:424:9:430:11 | m3 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:425:13:425:48 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:425:13:425:48 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:425:18:425:48 | "ConditionalInstanceMethods#m3" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:425:19:425:47 | ConditionalInstanceMethods#m3 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:427:13:429:15 | m4 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:428:17:428:52 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:428:17:428:52 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:428:22:428:52 | "ConditionalInstanceMethods#m4" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:428:23:428:51 | ConditionalInstanceMethods#m4 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:432:9:432:10 | call to m3 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:432:9:432:10 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:435:5:441:7 | if ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:435:8:435:13 | call to rand | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:435:8:435:13 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:435:8:435:17 | ... > ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:435:17:435:17 | 0 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:435:19:440:18 | then ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:436:9:436:13 | Class | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:436:9:440:11 | call to new | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:436:9:440:15 | call to new | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:436:9:440:18 | call to m5 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:436:19:440:11 | do ... end | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:437:13:439:15 | m5 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:438:17:438:40 | call to puts | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:438:17:438:40 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:438:22:438:40 | "AnonymousClass#m5" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:438:23:438:39 | AnonymousClass#m5 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:444:1:444:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:444:1:444:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:444:1:444:33 | call to m1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:445:1:445:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:445:1:445:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:445:1:445:33 | call to m3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:446:1:446:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:446:1:446:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:446:1:446:33 | call to m2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:447:1:447:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:447:1:447:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:447:1:447:33 | call to m3 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:448:1:448:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:448:1:448:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:448:1:448:33 | call to m4 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:449:1:449:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:449:1:449:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:449:1:449:33 | call to m5 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:451:1:451:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:451:1:469:3 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:451:27:451:31 | Class | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:451:27:469:3 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:451:37:469:3 | do ... end | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:452:5:452:11 | Array | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:452:5:452:11 | [...] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:452:5:452:11 | call to [] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:452:5:456:7 | call to each | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:452:6:452:6 | 0 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:452:8:452:8 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:452:10:452:10 | 2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:452:18:456:7 | do ... end | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:453:9:455:11 | foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:454:13:454:22 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:454:13:454:22 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:454:18:454:22 | "foo" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:454:19:454:21 | foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:458:5:458:9 | Class | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:458:5:462:7 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:458:5:462:11 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:458:5:462:15 | call to bar | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:458:15:462:7 | do ... end | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:459:9:461:11 | bar | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:460:13:460:22 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:460:13:460:22 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:460:18:460:22 | "bar" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:460:19:460:21 | bar | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:5:464:11 | Array | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:5:464:11 | [...] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:5:464:11 | call to [] | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:5:468:7 | call to each | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:6:464:6 | 0 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:8:464:8 | 1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:10:464:10 | 2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:18:468:7 | do ... end | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:22:464:22 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:464:22:464:22 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:465:9:467:11 | call to define_method | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:465:9:467:11 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:465:23:465:32 | "baz_#{...}" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:465:24:465:27 | baz_ | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:465:28:465:31 | #{...} | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:465:30:465:30 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:465:35:467:11 | do ... end | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:466:13:466:27 | call to puts | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:466:13:466:27 | self | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:466:18:466:27 | "baz_#{...}" | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:466:19:466:22 | baz_ | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:466:23:466:26 | #{...} | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:466:25:466:25 | i | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:471:1:471:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:471:1:471:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:471:1:471:31 | call to foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:472:1:472:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:472:1:472:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:472:1:472:31 | call to bar | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:473:1:473:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:473:1:473:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:473:1:473:33 | call to baz_0 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:474:1:474:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:474:1:474:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:474:1:474:33 | call to baz_1 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:475:1:475:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:475:1:475:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:475:1:475:33 | call to baz_2 | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:477:1:483:3 | ExtendSingletonMethod | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:478:5:480:7 | singleton | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:479:9:479:46 | call to puts | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:479:9:479:46 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:479:14:479:46 | "ExtendSingletonMethod#singleton" | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:479:15:479:45 | ExtendSingletonMethod#singleton | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:482:5:482:15 | call to extend | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:482:5:482:15 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:482:12:482:15 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:485:1:485:21 | ExtendSingletonMethod | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:485:1:485:31 | call to singleton | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:487:1:496:3 | ProtectedMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:488:5:490:7 | call to protected | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:488:5:490:7 | self | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:488:15:490:7 | foo | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:489:9:489:35 | call to puts | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:489:9:489:35 | self | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:489:14:489:35 | "ProtectedMethods#foo" | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:489:15:489:34 | ProtectedMethods#foo | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:492:5:495:7 | bar | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:493:9:493:11 | call to foo | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:493:9:493:11 | self | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:494:9:494:24 | ProtectedMethods | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:494:9:494:28 | call to new | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:494:9:494:32 | call to foo | calls.rb:487:1:496:3 | ProtectedMethods |
-| calls.rb:498:1:498:16 | ProtectedMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:498:1:498:20 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:498:1:498:24 | call to foo | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:499:1:499:16 | ProtectedMethods | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:499:1:499:20 | call to new | calls.rb:1:1:499:25 | calls.rb |
-| calls.rb:499:1:499:24 | call to bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:105:1:113:3 | Module | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:106:5:106:31 | alias ... | calls.rb:105:1:113:3 | Module |
+| calls.rb:106:11:106:22 | :old_include | calls.rb:105:1:113:3 | Module |
+| calls.rb:106:11:106:22 | old_include | calls.rb:105:1:113:3 | Module |
+| calls.rb:106:24:106:31 | :include | calls.rb:105:1:113:3 | Module |
+| calls.rb:106:24:106:31 | include | calls.rb:105:1:113:3 | Module |
+| calls.rb:107:5:107:24 | module_eval | calls.rb:105:1:113:3 | Module |
+| calls.rb:108:5:110:7 | include | calls.rb:105:1:113:3 | Module |
+| calls.rb:108:17:108:17 | x | calls.rb:105:1:113:3 | Module |
+| calls.rb:108:17:108:17 | x | calls.rb:105:1:113:3 | Module |
+| calls.rb:109:9:109:21 | call to old_include | calls.rb:105:1:113:3 | Module |
+| calls.rb:109:9:109:21 | self | calls.rb:105:1:113:3 | Module |
+| calls.rb:109:21:109:21 | x | calls.rb:105:1:113:3 | Module |
+| calls.rb:111:5:111:20 | prepend | calls.rb:105:1:113:3 | Module |
+| calls.rb:112:5:112:20 | private | calls.rb:105:1:113:3 | Module |
+| calls.rb:115:1:118:3 | Object | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:115:16:115:21 | Module | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:116:5:116:18 | call to include | calls.rb:115:1:118:3 | Object |
+| calls.rb:116:5:116:18 | self | calls.rb:115:1:118:3 | Object |
+| calls.rb:116:13:116:18 | Kernel | calls.rb:115:1:118:3 | Object |
+| calls.rb:117:5:117:16 | new | calls.rb:115:1:118:3 | Object |
+| calls.rb:120:1:123:3 | Hash | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:121:5:121:25 | alias ... | calls.rb:120:1:123:3 | Hash |
+| calls.rb:121:11:121:21 | :old_lookup | calls.rb:120:1:123:3 | Hash |
+| calls.rb:121:11:121:21 | old_lookup | calls.rb:120:1:123:3 | Hash |
+| calls.rb:121:23:121:25 | :[] | calls.rb:120:1:123:3 | Hash |
+| calls.rb:121:23:121:25 | [] | calls.rb:120:1:123:3 | Hash |
+| calls.rb:122:5:122:31 | [] | calls.rb:120:1:123:3 | Hash |
+| calls.rb:122:12:122:12 | x | calls.rb:120:1:123:3 | Hash |
+| calls.rb:122:12:122:12 | x | calls.rb:120:1:123:3 | Hash |
+| calls.rb:122:15:122:27 | call to old_lookup | calls.rb:120:1:123:3 | Hash |
+| calls.rb:122:15:122:27 | self | calls.rb:120:1:123:3 | Hash |
+| calls.rb:122:26:122:26 | x | calls.rb:120:1:123:3 | Hash |
+| calls.rb:125:1:138:3 | Array | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:126:3:126:23 | alias ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:126:9:126:19 | :old_lookup | calls.rb:125:1:138:3 | Array |
+| calls.rb:126:9:126:19 | old_lookup | calls.rb:125:1:138:3 | Array |
+| calls.rb:126:21:126:23 | :[] | calls.rb:125:1:138:3 | Array |
+| calls.rb:126:21:126:23 | [] | calls.rb:125:1:138:3 | Array |
+| calls.rb:127:3:127:29 | [] | calls.rb:125:1:138:3 | Array |
+| calls.rb:127:10:127:10 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:127:10:127:10 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:127:13:127:25 | call to old_lookup | calls.rb:125:1:138:3 | Array |
+| calls.rb:127:13:127:25 | self | calls.rb:125:1:138:3 | Array |
+| calls.rb:127:24:127:24 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:129:3:129:17 | length | calls.rb:125:1:138:3 | Array |
+| calls.rb:131:3:137:5 | foreach | calls.rb:125:1:138:3 | Array |
+| calls.rb:131:15:131:19 | &body | calls.rb:125:1:138:3 | Array |
+| calls.rb:131:16:131:19 | body | calls.rb:125:1:138:3 | Array |
+| calls.rb:132:5:132:5 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:132:5:132:9 | ... = ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:132:9:132:9 | 0 | calls.rb:125:1:138:3 | Array |
+| calls.rb:133:5:136:7 | while ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:133:11:133:11 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:133:11:133:25 | ... < ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:133:15:133:18 | self | calls.rb:125:1:138:3 | Array |
+| calls.rb:133:15:133:25 | call to length | calls.rb:125:1:138:3 | Array |
+| calls.rb:133:26:136:7 | do ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:134:9:134:24 | yield ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:134:15:134:15 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:134:18:134:21 | self | calls.rb:125:1:138:3 | Array |
+| calls.rb:134:18:134:24 | ...[...] | calls.rb:125:1:138:3 | Array |
+| calls.rb:134:23:134:23 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:135:9:135:9 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:135:9:135:9 | x | calls.rb:125:1:138:3 | Array |
+| calls.rb:135:9:135:14 | ... += ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:135:9:135:14 | ... = ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:135:11:135:12 | ... + ... | calls.rb:125:1:138:3 | Array |
+| calls.rb:135:14:135:14 | 1 | calls.rb:125:1:138:3 | Array |
+| calls.rb:140:1:142:3 | funny | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:141:5:141:20 | yield ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:141:11:141:20 | "prefix: " | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:141:12:141:19 | prefix:  | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:1:144:30 | call to funny | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:1:144:30 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:7:144:30 | { ... } | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:10:144:10 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:10:144:10 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:13:144:29 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:13:144:29 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:18:144:18 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:144:18:144:29 | call to capitalize | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:146:1:146:3 | "a" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:146:1:146:14 | call to capitalize | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:146:2:146:2 | a | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:147:1:147:1 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:147:1:147:12 | call to bit_length | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:148:1:148:1 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:148:1:148:5 | call to abs | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:1:150:13 | Array | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:1:150:13 | [...] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:1:150:13 | call to [] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:1:150:62 | call to foreach | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:2:150:4 | "a" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:3:150:3 | a | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:6:150:8 | "b" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:7:150:7 | b | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:10:150:12 | "c" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:11:150:11 | c | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:23:150:62 | { ... } | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:26:150:26 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:26:150:26 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:29:150:29 | v | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:29:150:29 | v | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:32:150:61 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:32:150:61 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:37:150:61 | "#{...} -> #{...}" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:38:150:41 | #{...} | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:40:150:40 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:42:150:45 |  ->  | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:46:150:60 | #{...} | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:48:150:48 | v | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:150:48:150:59 | call to capitalize | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:1:152:7 | Array | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:1:152:7 | [...] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:1:152:7 | call to [] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:1:152:35 | call to foreach | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:2:152:2 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:4:152:4 | 2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:6:152:6 | 3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:17:152:35 | { ... } | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:20:152:20 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:20:152:20 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:23:152:23 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:152:23:152:34 | call to bit_length | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:1:154:7 | Array | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:1:154:7 | [...] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:1:154:7 | call to [] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:1:154:40 | call to foreach | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:2:154:2 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:4:154:4 | 2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:6:154:6 | 3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:17:154:40 | { ... } | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:20:154:20 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:20:154:20 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:23:154:39 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:23:154:39 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:28:154:28 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:154:28:154:39 | call to capitalize | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:1:156:8 | Array | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:1:156:8 | [...] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:1:156:8 | call to [] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:1:156:37 | call to foreach | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:2:156:2 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:4:156:5 | - ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:5:156:5 | 2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:7:156:7 | 3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:18:156:37 | { ... } | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:21:156:21 | _ | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:21:156:21 | _ | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:24:156:24 | v | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:24:156:24 | v | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:27:156:36 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:27:156:36 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:32:156:32 | v | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:156:32:156:36 | call to abs | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:158:1:160:3 | indirect | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:158:14:158:15 | &b | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:158:15:158:15 | b | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:159:5:159:17 | call to call_block | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:159:5:159:17 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:159:16:159:17 | &... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:159:17:159:17 | b | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:162:1:162:28 | call to indirect | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:162:1:162:28 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:162:10:162:28 | { ... } | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:162:13:162:13 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:162:13:162:13 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:162:16:162:16 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:162:16:162:27 | call to bit_length | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:165:1:169:3 | S | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:166:5:168:7 | s_method | calls.rb:165:1:169:3 | S |
+| calls.rb:167:9:167:12 | self | calls.rb:165:1:169:3 | S |
+| calls.rb:167:9:167:17 | call to to_s | calls.rb:165:1:169:3 | S |
+| calls.rb:171:1:174:3 | A | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:171:11:171:11 | S | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:172:5:173:7 | to_s | calls.rb:171:1:174:3 | A |
+| calls.rb:176:1:179:3 | B | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:176:11:176:11 | S | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:177:5:178:7 | to_s | calls.rb:176:1:179:3 | B |
+| calls.rb:181:1:181:1 | S | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:181:1:181:5 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:181:1:181:14 | call to s_method | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:182:1:182:1 | A | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:182:1:182:5 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:182:1:182:14 | call to s_method | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:183:1:183:1 | B | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:183:1:183:5 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:183:1:183:14 | call to s_method | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:185:1:186:3 | private_on_main | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:188:1:188:15 | call to private_on_main | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:188:1:188:15 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:190:1:226:3 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:191:5:194:7 | singleton_a | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:191:9:191:12 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:192:9:192:26 | call to puts | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:192:9:192:26 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:192:14:192:26 | "singleton_a" | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:192:15:192:25 | singleton_a | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:193:9:193:12 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:193:9:193:24 | call to singleton_b | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:196:5:199:7 | singleton_b | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:196:9:196:12 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:197:9:197:26 | call to puts | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:197:9:197:26 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:197:14:197:26 | "singleton_b" | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:197:15:197:25 | singleton_b | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:198:9:198:12 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:198:9:198:24 | call to singleton_c | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:201:5:203:7 | singleton_c | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:201:9:201:12 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:202:9:202:26 | call to puts | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:202:9:202:26 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:202:14:202:26 | "singleton_c" | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:202:15:202:25 | singleton_c | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:205:5:208:7 | singleton_d | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:205:9:205:12 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:206:9:206:26 | call to puts | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:206:9:206:26 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:206:14:206:26 | "singleton_d" | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:206:15:206:25 | singleton_d | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:207:9:207:12 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:207:9:207:24 | call to singleton_a | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:210:5:215:7 | instance | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:211:9:213:11 | singleton_e | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:211:13:211:16 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:212:13:212:30 | call to puts | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:212:13:212:30 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:212:18:212:30 | "singleton_e" | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:212:19:212:29 | singleton_e | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:214:9:214:19 | call to singleton_e | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:214:9:214:19 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:217:5:221:7 | class << ... | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:217:14:217:17 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:218:9:220:11 | singleton_f | calls.rb:217:5:221:7 | class << ... |
+| calls.rb:219:13:219:30 | call to puts | calls.rb:217:5:221:7 | class << ... |
+| calls.rb:219:13:219:30 | self | calls.rb:217:5:221:7 | class << ... |
+| calls.rb:219:18:219:30 | "singleton_f" | calls.rb:217:5:221:7 | class << ... |
+| calls.rb:219:19:219:29 | singleton_f | calls.rb:217:5:221:7 | class << ... |
+| calls.rb:223:5:225:7 | call_singleton_g | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:224:9:224:12 | self | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:224:9:224:24 | call to singleton_g | calls.rb:190:1:226:3 | Singletons |
+| calls.rb:228:1:228:10 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:228:1:228:22 | call to singleton_a | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:229:1:229:10 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:229:1:229:22 | call to singleton_f | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:231:1:231:19 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:231:6:231:15 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:231:6:231:19 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:233:1:233:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:233:1:233:11 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:234:1:234:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:234:1:234:14 | call to singleton_e | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:236:1:238:3 | singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:236:5:236:6 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:237:5:237:24 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:237:5:237:24 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:237:10:237:24 | "singleton_g_1" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:237:11:237:23 | singleton_g_1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:240:1:240:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:240:1:240:14 | call to singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:241:1:241:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:241:1:241:19 | call to call_singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:243:1:245:3 | singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:243:5:243:6 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:244:5:244:24 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:244:5:244:24 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:244:10:244:24 | "singleton_g_2" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:244:11:244:23 | singleton_g_2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:247:1:247:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:247:1:247:14 | call to singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:248:1:248:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:248:1:248:19 | call to call_singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:250:1:254:3 | class << ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:250:10:250:11 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:251:5:253:7 | singleton_g | calls.rb:250:1:254:3 | class << ... |
+| calls.rb:252:9:252:28 | call to puts | calls.rb:250:1:254:3 | class << ... |
+| calls.rb:252:9:252:28 | self | calls.rb:250:1:254:3 | class << ... |
+| calls.rb:252:14:252:28 | "singleton_g_3" | calls.rb:250:1:254:3 | class << ... |
+| calls.rb:252:15:252:27 | singleton_g_3 | calls.rb:250:1:254:3 | class << ... |
+| calls.rb:256:1:256:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:256:1:256:14 | call to singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:257:1:257:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:257:1:257:19 | call to call_singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:259:1:259:2 | c2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:259:1:259:19 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:259:6:259:15 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:259:6:259:19 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:260:1:260:2 | c2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:260:1:260:14 | call to singleton_e | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:261:1:261:2 | c2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:263:1:263:4 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:263:1:263:8 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:265:1:265:16 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:265:1:265:16 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:265:6:265:16 | "top-level" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:265:7:265:15 | top-level | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:267:1:269:3 | singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:267:5:267:14 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:268:5:268:22 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:268:5:268:22 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:268:10:268:22 | "singleton_g" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:268:11:268:21 | singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:271:1:271:10 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:271:1:271:22 | call to singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:272:1:272:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:272:1:272:14 | call to singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:273:1:273:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:273:1:273:19 | call to call_singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:274:1:274:2 | c2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:274:1:274:14 | call to singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:275:1:275:2 | c3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:275:1:275:19 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:275:6:275:15 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:275:6:275:19 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:276:1:276:2 | c3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:276:1:276:14 | call to singleton_g | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:278:1:286:3 | create | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:278:12:278:15 | type | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:278:12:278:15 | type | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:279:5:279:8 | type | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:279:5:279:12 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:279:5:279:21 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:281:5:283:7 | singleton_h | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:281:9:281:12 | type | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:282:9:282:26 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:282:9:282:26 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:282:14:282:26 | "singleton_h" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:282:15:282:25 | singleton_h | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:285:5:285:8 | type | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:285:5:285:20 | call to singleton_h | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:288:1:288:17 | call to create | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:288:1:288:17 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:288:8:288:17 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:289:1:289:10 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:289:1:289:22 | call to singleton_h | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:291:1:291:1 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:291:1:291:14 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:291:5:291:14 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:293:1:297:3 | class << ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:293:10:293:10 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:294:5:296:7 | singleton_i | calls.rb:293:1:297:3 | class << ... |
+| calls.rb:295:9:295:26 | call to puts | calls.rb:293:1:297:3 | class << ... |
+| calls.rb:295:9:295:26 | self | calls.rb:293:1:297:3 | class << ... |
+| calls.rb:295:14:295:26 | "singleton_i" | calls.rb:293:1:297:3 | class << ... |
+| calls.rb:295:15:295:25 | singleton_i | calls.rb:293:1:297:3 | class << ... |
+| calls.rb:299:1:299:1 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:299:1:299:13 | call to singleton_i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:300:1:300:10 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:300:1:300:22 | call to singleton_i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:302:1:306:3 | class << ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:302:10:302:19 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:303:5:305:7 | singleton_j | calls.rb:302:1:306:3 | class << ... |
+| calls.rb:304:9:304:26 | call to puts | calls.rb:302:1:306:3 | class << ... |
+| calls.rb:304:9:304:26 | self | calls.rb:302:1:306:3 | class << ... |
+| calls.rb:304:14:304:26 | "singleton_j" | calls.rb:302:1:306:3 | class << ... |
+| calls.rb:304:15:304:25 | singleton_j | calls.rb:302:1:306:3 | class << ... |
+| calls.rb:308:1:308:10 | Singletons | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:308:1:308:22 | call to singleton_j | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:310:1:321:3 | SelfNew | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:311:5:314:7 | instance | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:312:9:312:31 | call to puts | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:312:9:312:31 | self | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:312:14:312:31 | "SelfNew#instance" | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:312:15:312:30 | SelfNew#instance | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:313:9:313:11 | call to new | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:313:9:313:11 | self | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:313:9:313:20 | call to instance | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:316:5:318:7 | singleton | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:316:9:316:12 | self | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:317:9:317:11 | call to new | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:317:9:317:11 | self | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:317:9:317:20 | call to instance | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:320:5:320:7 | call to new | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:320:5:320:7 | self | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:320:5:320:16 | call to instance | calls.rb:310:1:321:3 | SelfNew |
+| calls.rb:323:1:323:7 | SelfNew | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:323:1:323:17 | call to singleton | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:325:1:329:3 | C1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:326:5:328:7 | instance | calls.rb:325:1:329:3 | C1 |
+| calls.rb:327:9:327:26 | call to puts | calls.rb:325:1:329:3 | C1 |
+| calls.rb:327:9:327:26 | self | calls.rb:325:1:329:3 | C1 |
+| calls.rb:327:14:327:26 | "C1#instance" | calls.rb:325:1:329:3 | C1 |
+| calls.rb:327:15:327:25 | C1#instance | calls.rb:325:1:329:3 | C1 |
+| calls.rb:331:1:335:3 | C2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:331:12:331:13 | C1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:332:5:334:7 | instance | calls.rb:331:1:335:3 | C2 |
+| calls.rb:333:9:333:26 | call to puts | calls.rb:331:1:335:3 | C2 |
+| calls.rb:333:9:333:26 | self | calls.rb:331:1:335:3 | C2 |
+| calls.rb:333:14:333:26 | "C2#instance" | calls.rb:331:1:335:3 | C2 |
+| calls.rb:333:15:333:25 | C2#instance | calls.rb:331:1:335:3 | C2 |
+| calls.rb:337:1:341:3 | C3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:337:12:337:13 | C2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:338:5:340:7 | instance | calls.rb:337:1:341:3 | C3 |
+| calls.rb:339:9:339:26 | call to puts | calls.rb:337:1:341:3 | C3 |
+| calls.rb:339:9:339:26 | self | calls.rb:337:1:341:3 | C3 |
+| calls.rb:339:14:339:26 | "C3#instance" | calls.rb:337:1:341:3 | C3 |
+| calls.rb:339:15:339:25 | C3#instance | calls.rb:337:1:341:3 | C3 |
+| calls.rb:343:1:359:3 | pattern_dispatch | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:343:22:343:22 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:343:22:343:22 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:344:5:352:7 | case ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:344:10:344:10 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:345:5:346:18 | when ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:345:10:345:11 | C3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:345:12:346:18 | then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:346:9:346:9 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:346:9:346:18 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:347:5:348:18 | when ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:347:10:347:11 | C2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:347:12:348:18 | then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:348:9:348:9 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:348:9:348:18 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:349:5:350:18 | when ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:349:10:349:11 | C1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:349:12:350:18 | then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:350:9:350:9 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:350:9:350:18 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:351:5:351:8 | else ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:354:5:358:7 | case ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:354:10:354:10 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:355:9:355:29 | in ... then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:355:12:355:13 | C3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:355:15:355:29 | then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:355:20:355:20 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:355:20:355:29 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:356:9:356:36 | in ... then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:356:12:356:13 | C2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:356:12:356:19 | ... => ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:356:18:356:19 | c2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:356:21:356:36 | then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:356:26:356:27 | c2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:356:26:356:36 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:357:9:357:36 | in ... then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:357:12:357:13 | C1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:357:12:357:19 | ... => ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:357:18:357:19 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:357:21:357:36 | then ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:357:26:357:27 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:357:26:357:36 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:361:1:361:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:361:1:361:11 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:361:6:361:7 | C1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:361:6:361:11 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:362:1:362:2 | c1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:362:1:362:11 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:363:1:363:25 | call to pattern_dispatch | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:363:1:363:25 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:363:18:363:25 | ( ... ) | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:363:19:363:20 | C1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:363:19:363:24 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:364:1:364:25 | call to pattern_dispatch | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:364:1:364:25 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:364:18:364:25 | ( ... ) | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:364:19:364:20 | C2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:364:19:364:24 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:365:1:365:25 | call to pattern_dispatch | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:365:1:365:25 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:365:18:365:25 | ( ... ) | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:365:19:365:20 | C3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:365:19:365:24 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:367:1:371:3 | add_singleton | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:367:19:367:19 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:367:19:367:19 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:368:5:370:7 | instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:368:9:368:9 | x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:369:9:369:28 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:369:9:369:28 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:369:14:369:28 | "instance_on x" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:369:15:369:27 | instance_on x | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:373:1:373:2 | c3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:373:1:373:11 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:373:6:373:7 | C1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:373:6:373:11 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:374:1:374:16 | call to add_singleton | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:374:1:374:16 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:374:15:374:16 | c3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:375:1:375:2 | c3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:375:1:375:11 | call to instance | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:377:1:397:3 | SingletonOverride1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:378:5:386:7 | class << ... | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:378:14:378:17 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:379:9:381:11 | singleton1 | calls.rb:378:5:386:7 | class << ... |
+| calls.rb:380:13:380:48 | call to puts | calls.rb:378:5:386:7 | class << ... |
+| calls.rb:380:13:380:48 | self | calls.rb:378:5:386:7 | class << ... |
+| calls.rb:380:18:380:48 | "SingletonOverride1#singleton1" | calls.rb:378:5:386:7 | class << ... |
+| calls.rb:380:19:380:47 | SingletonOverride1#singleton1 | calls.rb:378:5:386:7 | class << ... |
+| calls.rb:383:9:385:11 | call_singleton1 | calls.rb:378:5:386:7 | class << ... |
+| calls.rb:384:13:384:22 | call to singleton1 | calls.rb:378:5:386:7 | class << ... |
+| calls.rb:384:13:384:22 | self | calls.rb:378:5:386:7 | class << ... |
+| calls.rb:388:5:390:7 | singleton2 | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:388:9:388:12 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:389:9:389:44 | call to puts | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:389:9:389:44 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:389:14:389:44 | "SingletonOverride1#singleton2" | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:389:15:389:43 | SingletonOverride1#singleton2 | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:392:5:394:7 | call_singleton2 | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:392:9:392:12 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:393:9:393:18 | call to singleton2 | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:393:9:393:18 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:396:5:396:14 | call to singleton2 | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:396:5:396:14 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:399:1:399:18 | SingletonOverride1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:399:1:399:34 | call to call_singleton1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:400:1:400:18 | SingletonOverride1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:400:1:400:34 | call to call_singleton2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:402:1:412:3 | SingletonOverride2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:402:28:402:45 | SingletonOverride1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:403:5:407:7 | class << ... | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:403:14:403:17 | self | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:404:9:406:11 | singleton1 | calls.rb:403:5:407:7 | class << ... |
+| calls.rb:405:13:405:48 | call to puts | calls.rb:403:5:407:7 | class << ... |
+| calls.rb:405:13:405:48 | self | calls.rb:403:5:407:7 | class << ... |
+| calls.rb:405:18:405:48 | "SingletonOverride2#singleton1" | calls.rb:403:5:407:7 | class << ... |
+| calls.rb:405:19:405:47 | SingletonOverride2#singleton1 | calls.rb:403:5:407:7 | class << ... |
+| calls.rb:409:5:411:7 | singleton2 | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:409:9:409:12 | self | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:410:9:410:44 | call to puts | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:410:9:410:44 | self | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:410:14:410:44 | "SingletonOverride2#singleton2" | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:410:15:410:43 | SingletonOverride2#singleton2 | calls.rb:402:1:412:3 | SingletonOverride2 |
+| calls.rb:414:1:414:18 | SingletonOverride2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:414:1:414:34 | call to call_singleton1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:415:1:415:18 | SingletonOverride2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:415:1:415:34 | call to call_singleton2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:417:1:445:3 | ConditionalInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:418:5:422:7 | if ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:418:8:418:13 | call to rand | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:418:8:418:13 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:418:8:418:17 | ... > ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:418:17:418:17 | 0 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:418:19:421:11 | then ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:419:9:421:11 | m1 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:420:13:420:48 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:420:13:420:48 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:420:18:420:48 | "ConditionalInstanceMethods#m1" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:420:19:420:47 | ConditionalInstanceMethods#m1 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:424:5:436:7 | m2 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:425:9:425:44 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:425:9:425:44 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:425:14:425:44 | "ConditionalInstanceMethods#m2" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:425:15:425:43 | ConditionalInstanceMethods#m2 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:427:9:433:11 | m3 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:428:13:428:48 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:428:13:428:48 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:428:18:428:48 | "ConditionalInstanceMethods#m3" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:428:19:428:47 | ConditionalInstanceMethods#m3 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:430:13:432:15 | m4 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:431:17:431:52 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:431:17:431:52 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:431:22:431:52 | "ConditionalInstanceMethods#m4" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:431:23:431:51 | ConditionalInstanceMethods#m4 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:435:9:435:10 | call to m3 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:435:9:435:10 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:438:5:444:7 | if ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:438:8:438:13 | call to rand | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:438:8:438:13 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:438:8:438:17 | ... > ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:438:17:438:17 | 0 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:438:19:443:18 | then ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:439:9:439:13 | Class | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:439:9:443:11 | call to new | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:439:9:443:15 | call to new | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:439:9:443:18 | call to m5 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:439:19:443:11 | do ... end | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:440:13:442:15 | m5 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:441:17:441:40 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:441:17:441:40 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:441:22:441:40 | "AnonymousClass#m5" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:441:23:441:39 | AnonymousClass#m5 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
+| calls.rb:447:1:447:26 | ConditionalInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:447:1:447:30 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:447:1:447:33 | call to m1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:448:1:448:26 | ConditionalInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:448:1:448:30 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:448:1:448:33 | call to m3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:449:1:449:26 | ConditionalInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:449:1:449:30 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:449:1:449:33 | call to m2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:450:1:450:26 | ConditionalInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:450:1:450:30 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:450:1:450:33 | call to m3 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:451:1:451:26 | ConditionalInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:451:1:451:30 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:451:1:451:33 | call to m4 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:452:1:452:26 | ConditionalInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:452:1:452:30 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:452:1:452:33 | call to m5 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:454:1:454:23 | EsotericInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:454:1:472:3 | ... = ... | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:454:27:454:31 | Class | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:454:27:472:3 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:454:37:472:3 | do ... end | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:455:5:455:11 | Array | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:455:5:455:11 | [...] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:455:5:455:11 | call to [] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:455:5:459:7 | call to each | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:455:6:455:6 | 0 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:455:8:455:8 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:455:10:455:10 | 2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:455:18:459:7 | do ... end | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:456:9:458:11 | foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:457:13:457:22 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:457:13:457:22 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:457:18:457:22 | "foo" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:457:19:457:21 | foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:461:5:461:9 | Class | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:461:5:465:7 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:461:5:465:11 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:461:5:465:15 | call to bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:461:15:465:7 | do ... end | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:462:9:464:11 | bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:463:13:463:22 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:463:13:463:22 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:463:18:463:22 | "bar" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:463:19:463:21 | bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:5:467:11 | Array | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:5:467:11 | [...] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:5:467:11 | call to [] | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:5:471:7 | call to each | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:6:467:6 | 0 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:8:467:8 | 1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:10:467:10 | 2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:18:471:7 | do ... end | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:22:467:22 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:467:22:467:22 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:468:9:470:11 | call to define_method | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:468:9:470:11 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:468:23:468:32 | "baz_#{...}" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:468:24:468:27 | baz_ | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:468:28:468:31 | #{...} | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:468:30:468:30 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:468:35:470:11 | do ... end | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:469:13:469:27 | call to puts | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:469:13:469:27 | self | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:469:18:469:27 | "baz_#{...}" | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:469:19:469:22 | baz_ | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:469:23:469:26 | #{...} | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:469:25:469:25 | i | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:474:1:474:23 | EsotericInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:474:1:474:27 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:474:1:474:31 | call to foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:475:1:475:23 | EsotericInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:475:1:475:27 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:475:1:475:31 | call to bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:476:1:476:23 | EsotericInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:476:1:476:27 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:476:1:476:33 | call to baz_0 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:477:1:477:23 | EsotericInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:477:1:477:27 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:477:1:477:33 | call to baz_1 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:478:1:478:23 | EsotericInstanceMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:478:1:478:27 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:478:1:478:33 | call to baz_2 | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:480:1:486:3 | ExtendSingletonMethod | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:481:5:483:7 | singleton | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:482:9:482:46 | call to puts | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:482:9:482:46 | self | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:482:14:482:46 | "ExtendSingletonMethod#singleton" | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:482:15:482:45 | ExtendSingletonMethod#singleton | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:485:5:485:15 | call to extend | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:485:5:485:15 | self | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:485:12:485:15 | self | calls.rb:480:1:486:3 | ExtendSingletonMethod |
+| calls.rb:488:1:488:21 | ExtendSingletonMethod | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:488:1:488:31 | call to singleton | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:490:1:494:3 | ProtectedMethodInModule | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:491:5:493:7 | call to protected | calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:491:5:493:7 | self | calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:491:15:493:7 | foo | calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:492:9:492:42 | call to puts | calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:492:9:492:42 | self | calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:492:14:492:42 | "ProtectedMethodInModule#foo" | calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:492:15:492:41 | ProtectedMethodInModule#foo | calls.rb:490:1:494:3 | ProtectedMethodInModule |
+| calls.rb:496:1:509:3 | ProtectedMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:497:5:497:35 | call to include | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:497:5:497:35 | self | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:497:13:497:35 | ProtectedMethodInModule | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:499:5:501:7 | call to protected | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:499:5:501:7 | self | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:499:15:501:7 | bar | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:500:9:500:35 | call to puts | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:500:9:500:35 | self | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:500:14:500:35 | "ProtectedMethods#bar" | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:500:15:500:34 | ProtectedMethods#bar | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:503:5:508:7 | baz | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:504:9:504:11 | call to foo | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:504:9:504:11 | self | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:505:9:505:11 | call to bar | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:505:9:505:11 | self | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:506:9:506:24 | ProtectedMethods | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:506:9:506:28 | call to new | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:506:9:506:32 | call to foo | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:507:9:507:24 | ProtectedMethods | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:507:9:507:28 | call to new | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:507:9:507:32 | call to bar | calls.rb:496:1:509:3 | ProtectedMethods |
+| calls.rb:511:1:511:16 | ProtectedMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:511:1:511:20 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:511:1:511:24 | call to foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:512:1:512:16 | ProtectedMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:512:1:512:20 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:512:1:512:24 | call to bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:513:1:513:16 | ProtectedMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:513:1:513:20 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:513:1:513:24 | call to baz | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:515:1:520:3 | ProtectedMethodsSub | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:515:29:515:44 | ProtectedMethods | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:516:5:519:7 | baz | calls.rb:515:1:520:3 | ProtectedMethodsSub |
+| calls.rb:517:9:517:11 | call to foo | calls.rb:515:1:520:3 | ProtectedMethodsSub |
+| calls.rb:517:9:517:11 | self | calls.rb:515:1:520:3 | ProtectedMethodsSub |
+| calls.rb:518:9:518:27 | ProtectedMethodsSub | calls.rb:515:1:520:3 | ProtectedMethodsSub |
+| calls.rb:518:9:518:31 | call to new | calls.rb:515:1:520:3 | ProtectedMethodsSub |
+| calls.rb:518:9:518:35 | call to foo | calls.rb:515:1:520:3 | ProtectedMethodsSub |
+| calls.rb:522:1:522:19 | ProtectedMethodsSub | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:522:1:522:23 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:522:1:522:27 | call to foo | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:523:1:523:19 | ProtectedMethodsSub | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:523:1:523:23 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:523:1:523:27 | call to bar | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:524:1:524:19 | ProtectedMethodsSub | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:524:1:524:23 | call to new | calls.rb:1:1:524:28 | calls.rb |
+| calls.rb:524:1:524:27 | call to baz | calls.rb:1:1:524:28 | calls.rb |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:22:3 | hello.rb |
 | hello.rb:2:5:4:7 | hello | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:3:9:3:22 | return | hello.rb:1:1:8:3 | EnglishWords |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -21,6 +21,7 @@ getModule
 | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
 | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:487:1:496:3 | ProtectedMethods |
 | file://:0:0:0:0 | BasicObject |
 | file://:0:0:0:0 | Class |
 | file://:0:0:0:0 | Complex |
@@ -79,7 +80,7 @@ getADeclaration
 | calls.rb:96:1:98:3 | String | calls.rb:96:1:98:3 | String |
 | calls.rb:100:1:103:3 | Kernel | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:105:1:110:3 | Module | calls.rb:105:1:110:3 | Module |
-| calls.rb:112:1:115:3 | Object | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:112:1:115:3 | Object | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:112:1:115:3 | Object | calls.rb:112:1:115:3 | Object |
 | calls.rb:112:1:115:3 | Object | hello.rb:1:1:22:3 | hello.rb |
 | calls.rb:112:1:115:3 | Object | modules.rb:1:1:129:4 | modules.rb |
@@ -100,6 +101,7 @@ getADeclaration
 | calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
 | calls.rb:477:1:483:3 | ExtendSingletonMethod | calls.rb:477:1:483:3 | ExtendSingletonMethod |
+| calls.rb:487:1:496:3 | ProtectedMethods | calls.rb:487:1:496:3 | ProtectedMethods |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
@@ -163,6 +165,7 @@ getSuperClass
 | calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:112:1:115:3 | Object |
 | calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:112:1:115:3 | Object |
+| calls.rb:487:1:496:3 | ProtectedMethods | calls.rb:112:1:115:3 | Object |
 | file://:0:0:0:0 | Class | calls.rb:105:1:110:3 | Module |
 | file://:0:0:0:0 | Complex | file://:0:0:0:0 | Numeric |
 | file://:0:0:0:0 | FalseClass | calls.rb:112:1:115:3 | Object |
@@ -260,6 +263,9 @@ resolveConstantReadAccess
 | calls.rb:458:5:458:9 | Class | Class |
 | calls.rb:464:5:464:11 | Array | Array |
 | calls.rb:485:1:485:21 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:494:9:494:24 | ProtectedMethods | ProtectedMethods |
+| calls.rb:498:1:498:16 | ProtectedMethods | ProtectedMethods |
+| calls.rb:499:1:499:16 | ProtectedMethods | ProtectedMethods |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
 | modules.rb:48:8:48:10 | Foo | Foo |
@@ -319,6 +325,7 @@ resolveConstantWriteAccess
 | calls.rb:414:1:442:3 | ConditionalInstanceMethods | ConditionalInstanceMethods |
 | calls.rb:451:1:451:23 | EsotericInstanceMethods | EsotericInstanceMethods |
 | calls.rb:477:1:483:3 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:487:1:496:3 | ProtectedMethods | ProtectedMethods |
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |
@@ -373,32 +380,32 @@ resolveConstantWriteAccess
 | private.rb:82:1:94:3 | PrivateOverride1 | PrivateOverride1 |
 | private.rb:96:1:102:3 | PrivateOverride2 | PrivateOverride2 |
 enclosingModule
-| calls.rb:1:1:3:3 | foo | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:2:5:2:14 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:2:11:2:13 | foo | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:5:1:5:3 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:7:1:9:3 | bar | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:7:5:7:8 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:8:5:8:15 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:11:1:11:4 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:13:1:15:3 | bar | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:13:5:13:8 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:14:5:14:15 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:17:1:17:4 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:19:1:19:4 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:21:1:34:3 | M | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:1:1:3:3 | foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:5:1:5:3 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:7:1:9:3 | bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:7:5:7:8 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:8:5:8:15 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:11:1:11:4 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:13:1:15:3 | bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:13:5:13:8 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:14:5:14:15 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:17:1:17:4 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:19:1:19:4 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:21:1:34:3 | M | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:22:5:24:7 | instance_m | calls.rb:21:1:34:3 | M |
 | calls.rb:23:9:23:19 | call to singleton_m | calls.rb:21:1:34:3 | M |
 | calls.rb:23:9:23:19 | self | calls.rb:21:1:34:3 | M |
@@ -414,14 +421,14 @@ enclosingModule
 | calls.rb:32:5:32:15 | self | calls.rb:21:1:34:3 | M |
 | calls.rb:33:5:33:8 | self | calls.rb:21:1:34:3 | M |
 | calls.rb:33:5:33:20 | call to singleton_m | calls.rb:21:1:34:3 | M |
-| calls.rb:36:1:36:1 | M | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:37:1:37:1 | M | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:40:5:40:14 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:43:1:58:3 | C | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:36:1:36:1 | M | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:37:1:37:1 | M | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:40:5:40:14 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:43:1:58:3 | C | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:44:5:44:13 | call to include | calls.rb:43:1:58:3 | C |
 | calls.rb:44:5:44:13 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:44:13:44:13 | M | calls.rb:43:1:58:3 | C |
@@ -442,66 +449,66 @@ enclosingModule
 | calls.rb:55:9:55:19 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:56:9:56:12 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:56:9:56:24 | call to singleton_m | calls.rb:43:1:58:3 | C |
-| calls.rb:60:1:60:1 | c | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:60:5:60:5 | C | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:61:1:61:1 | c | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:62:1:62:1 | c | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:63:1:63:1 | c | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:65:1:69:3 | D | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:65:11:65:11 | C | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:60:1:60:1 | c | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:60:5:60:5 | C | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:61:1:61:1 | c | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:62:1:62:1 | c | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:63:1:63:1 | c | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:65:1:69:3 | D | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:65:11:65:11 | C | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:66:5:68:7 | baz | calls.rb:65:1:69:3 | D |
 | calls.rb:67:9:67:13 | call to super | calls.rb:65:1:69:3 | D |
-| calls.rb:71:1:71:1 | d | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:71:5:71:5 | D | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:72:1:72:1 | d | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:73:1:73:1 | d | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:74:1:74:1 | d | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:76:18:76:18 | a | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:76:18:76:18 | a | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:76:25:76:25 | b | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:76:25:76:25 | b | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:77:5:77:5 | a | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:78:5:78:5 | b | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:85:1:89:3 | foo | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:86:5:86:7 | var | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:87:5:87:7 | var | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:88:5:88:29 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:88:19:88:19 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:88:19:88:19 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:88:22:88:24 | var | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:88:26:88:26 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:71:1:71:1 | d | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:71:5:71:5 | D | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:72:1:72:1 | d | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:73:1:73:1 | d | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:74:1:74:1 | d | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:77:5:77:5 | a | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:78:5:78:5 | b | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:85:1:89:3 | foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:86:5:86:7 | var | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:87:5:87:7 | var | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:88:5:88:29 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:88:22:88:24 | var | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:88:26:88:26 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:92:5:92:23 | bit_length | calls.rb:91:1:94:3 | Integer |
 | calls.rb:93:5:93:16 | abs | calls.rb:91:1:94:3 | Integer |
-| calls.rb:96:1:98:3 | String | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:96:1:98:3 | String | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:97:5:97:23 | capitalize | calls.rb:96:1:98:3 | String |
-| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:101:5:101:25 | alias ... | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:101:11:101:19 | :old_puts | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:101:11:101:19 | old_puts | calls.rb:100:1:103:3 | Kernel |
@@ -513,18 +520,18 @@ enclosingModule
 | calls.rb:102:17:102:26 | call to old_puts | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:102:17:102:26 | self | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:102:26:102:26 | x | calls.rb:100:1:103:3 | Kernel |
-| calls.rb:105:1:110:3 | Module | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:105:1:110:3 | Module | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:106:5:106:24 | module_eval | calls.rb:105:1:110:3 | Module |
 | calls.rb:107:5:107:20 | include | calls.rb:105:1:110:3 | Module |
 | calls.rb:108:5:108:20 | prepend | calls.rb:105:1:110:3 | Module |
 | calls.rb:109:5:109:20 | private | calls.rb:105:1:110:3 | Module |
-| calls.rb:112:1:115:3 | Object | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:112:16:112:21 | Module | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:112:1:115:3 | Object | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:112:16:112:21 | Module | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:113:5:113:18 | call to include | calls.rb:112:1:115:3 | Object |
 | calls.rb:113:5:113:18 | self | calls.rb:112:1:115:3 | Object |
 | calls.rb:113:13:113:18 | Kernel | calls.rb:112:1:115:3 | Object |
 | calls.rb:114:5:114:16 | new | calls.rb:112:1:115:3 | Object |
-| calls.rb:117:1:120:3 | Hash | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:117:1:120:3 | Hash | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:118:5:118:25 | alias ... | calls.rb:117:1:120:3 | Hash |
 | calls.rb:118:11:118:21 | :old_lookup | calls.rb:117:1:120:3 | Hash |
 | calls.rb:118:11:118:21 | old_lookup | calls.rb:117:1:120:3 | Hash |
@@ -536,7 +543,7 @@ enclosingModule
 | calls.rb:119:15:119:27 | call to old_lookup | calls.rb:117:1:120:3 | Hash |
 | calls.rb:119:15:119:27 | self | calls.rb:117:1:120:3 | Hash |
 | calls.rb:119:26:119:26 | x | calls.rb:117:1:120:3 | Hash |
-| calls.rb:122:1:135:3 | Array | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:122:1:135:3 | Array | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:123:3:123:23 | alias ... | calls.rb:122:1:135:3 | Array |
 | calls.rb:123:9:123:19 | :old_lookup | calls.rb:122:1:135:3 | Array |
 | calls.rb:123:9:123:19 | old_lookup | calls.rb:122:1:135:3 | Array |
@@ -572,130 +579,130 @@ enclosingModule
 | calls.rb:132:9:132:14 | ... = ... | calls.rb:122:1:135:3 | Array |
 | calls.rb:132:11:132:12 | ... + ... | calls.rb:122:1:135:3 | Array |
 | calls.rb:132:14:132:14 | 1 | calls.rb:122:1:135:3 | Array |
-| calls.rb:137:1:139:3 | funny | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:138:5:138:20 | yield ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:138:11:138:20 | "prefix: " | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:138:12:138:19 | prefix:  | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:1:141:30 | call to funny | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:1:141:30 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:7:141:30 | { ... } | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:10:141:10 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:10:141:10 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:13:141:29 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:13:141:29 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:18:141:18 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:141:18:141:29 | call to capitalize | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:143:1:143:3 | "a" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:143:1:143:14 | call to capitalize | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:143:2:143:2 | a | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:144:1:144:1 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:144:1:144:12 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:145:1:145:1 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:145:1:145:5 | call to abs | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:1:147:13 | Array | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:1:147:13 | [...] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:1:147:13 | call to [] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:1:147:62 | call to foreach | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:2:147:4 | "a" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:3:147:3 | a | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:6:147:8 | "b" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:7:147:7 | b | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:10:147:12 | "c" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:11:147:11 | c | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:23:147:62 | { ... } | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:26:147:26 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:26:147:26 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:29:147:29 | v | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:29:147:29 | v | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:32:147:61 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:32:147:61 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:37:147:61 | "#{...} -> #{...}" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:38:147:41 | #{...} | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:40:147:40 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:42:147:45 |  ->  | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:46:147:60 | #{...} | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:48:147:48 | v | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:147:48:147:59 | call to capitalize | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:1:149:7 | Array | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:1:149:7 | [...] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:1:149:7 | call to [] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:1:149:35 | call to foreach | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:2:149:2 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:4:149:4 | 2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:6:149:6 | 3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:17:149:35 | { ... } | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:20:149:20 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:20:149:20 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:23:149:23 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:149:23:149:34 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:1:151:7 | Array | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:1:151:7 | [...] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:1:151:7 | call to [] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:1:151:40 | call to foreach | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:2:151:2 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:4:151:4 | 2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:6:151:6 | 3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:17:151:40 | { ... } | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:20:151:20 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:20:151:20 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:23:151:39 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:23:151:39 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:28:151:28 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:151:28:151:39 | call to capitalize | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:1:153:8 | Array | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:1:153:8 | [...] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:1:153:8 | call to [] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:1:153:37 | call to foreach | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:2:153:2 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:4:153:5 | - ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:5:153:5 | 2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:7:153:7 | 3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:18:153:37 | { ... } | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:21:153:21 | _ | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:21:153:21 | _ | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:24:153:24 | v | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:24:153:24 | v | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:27:153:36 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:27:153:36 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:32:153:32 | v | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:153:32:153:36 | call to abs | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:155:1:157:3 | indirect | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:155:14:155:15 | &b | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:155:15:155:15 | b | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:156:5:156:17 | call to call_block | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:156:5:156:17 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:156:16:156:17 | &... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:156:17:156:17 | b | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:159:1:159:28 | call to indirect | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:159:1:159:28 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:159:10:159:28 | { ... } | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:159:13:159:13 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:159:13:159:13 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:159:16:159:16 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:159:16:159:27 | call to bit_length | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:162:1:166:3 | S | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:137:1:139:3 | funny | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:138:5:138:20 | yield ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:138:11:138:20 | "prefix: " | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:138:12:138:19 | prefix:  | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:1:141:30 | call to funny | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:1:141:30 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:7:141:30 | { ... } | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:10:141:10 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:10:141:10 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:13:141:29 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:13:141:29 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:18:141:18 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:141:18:141:29 | call to capitalize | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:143:1:143:3 | "a" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:143:1:143:14 | call to capitalize | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:143:2:143:2 | a | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:144:1:144:1 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:144:1:144:12 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:145:1:145:1 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:145:1:145:5 | call to abs | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:1:147:13 | Array | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:1:147:13 | [...] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:1:147:13 | call to [] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:1:147:62 | call to foreach | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:2:147:4 | "a" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:3:147:3 | a | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:6:147:8 | "b" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:7:147:7 | b | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:10:147:12 | "c" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:11:147:11 | c | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:23:147:62 | { ... } | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:26:147:26 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:26:147:26 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:29:147:29 | v | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:29:147:29 | v | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:32:147:61 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:32:147:61 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:37:147:61 | "#{...} -> #{...}" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:38:147:41 | #{...} | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:40:147:40 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:42:147:45 |  ->  | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:46:147:60 | #{...} | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:48:147:48 | v | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:147:48:147:59 | call to capitalize | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:1:149:7 | Array | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:1:149:7 | [...] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:1:149:7 | call to [] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:1:149:35 | call to foreach | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:2:149:2 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:4:149:4 | 2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:6:149:6 | 3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:17:149:35 | { ... } | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:20:149:20 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:20:149:20 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:23:149:23 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:149:23:149:34 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:1:151:7 | Array | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:1:151:7 | [...] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:1:151:7 | call to [] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:1:151:40 | call to foreach | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:2:151:2 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:4:151:4 | 2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:6:151:6 | 3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:17:151:40 | { ... } | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:20:151:20 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:20:151:20 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:23:151:39 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:23:151:39 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:28:151:28 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:151:28:151:39 | call to capitalize | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:1:153:8 | Array | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:1:153:8 | [...] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:1:153:8 | call to [] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:1:153:37 | call to foreach | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:2:153:2 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:4:153:5 | - ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:5:153:5 | 2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:7:153:7 | 3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:18:153:37 | { ... } | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:21:153:21 | _ | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:21:153:21 | _ | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:24:153:24 | v | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:24:153:24 | v | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:27:153:36 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:27:153:36 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:32:153:32 | v | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:153:32:153:36 | call to abs | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:155:1:157:3 | indirect | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:155:14:155:15 | &b | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:155:15:155:15 | b | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:156:5:156:17 | call to call_block | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:156:5:156:17 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:156:16:156:17 | &... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:156:17:156:17 | b | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:159:1:159:28 | call to indirect | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:159:1:159:28 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:159:10:159:28 | { ... } | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:159:13:159:13 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:159:13:159:13 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:159:16:159:16 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:159:16:159:27 | call to bit_length | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:162:1:166:3 | S | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:163:5:165:7 | s_method | calls.rb:162:1:166:3 | S |
 | calls.rb:164:9:164:12 | self | calls.rb:162:1:166:3 | S |
 | calls.rb:164:9:164:17 | call to to_s | calls.rb:162:1:166:3 | S |
-| calls.rb:168:1:171:3 | A | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:168:11:168:11 | S | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:168:1:171:3 | A | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:168:11:168:11 | S | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:169:5:170:7 | to_s | calls.rb:168:1:171:3 | A |
-| calls.rb:173:1:176:3 | B | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:173:11:173:11 | S | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:173:1:176:3 | B | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:173:11:173:11 | S | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:174:5:175:7 | to_s | calls.rb:173:1:176:3 | B |
-| calls.rb:178:1:178:1 | S | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:178:1:178:5 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:178:1:178:14 | call to s_method | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:179:1:179:1 | A | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:179:1:179:5 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:179:1:179:14 | call to s_method | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:180:1:180:1 | B | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:180:1:180:5 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:180:1:180:14 | call to s_method | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:182:1:183:3 | private_on_main | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:185:1:185:15 | call to private_on_main | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:185:1:185:15 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:187:1:223:3 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:178:1:178:1 | S | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:178:1:178:5 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:178:1:178:14 | call to s_method | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:179:1:179:1 | A | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:179:1:179:5 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:179:1:179:14 | call to s_method | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:180:1:180:1 | B | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:180:1:180:5 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:180:1:180:14 | call to s_method | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:182:1:183:3 | private_on_main | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:185:1:185:15 | call to private_on_main | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:185:1:185:15 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:187:1:223:3 | Singletons | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:188:5:191:7 | singleton_a | calls.rb:187:1:223:3 | Singletons |
 | calls.rb:188:9:188:12 | self | calls.rb:187:1:223:3 | Singletons |
 | calls.rb:189:9:189:26 | call to puts | calls.rb:187:1:223:3 | Singletons |
@@ -745,126 +752,126 @@ enclosingModule
 | calls.rb:220:5:222:7 | call_singleton_g | calls.rb:187:1:223:3 | Singletons |
 | calls.rb:221:9:221:12 | self | calls.rb:187:1:223:3 | Singletons |
 | calls.rb:221:9:221:24 | call to singleton_g | calls.rb:187:1:223:3 | Singletons |
-| calls.rb:225:1:225:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:225:1:225:22 | call to singleton_a | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:226:1:226:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:226:1:226:22 | call to singleton_f | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:228:1:228:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:228:1:228:19 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:228:6:228:15 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:228:6:228:19 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:230:1:230:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:230:1:230:11 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:231:1:231:14 | call to singleton_e | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:233:1:235:3 | singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:233:5:233:6 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:234:5:234:24 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:234:5:234:24 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:234:10:234:24 | "singleton_g_1" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:234:11:234:23 | singleton_g_1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:237:1:237:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:237:1:237:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:238:1:238:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:238:1:238:19 | call to call_singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:240:1:242:3 | singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:240:5:240:6 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:241:5:241:24 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:241:5:241:24 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:241:10:241:24 | "singleton_g_2" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:241:11:241:23 | singleton_g_2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:244:1:244:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:244:1:244:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:245:1:245:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:245:1:245:19 | call to call_singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:247:1:251:3 | class << ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:247:10:247:11 | c1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:225:1:225:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:225:1:225:22 | call to singleton_a | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:226:1:226:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:226:1:226:22 | call to singleton_f | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:228:1:228:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:228:1:228:19 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:228:6:228:15 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:228:6:228:19 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:230:1:230:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:230:1:230:11 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:231:1:231:14 | call to singleton_e | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:233:1:235:3 | singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:233:5:233:6 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:234:5:234:24 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:234:5:234:24 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:234:10:234:24 | "singleton_g_1" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:234:11:234:23 | singleton_g_1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:237:1:237:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:237:1:237:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:238:1:238:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:238:1:238:19 | call to call_singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:240:1:242:3 | singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:240:5:240:6 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:241:5:241:24 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:241:5:241:24 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:241:10:241:24 | "singleton_g_2" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:241:11:241:23 | singleton_g_2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:244:1:244:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:244:1:244:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:245:1:245:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:245:1:245:19 | call to call_singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:247:1:251:3 | class << ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:247:10:247:11 | c1 | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:248:5:250:7 | singleton_g | calls.rb:247:1:251:3 | class << ... |
 | calls.rb:249:9:249:28 | call to puts | calls.rb:247:1:251:3 | class << ... |
 | calls.rb:249:9:249:28 | self | calls.rb:247:1:251:3 | class << ... |
 | calls.rb:249:14:249:28 | "singleton_g_3" | calls.rb:247:1:251:3 | class << ... |
 | calls.rb:249:15:249:27 | singleton_g_3 | calls.rb:247:1:251:3 | class << ... |
-| calls.rb:253:1:253:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:253:1:253:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:254:1:254:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:254:1:254:19 | call to call_singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:256:1:256:2 | c2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:256:1:256:19 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:256:6:256:15 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:256:6:256:19 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:257:1:257:2 | c2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:257:1:257:14 | call to singleton_e | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:258:1:258:2 | c2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:258:1:258:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:260:1:260:4 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:260:1:260:8 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:262:1:262:16 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:262:1:262:16 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:262:6:262:16 | "top-level" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:262:7:262:15 | top-level | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:264:1:266:3 | singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:264:5:264:14 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:265:5:265:22 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:265:5:265:22 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:265:10:265:22 | "singleton_g" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:265:11:265:21 | singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:268:1:268:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:268:1:268:22 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:269:1:269:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:270:1:270:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:270:1:270:19 | call to call_singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:271:1:271:2 | c2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:271:1:271:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:272:1:272:2 | c3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:272:1:272:19 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:272:6:272:15 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:272:6:272:19 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:273:1:273:2 | c3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:273:1:273:14 | call to singleton_g | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:275:1:283:3 | create | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:275:12:275:15 | type | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:275:12:275:15 | type | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:276:5:276:8 | type | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:276:5:276:12 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:276:5:276:21 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:278:5:280:7 | singleton_h | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:278:9:278:12 | type | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:279:9:279:26 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:279:9:279:26 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:279:14:279:26 | "singleton_h" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:279:15:279:25 | singleton_h | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:282:5:282:8 | type | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:285:1:285:17 | call to create | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:285:1:285:17 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:285:8:285:17 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:286:1:286:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:286:1:286:22 | call to singleton_h | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:288:1:288:1 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:288:1:288:14 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:288:5:288:14 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:290:1:294:3 | class << ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:290:10:290:10 | x | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:253:1:253:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:253:1:253:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:254:1:254:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:254:1:254:19 | call to call_singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:256:1:256:2 | c2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:256:1:256:19 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:256:6:256:15 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:256:6:256:19 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:257:1:257:2 | c2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:257:1:257:14 | call to singleton_e | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:258:1:258:2 | c2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:258:1:258:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:260:1:260:4 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:260:1:260:8 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:262:1:262:16 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:262:1:262:16 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:262:6:262:16 | "top-level" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:262:7:262:15 | top-level | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:264:1:266:3 | singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:264:5:264:14 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:265:5:265:22 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:265:5:265:22 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:265:10:265:22 | "singleton_g" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:265:11:265:21 | singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:268:1:268:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:268:1:268:22 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:269:1:269:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:269:1:269:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:270:1:270:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:270:1:270:19 | call to call_singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:271:1:271:2 | c2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:271:1:271:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:272:1:272:2 | c3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:272:1:272:19 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:272:6:272:15 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:272:6:272:19 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:273:1:273:2 | c3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:273:1:273:14 | call to singleton_g | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:275:1:283:3 | create | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:275:12:275:15 | type | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:275:12:275:15 | type | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:276:5:276:8 | type | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:276:5:276:12 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:276:5:276:21 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:278:5:280:7 | singleton_h | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:278:9:278:12 | type | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:279:9:279:26 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:279:9:279:26 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:279:14:279:26 | "singleton_h" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:279:15:279:25 | singleton_h | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:282:5:282:8 | type | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:282:5:282:20 | call to singleton_h | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:285:1:285:17 | call to create | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:285:1:285:17 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:285:8:285:17 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:286:1:286:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:286:1:286:22 | call to singleton_h | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:288:1:288:1 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:288:1:288:14 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:288:5:288:14 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:290:1:294:3 | class << ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:290:10:290:10 | x | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:291:5:293:7 | singleton_i | calls.rb:290:1:294:3 | class << ... |
 | calls.rb:292:9:292:26 | call to puts | calls.rb:290:1:294:3 | class << ... |
 | calls.rb:292:9:292:26 | self | calls.rb:290:1:294:3 | class << ... |
 | calls.rb:292:14:292:26 | "singleton_i" | calls.rb:290:1:294:3 | class << ... |
 | calls.rb:292:15:292:25 | singleton_i | calls.rb:290:1:294:3 | class << ... |
-| calls.rb:296:1:296:1 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:296:1:296:13 | call to singleton_i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:297:1:297:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:297:1:297:22 | call to singleton_i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:299:1:303:3 | class << ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:299:10:299:19 | Singletons | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:296:1:296:1 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:296:1:296:13 | call to singleton_i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:297:1:297:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:297:1:297:22 | call to singleton_i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:299:1:303:3 | class << ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:299:10:299:19 | Singletons | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:300:5:302:7 | singleton_j | calls.rb:299:1:303:3 | class << ... |
 | calls.rb:301:9:301:26 | call to puts | calls.rb:299:1:303:3 | class << ... |
 | calls.rb:301:9:301:26 | self | calls.rb:299:1:303:3 | class << ... |
 | calls.rb:301:14:301:26 | "singleton_j" | calls.rb:299:1:303:3 | class << ... |
 | calls.rb:301:15:301:25 | singleton_j | calls.rb:299:1:303:3 | class << ... |
-| calls.rb:305:1:305:10 | Singletons | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:305:1:305:22 | call to singleton_j | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:307:1:318:3 | SelfNew | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:305:1:305:10 | Singletons | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:305:1:305:22 | call to singleton_j | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:307:1:318:3 | SelfNew | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:308:5:311:7 | instance | calls.rb:307:1:318:3 | SelfNew |
 | calls.rb:309:9:309:31 | call to puts | calls.rb:307:1:318:3 | SelfNew |
 | calls.rb:309:9:309:31 | self | calls.rb:307:1:318:3 | SelfNew |
@@ -881,110 +888,110 @@ enclosingModule
 | calls.rb:317:5:317:7 | call to new | calls.rb:307:1:318:3 | SelfNew |
 | calls.rb:317:5:317:7 | self | calls.rb:307:1:318:3 | SelfNew |
 | calls.rb:317:5:317:16 | call to instance | calls.rb:307:1:318:3 | SelfNew |
-| calls.rb:320:1:320:7 | SelfNew | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:320:1:320:17 | call to singleton | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:322:1:326:3 | C1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:320:1:320:7 | SelfNew | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:320:1:320:17 | call to singleton | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:322:1:326:3 | C1 | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:323:5:325:7 | instance | calls.rb:322:1:326:3 | C1 |
 | calls.rb:324:9:324:26 | call to puts | calls.rb:322:1:326:3 | C1 |
 | calls.rb:324:9:324:26 | self | calls.rb:322:1:326:3 | C1 |
 | calls.rb:324:14:324:26 | "C1#instance" | calls.rb:322:1:326:3 | C1 |
 | calls.rb:324:15:324:25 | C1#instance | calls.rb:322:1:326:3 | C1 |
-| calls.rb:328:1:332:3 | C2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:328:12:328:13 | C1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:328:1:332:3 | C2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:328:12:328:13 | C1 | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:329:5:331:7 | instance | calls.rb:328:1:332:3 | C2 |
 | calls.rb:330:9:330:26 | call to puts | calls.rb:328:1:332:3 | C2 |
 | calls.rb:330:9:330:26 | self | calls.rb:328:1:332:3 | C2 |
 | calls.rb:330:14:330:26 | "C2#instance" | calls.rb:328:1:332:3 | C2 |
 | calls.rb:330:15:330:25 | C2#instance | calls.rb:328:1:332:3 | C2 |
-| calls.rb:334:1:338:3 | C3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:334:12:334:13 | C2 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:334:1:338:3 | C3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:334:12:334:13 | C2 | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:335:5:337:7 | instance | calls.rb:334:1:338:3 | C3 |
 | calls.rb:336:9:336:26 | call to puts | calls.rb:334:1:338:3 | C3 |
 | calls.rb:336:9:336:26 | self | calls.rb:334:1:338:3 | C3 |
 | calls.rb:336:14:336:26 | "C3#instance" | calls.rb:334:1:338:3 | C3 |
 | calls.rb:336:15:336:25 | C3#instance | calls.rb:334:1:338:3 | C3 |
-| calls.rb:340:1:356:3 | pattern_dispatch | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:340:22:340:22 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:340:22:340:22 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:341:5:349:7 | case ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:341:10:341:10 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:342:5:343:18 | when ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:342:10:342:11 | C3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:342:12:343:18 | then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:343:9:343:9 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:343:9:343:18 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:344:5:345:18 | when ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:344:10:344:11 | C2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:344:12:345:18 | then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:345:9:345:9 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:345:9:345:18 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:346:5:347:18 | when ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:346:10:346:11 | C1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:346:12:347:18 | then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:347:9:347:9 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:347:9:347:18 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:348:5:348:8 | else ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:351:5:355:7 | case ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:351:10:351:10 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:352:9:352:29 | in ... then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:352:12:352:13 | C3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:352:15:352:29 | then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:352:20:352:20 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:352:20:352:29 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:353:9:353:36 | in ... then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:353:12:353:13 | C2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:353:12:353:19 | ... => ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:353:18:353:19 | c2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:353:21:353:36 | then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:353:26:353:27 | c2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:353:26:353:36 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:354:9:354:36 | in ... then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:354:12:354:13 | C1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:354:12:354:19 | ... => ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:354:18:354:19 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:354:21:354:36 | then ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:354:26:354:27 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:354:26:354:36 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:358:1:358:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:358:1:358:11 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:358:6:358:7 | C1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:358:6:358:11 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:359:1:359:2 | c1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:359:1:359:11 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:360:1:360:25 | call to pattern_dispatch | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:360:1:360:25 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:360:18:360:25 | ( ... ) | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:360:19:360:20 | C1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:360:19:360:24 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:361:1:361:25 | call to pattern_dispatch | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:361:1:361:25 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:361:18:361:25 | ( ... ) | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:361:19:361:20 | C2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:361:19:361:24 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:362:1:362:25 | call to pattern_dispatch | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:362:1:362:25 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:362:18:362:25 | ( ... ) | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:362:19:362:20 | C3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:362:19:362:24 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:364:1:368:3 | add_singleton | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:364:19:364:19 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:364:19:364:19 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:365:5:367:7 | instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:365:9:365:9 | x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:366:9:366:28 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:366:9:366:28 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:366:14:366:28 | "instance_on x" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:366:15:366:27 | instance_on x | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:370:1:370:2 | c3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:370:1:370:11 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:370:6:370:7 | C1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:370:6:370:11 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:371:1:371:16 | call to add_singleton | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:371:1:371:16 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:371:15:371:16 | c3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:372:1:372:2 | c3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:372:1:372:11 | call to instance | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:340:1:356:3 | pattern_dispatch | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:340:22:340:22 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:340:22:340:22 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:341:5:349:7 | case ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:341:10:341:10 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:342:5:343:18 | when ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:342:10:342:11 | C3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:342:12:343:18 | then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:343:9:343:9 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:343:9:343:18 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:344:5:345:18 | when ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:344:10:344:11 | C2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:344:12:345:18 | then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:345:9:345:9 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:345:9:345:18 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:346:5:347:18 | when ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:346:10:346:11 | C1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:346:12:347:18 | then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:347:9:347:9 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:347:9:347:18 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:348:5:348:8 | else ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:351:5:355:7 | case ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:351:10:351:10 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:352:9:352:29 | in ... then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:352:12:352:13 | C3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:352:15:352:29 | then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:352:20:352:20 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:352:20:352:29 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:353:9:353:36 | in ... then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:353:12:353:13 | C2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:353:12:353:19 | ... => ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:353:18:353:19 | c2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:353:21:353:36 | then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:353:26:353:27 | c2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:353:26:353:36 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:354:9:354:36 | in ... then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:354:12:354:13 | C1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:354:12:354:19 | ... => ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:354:18:354:19 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:354:21:354:36 | then ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:354:26:354:27 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:354:26:354:36 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:358:1:358:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:358:1:358:11 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:358:6:358:7 | C1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:358:6:358:11 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:359:1:359:2 | c1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:359:1:359:11 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:360:1:360:25 | call to pattern_dispatch | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:360:1:360:25 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:360:18:360:25 | ( ... ) | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:360:19:360:20 | C1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:360:19:360:24 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:361:1:361:25 | call to pattern_dispatch | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:361:1:361:25 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:361:18:361:25 | ( ... ) | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:361:19:361:20 | C2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:361:19:361:24 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:362:1:362:25 | call to pattern_dispatch | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:362:1:362:25 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:362:18:362:25 | ( ... ) | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:362:19:362:20 | C3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:362:19:362:24 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:364:1:368:3 | add_singleton | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:364:19:364:19 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:364:19:364:19 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:365:5:367:7 | instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:365:9:365:9 | x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:366:9:366:28 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:366:9:366:28 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:366:14:366:28 | "instance_on x" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:366:15:366:27 | instance_on x | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:370:1:370:2 | c3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:370:1:370:11 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:370:6:370:7 | C1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:370:6:370:11 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:371:1:371:16 | call to add_singleton | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:371:1:371:16 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:371:15:371:16 | c3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:372:1:372:2 | c3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:372:1:372:11 | call to instance | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:374:1:394:3 | SingletonOverride1 | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:375:5:383:7 | class << ... | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:375:14:375:17 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:376:9:378:11 | singleton1 | calls.rb:375:5:383:7 | class << ... |
@@ -1007,12 +1014,12 @@ enclosingModule
 | calls.rb:390:9:390:18 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:393:5:393:14 | call to singleton2 | calls.rb:374:1:394:3 | SingletonOverride1 |
 | calls.rb:393:5:393:14 | self | calls.rb:374:1:394:3 | SingletonOverride1 |
-| calls.rb:396:1:396:18 | SingletonOverride1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:397:1:397:18 | SingletonOverride1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:399:28:399:45 | SingletonOverride1 | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:396:1:396:18 | SingletonOverride1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:396:1:396:34 | call to call_singleton1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:397:1:397:18 | SingletonOverride1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:397:1:397:34 | call to call_singleton2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:399:1:409:3 | SingletonOverride2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:399:28:399:45 | SingletonOverride1 | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:400:5:404:7 | class << ... | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:400:14:400:17 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:401:9:403:11 | singleton1 | calls.rb:400:5:404:7 | class << ... |
@@ -1026,11 +1033,11 @@ enclosingModule
 | calls.rb:407:9:407:44 | self | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:407:14:407:44 | "SingletonOverride2#singleton2" | calls.rb:399:1:409:3 | SingletonOverride2 |
 | calls.rb:407:15:407:43 | SingletonOverride2#singleton2 | calls.rb:399:1:409:3 | SingletonOverride2 |
-| calls.rb:411:1:411:18 | SingletonOverride2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:411:1:411:34 | call to call_singleton1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:412:1:412:18 | SingletonOverride2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:412:1:412:34 | call to call_singleton2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:411:1:411:18 | SingletonOverride2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:411:1:411:34 | call to call_singleton1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:412:1:412:18 | SingletonOverride2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:412:1:412:34 | call to call_singleton2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:414:1:442:3 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:415:5:419:7 | if ... | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
 | calls.rb:415:8:415:13 | call to rand | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
 | calls.rb:415:8:415:13 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
@@ -1075,93 +1082,91 @@ enclosingModule
 | calls.rb:438:17:438:40 | self | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
 | calls.rb:438:22:438:40 | "AnonymousClass#m5" | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
 | calls.rb:438:23:438:39 | AnonymousClass#m5 | calls.rb:414:1:442:3 | ConditionalInstanceMethods |
-| calls.rb:444:1:444:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:444:1:444:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:444:1:444:33 | call to m1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:445:1:445:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:445:1:445:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:445:1:445:33 | call to m3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:446:1:446:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:446:1:446:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:446:1:446:33 | call to m2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:447:1:447:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:447:1:447:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:447:1:447:33 | call to m3 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:448:1:448:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:448:1:448:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:448:1:448:33 | call to m4 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:449:1:449:26 | ConditionalInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:449:1:449:30 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:449:1:449:33 | call to m5 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:450:1:450:4 | call to exit | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:450:1:450:4 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:451:1:451:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:451:1:469:3 | ... = ... | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:451:27:451:31 | Class | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:451:27:469:3 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:451:37:469:3 | do ... end | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:452:5:452:11 | Array | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:452:5:452:11 | [...] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:452:5:452:11 | call to [] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:452:5:456:7 | call to each | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:452:6:452:6 | 0 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:452:8:452:8 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:452:10:452:10 | 2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:452:18:456:7 | do ... end | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:453:9:455:11 | foo | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:454:13:454:22 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:454:13:454:22 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:454:18:454:22 | "foo" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:454:19:454:21 | foo | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:458:5:458:9 | Class | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:458:5:462:7 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:458:5:462:11 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:458:5:462:15 | call to bar | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:458:15:462:7 | do ... end | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:459:9:461:11 | bar | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:460:13:460:22 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:460:13:460:22 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:460:18:460:22 | "bar" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:460:19:460:21 | bar | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:5:464:11 | Array | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:5:464:11 | [...] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:5:464:11 | call to [] | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:5:468:7 | call to each | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:6:464:6 | 0 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:8:464:8 | 1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:10:464:10 | 2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:18:468:7 | do ... end | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:22:464:22 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:464:22:464:22 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:465:9:467:11 | call to define_method | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:465:9:467:11 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:465:23:465:32 | "baz_#{...}" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:465:24:465:27 | baz_ | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:465:28:465:31 | #{...} | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:465:30:465:30 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:465:35:467:11 | do ... end | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:466:13:466:27 | call to puts | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:466:13:466:27 | self | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:466:18:466:27 | "baz_#{...}" | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:466:19:466:22 | baz_ | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:466:23:466:26 | #{...} | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:466:25:466:25 | i | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:471:1:471:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:471:1:471:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:471:1:471:31 | call to foo | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:472:1:472:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:472:1:472:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:472:1:472:31 | call to bar | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:473:1:473:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:473:1:473:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:473:1:473:33 | call to baz_0 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:474:1:474:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:474:1:474:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:474:1:474:33 | call to baz_1 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:475:1:475:23 | EsotericInstanceMethods | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:475:1:475:27 | call to new | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:475:1:475:33 | call to baz_2 | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:477:1:483:3 | ExtendSingletonMethod | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:444:1:444:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:444:1:444:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:444:1:444:33 | call to m1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:445:1:445:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:445:1:445:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:445:1:445:33 | call to m3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:446:1:446:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:446:1:446:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:446:1:446:33 | call to m2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:447:1:447:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:447:1:447:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:447:1:447:33 | call to m3 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:448:1:448:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:448:1:448:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:448:1:448:33 | call to m4 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:449:1:449:26 | ConditionalInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:449:1:449:30 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:449:1:449:33 | call to m5 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:451:1:451:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:451:1:469:3 | ... = ... | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:451:27:451:31 | Class | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:451:27:469:3 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:451:37:469:3 | do ... end | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:452:5:452:11 | Array | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:452:5:452:11 | [...] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:452:5:452:11 | call to [] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:452:5:456:7 | call to each | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:452:6:452:6 | 0 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:452:8:452:8 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:452:10:452:10 | 2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:452:18:456:7 | do ... end | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:453:9:455:11 | foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:454:13:454:22 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:454:13:454:22 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:454:18:454:22 | "foo" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:454:19:454:21 | foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:458:5:458:9 | Class | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:458:5:462:7 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:458:5:462:11 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:458:5:462:15 | call to bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:458:15:462:7 | do ... end | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:459:9:461:11 | bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:460:13:460:22 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:460:13:460:22 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:460:18:460:22 | "bar" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:460:19:460:21 | bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:5:464:11 | Array | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:5:464:11 | [...] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:5:464:11 | call to [] | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:5:468:7 | call to each | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:6:464:6 | 0 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:8:464:8 | 1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:10:464:10 | 2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:18:468:7 | do ... end | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:22:464:22 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:464:22:464:22 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:465:9:467:11 | call to define_method | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:465:9:467:11 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:465:23:465:32 | "baz_#{...}" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:465:24:465:27 | baz_ | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:465:28:465:31 | #{...} | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:465:30:465:30 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:465:35:467:11 | do ... end | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:466:13:466:27 | call to puts | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:466:13:466:27 | self | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:466:18:466:27 | "baz_#{...}" | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:466:19:466:22 | baz_ | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:466:23:466:26 | #{...} | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:466:25:466:25 | i | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:471:1:471:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:471:1:471:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:471:1:471:31 | call to foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:472:1:472:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:472:1:472:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:472:1:472:31 | call to bar | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:473:1:473:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:473:1:473:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:473:1:473:33 | call to baz_0 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:474:1:474:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:474:1:474:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:474:1:474:33 | call to baz_1 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:475:1:475:23 | EsotericInstanceMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:475:1:475:27 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:475:1:475:33 | call to baz_2 | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:477:1:483:3 | ExtendSingletonMethod | calls.rb:1:1:499:25 | calls.rb |
 | calls.rb:478:5:480:7 | singleton | calls.rb:477:1:483:3 | ExtendSingletonMethod |
 | calls.rb:479:9:479:46 | call to puts | calls.rb:477:1:483:3 | ExtendSingletonMethod |
 | calls.rb:479:9:479:46 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
@@ -1170,8 +1175,28 @@ enclosingModule
 | calls.rb:482:5:482:15 | call to extend | calls.rb:477:1:483:3 | ExtendSingletonMethod |
 | calls.rb:482:5:482:15 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
 | calls.rb:482:12:482:15 | self | calls.rb:477:1:483:3 | ExtendSingletonMethod |
-| calls.rb:485:1:485:21 | ExtendSingletonMethod | calls.rb:1:1:485:62 | calls.rb |
-| calls.rb:485:1:485:31 | call to singleton | calls.rb:1:1:485:62 | calls.rb |
+| calls.rb:485:1:485:21 | ExtendSingletonMethod | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:485:1:485:31 | call to singleton | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:487:1:496:3 | ProtectedMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:488:5:490:7 | call to protected | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:488:5:490:7 | self | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:488:15:490:7 | foo | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:489:9:489:35 | call to puts | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:489:9:489:35 | self | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:489:14:489:35 | "ProtectedMethods#foo" | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:489:15:489:34 | ProtectedMethods#foo | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:492:5:495:7 | bar | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:493:9:493:11 | call to foo | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:493:9:493:11 | self | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:494:9:494:24 | ProtectedMethods | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:494:9:494:28 | call to new | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:494:9:494:32 | call to foo | calls.rb:487:1:496:3 | ProtectedMethods |
+| calls.rb:498:1:498:16 | ProtectedMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:498:1:498:20 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:498:1:498:24 | call to foo | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:499:1:499:16 | ProtectedMethods | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:499:1:499:20 | call to new | calls.rb:1:1:499:25 | calls.rb |
+| calls.rb:499:1:499:24 | call to bar | calls.rb:1:1:499:25 | calls.rb |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:22:3 | hello.rb |
 | hello.rb:2:5:4:7 | hello | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:3:9:3:22 | return | hello.rb:1:1:8:3 | EnglishWords |

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -48,53 +48,58 @@ calls.rb:
 #  105| Module
 #-----|  -> Object
 
-#  112| Object
+#  115| Object
 #-----|  -> BasicObject
 
-#  117| Hash
+#  120| Hash
 #-----|  -> Object
 
-#  122| Array
+#  125| Array
 #-----|  -> Object
 
-#  162| S
+#  165| S
 #-----|  -> Object
 
-#  168| A
+#  171| A
 #-----|  -> B
 #-----|  -> S
 
-#  173| B
+#  176| B
 #-----|  -> S
 
-#  187| Singletons
+#  190| Singletons
 #-----|  -> Object
 
-#  307| SelfNew
+#  310| SelfNew
 #-----|  -> Object
 
-#  322| C1
+#  325| C1
 #-----|  -> Object
 
-#  328| C2
+#  331| C2
 #-----|  -> C1
 
-#  334| C3
+#  337| C3
 #-----|  -> C2
 
-#  374| SingletonOverride1
+#  377| SingletonOverride1
 #-----|  -> Object
 
-#  399| SingletonOverride2
+#  402| SingletonOverride2
 #-----|  -> SingletonOverride1
 
-#  414| ConditionalInstanceMethods
+#  417| ConditionalInstanceMethods
 #-----|  -> Object
 
-#  477| ExtendSingletonMethod
+#  480| ExtendSingletonMethod
 
-#  487| ProtectedMethods
+#  490| ProtectedMethodInModule
+
+#  496| ProtectedMethods
 #-----|  -> Object
+
+#  515| ProtectedMethodsSub
+#-----|  -> ProtectedMethods
 
 hello.rb:
 #    1| EnglishWords

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -93,6 +93,9 @@ calls.rb:
 
 #  477| ExtendSingletonMethod
 
+#  487| ProtectedMethods
+#-----|  -> Object
+
 hello.rb:
 #    1| EnglishWords
 


### PR DESCRIPTION
https://github.com/github/codeql/pull/10002 follow-up.