### PR TITLE
Java: Add jump steps for summarized callables

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/FlowSummary.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSummary.qll
@@ -5,6 +5,7 @@
 import java
 private import internal.FlowSummaryImpl as Impl
 private import internal.DataFlowDispatch
+private import internal.DataFlowPrivate
 private import internal.DataFlowUtil
 
 // import all instances of SummarizedCallable below
@@ -26,6 +27,9 @@ module SummaryComponent {
 
   /** Gets a summary component that represents the return value of a call. */
   SummaryComponent return() { result = return(_) }
+
+  /** Gets a summary component that represents a jump to `c`. */
+  SummaryComponent jump(Call c) { result = return(any(JumpReturnKind jrk | jrk.getTarget() = c)) }
 }
 
 class SummaryComponentStack = Impl::Public::SummaryComponentStack;
@@ -44,6 +48,9 @@ module SummaryComponentStack {
 
   /** Gets a singleton stack representing a (normal) return. */
   SummaryComponentStack return() { result = singleton(SummaryComponent::return()) }
+
+  /** Gets a singleton stack representing a jump to `c`. */
+  SummaryComponentStack jump(Call c) { result = singleton(SummaryComponent::jump(c)) }
 }
 
 class SummarizedCallable = Impl::Public::SummarizedCallable;

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
@@ -401,7 +401,7 @@ module Private {
     }
 
     /** Gets the kind of this returned value. */
-    ReturnKind getKind() { any() }
+    NormalReturnKind getKind() { any() }
   }
 
   /** A data flow node that represents the output of a call. */
@@ -439,7 +439,9 @@ module Private {
     }
 
     /** Holds if this summary node is a return node. */
-    predicate isReturn() { FlowSummaryImpl::Private::summaryReturnNode(this, _) }
+    predicate isReturn() {
+      exists(NormalReturnKind rk | FlowSummaryImpl::Private::summaryReturnNode(this, rk))
+    }
 
     /** Holds if this summary node is an out node for `call`. */
     predicate isOut(DataFlowCall call) { FlowSummaryImpl::Private::summaryOutNode(call, this, _) }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -11,15 +11,42 @@ private import FlowSummaryImpl as FlowSummaryImpl
 private import DataFlowImplConsistency
 import DataFlowNodes::Private
 
-private newtype TReturnKind = TNormalReturnKind()
+private newtype TReturnKind =
+  TNormalReturnKind() or
+  TJumpReturnKind(Call target)
 
 /**
  * A return kind. A return kind describes how a value can be returned
- * from a callable. For Java, this is simply a method return.
+ * from a callable.
  */
-class ReturnKind extends TReturnKind {
+abstract class ReturnKind extends TReturnKind {
   /** Gets a textual representation of this return kind. */
-  string toString() { result = "return" }
+  abstract string toString();
+}
+
+/**
+ * A value returned from a callable using a `return` statement or an expression
+ * body, that is, a "normal" return.
+ */
+class NormalReturnKind extends ReturnKind, TNormalReturnKind {
+  override string toString() { result = "return" }
+}
+
+/**
+ * A value returned through the output of another call.
+ *
+ * This is currently only used to model flow summaries where data may flow into
+ * one API entry point and out of another.
+ */
+class JumpReturnKind extends ReturnKind, TJumpReturnKind {
+  private Call target;
+
+  JumpReturnKind() { this = TJumpReturnKind(target) }
+
+  /** Gets the target of the jump. */
+  Call getTarget() { result = target }
+
+  override string toString() { result = "jump to " + target }
 }
 
 /**
@@ -71,8 +98,8 @@ private predicate variableCaptureStep(Node node1, ExprNode node2) {
 }
 
 /**
- * Holds if data can flow from `node1` to `node2` through a static field or
- * variable capture.
+ * Holds if data can flow from `node1` to `node2` through a static field,
+ * variable capture, or by jumping from one callabe to another call.
  */
 predicate jumpStep(Node node1, Node node2) {
   staticFieldStep(node1, node2)
@@ -83,6 +110,12 @@ predicate jumpStep(Node node1, Node node2) {
   or
   any(AdditionalValueStep a).step(node1, node2) and
   node1.getEnclosingCallable() != node2.getEnclosingCallable()
+  or
+  exists(JumpReturnKind jrk, SrcCall call |
+    FlowSummaryImpl::Private::summaryReturnNode(node1, jrk) and
+    jrk.getTarget() = call.asCall() and
+    node2.(OutNode).getCall() = call
+  )
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -31,9 +31,12 @@ SummaryCall summaryDataFlowCall(Node receiver) { result.getReceiver() = receiver
 DataFlowType getContentType(Content c) { result = c.getType() }
 
 /** Gets the return type of kind `rk` for callable `c`. */
+bindingset[c]
 DataFlowType getReturnType(SummarizedCallable c, ReturnKind rk) {
-  result = getErasedRepr(c.getReturnType()) and
-  exists(rk)
+  rk instanceof NormalReturnKind and
+  result = getErasedRepr(c.getReturnType())
+  or
+  rk = any(JumpReturnKind jrk | result = getErasedRepr(exprNode(jrk.getTarget()).getTypeBound()))
 }
 
 /**
@@ -51,8 +54,8 @@ DataFlowType getCallbackParameterType(DataFlowType t, int i) {
  * callback of type `t`.
  */
 DataFlowType getCallbackReturnType(DataFlowType t, ReturnKind rk) {
-  result = getErasedRepr(t.(FunctionalInterface).getRunMethod().getReturnType()) and
-  exists(rk)
+  rk instanceof NormalReturnKind and
+  result = getErasedRepr(t.(FunctionalInterface).getRunMethod().getReturnType())
 }
 
 bindingset[provenance]
@@ -169,7 +172,7 @@ predicate sinkElement(SourceOrSinkElement e, string input, string kind, boolean 
 }
 
 /** Gets the return kind corresponding to specification `"ReturnValue"`. */
-ReturnKind getReturnValueKind() { any() }
+NormalReturnKind getReturnValueKind() { any() }
 
 private newtype TInterpretNode =
   TElement(SourceOrSinkElement n) or


### PR DESCRIPTION
Adds the ability to define `jump` `SummaryComponent`s that flow from a summarized callable to the return value of another call.  This is useful to model flow summaries where data may flow into one API entry point and out of another. Credits to @hvitved for making this work properly.