### PR TITLE
Python: Remove last `-p ../lib/` in `options` files

### DIFF
--- a/python/ql/test/query-tests/Security/CWE-078-CommandInjection/options
+++ b/python/ql/test/query-tests/Security/CWE-078-CommandInjection/options
@@ -1,1 +1,0 @@
-semmle-extractor-options: -p ../lib/ --max-import-depth=3

--- a/python/ql/test/query-tests/Security/CWE-079-Jinja2WithoutEscaping/options
+++ b/python/ql/test/query-tests/Security/CWE-079-Jinja2WithoutEscaping/options
@@ -1,1 +1,0 @@
-semmle-extractor-options: -p ../lib/ --max-import-depth=3

--- a/python/ql/test/query-tests/Security/CWE-209-StackTraceExposure/options
+++ b/python/ql/test/query-tests/Security/CWE-209-StackTraceExposure/options
@@ -1,1 +1,0 @@
-semmle-extractor-options: -p ../lib/ --max-import-depth=2

--- a/python/ql/test/query-tests/Security/CWE-215-FlaskDebug/options
+++ b/python/ql/test/query-tests/Security/CWE-215-FlaskDebug/options
@@ -1,1 +1,0 @@
-semmle-extractor-options: --max-import-depth=2 -p ../lib

--- a/python/ql/test/query-tests/Security/CWE-327-InsecureProtocol/options
+++ b/python/ql/test/query-tests/Security/CWE-327-InsecureProtocol/options
@@ -1,1 +1,0 @@
-semmle-extractor-options: -p ../lib/ --max-import-depth=3

--- a/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/options
+++ b/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --lang=3 --max-import-depth=2 -p ../lib
+semmle-extractor-options: --lang=3 --max-import-depth=2

--- a/python/ql/test/query-tests/Security/CWE-732-WeakFilePermissions/options
+++ b/python/ql/test/query-tests/Security/CWE-732-WeakFilePermissions/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --max-import-depth=2 -p ../lib --lang=3
+semmle-extractor-options: --max-import-depth=2 --lang=3


### PR DESCRIPTION
These were only needed for points-to.

If they only contained `--max-import-depth`, I've removed the `options` file entirely.