### PR TITLE
Ruby: summarize unary splat operators and add local field step

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -522,7 +522,8 @@ module API {
       or
       exists(TypeTrackerSpecific::TypeTrackerContent c |
         TypeTrackerSpecific::basicLoadStep(node, ref, c) and
-        lbl = Label::content(c.getAStoreContent())
+        lbl = Label::content(c.getAStoreContent()) and
+        not c.isSingleton(any(DataFlow::Content::AttributeNameContent k))
       )
       // note: method calls are not handled here as there is no DataFlow::Node for the intermediate MkMethodAccessNode API node
     }

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -639,7 +639,10 @@ module API {
       isUse(src) and
       t.start()
       or
-      exists(TypeTracker t2 | result = trackUseNode(src, t2).track(t2, t))
+      exists(TypeTracker t2 |
+        result = trackUseNode(src, t2).track(t2, t) and
+        not result instanceof DataFlowPrivate::SelfParameterNode
+      )
     }
 
     /**
@@ -658,7 +661,11 @@ module API {
       isDef(rhs) and
       result = rhs.getALocalSource()
       or
-      exists(TypeBackTracker t2 | result = trackDefNode(rhs, t2).backtrack(t2, t))
+      exists(TypeBackTracker t2, DataFlow::LocalSourceNode mid |
+        mid = trackDefNode(rhs, t2) and
+        not mid instanceof DataFlowPrivate::SelfParameterNode and
+        result = mid.backtrack(t2, t)
+      )
     }
 
     /** Gets a data flow node reaching the RHS of the given def node. */

--- a/ruby/ql/lib/codeql/ruby/frameworks/Core.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Core.qll
@@ -58,7 +58,7 @@ class SubshellHeredocExecution extends SystemCommandExecution::Range {
 private class SplatSummary extends SummarizedCallable {
   SplatSummary() { this = "*(splat)" }
 
-  override SplatExpr getACall() { any() }
+  override SplatExpr getACallSimple() { any() }
 
   override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
     (

--- a/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
@@ -1,6 +1,3 @@
-| array_flow.rb:3:16:3:35 | # $ hasValueFlow=0.1 | Missing result:hasValueFlow=0.1 |
-| array_flow.rb:5:16:5:35 | # $ hasValueFlow=0.1 | Missing result:hasValueFlow=0.1 |
-| array_flow.rb:83:13:83:30 | # $ hasValueFlow=9 | Missing result:hasValueFlow=9 |
 | array_flow.rb:107:10:107:13 | ...[...] | Unexpected result: hasValueFlow=11.2 |
 | array_flow.rb:179:28:179:46 | # $ hasValueFlow=19 | Missing result:hasValueFlow=19 |
 | array_flow.rb:180:28:180:46 | # $ hasValueFlow=19 | Missing result:hasValueFlow=19 |

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -16,11 +16,16 @@ track
 | type_tracker.rb:2:5:5:7 | self in field= | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:2:5:5:7 | self in field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | self in field= |
 | type_tracker.rb:2:16:2:18 | val | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
+| type_tracker.rb:2:16:2:18 | val | type tracker with call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:5:5:7 | return return in field= |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:16:2:18 | val |
+| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
+| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:7:5:9:7 | return return in field |
+| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
+| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:3:9:3:23 | call to puts | type tracker without call steps | type_tracker.rb:3:9:3:23 | call to puts |
 | type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:4:9:4:14 | @field | type tracker without call steps | type_tracker.rb:4:9:4:14 | @field |
@@ -55,6 +60,7 @@ track
 | type_tracker.rb:14:5:14:13 | call to field= | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
+| type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content attribute field | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content attribute field | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
@@ -368,11 +374,16 @@ trackEnd
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
+| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:4:9:4:20 | ... = ... |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:4:9:4:20 | ... = ... |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:4:18:4:20 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:4:18:4:20 | val |
+| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:7:5:9:7 | return return in field |
+| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:8:9:8:14 | @field |
+| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:14:5:14:13 | call to field= |
+| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:3:9:3:23 | call to puts | type_tracker.rb:3:9:3:23 | call to puts |
 | type_tracker.rb:3:14:3:23 | call to field | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:4:9:4:14 | @field | type_tracker.rb:4:9:4:14 | @field |
@@ -424,6 +435,7 @@ trackEnd
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:4:9:4:20 | ... = ... |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:4:18:4:20 | val |
+| type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:5:14:13 | __synth__0 |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:5:14:23 | ... |


### PR DESCRIPTION
Adds the local field step to type-tracking, such that any write to an instance variable can flow to a read.
```rb
class Foo
  def foo(x)
    @field = Bar.new
  end
  def bar
    @field # 'Bar.new' flows here
  end
end
```
For the time being it doesn't take inheritance into account.

This initially caused a regression in `opal`. Investigating it I noticed some dubious API graph edges, and concluded that we should not propagate use/def nodes through self-argument passing.

I wonder if we should remove self-argument passing from type-tracking altogether, since some parts of the call-graph construction also block this. But tracking of singleton methods still relies on self-argument passing so I didn't go that far in this PR, and just blocked it directly in API graphs instead.

Also marks the unary `*` operator as a simple callable.

[Evaluation](https://github.com/github/codeql-dca-main/issues/7706) shows
- 39k new call edges
- Lost some taint sinks and sources inside the source code of libraries for which we have a model. AFAICT a model would find a use of a class which then flows into `self` in one of its methods, and then starts flagging up sinks inside the class. If we _want_ to flag these sinks, the better solution is to directly treat `self` in the class as uses of it, and not rely on finding a call site. I don't believe we currently lose any sources/sinks in clients of these libraries.
- Gained a few taint sinks and sources which seem legit.
- Gained a new cleartext-storage alert due to the new call edges. It seems to be a FP due to `HashLiteralPasswordSource` treating an entire hash literal as a source, but where the value being read in the end isn't the key containing the password