### PR TITLE
Run QLHelp preview for all languages

### DIFF
--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -27,7 +27,7 @@ on:
       - main
       - "rc/*"
     paths:
-      - "ruby/**/*.qhelp"
+      - "**/*.qhelp"
 
 jobs:
   qhelp:


### PR DESCRIPTION
[Here’s an example](https://github.com/github/codeql/pull/10008#issuecomment-1210861535) of a qhelp preview that the workflow generates. 

If you don't want this for your language then please speak up before this is merged. You can always opt-out later with a paths-ignore property if needed.