### PR TITLE
Java Guidance: ExecTainted.ql (experimental version)

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.java
@@ -1,0 +1,9 @@
+class Test {
+    public static void main(String[] args) {
+        String script = System.getenv("SCRIPTNAME");
+        if (script != null) {
+            // BAD: The script to be executed is controlled by the user.
+            Runtime.getRuntime().exec(script);
+        }
+    }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.qhelp
@@ -1,0 +1,47 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Code that passes user input directly to <code>Runtime.exec</code>, or
+some other library routine that executes a command, allows the
+user to execute malicious code.</p>
+
+</overview>
+<recommendation>
+
+<p>If possible, use hard-coded string literals to specify the command to run
+or library to load. Instead of passing the user input directly to the
+process or library function, examine the user input and then choose
+among hard-coded string literals.</p>
+
+<p>If the applicable libraries or commands cannot be determined at
+compile time, then add code to verify that the user input string is
+safe before using it.</p>
+
+</recommendation>
+<example>
+
+<p>The following example shows code that takes a shell script that can be changed
+maliciously by a user, and passes it straight to <code>Runtime.exec</code>
+without examining it first.</p>
+
+<sample src="ExecTainted.java" />
+
+</example>
+<references>
+
+<li>
+OWASP:
+<a href="https://www.owasp.org/index.php/Command_Injection">Command Injection</a>.
+</li>
+<li>SEI CERT Oracle Coding Standard for Java:
+  <a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec()+method">IDS07-J. Sanitize untrusted data passed to the Runtime.exec() method</a>.</li>
+
+
+
+<!--  LocalWords:  CWE untrusted unsanitized Runtime
+ -->
+
+</references>
+</qhelp>


### PR DESCRIPTION
Porting over guidance for ExecTainted.ql so that it is also included alongside experimental version.