### PR TITLE
C++: Recognize allocation functions heuristically

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
@@ -133,6 +133,18 @@ module ProductFlow {
       this.isAdditionalFlowStep2(node1, node2)
     }
 
+    /**
+     * Holds if data flow into `node` is prohibited in the first projection of the product
+     * dataflow graph.
+     */
+    predicate isBarrierIn1(DataFlow::Node node) { none() }
+
+    /**
+     * Holds if data flow into `node` is prohibited in the second projection of the product
+     * dataflow graph.
+     */
+    predicate isBarrierIn2(DataFlow::Node node) { none() }
+
     predicate hasFlowPath(
       DataFlow::PathNode source1, DataFlow2::PathNode source2, DataFlow::PathNode sink1,
       DataFlow2::PathNode sink2
@@ -169,6 +181,10 @@ module ProductFlow {
       ) {
         exists(Configuration conf | conf.isAdditionalFlowStep1(node1, state1, node2, state2))
       }
+
+      override predicate isBarrierIn(DataFlow::Node node) {
+        exists(Configuration conf | conf.isBarrierIn1(node))
+      }
     }
 
     class Conf2 extends DataFlow2::Configuration {
@@ -202,9 +218,14 @@ module ProductFlow {
       ) {
         exists(Configuration conf | conf.isAdditionalFlowStep2(node1, state1, node2, state2))
       }
+
+      override predicate isBarrierIn(DataFlow::Node node) {
+        exists(Configuration conf | conf.isBarrierIn2(node))
+      }
     }
   }
 
+  pragma[nomagic]
   private predicate reachableInterprocEntry(
     Configuration conf, DataFlow::PathNode source1, DataFlow2::PathNode source2,
     DataFlow::PathNode node1, DataFlow2::PathNode node2

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
@@ -252,7 +252,7 @@ private module CallAllocationExprBase<CallAllocationExprTarget Target> {
 
   /**
    * A module that abstracts over a collection of predicates in
-   * the `Param` module). This should really be memeber-predicates
+   * the `Param` module). This should really be member-predicates
    * on `CallAllocationExprTarget`, but we cannot yet write this in QL.
    */
   module With<Param P> {

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/Allocation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/Allocation.qll
@@ -113,3 +113,84 @@ class OperatorNewAllocationFunction extends AllocationFunction {
     result = 1
   }
 }
+
+/**
+ * An expression that _might_ allocate memory.
+ *
+ * Unlike `AllocationExpr`, this class uses heuristics (such as a call target's
+ * name and parameters) to include additional expressions.
+ */
+abstract class HeuristicAllocationExpr extends Expr {
+  /**
+   * Gets an expression for the allocation size, if any. The actual allocation
+   * size is the value of this expression multiplied by the result of
+   * `getSizeMult()`, in bytes.
+   */
+  Expr getSizeExpr() { none() }
+
+  /**
+   * Gets a constant multiplier for the allocation size given by `getSizeExpr`,
+   * in bytes.
+   */
+  int getSizeMult() { none() }
+
+  /**
+   * Gets the size of this allocation in bytes, if it is a fixed size and that
+   * size can be determined.
+   */
+  int getSizeBytes() { none() }
+
+  /**
+   * Gets the expression for the input pointer argument to be reallocated, if
+   * this is a `realloc` function.
+   */
+  Expr getReallocPtr() { none() }
+
+  /**
+   * Gets the type of the elements that are allocated, if it can be determined.
+   */
+  Type getAllocatedElementType() { none() }
+
+  /**
+   * Whether or not this allocation requires a corresponding deallocation of
+   * some sort (most do, but `alloca` for example does not).  If it is unclear,
+   * we default to no (for example a placement `new` allocation may or may not
+   * require a corresponding `delete`).
+   */
+  predicate requiresDealloc() { any() }
+}
+
+/**
+ * An function that _might_ allocate memory.
+ *
+ * Unlike `AllocationFunction`, this class uses heuristics (such as the function's
+ * name and its parameters) to include additional functions.
+ */
+abstract class HeuristicAllocationFunction extends Function {
+  /**
+   * Gets the index of the argument for the allocation size, if any. The actual
+   * allocation size is the value of this argument multiplied by the result of
+   * `getSizeMult()`, in bytes.
+   */
+  int getSizeArg() { none() }
+
+  /**
+   * Gets the index of an argument that multiplies the allocation size given by
+   * `getSizeArg`, if any.
+   */
+  int getSizeMult() { none() }
+
+  /**
+   * Gets the index of the input pointer argument to be reallocated, if this
+   * is a `realloc` function.
+   */
+  int getReallocPtrArg() { none() }
+
+  /**
+   * Whether or not this allocation requires a corresponding deallocation of
+   * some sort (most do, but `alloca` for example does not).  If it is unclear,
+   * we default to no (for example a placement `new` allocation may or may not
+   * require a corresponding `delete`).
+   */
+  predicate requiresDealloc() { any() }
+}

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
@@ -133,7 +133,7 @@ class AllocToInvalidPointerConf extends ProductFlow::Configuration {
     node = any(DataFlow::SsaPhiNode phi).getAnInput(true)
   }
 
-  override predicate isBarrierIn1(DataFlow::Node node) { isSourcePair(node, _, _, _) }
+  override predicate isBarrierIn1(DataFlow::Node node) { this.isSourcePair(node, _, _, _) }
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
@@ -76,7 +76,7 @@ private predicate hasSizeImpl(Expr e, DataFlow::Node n, string state) {
  * Holds if `(n, state)` pair represents the source of flow for the size
  * expression associated with `alloc`.
  */
-predicate hasSize(AllocationExpr alloc, DataFlow::Node n, string state) {
+predicate hasSize(HeuristicAllocationExpr alloc, DataFlow::Node n, string state) {
   hasSizeImpl(alloc.getSizeExpr(), n, state)
 }
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
@@ -132,6 +132,8 @@ class AllocToInvalidPointerConf extends ProductFlow::Configuration {
   override predicate isBarrierOut2(DataFlow::Node node) {
     node = any(DataFlow::SsaPhiNode phi).getAnInput(true)
   }
+
+  override predicate isBarrierIn1(DataFlow::Node node) { isSourcePair(node, _, _, _) }
 }
 
 pragma[nomagic]


### PR DESCRIPTION
This PR does two things:
- It adds a couple of new interface classes, `HeuristicAllocationExpr` and `HeuristicAllocationFunction`, that complement the already existing `AllocationExpr` and `HeuristicAllocation` classes with functions that we think may perform allocations.
- It switched the new `cpp/invalid-pointer-deref` query to use `HeuristicAllocationExpr` instead of `AllocationExpr` as a source of flow.

Currently, the heuristics used for detecting an `HeuristicAllocationFunction` is:
1. The function name matches `%alloc%`
2. It returns a pointer type
3. We can find a unique parameter of `unsigned` integral type

In addition, a `HeuristicAllocationFunction` is recognized as a `realloc`-like function if, in addition to the above, it:
1. Matches the name `%realloc%`, and
2. We can find a unique parameter of a pointer type

This finds a bunch of new allocation functions on the databases I've tried. For example, on `php` we recognize the following set of new allocation functions:

<img width="279" alt="Screenshot 2022-09-29 at 20 04 07" src="https://user-images.githubusercontent.com/4527323/193120184-4fe4a0e6-8d12-4fa6-8de9-a889b12e9926.png">

I've manually verified that these are all implementations that we want to recognize as allocation functions.

Commit-by-commit review encouraged.
- https://github.com/github/codeql/commit/a9710453f4366ebb999b6e383e4cbc71ec364d51 adds the new classes by wrapping a parameterized module around the logic for generating an `AllocationExpr` from a call to an `AllocationFunction`.
- https://github.com/github/codeql/commit/d12a76559a44708274446cb4527da862ebaf5dcb uses the new class in `cpp/invalid-pointer-deref`.
- https://github.com/github/codeql/commit/2a514d60d448b3ef1ef0d7810c66cf158b3973a9 adds a `isBarrierIn` predicate to the product dataflow library. This is necessary since many of the heuristic allocators are just simple wrappers around allocation expressions that we already know, and we'd otherwise get duplicated paths from starting flow both inside those functions, _and_ from the return value of the function we now recognize as a heuristic allocation expression.

Finally, I had to add `nomagic` to a predicate in the product dataflow library because I was observing a bad join due to bad magic.

With this PR, we now recognize https://nvd.nist.gov/vuln/detail/CVE-2016-10160 out of the box 🎉.