### PR TITLE
C#: Recognize options to `dotnet run` in tracer when injecting `-p:UseSharedCompilation=false`

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
@@ -41,3 +41,7 @@ check_build_out("hello, world", s)
 # to `dotnet run -p:UseSharedCompilation=true -p:UseSharedCompilation=false -- hello world`
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test6-db', 'dotnet run -p:UseSharedCompilation=true -- hello world'], "test7-db")
 check_build_out("hello, world", s)
+
+# option passed into `dotnet run`
+s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test7-db', 'dotnet build', 'dotnet run --no-build hello world'], "test8-db")
+check_build_out("hello, world", s)

--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -21,8 +21,8 @@ function RegisterExtractorPack(id)
         -- if that's `build`, we append `-p:UseSharedCompilation=false` to the command line,
         -- otherwise we do nothing.
         local match = false
-        local needsSeparator = false;
-        local injectionIndex = nil;
+        local dotnetRunNeedsSeparator = false;
+        local dotnetRunInjectionIndex = nil;
         local argv = compilerArguments.argv
         if OperatingSystem == 'windows' then
             -- let's hope that this split matches the escaping rules `dotnet` applies to command line arguments
@@ -34,7 +34,9 @@ function RegisterExtractorPack(id)
             -- dotnet options start with either - or / (both are legal)
             local firstCharacter = string.sub(arg, 1, 1)
             if not (firstCharacter == '-') and not (firstCharacter == '/') then
-                Log(1, 'Dotnet subcommand detected: %s', arg)
+                if (not match) then
+                    Log(1, 'Dotnet subcommand detected: %s', arg)
+                end
                 if arg == 'build' or arg == 'msbuild' or arg == 'publish' or arg == 'pack' or arg == 'test' then
                     match = true
                     break
@@ -43,22 +45,29 @@ function RegisterExtractorPack(id)
                     -- for `dotnet run`, we need to make sure that `-p:UseSharedCompilation=false` is
                     -- not passed in as an argument to the program that is run
                     match = true
-                    needsSeparator = true
-                    injectionIndex = i + 1
+                    dotnetRunNeedsSeparator = true
+                    dotnetRunInjectionIndex = i + 1
                 end
             end
+            -- if we see a separator to `dotnet run`, inject just prior to the existing separator
             if arg == '--' then
-                needsSeparator = false
-                injectionIndex = i
+                dotnetRunNeedsSeparator = false
+                dotnetRunInjectionIndex = i
                 break
+            end
+            -- if we see an option to `dotnet run` (e.g., `--project`), inject just prior
+            -- to the last option
+            if firstCharacter == '-' then
+                dotnetRunNeedsSeparator = false
+                dotnetRunInjectionIndex = i
             end
         end
         if match then
             local injections = { '-p:UseSharedCompilation=false' }
-            if needsSeparator then
+            if dotnetRunNeedsSeparator then
                 table.insert(injections, '--')
             end
-            if injectionIndex == nil then
+            if dotnetRunInjectionIndex == nil then
                 -- Simple case; just append at the end
                 return {
                     order = ORDER_REPLACE,
@@ -69,7 +78,7 @@ function RegisterExtractorPack(id)
 
             -- Complex case; splice injections into the middle of the command line
             for i, injectionArg in ipairs(injections) do
-                table.insert(argv, injectionIndex + i - 1, injectionArg)
+                table.insert(argv, dotnetRunInjectionIndex + i - 1, injectionArg)
             end
 
             if OperatingSystem == 'windows' then


### PR DESCRIPTION
Invocations like
```
dotnet run --no-build arg
```
would incorrectly be rewritten to
```
dotnet run -p:UseSharedCompilation=false -- --no-build arg
```

With this PR, they instead get rewritten to
```
dotnet run -p:UseSharedCompilation=false --no-build arg
```