### PR TITLE
Ruby: Do not attempt to track precise hash indices for floats and complex numbers

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
@@ -91,7 +91,7 @@ module SummaryComponent {
 
   /** Gets a summary component that represents a value in a pair at a known key. */
   SummaryComponent pairValueKnown(ConstantValue key) {
-    result = SC::content(TSingletonContent(TKnownPairValueContent(key)))
+    result = SC::content(TSingletonContent(DataFlow::Content::getPairValueContent(key)))
   }
 
   /** Gets a summary component that represents the return value of a call. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -315,6 +315,14 @@ module Content {
     override string toString() { result = "pair" }
   }
 
+  /** Gets the content representing a value in a pair corresponding to constant value `cv`. */
+  PairValueContent getPairValueContent(ConstantValue cv) {
+    result = TKnownPairValueContent(cv)
+    or
+    not exists(TKnownPairValueContent(cv)) and
+    result = TUnknownPairValueContent()
+  }
+
   /**
    * A value stored behind a getter/setter pair.
    *

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -3395,6 +3395,46 @@ edges
 | array_flow.rb:1615:10:1615:10 | a [element, element 0] :  | array_flow.rb:1615:10:1615:13 | ...[...] [element 0] :  |
 | array_flow.rb:1615:10:1615:13 | ...[...] [element 0] :  | array_flow.rb:1615:10:1615:16 | ...[...] |
 | array_flow.rb:1615:10:1615:13 | ...[...] [element 0] :  | array_flow.rb:1615:10:1615:16 | ...[...] |
+| array_flow.rb:1620:5:1620:5 | [post] a [element 0] :  | array_flow.rb:1629:10:1629:10 | a [element 0] :  |
+| array_flow.rb:1620:5:1620:5 | [post] a [element 0] :  | array_flow.rb:1629:10:1629:10 | a [element 0] :  |
+| array_flow.rb:1620:5:1620:5 | [post] a [element 0] :  | array_flow.rb:1631:10:1631:10 | a [element 0] :  |
+| array_flow.rb:1620:5:1620:5 | [post] a [element 0] :  | array_flow.rb:1631:10:1631:10 | a [element 0] :  |
+| array_flow.rb:1620:12:1620:24 | call to source :  | array_flow.rb:1620:5:1620:5 | [post] a [element 0] :  |
+| array_flow.rb:1620:12:1620:24 | call to source :  | array_flow.rb:1620:5:1620:5 | [post] a [element 0] :  |
+| array_flow.rb:1622:5:1622:5 | [post] a [element] :  | array_flow.rb:1627:10:1627:10 | a [element] :  |
+| array_flow.rb:1622:5:1622:5 | [post] a [element] :  | array_flow.rb:1627:10:1627:10 | a [element] :  |
+| array_flow.rb:1622:5:1622:5 | [post] a [element] :  | array_flow.rb:1629:10:1629:10 | a [element] :  |
+| array_flow.rb:1622:5:1622:5 | [post] a [element] :  | array_flow.rb:1629:10:1629:10 | a [element] :  |
+| array_flow.rb:1622:5:1622:5 | [post] a [element] :  | array_flow.rb:1631:10:1631:10 | a [element] :  |
+| array_flow.rb:1622:5:1622:5 | [post] a [element] :  | array_flow.rb:1631:10:1631:10 | a [element] :  |
+| array_flow.rb:1622:16:1622:28 | call to source :  | array_flow.rb:1622:5:1622:5 | [post] a [element] :  |
+| array_flow.rb:1622:16:1622:28 | call to source :  | array_flow.rb:1622:5:1622:5 | [post] a [element] :  |
+| array_flow.rb:1624:5:1624:5 | [post] a [element] :  | array_flow.rb:1627:10:1627:10 | a [element] :  |
+| array_flow.rb:1624:5:1624:5 | [post] a [element] :  | array_flow.rb:1627:10:1627:10 | a [element] :  |
+| array_flow.rb:1624:5:1624:5 | [post] a [element] :  | array_flow.rb:1629:10:1629:10 | a [element] :  |
+| array_flow.rb:1624:5:1624:5 | [post] a [element] :  | array_flow.rb:1629:10:1629:10 | a [element] :  |
+| array_flow.rb:1624:5:1624:5 | [post] a [element] :  | array_flow.rb:1631:10:1631:10 | a [element] :  |
+| array_flow.rb:1624:5:1624:5 | [post] a [element] :  | array_flow.rb:1631:10:1631:10 | a [element] :  |
+| array_flow.rb:1624:14:1624:26 | call to source :  | array_flow.rb:1624:5:1624:5 | [post] a [element] :  |
+| array_flow.rb:1624:14:1624:26 | call to source :  | array_flow.rb:1624:5:1624:5 | [post] a [element] :  |
+| array_flow.rb:1626:5:1626:5 | [post] a [element] :  | array_flow.rb:1627:10:1627:10 | a [element] :  |
+| array_flow.rb:1626:5:1626:5 | [post] a [element] :  | array_flow.rb:1627:10:1627:10 | a [element] :  |
+| array_flow.rb:1626:5:1626:5 | [post] a [element] :  | array_flow.rb:1629:10:1629:10 | a [element] :  |
+| array_flow.rb:1626:5:1626:5 | [post] a [element] :  | array_flow.rb:1629:10:1629:10 | a [element] :  |
+| array_flow.rb:1626:5:1626:5 | [post] a [element] :  | array_flow.rb:1631:10:1631:10 | a [element] :  |
+| array_flow.rb:1626:5:1626:5 | [post] a [element] :  | array_flow.rb:1631:10:1631:10 | a [element] :  |
+| array_flow.rb:1626:16:1626:28 | call to source :  | array_flow.rb:1626:5:1626:5 | [post] a [element] :  |
+| array_flow.rb:1626:16:1626:28 | call to source :  | array_flow.rb:1626:5:1626:5 | [post] a [element] :  |
+| array_flow.rb:1627:10:1627:10 | a [element] :  | array_flow.rb:1627:10:1627:13 | ...[...] |
+| array_flow.rb:1627:10:1627:10 | a [element] :  | array_flow.rb:1627:10:1627:13 | ...[...] |
+| array_flow.rb:1629:10:1629:10 | a [element 0] :  | array_flow.rb:1629:10:1629:17 | ...[...] |
+| array_flow.rb:1629:10:1629:10 | a [element 0] :  | array_flow.rb:1629:10:1629:17 | ...[...] |
+| array_flow.rb:1629:10:1629:10 | a [element] :  | array_flow.rb:1629:10:1629:17 | ...[...] |
+| array_flow.rb:1629:10:1629:10 | a [element] :  | array_flow.rb:1629:10:1629:17 | ...[...] |
+| array_flow.rb:1631:10:1631:10 | a [element 0] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
+| array_flow.rb:1631:10:1631:10 | a [element 0] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
+| array_flow.rb:1631:10:1631:10 | a [element] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
+| array_flow.rb:1631:10:1631:10 | a [element] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
 nodes
 | array_flow.rb:2:9:2:20 | * ... [element 0] :  | semmle.label | * ... [element 0] :  |
 | array_flow.rb:2:9:2:20 | * ... [element 0] :  | semmle.label | * ... [element 0] :  |
@@ -7050,6 +7090,38 @@ nodes
 | array_flow.rb:1615:10:1615:13 | ...[...] [element 0] :  | semmle.label | ...[...] [element 0] :  |
 | array_flow.rb:1615:10:1615:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1615:10:1615:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1620:5:1620:5 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
+| array_flow.rb:1620:5:1620:5 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
+| array_flow.rb:1620:12:1620:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1620:12:1620:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1622:5:1622:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| array_flow.rb:1622:5:1622:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| array_flow.rb:1622:16:1622:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1622:16:1622:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1624:5:1624:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| array_flow.rb:1624:5:1624:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| array_flow.rb:1624:14:1624:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1624:14:1624:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1626:5:1626:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| array_flow.rb:1626:5:1626:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| array_flow.rb:1626:16:1626:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1626:16:1626:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1627:10:1627:10 | a [element] :  | semmle.label | a [element] :  |
+| array_flow.rb:1627:10:1627:10 | a [element] :  | semmle.label | a [element] :  |
+| array_flow.rb:1627:10:1627:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1627:10:1627:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1629:10:1629:10 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1629:10:1629:10 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1629:10:1629:10 | a [element] :  | semmle.label | a [element] :  |
+| array_flow.rb:1629:10:1629:10 | a [element] :  | semmle.label | a [element] :  |
+| array_flow.rb:1629:10:1629:17 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1629:10:1629:17 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1631:10:1631:10 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1631:10:1631:10 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1631:10:1631:10 | a [element] :  | semmle.label | a [element] :  |
+| array_flow.rb:1631:10:1631:10 | a [element] :  | semmle.label | a [element] :  |
+| array_flow.rb:1631:10:1631:15 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1631:10:1631:15 | ...[...] | semmle.label | ...[...] |
 subpaths
 #select
 | array_flow.rb:3:10:3:13 | ...[...] | array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:3:10:3:13 | ...[...] | $@ | array_flow.rb:2:10:2:20 | call to source :  | call to source :  |
@@ -7737,3 +7809,14 @@ subpaths
 | array_flow.rb:1614:10:1614:16 | ...[...] | array_flow.rb:1610:15:1610:27 | call to source :  | array_flow.rb:1614:10:1614:16 | ...[...] | $@ | array_flow.rb:1610:15:1610:27 | call to source :  | call to source :  |
 | array_flow.rb:1614:10:1614:16 | ...[...] | array_flow.rb:1613:15:1613:27 | call to source :  | array_flow.rb:1614:10:1614:16 | ...[...] | $@ | array_flow.rb:1613:15:1613:27 | call to source :  | call to source :  |
 | array_flow.rb:1615:10:1615:16 | ...[...] | array_flow.rb:1610:15:1610:27 | call to source :  | array_flow.rb:1615:10:1615:16 | ...[...] | $@ | array_flow.rb:1610:15:1610:27 | call to source :  | call to source :  |
+| array_flow.rb:1627:10:1627:13 | ...[...] | array_flow.rb:1622:16:1622:28 | call to source :  | array_flow.rb:1627:10:1627:13 | ...[...] | $@ | array_flow.rb:1622:16:1622:28 | call to source :  | call to source :  |
+| array_flow.rb:1627:10:1627:13 | ...[...] | array_flow.rb:1624:14:1624:26 | call to source :  | array_flow.rb:1627:10:1627:13 | ...[...] | $@ | array_flow.rb:1624:14:1624:26 | call to source :  | call to source :  |
+| array_flow.rb:1627:10:1627:13 | ...[...] | array_flow.rb:1626:16:1626:28 | call to source :  | array_flow.rb:1627:10:1627:13 | ...[...] | $@ | array_flow.rb:1626:16:1626:28 | call to source :  | call to source :  |
+| array_flow.rb:1629:10:1629:17 | ...[...] | array_flow.rb:1620:12:1620:24 | call to source :  | array_flow.rb:1629:10:1629:17 | ...[...] | $@ | array_flow.rb:1620:12:1620:24 | call to source :  | call to source :  |
+| array_flow.rb:1629:10:1629:17 | ...[...] | array_flow.rb:1622:16:1622:28 | call to source :  | array_flow.rb:1629:10:1629:17 | ...[...] | $@ | array_flow.rb:1622:16:1622:28 | call to source :  | call to source :  |
+| array_flow.rb:1629:10:1629:17 | ...[...] | array_flow.rb:1624:14:1624:26 | call to source :  | array_flow.rb:1629:10:1629:17 | ...[...] | $@ | array_flow.rb:1624:14:1624:26 | call to source :  | call to source :  |
+| array_flow.rb:1629:10:1629:17 | ...[...] | array_flow.rb:1626:16:1626:28 | call to source :  | array_flow.rb:1629:10:1629:17 | ...[...] | $@ | array_flow.rb:1626:16:1626:28 | call to source :  | call to source :  |
+| array_flow.rb:1631:10:1631:15 | ...[...] | array_flow.rb:1620:12:1620:24 | call to source :  | array_flow.rb:1631:10:1631:15 | ...[...] | $@ | array_flow.rb:1620:12:1620:24 | call to source :  | call to source :  |
+| array_flow.rb:1631:10:1631:15 | ...[...] | array_flow.rb:1622:16:1622:28 | call to source :  | array_flow.rb:1631:10:1631:15 | ...[...] | $@ | array_flow.rb:1622:16:1622:28 | call to source :  | call to source :  |
+| array_flow.rb:1631:10:1631:15 | ...[...] | array_flow.rb:1624:14:1624:26 | call to source :  | array_flow.rb:1631:10:1631:15 | ...[...] | $@ | array_flow.rb:1624:14:1624:26 | call to source :  | call to source :  |
+| array_flow.rb:1631:10:1631:15 | ...[...] | array_flow.rb:1626:16:1626:28 | call to source :  | array_flow.rb:1631:10:1631:15 | ...[...] | $@ | array_flow.rb:1626:16:1626:28 | call to source :  | call to source :  |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -1614,3 +1614,19 @@ def m136(i)
     sink(a[1][0]) # $ hasValueFlow=136.2 $ SPURIOUS hasValueFlow=136.1
     sink(a[2][0]) # $ hasValueFlow=136.1
 end
+
+def m137
+    a = Array.new
+    a[0] = source(137.1)
+    # unknown store (we only track indices 0..10)
+    a[10000] = source(137.2)
+    # unknown store (we don't track floats)
+    a[1.0] = source(137.3)
+    # unknown store (we don't track complex numbers)
+    a[1.0+i] = source(137.4)
+    sink(a[2]) # $ hasValueFlow=137.2 $ hasValueFlow=137.3 $ hasValueFlow=137.4
+    # unknown read
+    sink(a[10001]) # $ hasValueFlow=137.1 $ hasValueFlow=137.2 $ hasValueFlow=137.3 $ hasValueFlow=137.4
+    # unknown read
+    sink(a[1.0]) # $ hasValueFlow=137.1 $ hasValueFlow=137.2 $ hasValueFlow=137.3 $ hasValueFlow=137.4
+end


### PR DESCRIPTION
As pointed out by @asgerf, the inherent imprecision when comparing floats (and complex numbers) makes them unsuitable for tracking precise hash index information. We therefore simply treat reads and stores with float/complex indices as unknown indices.