### PR TITLE
JS: recognize another kind of dummy passwords to fix an FP in hardcoded-credentials

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/SensitiveActions.qll
+++ b/javascript/ql/lib/semmle/javascript/security/SensitiveActions.qll
@@ -213,6 +213,9 @@ module PasswordHeuristics {
       normalized
           .regexpMatch(".*(pass|test|sample|example|secret|root|admin|user|change|auth|fake|(my(token|password))|string|foo|bar|baz|qux|1234|3141|abcd).*")
     )
+    or
+    // repeats the same char more than 10 times
+    password.regexpMatch(".*([a-zA-Z0-9])\\1{10,}.*")
   }
 
   /**

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.expected
@@ -259,6 +259,18 @@ nodes
 | HardcodedCredentials.js:286:36:286:55 | "user:custom string" |
 | HardcodedCredentials.js:286:36:286:55 | "user:custom string" |
 | HardcodedCredentials.js:286:36:286:55 | "user:custom string" |
+| HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` |
+| HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` |
+| HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` |
+| HardcodedCredentials.js:293:37:293:65 | `Basic  ... xxxxxx` |
+| HardcodedCredentials.js:293:37:293:65 | `Basic  ... xxxxxx` |
+| HardcodedCredentials.js:293:37:293:65 | `Basic  ... xxxxxx` |
+| HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` |
+| HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` |
+| HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` |
+| HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
+| HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
+| HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
 edges
 | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' |
 | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' |
@@ -383,6 +395,10 @@ edges
 | HardcodedCredentials.js:284:36:284:52 | "user:fake token" | HardcodedCredentials.js:284:36:284:52 | "user:fake token" |
 | HardcodedCredentials.js:285:36:285:46 | "user:dcba" | HardcodedCredentials.js:285:36:285:46 | "user:dcba" |
 | HardcodedCredentials.js:286:36:286:55 | "user:custom string" | HardcodedCredentials.js:286:36:286:55 | "user:custom string" |
+| HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` |
+| HardcodedCredentials.js:293:37:293:65 | `Basic  ... xxxxxx` | HardcodedCredentials.js:293:37:293:65 | `Basic  ... xxxxxx` |
+| HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` |
+| HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` | HardcodedCredentials.js:295:37:295:66 | `Basic  ... 000001` |
 #select
 | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | The hard-coded value "dbuser" is used as $@. | HardcodedCredentials.js:5:15:5:22 | 'dbuser' | user name |
 | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | The hard-coded value "hgfedcba" is used as $@. | HardcodedCredentials.js:8:19:8:28 | 'hgfedcba' | password |
@@ -446,3 +462,5 @@ edges
 | HardcodedCredentials.js:215:18:215:25 | 'sdsdag' | HardcodedCredentials.js:215:18:215:25 | 'sdsdag' | HardcodedCredentials.js:221:37:221:51 | `Basic ${AUTH}` | The hard-coded value "sdsdag" is used as $@. | HardcodedCredentials.js:221:37:221:51 | `Basic ${AUTH}` | authorization header |
 | HardcodedCredentials.js:231:22:231:29 | 'sdsdag' | HardcodedCredentials.js:231:22:231:29 | 'sdsdag' | HardcodedCredentials.js:237:24:237:91 | 'Basic  ... ase64') | The hard-coded value "sdsdag" is used as $@. | HardcodedCredentials.js:237:24:237:91 | 'Basic  ... ase64') | authorization header |
 | HardcodedCredentials.js:245:22:245:44 | "myHard ... ateKey" | HardcodedCredentials.js:245:22:245:44 | "myHard ... ateKey" | HardcodedCredentials.js:246:42:246:51 | privateKey | The hard-coded value "myHardCodedPrivateKey" is used as $@. | HardcodedCredentials.js:246:42:246:51 | privateKey | key |
+| HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | The hard-coded value "Basic sdsdag:sdsdag" is used as $@. | HardcodedCredentials.js:292:37:292:57 | `Basic  ... sdsdag` | authorization header |
+| HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | The hard-coded value "Basic sdsdag:aaaiuogrweuibgbbbbb" is used as $@. | HardcodedCredentials.js:294:37:294:70 | `Basic  ... gbbbbb` | authorization header |

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
@@ -285,3 +285,12 @@
     require("http").request({auth: "user:dcba"}) // OK
     require("http").request({auth: "user:custom string"}) // OK
 });
+
+(function () {
+    // browser API
+    var headers = new Headers();
+    headers.append("Authorization", `Basic sdsdag:sdsdag`); // NOT OK
+    headers.append("Authorization", `Basic sdsdag:xxxxxxxxxxxxxx`); // OK
+    headers.append("Authorization", `Basic sdsdag:aaaiuogrweuibgbbbbb`); // NOT OK
+    headers.append("Authorization", `Basic sdsdag:000000000000001`); // OK
+});


### PR DESCRIPTION
First I spent some time learning how backreferences work in regular expressions. 
Then I wrote `repeats the same char more than 10 times` in a comment. 
Then Copilot wrote the entire implementation..... 

There were a whole bunch of FPs in https://github.com/octokit/octokit-next.js/ that are fixed by this PR.  

[Evaluation was unevenful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-10636-0a5ff1__nightly-old__CustomSuite/reports) 