### PR TITLE
Swift: Use ClassOrStructDecl

### DIFF
--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
@@ -31,7 +31,7 @@ class Sink extends DataFlow::Node {
       int baseUrlArg
     |
       // arguments to method calls...
-      exists(string className, ClassDecl c |
+      exists(string className, ClassOrStructDecl c |
         (
           // `loadHTMLString`
           className = ["UIWebView", "WKWebView"] and

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -99,7 +99,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
     |
       (
         // arguments to method calls...
-        exists(string className, ClassDecl c |
+        exists(string className, ClassOrStructDecl c |
           (
             // `NSRange.init`
             className = "NSRange" and
@@ -127,7 +127,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
             paramName = "at"
           ) and
           c.getName() = className and
-          c.getABaseTypeDecl*().(ClassDecl).getAMember() = funcDecl and
+          c.getABaseTypeDecl*().(ClassOrStructDecl).getAMember() = funcDecl and
           call.getStaticTarget() = funcDecl and
           flowstate = "NSString"
         )

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -28,7 +28,7 @@ abstract class Stored extends DataFlow::Node { }
 class CoreDataStore extends Stored {
   CoreDataStore() {
     // `content` arg to `NWConnection.send` is a sink
-    exists(ClassDecl c, AbstractFunctionDecl f, CallExpr call |
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getName() = "NSManagedObject" and
       c.getAMember() = f and
       f.getName() = ["setValue(_:forKey:)", "setPrimitiveValue(_:forKey:)"] and
@@ -47,7 +47,7 @@ class RealmStore extends Stored instanceof DataFlow::PostUpdateNode {
     // any write into a class derived from `RealmSwiftObject` is a sink. For
     // example in `realmObj.data = sensitive` the post-update node corresponding
     // with `realmObj.data` is a sink.
-    exists(ClassDecl cd, Expr e |
+    exists(ClassOrStructDecl cd, Expr e |
       cd.getABaseTypeDecl*().getName() = "RealmSwiftObject" and
       this.getPreUpdateNode().asExpr() = e and
       e.getFullyConverted().getType() = cd.getType() and
@@ -81,7 +81,7 @@ class CleartextStorageConfig extends TaintTracking::Configuration {
     // flow out from fields of a `RealmSwiftObject` at the sink, for example in
     // `realmObj.data = sensitive`.
     isSink(node) and
-    exists(ClassDecl cd |
+    exists(ClassOrStructDecl cd |
       c.getAReadContent().(DataFlow::Content::FieldContent).getField() = cd.getAMember() and
       cd.getABaseTypeDecl*().getName() = "RealmSwiftObject"
     )

--- a/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
@@ -28,7 +28,7 @@ abstract class Transmitted extends Expr { }
 class NWConnectionSend extends Transmitted {
   NWConnectionSend() {
     // `content` arg to `NWConnection.send` is a sink
-    exists(ClassDecl c, AbstractFunctionDecl f, CallExpr call |
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getName() = "NWConnection" and
       c.getAMember() = f and
       f.getName() = "send(content:contentContext:isComplete:completion:)" and
@@ -46,7 +46,7 @@ class Url extends Transmitted {
   Url() {
     // `string` arg in `URL.init` is a sink
     // (we assume here that the URL goes on to be used in a network operation)
-    exists(StructDecl c, AbstractFunctionDecl f, CallExpr call |
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getName() = "URL" and
       c.getAMember() = f and
       f.getName() = ["init(string:)", "init(string:relativeTo:)"] and

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql
@@ -42,7 +42,7 @@ module WeakHashingConfig {
         call.getAnArgument().getExpr() = this.asExpr() and
         call.getStaticTarget() = func and
         func.getName().matches(["hash(%", "update(%"]) and
-        algorithm = func.getEnclosingDecl().(StructDecl).getName() and
+        algorithm = func.getEnclosingDecl().(ClassOrStructDecl).getName() and
         algorithm = ["MD5", "SHA1"]
       )
     }

--- a/swift/ql/src/queries/Security/ECB-Encryption/ECBEncryption.ql
+++ b/swift/ql/src/queries/Security/ECB-Encryption/ECBEncryption.ql
@@ -26,7 +26,7 @@ abstract class BlockMode extends Expr { }
 class AES extends BlockMode {
   AES() {
     // `blockMode` arg in `AES.init` is a sink
-    exists(ClassDecl c, AbstractFunctionDecl f, CallExpr call |
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getName() = "AES" and
       c.getAMember() = f and
       f.getName() = ["init(key:blockMode:)", "init(key:blockMode:padding:)"] and
@@ -42,7 +42,7 @@ class AES extends BlockMode {
 class Blowfish extends BlockMode {
   Blowfish() {
     // `blockMode` arg in `Blowfish.init` is a sink
-    exists(ClassDecl c, AbstractFunctionDecl f, CallExpr call |
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getName() = "Blowfish" and
       c.getAMember() = f and
       f.getName() = "init(key:blockMode:padding:)" and
@@ -60,7 +60,7 @@ class EcbEncryptionConfig extends DataFlow::Configuration {
   EcbEncryptionConfig() { this = "EcbEncryptionConfig" }
 
   override predicate isSource(DataFlow::Node node) {
-    exists(StructDecl s, AbstractFunctionDecl f, CallExpr call |
+    exists(ClassOrStructDecl s, AbstractFunctionDecl f, CallExpr call |
       s.getName() = "ECB" and
       s.getAMember() = f and
       f.getName() = "init()" and

--- a/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
@@ -1,7 +1,7 @@
 
 // --- stubs ---
 
-class Data {
+struct Data {
     init<S>(_ elements: S) {}
 }
 
@@ -13,7 +13,7 @@ class NWConnection {
 	class ContentContext {
         static let defaultMessage = ContentContext()
     }
-	
+
 	func send(content: Data?, contentContext: NWConnection.ContentContext = .defaultMessage, isComplete: Bool = true, completion: NWConnection.SendCompletion) { }
 	func send<Content>(content: Content?, contentContext: NWConnection.ContentContext = .defaultMessage, isComplete: Bool = true, completion: NWConnection.SendCompletion) { }
 }


### PR DESCRIPTION
Use the new `ClassOrStructDecl` (from https://github.com/github/codeql/pull/10595 by @MathiasVP), in place of `ClassDecl` and `StructDecl` in all Swift queries.  I consider this more robust in several ways:
 - when the query + test were written with the wrong one (out of `class` / `struct`).  Such a mistake is hard to spot but will mean we find no results in real world usage.  I've made this mistake myself, twice, and I've seen someone else make it as well.
   - an alternative solution would be to check all current QL for Swift diligently.
 - if something in a standard library changes between `struct` and `class` in future.
 - if the QL is reused (copy-pasted) to match a different thing in the standard library in future.

The downside is minimal - if there is a thing matching the standard library one in all ways except being the opposite between `struct` / `class`, we could match it in addition to the correct thing.