### PR TITLE
Java: Fix cartesian product

### DIFF
--- a/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
+++ b/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
@@ -16,19 +16,14 @@ ClassOrInterface getTaggedType(ThrowsTag tag) {
   result = tag.getFile().(CompilationUnit).getATypeInScope()
 }
 
-predicate canThrow(Callable callable, Class exception) {
-  exception instanceof UncheckedThrowableType
-  or
-  callable.getAnException().getType().getADescendant() = exception
-}
-
 // Uses ClassOrInterface as type for thrownType to also cover case where erroneously an interface
 // type is declared as thrown exception
 from ThrowsTag throwsTag, ClassOrInterface thrownType, Callable docMethod
 where
   getTaggedType(throwsTag) = thrownType and
   docMethod.getDoc().getJavadoc().getAChild*() = throwsTag and
-  not canThrow(docMethod, thrownType)
+  not thrownType instanceof UncheckedThrowableType and
+  not docMethod.getAnException().getType().getADescendant() = thrownType
 select throwsTag,
   "Javadoc for " + docMethod + " claims to throw " + thrownType.getName() +
     " but this is impossible."


### PR DESCRIPTION
Fixes a cartesian product in the `canThrow` predicate, where `callable` wasn't bound in one side of the disjunct.