### PR TITLE
Ruby: update dependencies

### DIFF
--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -96,8 +96,8 @@ jobs:
       - name: Build Query Pack
         run: |
           codeql pack create ../shared/ssa --output target/packs
+          codeql pack create ../misc/suite-helpers --output target/packs
           codeql pack create ql/lib --output target/packs
-          codeql pack install ql/src
           codeql pack create ql/src --output target/packs
           PACK_FOLDER=$(readlink -f target/packs/codeql/ruby-queries/*)
           codeql generate query-help --format=sarifv2.1.0 --output="${PACK_FOLDER}/rules.sarif" ql/src
@@ -202,13 +202,14 @@ jobs:
           echo 'name: sample-tests
           version: 0.0.0
           dependencies:
-            codeql/ruby-all: 0.0.1
+            codeql/ruby-all: "*"
           extractor: ruby
           tests: .
           ' > qlpack.yml
       - name: Run QL test
         shell: bash
         run: |
+          codeql pack install .
           codeql test run --search-path "${{ runner.temp }}/ruby-bundle" --additional-packs "${{ runner.temp }}/ruby-bundle" .
       - name: Create database
         shell: bash

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -209,7 +209,6 @@ jobs:
       - name: Run QL test
         shell: bash
         run: |
-          codeql pack install .
           codeql test run --search-path "${{ runner.temp }}/ruby-bundle" --additional-packs "${{ runner.temp }}/ruby-bundle" .
       - name: Create database
         shell: bash

--- a/go/ql/src/qlpack.lock.yml
+++ b/go/ql/src/qlpack.lock.yml
@@ -1,6 +1,4 @@
 ---
-dependencies:
-  codeql/suite-helpers:
-    version: 0.0.2
+dependencies: {}
 compiled: false
 lockVersion: 1.0.0

--- a/go/ql/test/qlpack.lock.yml
+++ b/go/ql/test/qlpack.lock.yml
@@ -1,6 +1,4 @@
 ---
-dependencies:
-  codeql/suite-helpers:
-    version: 0.0.2
+dependencies: {}
 compiled: false
 lockVersion: 1.0.0

--- a/ruby/ql/lib/qlpack.lock.yml
+++ b/ruby/ql/lib/qlpack.lock.yml
@@ -1,4 +1,6 @@
 ---
-dependencies: {}
+dependencies:
+  codeql/ssa:
+    version: 0.0.1
 compiled: false
 lockVersion: 1.0.0

--- a/ruby/ql/lib/qlpack.lock.yml
+++ b/ruby/ql/lib/qlpack.lock.yml
@@ -1,6 +1,4 @@
 ---
-dependencies:
-  codeql/ssa:
-    version: 0.0.1
+dependencies: {}
 compiled: false
 lockVersion: 1.0.0

--- a/ruby/ql/src/qlpack.lock.yml
+++ b/ruby/ql/src/qlpack.lock.yml
@@ -2,5 +2,7 @@
 dependencies:
   codeql/suite-helpers:
     version: 0.0.2
+  codeql/ssa:
+    version: 0.0.1
 compiled: false
 lockVersion: 1.0.0

--- a/ruby/ql/src/qlpack.lock.yml
+++ b/ruby/ql/src/qlpack.lock.yml
@@ -1,8 +1,4 @@
 ---
-dependencies:
-  codeql/suite-helpers:
-    version: 0.0.2
-  codeql/ssa:
-    version: 0.0.1
+dependencies: {}
 compiled: false
 lockVersion: 1.0.0

--- a/ruby/ql/test/qlpack.lock.yml
+++ b/ruby/ql/test/qlpack.lock.yml
@@ -1,6 +1,4 @@
 ---
-dependencies:
-  codeql/suite-helpers:
-    version: 0.0.2
+dependencies: {}
 compiled: false
 lockVersion: 1.0.0

--- a/shared/ssa/codeql-pack.lock.yml
+++ b/shared/ssa/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0


### PR DESCRIPTION
Update the lock files to include the `codeql/ssa` library and replace ad-hoc pack create command with a proper `codeql pack install` command now the ssa library has been published.