### PR TITLE
Ruby: Reduce size of input predicate for non-linear recursion

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Synthesis.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Synthesis.qll
@@ -255,8 +255,11 @@ private module SetterDesugar {
     MethodCall getMethodCall() { result = mc }
 
     pragma[nomagic]
-    MethodCallKind getCallKind(boolean setter, int arity) {
-      result = MethodCallKind(mc.getMethodName(), setter, arity)
+    private string getMethodName() { result = mc.getMethodName() }
+
+    pragma[nomagic]
+    MethodCallKind getCallKind(int arity) {
+      result = MethodCallKind(this.getMethodName(), true, arity)
     }
 
     pragma[nomagic]
@@ -282,7 +285,7 @@ private module SetterDesugar {
       exists(AstNode seq | seq = TStmtSequenceSynth(sae, -1) |
         parent = seq and
         i = 0 and
-        child = SynthChild(sae.getCallKind(true, sae.getNumberOfArguments() + 1))
+        child = SynthChild(sae.getCallKind(sae.getNumberOfArguments() + 1))
         or
         exists(AstNode call | call = TMethodCallSynth(seq, 0, _, _, _) |
           parent = call and
@@ -493,8 +496,11 @@ private module AssignOperationDesugar {
     MethodCall getMethodCall() { result = mc }
 
     pragma[nomagic]
+    private string getMethodName() { result = mc.getMethodName() }
+
+    pragma[nomagic]
     MethodCallKind getCallKind(boolean setter, int arity) {
-      result = MethodCallKind(mc.getMethodName(), setter, arity)
+      result = MethodCallKind(this.getMethodName(), setter, arity)
     }
 
     pragma[nomagic]


### PR DESCRIPTION
Before, we would be recursive in all of `MethodCall::getMethodName`:

```
Evaluated named local Synthesis#d9ff06b1::AssignOperationDesugar::SetterAssignOperation::getCallKind#ffff#shared#3@Synthesi in 9803ms on iteration 14 (size: 31006941).
Evaluated relational algebra for predicate Synthesis#d9ff06b1::AssignOperationDesugar::SetterAssignOperation::getCallKind#ffff#shared#3@Synthesi on iteration 14 running pipeline main with tuple counts:
          256419  ~1%    {2} r1 = SCAN Call#841c84e8::MethodCall::getMethodName#0#dispred#ff#prev_delta OUTPUT In.1, In.0
        31006941  ~8%    {4} r2 = JOIN r1 WITH Synthesis#d9ff06b1::MethodCallKind#ffff#prev ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Rhs.2, Rhs.3
                         return r2
```

Now, we have restricted that to be only the relevant method names.