### PR TITLE
C#/Java: Limit telemetry results.

### DIFF
--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -17,8 +17,10 @@ private import semmle.code.csharp.security.dataflow.flowsources.Remote
 class TestLibrary extends RefType {
   TestLibrary() {
     this.getNamespace()
-        .getName()
-        .matches(["NUnit.Framework%", "Xunit%", "Microsoft.VisualStudio.TestTools.UnitTesting%"])
+        .getQualifiedName()
+        .matches([
+            "NUnit.Framework%", "Xunit%", "Microsoft.VisualStudio.TestTools.UnitTesting%", "Moq%"
+          ])
   }
 }
 

--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -114,29 +114,29 @@ class ExternalApi extends DotNet::Callable {
 int resultLimit() { result = 1000 }
 
 /**
- * Holds if the relevant usage count of `api` is `usages`.
+ * Holds if the relevant usage count of api with `apiInfo` is `usages`.
  */
-signature predicate relevantUsagesSig(ExternalApi api, int usages);
+signature predicate relevantUsagesSig(string apiInfo, int usages);
 
 /**
  * Given a predicate to count relevant API usages, this module provides a predicate
  * for restricting the number or returned results based on a certain limit.
  */
 module Results<relevantUsagesSig/2 getRelevantUsages> {
-  private int getOrder(ExternalApi api) {
-    api =
-      rank[result](ExternalApi a, int usages |
-        getRelevantUsages(a, usages)
+  private int getOrder(string apiInfo) {
+    apiInfo =
+      rank[result](string info, int usages |
+        getRelevantUsages(info, usages)
       |
-        a order by usages desc, a.getInfo()
+        info order by usages desc, info
       )
   }
 
   /**
-   * Holds if `api` is being used `usages` times and if it is
-   * in the top results (guarded by resultLimit).
+   * Holds if there exists an API with `apiInfo` that is being used `usages` times
+   * and if it is in the top results (guarded by resultLimit).
    */
-  predicate restrict(ExternalApi api, int usages) {
-    getRelevantUsages(api, usages) and getOrder(api) <= resultLimit()
+  predicate restrict(string apiInfo, int usages) {
+    getRelevantUsages(apiInfo, usages) and getOrder(apiInfo) <= resultLimit()
   }
 }

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -10,16 +10,11 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate getRelevantUsages(string apiInfo, int usages) {
-  usages =
-    strictcount(DispatchCall c, ExternalApi api |
-      apiInfo = api.getInfo() and
-      c = api.getACall() and
-      not api.isUninteresting() and
-      api.isSink()
-    )
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.isSink()
 }
 
 from string info, int usages
-where Results<getRelevantUsages/2>::restrict(info, usages)
+where Results<relevant/1>::restrict(info, usages)
 select info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -10,12 +10,16 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate getRelevantUsages(ExternalApi api, int usages) {
-  not api.isUninteresting() and
-  api.isSink() and
-  usages = strictcount(DispatchCall c | c = api.getACall())
+private predicate getRelevantUsages(string apiInfo, int usages) {
+  usages =
+    strictcount(DispatchCall c, ExternalApi api |
+      apiInfo = api.getInfo() and
+      c = api.getACall() and
+      not api.isUninteresting() and
+      api.isSink()
+    )
 }
 
-from ExternalApi api, int usages
-where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getInfo() as info, usages order by usages desc
+from string info, int usages
+where Results<getRelevantUsages/2>::restrict(info, usages)
+select info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -10,16 +10,11 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate getRelevantUsages(string apiInfo, int usages) {
-  usages =
-    strictcount(DispatchCall c, ExternalApi api |
-      c = api.getACall() and
-      apiInfo = api.getInfo() and
-      not api.isUninteresting() and
-      api.isSource()
-    )
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.isSource()
 }
 
 from string info, int usages
-where Results<getRelevantUsages/2>::restrict(info, usages)
+where Results<relevant/1>::restrict(info, usages)
 select info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -10,12 +10,16 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate getRelevantUsages(ExternalApi api, int usages) {
-  not api.isUninteresting() and
-  api.isSource() and
-  usages = strictcount(DispatchCall c | c = api.getACall())
+private predicate getRelevantUsages(string apiInfo, int usages) {
+  usages =
+    strictcount(DispatchCall c, ExternalApi api |
+      c = api.getACall() and
+      apiInfo = api.getInfo() and
+      not api.isUninteresting() and
+      api.isSource()
+    )
 }
 
-from ExternalApi api, int usages
-where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getInfo() as info, usages order by usages desc
+from string info, int usages
+where Results<getRelevantUsages/2>::restrict(info, usages)
+select info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -10,12 +10,16 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate getRelevantUsages(ExternalApi api, int usages) {
-  not api.isUninteresting() and
-  api.hasSummary() and
-  usages = strictcount(DispatchCall c | c = api.getACall())
+private predicate getRelevantUsages(string apiInfo, int usages) {
+  usages =
+    strictcount(DispatchCall c, ExternalApi api |
+      apiInfo = api.getInfo() and
+      c = api.getACall() and
+      not api.isUninteresting() and
+      api.hasSummary()
+    )
 }
 
-from ExternalApi api, int usages
-where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getInfo() as info, usages order by usages desc
+from string info, int usages
+where Results<getRelevantUsages/2>::restrict(info, usages)
+select info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -10,16 +10,11 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate getRelevantUsages(string apiInfo, int usages) {
-  usages =
-    strictcount(DispatchCall c, ExternalApi api |
-      apiInfo = api.getInfo() and
-      c = api.getACall() and
-      not api.isUninteresting() and
-      api.hasSummary()
-    )
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.hasSummary()
 }
 
 from string info, int usages
-where Results<getRelevantUsages/2>::restrict(info, usages)
+where Results<relevant/1>::restrict(info, usages)
 select info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -12,17 +12,12 @@ private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSumma
 private import semmle.code.csharp.dataflow.internal.NegativeSummary
 private import ExternalApi
 
-private predicate getRelevantUsages(string apiInfo, int usages) {
-  usages =
-    strictcount(DispatchCall c, ExternalApi api |
-      apiInfo = api.getInfo() and
-      c = api.getACall() and
-      not api.isUninteresting() and
-      not api.isSupported() and
-      not api instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable
-    )
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  not api.isSupported() and
+  not api instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable
 }
 
 from string info, int usages
-where Results<getRelevantUsages/2>::restrict(info, usages)
+where Results<relevant/1>::restrict(info, usages)
 select info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -12,13 +12,17 @@ private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSumma
 private import semmle.code.csharp.dataflow.internal.NegativeSummary
 private import ExternalApi
 
-private predicate getRelevantUsages(ExternalApi api, int usages) {
-  not api.isUninteresting() and
-  not api.isSupported() and
-  not api instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable and
-  usages = strictcount(DispatchCall c | c = api.getACall())
+private predicate getRelevantUsages(string apiInfo, int usages) {
+  usages =
+    strictcount(DispatchCall c, ExternalApi api |
+      apiInfo = api.getInfo() and
+      c = api.getACall() and
+      not api.isUninteresting() and
+      not api.isSupported() and
+      not api instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable
+    )
 }
 
-from ExternalApi api, int usages
-where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getInfo() as info, usages order by usages desc
+from string info, int usages
+where Results<getRelevantUsages/2>::restrict(info, usages)
+select info, usages order by usages desc

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -105,29 +105,40 @@ deprecated class ExternalAPI = ExternalApi;
 int resultLimit() { result = 1000 }
 
 /**
- * Holds if the relevant usage count of `api` is `usages`.
+ * Holds if it is relevant to count usages of `api`.
  */
-signature predicate relevantUsagesSig(ExternalApi api, int usages);
+signature predicate relevantApi(ExternalApi api);
 
 /**
  * Given a predicate to count relevant API usages, this module provides a predicate
  * for restricting the number or returned results based on a certain limit.
  */
-module Results<relevantUsagesSig/2 getRelevantUsages> {
-  private int getOrder(ExternalApi api) {
-    api =
-      rank[result](ExternalApi a, int usages |
-        getRelevantUsages(a, usages)
+module Results<relevantApi/1 getRelevantUsages> {
+  private int getUsages(string apiName) {
+    result =
+      strictcount(Call c, ExternalApi api |
+        c.getCallee().getSourceDeclaration() = api and
+        not c.getFile() instanceof GeneratedFile and
+        apiName = api.getApiName() and
+        getRelevantUsages(api)
+      )
+  }
+
+  private int getOrder(string apiInfo) {
+    apiInfo =
+      rank[result](string info, int usages |
+        usages = getUsages(info)
       |
-        a order by usages desc, a.getApiName()
+        info order by usages desc, info
       )
   }
 
   /**
-   * Holds if `api` is being used `usages` times and if it is
-   * in the top results (guarded by resultLimit).
+   * Holds if there exists an API with `apiName` that is being used `usages` times
+   * and if it is in the top results (guarded by resultLimit).
    */
-  predicate restrict(ExternalApi api, int usages) {
-    getRelevantUsages(api, usages) and getOrder(api) <= resultLimit()
+  predicate restrict(string apiName, int usages) {
+    usages = getUsages(apiName) and
+    getOrder(apiName) <= resultLimit()
   }
 }

--- a/java/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -9,16 +9,11 @@
 import java
 import ExternalApi
 
-private predicate getRelevantUsages(ExternalApi api, int usages) {
+private predicate relevant(ExternalApi api) {
   not api.isUninteresting() and
-  api.isSink() and
-  usages =
-    strictcount(Call c |
-      c.getCallee().getSourceDeclaration() = api and
-      not c.getFile() instanceof GeneratedFile
-    )
+  api.isSink()
 }
 
-from ExternalApi api, int usages
-where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getApiName() as apiname, usages order by usages desc
+from string apiName, int usages
+where Results<relevant/1>::restrict(apiName, usages)
+select apiName, usages order by usages desc

--- a/java/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSources.ql
@@ -9,16 +9,11 @@
 import java
 import ExternalApi
 
-private predicate getRelevantUsages(ExternalApi api, int usages) {
+private predicate relevant(ExternalApi api) {
   not api.isUninteresting() and
-  api.isSource() and
-  usages =
-    strictcount(Call c |
-      c.getCallee().getSourceDeclaration() = api and
-      not c.getFile() instanceof GeneratedFile
-    )
+  api.isSource()
 }
 
-from ExternalApi api, int usages
-where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getApiName() as apiname, usages order by usages desc
+from string apiName, int usages
+where Results<relevant/1>::restrict(apiName, usages)
+select apiName, usages order by usages desc

--- a/java/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/java/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -9,16 +9,11 @@
 import java
 import ExternalApi
 
-private predicate getRelevantUsages(ExternalApi api, int usages) {
+private predicate relevant(ExternalApi api) {
   not api.isUninteresting() and
-  api.hasSummary() and
-  usages =
-    strictcount(Call c |
-      c.getCallee().getSourceDeclaration() = api and
-      not c.getFile() instanceof GeneratedFile
-    )
+  api.hasSummary()
 }
 
-from ExternalApi api, int usages
-where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getApiName() as apiname, usages order by usages desc
+from string apiName, int usages
+where Results<relevant/1>::restrict(apiName, usages)
+select apiName, usages order by usages desc

--- a/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -11,17 +11,12 @@ import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 import semmle.code.java.dataflow.internal.NegativeSummary
 import ExternalApi
 
-private predicate getRelevantUsages(ExternalApi api, int usages) {
+private predicate relevant(ExternalApi api) {
   not api.isUninteresting() and
   not api.isSupported() and
-  not api instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable and
-  usages =
-    strictcount(Call c |
-      c.getCallee().getSourceDeclaration() = api and
-      not c.getFile() instanceof GeneratedFile
-    )
+  not api instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable
 }
 
-from ExternalApi api, int usages
-where Results<getRelevantUsages/2>::restrict(api, usages)
-select api.getApiName() as apiname, usages order by usages desc
+from string apiName, int usages
+where Results<relevant/1>::restrict(apiName, usages)
+select apiName, usages order by usages desc


### PR DESCRIPTION
It turns out that there are some minor issues with the number of reported results by the telemetry queries.
The queries are supposed to *limit* the results to the top 1k most relevant (most frequent) results.
However, the ordering (ranking) was based on the callables themselves and not the string representation used for the result. Unfortunately, the string representation is not a precise description of a callable, which means that multiple callables can map to the same description causes slight inconsistencies in the *ranking* (ie. we can risk getting less than 1k results even though there result set we try to limit is bigger than 1k).

For C# some examples cases are callables of the same name in subclasses of the same name, but nested in classes with different names.
To solve this the string representation are now used in the *ranking*. However, this might give a slight inconsistency in the usage count as callables that have the same string representation gets their usage count collapsed.

Furthermore, it was also discovered that for C#, calls to testing frameworks were not excluded correctly. This has also been fixed.