### PR TITLE
Ruby: Fix bad join-order

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -848,9 +848,10 @@ private predicate mayBenefitFromCallContext1(
   Module tp, boolean exact, string name
 ) {
   exists(ArgumentNode arg |
-    mayBenefitFromCallContext0(ctx, arg, call, encl, name) and
+    mayBenefitFromCallContext0(ctx, pragma[only_bind_into](arg), call, encl,
+      pragma[only_bind_into](name)) and
     // `arg` has a relevant instance type
-    isInstanceLocalMustFlow(arg, pragma[only_bind_out](tp), exact) and
+    isInstanceLocalMustFlow(arg, tp, exact) and
     exists(lookupMethod(tp, pragma[only_bind_into](name)))
   )
 }


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate DataFlowDispatch#36b84300::mayBenefitFromCallContext1#6#ffffff@ba617c9q with tuple counts:
          1066626  ~2%    {3} r1 = SCAN project#Module#fe82a56b::Cached::lookupMethod#2 OUTPUT In.0, In.0, In.1
        931393128  ~0%    {4} r2 = JOIN r1 WITH DataFlowDispatch#36b84300::isInstanceLocalMustFlow#3#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1, Rhs.2
           298573  ~0%    {6} r3 = JOIN r2 WITH DataFlowDispatch#36b84300::mayBenefitFromCallContext0#5#fffff_14023#join_rhs ON FIRST 2 OUTPUT Rhs.2, Rhs.3, Rhs.4, Lhs.2, Lhs.3, Lhs.1
                          return r3
```

After
```
Evaluated relational algebra for predicate DataFlowDispatch#36b84300::mayBenefitFromCallContext1#6#ffffff@f68de4dn with tuple counts:
        583298  ~1%    {5} r1 = SCAN DataFlowDispatch#36b84300::mayBenefitFromCallContext0#5#fffff OUTPUT In.1, In.0, In.2, In.3, In.4
        583298  ~1%    {5} r2 = JOIN r1 WITH DataFlowPrivate#462ff392::ArgumentNode#class#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4
        442278  ~0%    {6} r3 = JOIN r2 WITH DataFlowDispatch#36b84300::isInstanceLocalMustFlow#3#fff ON FIRST 1 OUTPUT Rhs.1, Lhs.4, Lhs.1, Lhs.2, Lhs.3, Rhs.2
        298573  ~0%    {6} r4 = JOIN r3 WITH project#Module#fe82a56b::Cached::lookupMethod#2 ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4, Lhs.0, Lhs.5, Lhs.1
                       return r4
```