### PR TITLE
C++: Fix potentially bad join

### DIFF
--- a/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
@@ -46,7 +46,7 @@ class CastToPointerArithFlow extends DataFlow::Configuration {
  */
 pragma[inline]
 predicate hasBaseType(Expr e, Type base) {
-  pragma[only_bind_into](base) = pragma[only_bind_out](e.getType().(DerivedType).getBaseType())
+  pragma[only_bind_into](base) = e.getType().(DerivedType).getBaseType()
 }
 
 /**

--- a/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
@@ -39,7 +39,7 @@ class CastToPointerArithFlow extends DataFlow::Configuration {
 }
 
 /**
- * Gets the base type of `e` if the type of `e` is a `DerivedType`.
+ * Holds if the type of `e` is a `DerivedType` with `base` as its base type.
  *
  * This predicate ensures that joins go from `e` to `base` instead
  * of the other way around.


### PR DESCRIPTION
The joins in this predicate turned out to be quite bad after I tried to switch to IR use-use dataflow instead of AST dataflow. This PR should hopefully prevent the optimizer from trying to do a join on the base type.