### PR TITLE
Data flow: Take conjunctive `With(out)Contents` into account in `prohibitsUseUseFlow`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -751,6 +751,27 @@ module Private {
     }
 
     /**
+     * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
+     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * `n` either clears or expects contents.
+     */
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+      viableParam(_, _, _, p) and
+      n = p and
+      clearsOrExcepts = false
+      or
+      exists(Node mid, boolean clearsOrExceptsMid |
+        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+        summaryLocalStep(mid, n, true) and
+        if
+          summaryClearsContent(n, _) or
+          summaryExpectsContent(n, _)
+        then clearsOrExcepts = true
+        else clearsOrExcepts = clearsOrExceptsMid
+      )
+    }
+
+    /**
      * Holds if use-use flow starting from `arg` should be prohibited.
      *
      * This is the case when `arg` is the argument of a call that targets a
@@ -759,15 +780,11 @@ module Private {
      */
     pragma[nomagic]
     predicate prohibitsUseUseFlow(ArgNode arg, SummarizedCallable sc) {
-      exists(ParamNode p, Node mid, ParameterPosition ppos, Node ret |
+      exists(ParamNode p, ParameterPosition ppos, Node ret |
+        paramReachesLocal(p, ret, true) and
         p = summaryArgParam0(_, arg, sc) and
         p.isParameterOf(_, pragma[only_bind_into](ppos)) and
-        summaryLocalStep(p, mid, true) and
-        summaryLocalStep(mid, ret, true) and
         isParameterPostUpdate(ret, _, pragma[only_bind_into](ppos))
-      |
-        summaryClearsContent(mid, _) or
-        summaryExpectsContent(mid, _)
       )
     }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -752,22 +752,22 @@ module Private {
 
     /**
      * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
-     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * local steps. `clearsOrExpects` records whether any node on the path from `p` to
      * `n` either clears or expects contents.
      */
-    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExpects) {
       viableParam(_, _, _, p) and
       n = p and
-      clearsOrExcepts = false
+      clearsOrExpects = false
       or
-      exists(Node mid, boolean clearsOrExceptsMid |
-        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+      exists(Node mid, boolean clearsOrExpectsMid |
+        paramReachesLocal(p, mid, clearsOrExpectsMid) and
         summaryLocalStep(mid, n, true) and
         if
           summaryClearsContent(n, _) or
           summaryExpectsContent(n, _)
-        then clearsOrExcepts = true
-        else clearsOrExcepts = clearsOrExceptsMid
+        then clearsOrExpects = true
+        else clearsOrExpects = clearsOrExpectsMid
       )
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -751,6 +751,27 @@ module Private {
     }
 
     /**
+     * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
+     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * `n` either clears or expects contents.
+     */
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+      viableParam(_, _, _, p) and
+      n = p and
+      clearsOrExcepts = false
+      or
+      exists(Node mid, boolean clearsOrExceptsMid |
+        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+        summaryLocalStep(mid, n, true) and
+        if
+          summaryClearsContent(n, _) or
+          summaryExpectsContent(n, _)
+        then clearsOrExcepts = true
+        else clearsOrExcepts = clearsOrExceptsMid
+      )
+    }
+
+    /**
      * Holds if use-use flow starting from `arg` should be prohibited.
      *
      * This is the case when `arg` is the argument of a call that targets a
@@ -759,15 +780,11 @@ module Private {
      */
     pragma[nomagic]
     predicate prohibitsUseUseFlow(ArgNode arg, SummarizedCallable sc) {
-      exists(ParamNode p, Node mid, ParameterPosition ppos, Node ret |
+      exists(ParamNode p, ParameterPosition ppos, Node ret |
+        paramReachesLocal(p, ret, true) and
         p = summaryArgParam0(_, arg, sc) and
         p.isParameterOf(_, pragma[only_bind_into](ppos)) and
-        summaryLocalStep(p, mid, true) and
-        summaryLocalStep(mid, ret, true) and
         isParameterPostUpdate(ret, _, pragma[only_bind_into](ppos))
-      |
-        summaryClearsContent(mid, _) or
-        summaryExpectsContent(mid, _)
       )
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -752,22 +752,22 @@ module Private {
 
     /**
      * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
-     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * local steps. `clearsOrExpects` records whether any node on the path from `p` to
      * `n` either clears or expects contents.
      */
-    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExpects) {
       viableParam(_, _, _, p) and
       n = p and
-      clearsOrExcepts = false
+      clearsOrExpects = false
       or
-      exists(Node mid, boolean clearsOrExceptsMid |
-        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+      exists(Node mid, boolean clearsOrExpectsMid |
+        paramReachesLocal(p, mid, clearsOrExpectsMid) and
         summaryLocalStep(mid, n, true) and
         if
           summaryClearsContent(n, _) or
           summaryExpectsContent(n, _)
-        then clearsOrExcepts = true
-        else clearsOrExcepts = clearsOrExceptsMid
+        then clearsOrExpects = true
+        else clearsOrExpects = clearsOrExpectsMid
       )
     }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
@@ -751,6 +751,27 @@ module Private {
     }
 
     /**
+     * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
+     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * `n` either clears or expects contents.
+     */
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+      viableParam(_, _, _, p) and
+      n = p and
+      clearsOrExcepts = false
+      or
+      exists(Node mid, boolean clearsOrExceptsMid |
+        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+        summaryLocalStep(mid, n, true) and
+        if
+          summaryClearsContent(n, _) or
+          summaryExpectsContent(n, _)
+        then clearsOrExcepts = true
+        else clearsOrExcepts = clearsOrExceptsMid
+      )
+    }
+
+    /**
      * Holds if use-use flow starting from `arg` should be prohibited.
      *
      * This is the case when `arg` is the argument of a call that targets a
@@ -759,15 +780,11 @@ module Private {
      */
     pragma[nomagic]
     predicate prohibitsUseUseFlow(ArgNode arg, SummarizedCallable sc) {
-      exists(ParamNode p, Node mid, ParameterPosition ppos, Node ret |
+      exists(ParamNode p, ParameterPosition ppos, Node ret |
+        paramReachesLocal(p, ret, true) and
         p = summaryArgParam0(_, arg, sc) and
         p.isParameterOf(_, pragma[only_bind_into](ppos)) and
-        summaryLocalStep(p, mid, true) and
-        summaryLocalStep(mid, ret, true) and
         isParameterPostUpdate(ret, _, pragma[only_bind_into](ppos))
-      |
-        summaryClearsContent(mid, _) or
-        summaryExpectsContent(mid, _)
       )
     }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
@@ -752,22 +752,22 @@ module Private {
 
     /**
      * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
-     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * local steps. `clearsOrExpects` records whether any node on the path from `p` to
      * `n` either clears or expects contents.
      */
-    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExpects) {
       viableParam(_, _, _, p) and
       n = p and
-      clearsOrExcepts = false
+      clearsOrExpects = false
       or
-      exists(Node mid, boolean clearsOrExceptsMid |
-        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+      exists(Node mid, boolean clearsOrExpectsMid |
+        paramReachesLocal(p, mid, clearsOrExpectsMid) and
         summaryLocalStep(mid, n, true) and
         if
           summaryClearsContent(n, _) or
           summaryExpectsContent(n, _)
-        then clearsOrExcepts = true
-        else clearsOrExcepts = clearsOrExceptsMid
+        then clearsOrExpects = true
+        else clearsOrExpects = clearsOrExpectsMid
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -751,6 +751,27 @@ module Private {
     }
 
     /**
+     * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
+     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * `n` either clears or expects contents.
+     */
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+      viableParam(_, _, _, p) and
+      n = p and
+      clearsOrExcepts = false
+      or
+      exists(Node mid, boolean clearsOrExceptsMid |
+        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+        summaryLocalStep(mid, n, true) and
+        if
+          summaryClearsContent(n, _) or
+          summaryExpectsContent(n, _)
+        then clearsOrExcepts = true
+        else clearsOrExcepts = clearsOrExceptsMid
+      )
+    }
+
+    /**
      * Holds if use-use flow starting from `arg` should be prohibited.
      *
      * This is the case when `arg` is the argument of a call that targets a
@@ -759,15 +780,11 @@ module Private {
      */
     pragma[nomagic]
     predicate prohibitsUseUseFlow(ArgNode arg, SummarizedCallable sc) {
-      exists(ParamNode p, Node mid, ParameterPosition ppos, Node ret |
+      exists(ParamNode p, ParameterPosition ppos, Node ret |
+        paramReachesLocal(p, ret, true) and
         p = summaryArgParam0(_, arg, sc) and
         p.isParameterOf(_, pragma[only_bind_into](ppos)) and
-        summaryLocalStep(p, mid, true) and
-        summaryLocalStep(mid, ret, true) and
         isParameterPostUpdate(ret, _, pragma[only_bind_into](ppos))
-      |
-        summaryClearsContent(mid, _) or
-        summaryExpectsContent(mid, _)
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -752,22 +752,22 @@ module Private {
 
     /**
      * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
-     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * local steps. `clearsOrExpects` records whether any node on the path from `p` to
      * `n` either clears or expects contents.
      */
-    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExpects) {
       viableParam(_, _, _, p) and
       n = p and
-      clearsOrExcepts = false
+      clearsOrExpects = false
       or
-      exists(Node mid, boolean clearsOrExceptsMid |
-        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+      exists(Node mid, boolean clearsOrExpectsMid |
+        paramReachesLocal(p, mid, clearsOrExpectsMid) and
         summaryLocalStep(mid, n, true) and
         if
           summaryClearsContent(n, _) or
           summaryExpectsContent(n, _)
-        then clearsOrExcepts = true
-        else clearsOrExcepts = clearsOrExceptsMid
+        then clearsOrExpects = true
+        else clearsOrExpects = clearsOrExpectsMid
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Hash.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Hash.qll
@@ -267,7 +267,7 @@ module Hash {
             s = getExceptComponent(mc, i)
           |
             ".WithoutElement[" + s + "!]" order by i
-          ) and
+          ) + ".WithElement[any]" and
       output = "ReturnValue" and
       preservesValue = true
     }

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -564,8 +564,6 @@ edges
 | array_flow.rb:334:10:334:10 | a [element] :  | array_flow.rb:334:10:334:13 | ...[...] |
 | array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:339:9:339:9 | a [element 2] :  |
 | array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:339:9:339:9 | a [element 2] :  |
-| array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:345:10:345:10 | a [element 2] :  |
-| array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:345:10:345:10 | a [element 2] :  |
 | array_flow.rb:339:9:339:9 | [post] a [element] :  | array_flow.rb:343:10:343:10 | a [element] :  |
 | array_flow.rb:339:9:339:9 | [post] a [element] :  | array_flow.rb:343:10:343:10 | a [element] :  |
 | array_flow.rb:339:9:339:9 | [post] a [element] :  | array_flow.rb:344:10:344:10 | a [element] :  |
@@ -588,8 +586,6 @@ edges
 | array_flow.rb:343:10:343:10 | a [element] :  | array_flow.rb:343:10:343:13 | ...[...] |
 | array_flow.rb:344:10:344:10 | a [element] :  | array_flow.rb:344:10:344:13 | ...[...] |
 | array_flow.rb:344:10:344:10 | a [element] :  | array_flow.rb:344:10:344:13 | ...[...] |
-| array_flow.rb:345:10:345:10 | a [element 2] :  | array_flow.rb:345:10:345:13 | ...[...] |
-| array_flow.rb:345:10:345:10 | a [element 2] :  | array_flow.rb:345:10:345:13 | ...[...] |
 | array_flow.rb:345:10:345:10 | a [element] :  | array_flow.rb:345:10:345:13 | ...[...] |
 | array_flow.rb:345:10:345:10 | a [element] :  | array_flow.rb:345:10:345:13 | ...[...] |
 | array_flow.rb:349:16:349:25 | call to source :  | array_flow.rb:350:9:350:9 | a [element 2] :  |
@@ -4098,8 +4094,6 @@ nodes
 | array_flow.rb:344:10:344:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:344:10:344:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:344:10:344:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:345:10:345:10 | a [element 2] :  | semmle.label | a [element 2] :  |
-| array_flow.rb:345:10:345:10 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:345:10:345:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:345:10:345:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -102,7 +102,6 @@ edges
 | hash_flow.rb:185:9:185:12 | hash [element :a] :  | hash_flow.rb:185:9:185:23 | call to delete :  |
 | hash_flow.rb:185:9:185:23 | call to delete :  | hash_flow.rb:186:10:186:10 | a |
 | hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:197:9:197:12 | hash [element :a] :  |
-| hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:202:10:202:13 | hash [element :a] :  |
 | hash_flow.rb:197:9:197:12 | [post] hash [element :a] :  | hash_flow.rb:202:10:202:13 | hash [element :a] :  |
 | hash_flow.rb:197:9:197:12 | hash [element :a] :  | hash_flow.rb:197:9:197:12 | [post] hash [element :a] :  |
 | hash_flow.rb:197:9:197:12 | hash [element :a] :  | hash_flow.rb:197:9:200:7 | call to delete_if [element :a] :  |
@@ -307,7 +306,6 @@ edges
 | hash_flow.rb:477:29:477:33 | value :  | hash_flow.rb:479:14:479:18 | value |
 | hash_flow.rb:482:10:482:10 | b [element :a] :  | hash_flow.rb:482:10:482:14 | ...[...] |
 | hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:492:9:492:12 | hash [element :a] :  |
-| hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:498:10:498:13 | hash [element :a] :  |
 | hash_flow.rb:492:9:492:12 | [post] hash [element :a] :  | hash_flow.rb:498:10:498:13 | hash [element :a] :  |
 | hash_flow.rb:492:9:492:12 | hash [element :a] :  | hash_flow.rb:492:9:492:12 | [post] hash [element :a] :  |
 | hash_flow.rb:492:9:492:12 | hash [element :a] :  | hash_flow.rb:492:9:496:7 | call to reject! [element :a] :  |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -1,4 +1,6 @@
 failures
+| summaries.rb:106:6:106:9 | ...[...] | Unexpected result: hasValueFlow=elem1 |
+| summaries.rb:107:6:107:9 | ...[...] | Unexpected result: hasValueFlow=elem2 |
 edges
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
@@ -24,26 +26,26 @@ edges
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:59:27:59:33 | tainted :  |
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:63:32:63:38 | tainted :  |
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:65:23:65:29 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:115:16:115:22 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:121:14:121:20 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:124:16:124:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:124:16:124:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:125:21:125:27 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:125:21:125:27 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:128:26:128:32 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:128:26:128:32 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:130:23:130:29 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:130:23:130:29 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:133:19:133:25 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:133:19:133:25 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:134:19:134:25 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:134:19:134:25 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:138:26:138:32 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:138:26:138:32 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:140:16:140:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:140:16:140:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:143:39:143:45 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:143:39:143:45 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:122:16:122:22 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:128:14:128:20 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:132:21:132:27 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:132:21:132:27 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:135:26:135:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:135:26:135:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:137:23:137:29 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:137:23:137:29 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:140:19:140:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:140:19:140:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:141:19:141:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:141:19:141:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:145:26:145:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:145:26:145:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:147:16:147:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:147:16:147:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:150:39:150:45 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:150:39:150:45 | tainted |
 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
 | summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
@@ -87,127 +89,155 @@ edges
 | summaries.rb:65:40:65:40 | x :  | summaries.rb:66:8:66:8 | x |
 | summaries.rb:73:24:73:53 | call to source :  | summaries.rb:73:8:73:54 | call to preserveTaint |
 | summaries.rb:76:26:76:56 | call to source :  | summaries.rb:76:8:76:57 | call to preserveTaint |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:81:6:81:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:81:6:81:6 | a [element 1] :  |
 | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:82:6:82:6 | a [element 1] :  |
 | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:82:6:82:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:84:6:84:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:84:6:84:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:86:5:86:5 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:86:5:86:5 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:90:5:90:5 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:90:5:90:5 | a [element 1] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:85:6:85:6 | a [element 2] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:85:6:85:6 | a [element 2] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:94:1:94:1 | a [element 2] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:94:1:94:1 | a [element 2] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:81:6:81:6 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:81:6:81:6 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:83:6:83:6 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:83:6:83:6 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:84:6:84:6 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:84:6:84:6 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:85:6:85:6 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:85:6:85:6 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:86:5:86:5 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:86:5:86:5 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:94:1:94:1 | a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | summaries.rb:94:1:94:1 | a [element] :  |
-| summaries.rb:80:13:80:27 | call to source :  | summaries.rb:80:1:80:1 | [post] a [element] :  |
-| summaries.rb:80:13:80:27 | call to source :  | summaries.rb:80:1:80:1 | [post] a [element] :  |
-| summaries.rb:81:6:81:6 | a [element 1] :  | summaries.rb:81:6:81:24 | call to readElementOne |
-| summaries.rb:81:6:81:6 | a [element 1] :  | summaries.rb:81:6:81:24 | call to readElementOne |
-| summaries.rb:81:6:81:6 | a [element] :  | summaries.rb:81:6:81:24 | call to readElementOne |
-| summaries.rb:81:6:81:6 | a [element] :  | summaries.rb:81:6:81:24 | call to readElementOne |
-| summaries.rb:82:6:82:6 | a [element 1] :  | summaries.rb:82:6:82:31 | call to readExactlyElementOne |
-| summaries.rb:82:6:82:6 | a [element 1] :  | summaries.rb:82:6:82:31 | call to readExactlyElementOne |
-| summaries.rb:83:6:83:6 | a [element] :  | summaries.rb:83:6:83:9 | ...[...] |
-| summaries.rb:83:6:83:6 | a [element] :  | summaries.rb:83:6:83:9 | ...[...] |
-| summaries.rb:84:6:84:6 | a [element 1] :  | summaries.rb:84:6:84:9 | ...[...] |
-| summaries.rb:84:6:84:6 | a [element 1] :  | summaries.rb:84:6:84:9 | ...[...] |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:83:6:83:6 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:83:6:83:6 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:85:6:85:6 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:85:6:85:6 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:87:5:87:5 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:87:5:87:5 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:91:5:91:5 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:91:5:91:5 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:103:1:103:1 | d [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:103:1:103:1 | d [element 1] :  |
+| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:86:6:86:6 | a [element 2] :  |
+| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:86:6:86:6 | a [element 2] :  |
+| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:95:1:95:1 | a [element 2] :  |
+| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:95:1:95:1 | a [element 2] :  |
+| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:103:1:103:1 | d [element 2] :  |
+| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:103:1:103:1 | d [element 2] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:82:6:82:6 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:82:6:82:6 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:84:6:84:6 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:84:6:84:6 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:85:6:85:6 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:85:6:85:6 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:86:6:86:6 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:86:6:86:6 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:87:5:87:5 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:87:5:87:5 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:95:1:95:1 | a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:95:1:95:1 | a [element] :  |
+| summaries.rb:81:13:81:27 | call to source :  | summaries.rb:81:1:81:1 | [post] a [element] :  |
+| summaries.rb:81:13:81:27 | call to source :  | summaries.rb:81:1:81:1 | [post] a [element] :  |
+| summaries.rb:82:6:82:6 | a [element 1] :  | summaries.rb:82:6:82:24 | call to readElementOne |
+| summaries.rb:82:6:82:6 | a [element 1] :  | summaries.rb:82:6:82:24 | call to readElementOne |
+| summaries.rb:82:6:82:6 | a [element] :  | summaries.rb:82:6:82:24 | call to readElementOne |
+| summaries.rb:82:6:82:6 | a [element] :  | summaries.rb:82:6:82:24 | call to readElementOne |
+| summaries.rb:83:6:83:6 | a [element 1] :  | summaries.rb:83:6:83:31 | call to readExactlyElementOne |
+| summaries.rb:83:6:83:6 | a [element 1] :  | summaries.rb:83:6:83:31 | call to readExactlyElementOne |
 | summaries.rb:84:6:84:6 | a [element] :  | summaries.rb:84:6:84:9 | ...[...] |
 | summaries.rb:84:6:84:6 | a [element] :  | summaries.rb:84:6:84:9 | ...[...] |
-| summaries.rb:85:6:85:6 | a [element 2] :  | summaries.rb:85:6:85:9 | ...[...] |
-| summaries.rb:85:6:85:6 | a [element 2] :  | summaries.rb:85:6:85:9 | ...[...] |
+| summaries.rb:85:6:85:6 | a [element 1] :  | summaries.rb:85:6:85:9 | ...[...] |
+| summaries.rb:85:6:85:6 | a [element 1] :  | summaries.rb:85:6:85:9 | ...[...] |
 | summaries.rb:85:6:85:6 | a [element] :  | summaries.rb:85:6:85:9 | ...[...] |
 | summaries.rb:85:6:85:6 | a [element] :  | summaries.rb:85:6:85:9 | ...[...] |
-| summaries.rb:86:5:86:5 | a [element 1] :  | summaries.rb:86:5:86:22 | call to withElementOne [element 1] :  |
-| summaries.rb:86:5:86:5 | a [element 1] :  | summaries.rb:86:5:86:22 | call to withElementOne [element 1] :  |
-| summaries.rb:86:5:86:5 | a [element] :  | summaries.rb:86:5:86:22 | call to withElementOne [element] :  |
-| summaries.rb:86:5:86:5 | a [element] :  | summaries.rb:86:5:86:22 | call to withElementOne [element] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element 1] :  | summaries.rb:88:6:88:6 | b [element 1] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element 1] :  | summaries.rb:88:6:88:6 | b [element 1] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element] :  | summaries.rb:87:6:87:6 | b [element] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element] :  | summaries.rb:87:6:87:6 | b [element] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element] :  | summaries.rb:88:6:88:6 | b [element] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element] :  | summaries.rb:88:6:88:6 | b [element] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element] :  | summaries.rb:89:6:89:6 | b [element] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element] :  | summaries.rb:89:6:89:6 | b [element] :  |
-| summaries.rb:87:6:87:6 | b [element] :  | summaries.rb:87:6:87:9 | ...[...] |
-| summaries.rb:87:6:87:6 | b [element] :  | summaries.rb:87:6:87:9 | ...[...] |
-| summaries.rb:88:6:88:6 | b [element 1] :  | summaries.rb:88:6:88:9 | ...[...] |
-| summaries.rb:88:6:88:6 | b [element 1] :  | summaries.rb:88:6:88:9 | ...[...] |
+| summaries.rb:86:6:86:6 | a [element 2] :  | summaries.rb:86:6:86:9 | ...[...] |
+| summaries.rb:86:6:86:6 | a [element 2] :  | summaries.rb:86:6:86:9 | ...[...] |
+| summaries.rb:86:6:86:6 | a [element] :  | summaries.rb:86:6:86:9 | ...[...] |
+| summaries.rb:86:6:86:6 | a [element] :  | summaries.rb:86:6:86:9 | ...[...] |
+| summaries.rb:87:5:87:5 | a [element 1] :  | summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  |
+| summaries.rb:87:5:87:5 | a [element 1] :  | summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  |
+| summaries.rb:87:5:87:5 | a [element] :  | summaries.rb:87:5:87:22 | call to withElementOne [element] :  |
+| summaries.rb:87:5:87:5 | a [element] :  | summaries.rb:87:5:87:22 | call to withElementOne [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  | summaries.rb:89:6:89:6 | b [element 1] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  | summaries.rb:89:6:89:6 | b [element 1] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:88:6:88:6 | b [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:88:6:88:6 | b [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:89:6:89:6 | b [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:89:6:89:6 | b [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:90:6:90:6 | b [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:90:6:90:6 | b [element] :  |
 | summaries.rb:88:6:88:6 | b [element] :  | summaries.rb:88:6:88:9 | ...[...] |
 | summaries.rb:88:6:88:6 | b [element] :  | summaries.rb:88:6:88:9 | ...[...] |
+| summaries.rb:89:6:89:6 | b [element 1] :  | summaries.rb:89:6:89:9 | ...[...] |
+| summaries.rb:89:6:89:6 | b [element 1] :  | summaries.rb:89:6:89:9 | ...[...] |
 | summaries.rb:89:6:89:6 | b [element] :  | summaries.rb:89:6:89:9 | ...[...] |
 | summaries.rb:89:6:89:6 | b [element] :  | summaries.rb:89:6:89:9 | ...[...] |
-| summaries.rb:90:5:90:5 | a [element 1] :  | summaries.rb:90:5:90:29 | call to withExactlyElementOne [element 1] :  |
-| summaries.rb:90:5:90:5 | a [element 1] :  | summaries.rb:90:5:90:29 | call to withExactlyElementOne [element 1] :  |
-| summaries.rb:90:5:90:29 | call to withExactlyElementOne [element 1] :  | summaries.rb:92:6:92:6 | c [element 1] :  |
-| summaries.rb:90:5:90:29 | call to withExactlyElementOne [element 1] :  | summaries.rb:92:6:92:6 | c [element 1] :  |
-| summaries.rb:92:6:92:6 | c [element 1] :  | summaries.rb:92:6:92:9 | ...[...] |
-| summaries.rb:92:6:92:6 | c [element 1] :  | summaries.rb:92:6:92:9 | ...[...] |
-| summaries.rb:94:1:94:1 | [post] a [element 2] :  | summaries.rb:97:6:97:6 | a [element 2] :  |
-| summaries.rb:94:1:94:1 | [post] a [element 2] :  | summaries.rb:97:6:97:6 | a [element 2] :  |
-| summaries.rb:94:1:94:1 | [post] a [element 2] :  | summaries.rb:98:1:98:1 | a [element 2] :  |
-| summaries.rb:94:1:94:1 | [post] a [element 2] :  | summaries.rb:98:1:98:1 | a [element 2] :  |
-| summaries.rb:94:1:94:1 | [post] a [element] :  | summaries.rb:95:6:95:6 | a [element] :  |
-| summaries.rb:94:1:94:1 | [post] a [element] :  | summaries.rb:95:6:95:6 | a [element] :  |
-| summaries.rb:94:1:94:1 | [post] a [element] :  | summaries.rb:96:6:96:6 | a [element] :  |
-| summaries.rb:94:1:94:1 | [post] a [element] :  | summaries.rb:96:6:96:6 | a [element] :  |
-| summaries.rb:94:1:94:1 | [post] a [element] :  | summaries.rb:97:6:97:6 | a [element] :  |
-| summaries.rb:94:1:94:1 | [post] a [element] :  | summaries.rb:97:6:97:6 | a [element] :  |
-| summaries.rb:94:1:94:1 | a [element 2] :  | summaries.rb:94:1:94:1 | [post] a [element 2] :  |
-| summaries.rb:94:1:94:1 | a [element 2] :  | summaries.rb:94:1:94:1 | [post] a [element 2] :  |
-| summaries.rb:94:1:94:1 | a [element] :  | summaries.rb:94:1:94:1 | [post] a [element] :  |
-| summaries.rb:94:1:94:1 | a [element] :  | summaries.rb:94:1:94:1 | [post] a [element] :  |
-| summaries.rb:95:6:95:6 | a [element] :  | summaries.rb:95:6:95:9 | ...[...] |
-| summaries.rb:95:6:95:6 | a [element] :  | summaries.rb:95:6:95:9 | ...[...] |
+| summaries.rb:90:6:90:6 | b [element] :  | summaries.rb:90:6:90:9 | ...[...] |
+| summaries.rb:90:6:90:6 | b [element] :  | summaries.rb:90:6:90:9 | ...[...] |
+| summaries.rb:91:5:91:5 | a [element 1] :  | summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  |
+| summaries.rb:91:5:91:5 | a [element 1] :  | summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | summaries.rb:93:6:93:6 | c [element 1] :  |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | summaries.rb:93:6:93:6 | c [element 1] :  |
+| summaries.rb:93:6:93:6 | c [element 1] :  | summaries.rb:93:6:93:9 | ...[...] |
+| summaries.rb:93:6:93:6 | c [element 1] :  | summaries.rb:93:6:93:9 | ...[...] |
+| summaries.rb:95:1:95:1 | [post] a [element 2] :  | summaries.rb:98:6:98:6 | a [element 2] :  |
+| summaries.rb:95:1:95:1 | [post] a [element 2] :  | summaries.rb:98:6:98:6 | a [element 2] :  |
+| summaries.rb:95:1:95:1 | [post] a [element 2] :  | summaries.rb:99:1:99:1 | a [element 2] :  |
+| summaries.rb:95:1:95:1 | [post] a [element 2] :  | summaries.rb:99:1:99:1 | a [element 2] :  |
+| summaries.rb:95:1:95:1 | [post] a [element] :  | summaries.rb:96:6:96:6 | a [element] :  |
+| summaries.rb:95:1:95:1 | [post] a [element] :  | summaries.rb:96:6:96:6 | a [element] :  |
+| summaries.rb:95:1:95:1 | [post] a [element] :  | summaries.rb:97:6:97:6 | a [element] :  |
+| summaries.rb:95:1:95:1 | [post] a [element] :  | summaries.rb:97:6:97:6 | a [element] :  |
+| summaries.rb:95:1:95:1 | [post] a [element] :  | summaries.rb:98:6:98:6 | a [element] :  |
+| summaries.rb:95:1:95:1 | [post] a [element] :  | summaries.rb:98:6:98:6 | a [element] :  |
+| summaries.rb:95:1:95:1 | a [element 2] :  | summaries.rb:95:1:95:1 | [post] a [element 2] :  |
+| summaries.rb:95:1:95:1 | a [element 2] :  | summaries.rb:95:1:95:1 | [post] a [element 2] :  |
+| summaries.rb:95:1:95:1 | a [element] :  | summaries.rb:95:1:95:1 | [post] a [element] :  |
+| summaries.rb:95:1:95:1 | a [element] :  | summaries.rb:95:1:95:1 | [post] a [element] :  |
 | summaries.rb:96:6:96:6 | a [element] :  | summaries.rb:96:6:96:9 | ...[...] |
 | summaries.rb:96:6:96:6 | a [element] :  | summaries.rb:96:6:96:9 | ...[...] |
-| summaries.rb:97:6:97:6 | a [element 2] :  | summaries.rb:97:6:97:9 | ...[...] |
-| summaries.rb:97:6:97:6 | a [element 2] :  | summaries.rb:97:6:97:9 | ...[...] |
 | summaries.rb:97:6:97:6 | a [element] :  | summaries.rb:97:6:97:9 | ...[...] |
 | summaries.rb:97:6:97:6 | a [element] :  | summaries.rb:97:6:97:9 | ...[...] |
-| summaries.rb:98:1:98:1 | [post] a [element 2] :  | summaries.rb:101:6:101:6 | a [element 2] :  |
-| summaries.rb:98:1:98:1 | [post] a [element 2] :  | summaries.rb:101:6:101:6 | a [element 2] :  |
-| summaries.rb:98:1:98:1 | a [element 2] :  | summaries.rb:98:1:98:1 | [post] a [element 2] :  |
-| summaries.rb:98:1:98:1 | a [element 2] :  | summaries.rb:98:1:98:1 | [post] a [element 2] :  |
-| summaries.rb:101:6:101:6 | a [element 2] :  | summaries.rb:101:6:101:9 | ...[...] |
-| summaries.rb:101:6:101:6 | a [element 2] :  | summaries.rb:101:6:101:9 | ...[...] |
-| summaries.rb:104:1:104:1 | [post] x [@value] :  | summaries.rb:105:6:105:6 | x [@value] :  |
-| summaries.rb:104:1:104:1 | [post] x [@value] :  | summaries.rb:105:6:105:6 | x [@value] :  |
-| summaries.rb:104:13:104:26 | call to source :  | summaries.rb:104:1:104:1 | [post] x [@value] :  |
-| summaries.rb:104:13:104:26 | call to source :  | summaries.rb:104:1:104:1 | [post] x [@value] :  |
-| summaries.rb:105:6:105:6 | x [@value] :  | summaries.rb:105:6:105:16 | call to get_value |
-| summaries.rb:105:6:105:6 | x [@value] :  | summaries.rb:105:6:105:16 | call to get_value |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:121:14:121:20 | tainted :  |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:124:16:124:22 | tainted |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:125:21:125:27 | tainted |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:128:26:128:32 | tainted |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:130:23:130:29 | tainted |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:133:19:133:25 | tainted |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:134:19:134:25 | tainted |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:138:26:138:32 | tainted |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:140:16:140:22 | tainted |
-| summaries.rb:115:16:115:22 | [post] tainted :  | summaries.rb:143:39:143:45 | tainted |
-| summaries.rb:115:16:115:22 | tainted :  | summaries.rb:115:16:115:22 | [post] tainted :  |
-| summaries.rb:115:16:115:22 | tainted :  | summaries.rb:115:25:115:25 | [post] y :  |
-| summaries.rb:115:16:115:22 | tainted :  | summaries.rb:115:33:115:33 | [post] z :  |
-| summaries.rb:115:25:115:25 | [post] y :  | summaries.rb:117:6:117:6 | y |
-| summaries.rb:115:33:115:33 | [post] z :  | summaries.rb:118:6:118:6 | z |
-| summaries.rb:121:1:121:1 | [post] x :  | summaries.rb:122:6:122:6 | x |
-| summaries.rb:121:14:121:20 | tainted :  | summaries.rb:121:1:121:1 | [post] x :  |
+| summaries.rb:98:6:98:6 | a [element 2] :  | summaries.rb:98:6:98:9 | ...[...] |
+| summaries.rb:98:6:98:6 | a [element 2] :  | summaries.rb:98:6:98:9 | ...[...] |
+| summaries.rb:98:6:98:6 | a [element] :  | summaries.rb:98:6:98:9 | ...[...] |
+| summaries.rb:98:6:98:6 | a [element] :  | summaries.rb:98:6:98:9 | ...[...] |
+| summaries.rb:99:1:99:1 | [post] a [element 2] :  | summaries.rb:102:6:102:6 | a [element 2] :  |
+| summaries.rb:99:1:99:1 | [post] a [element 2] :  | summaries.rb:102:6:102:6 | a [element 2] :  |
+| summaries.rb:99:1:99:1 | a [element 2] :  | summaries.rb:99:1:99:1 | [post] a [element 2] :  |
+| summaries.rb:99:1:99:1 | a [element 2] :  | summaries.rb:99:1:99:1 | [post] a [element 2] :  |
+| summaries.rb:102:6:102:6 | a [element 2] :  | summaries.rb:102:6:102:9 | ...[...] |
+| summaries.rb:102:6:102:6 | a [element 2] :  | summaries.rb:102:6:102:9 | ...[...] |
+| summaries.rb:103:1:103:1 | [post] d [element 1] :  | summaries.rb:106:6:106:6 | d [element 1] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 1] :  | summaries.rb:106:6:106:6 | d [element 1] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 2] :  | summaries.rb:107:6:107:6 | d [element 2] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 2] :  | summaries.rb:107:6:107:6 | d [element 2] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 3] :  | summaries.rb:104:1:104:1 | d [element 3] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 3] :  | summaries.rb:104:1:104:1 | d [element 3] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 3] :  | summaries.rb:108:6:108:6 | d [element 3] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 3] :  | summaries.rb:108:6:108:6 | d [element 3] :  |
+| summaries.rb:103:1:103:1 | d [element 1] :  | summaries.rb:103:1:103:1 | [post] d [element 1] :  |
+| summaries.rb:103:1:103:1 | d [element 1] :  | summaries.rb:103:1:103:1 | [post] d [element 1] :  |
+| summaries.rb:103:1:103:1 | d [element 2] :  | summaries.rb:103:1:103:1 | [post] d [element 2] :  |
+| summaries.rb:103:1:103:1 | d [element 2] :  | summaries.rb:103:1:103:1 | [post] d [element 2] :  |
+| summaries.rb:103:8:103:22 | call to source :  | summaries.rb:103:1:103:1 | [post] d [element 3] :  |
+| summaries.rb:103:8:103:22 | call to source :  | summaries.rb:103:1:103:1 | [post] d [element 3] :  |
+| summaries.rb:104:1:104:1 | [post] d [element 3] :  | summaries.rb:108:6:108:6 | d [element 3] :  |
+| summaries.rb:104:1:104:1 | [post] d [element 3] :  | summaries.rb:108:6:108:6 | d [element 3] :  |
+| summaries.rb:104:1:104:1 | d [element 3] :  | summaries.rb:104:1:104:1 | [post] d [element 3] :  |
+| summaries.rb:104:1:104:1 | d [element 3] :  | summaries.rb:104:1:104:1 | [post] d [element 3] :  |
+| summaries.rb:106:6:106:6 | d [element 1] :  | summaries.rb:106:6:106:9 | ...[...] |
+| summaries.rb:106:6:106:6 | d [element 1] :  | summaries.rb:106:6:106:9 | ...[...] |
+| summaries.rb:107:6:107:6 | d [element 2] :  | summaries.rb:107:6:107:9 | ...[...] |
+| summaries.rb:107:6:107:6 | d [element 2] :  | summaries.rb:107:6:107:9 | ...[...] |
+| summaries.rb:108:6:108:6 | d [element 3] :  | summaries.rb:108:6:108:9 | ...[...] |
+| summaries.rb:108:6:108:6 | d [element 3] :  | summaries.rb:108:6:108:9 | ...[...] |
+| summaries.rb:111:1:111:1 | [post] x [@value] :  | summaries.rb:112:6:112:6 | x [@value] :  |
+| summaries.rb:111:1:111:1 | [post] x [@value] :  | summaries.rb:112:6:112:6 | x [@value] :  |
+| summaries.rb:111:13:111:26 | call to source :  | summaries.rb:111:1:111:1 | [post] x [@value] :  |
+| summaries.rb:111:13:111:26 | call to source :  | summaries.rb:111:1:111:1 | [post] x [@value] :  |
+| summaries.rb:112:6:112:6 | x [@value] :  | summaries.rb:112:6:112:16 | call to get_value |
+| summaries.rb:112:6:112:6 | x [@value] :  | summaries.rb:112:6:112:16 | call to get_value |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:128:14:128:20 | tainted :  |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:132:21:132:27 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:135:26:135:32 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:137:23:137:29 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:140:19:140:25 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:141:19:141:25 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:145:26:145:32 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:147:16:147:22 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted :  | summaries.rb:150:39:150:45 | tainted |
+| summaries.rb:122:16:122:22 | tainted :  | summaries.rb:122:16:122:22 | [post] tainted :  |
+| summaries.rb:122:16:122:22 | tainted :  | summaries.rb:122:25:122:25 | [post] y :  |
+| summaries.rb:122:16:122:22 | tainted :  | summaries.rb:122:33:122:33 | [post] z :  |
+| summaries.rb:122:25:122:25 | [post] y :  | summaries.rb:124:6:124:6 | y |
+| summaries.rb:122:33:122:33 | [post] z :  | summaries.rb:125:6:125:6 | z |
+| summaries.rb:128:1:128:1 | [post] x :  | summaries.rb:129:6:129:6 | x |
+| summaries.rb:128:14:128:20 | tainted :  | summaries.rb:128:1:128:1 | [post] x :  |
 nodes
 | summaries.rb:1:11:1:36 | call to identity :  | semmle.label | call to identity :  |
 | summaries.rb:1:11:1:36 | call to identity :  | semmle.label | call to identity :  |
@@ -287,131 +317,159 @@ nodes
 | summaries.rb:79:15:79:29 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:79:32:79:46 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:79:32:79:46 | call to source :  | semmle.label | call to source :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | semmle.label | [post] a [element] :  |
-| summaries.rb:80:1:80:1 | [post] a [element] :  | semmle.label | [post] a [element] :  |
-| summaries.rb:80:13:80:27 | call to source :  | semmle.label | call to source :  |
-| summaries.rb:80:13:80:27 | call to source :  | semmle.label | call to source :  |
-| summaries.rb:81:6:81:6 | a [element 1] :  | semmle.label | a [element 1] :  |
-| summaries.rb:81:6:81:6 | a [element 1] :  | semmle.label | a [element 1] :  |
-| summaries.rb:81:6:81:6 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:81:6:81:6 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:81:6:81:24 | call to readElementOne | semmle.label | call to readElementOne |
-| summaries.rb:81:6:81:24 | call to readElementOne | semmle.label | call to readElementOne |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| summaries.rb:81:1:81:1 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| summaries.rb:81:13:81:27 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:81:13:81:27 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:82:6:82:6 | a [element 1] :  | semmle.label | a [element 1] :  |
 | summaries.rb:82:6:82:6 | a [element 1] :  | semmle.label | a [element 1] :  |
-| summaries.rb:82:6:82:31 | call to readExactlyElementOne | semmle.label | call to readExactlyElementOne |
-| summaries.rb:82:6:82:31 | call to readExactlyElementOne | semmle.label | call to readExactlyElementOne |
-| summaries.rb:83:6:83:6 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:83:6:83:6 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:83:6:83:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:83:6:83:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:84:6:84:6 | a [element 1] :  | semmle.label | a [element 1] :  |
-| summaries.rb:84:6:84:6 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:82:6:82:6 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:82:6:82:6 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:82:6:82:24 | call to readElementOne | semmle.label | call to readElementOne |
+| summaries.rb:82:6:82:24 | call to readElementOne | semmle.label | call to readElementOne |
+| summaries.rb:83:6:83:6 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:83:6:83:6 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:83:6:83:31 | call to readExactlyElementOne | semmle.label | call to readExactlyElementOne |
+| summaries.rb:83:6:83:31 | call to readExactlyElementOne | semmle.label | call to readExactlyElementOne |
 | summaries.rb:84:6:84:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:84:6:84:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:84:6:84:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:84:6:84:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:85:6:85:6 | a [element 2] :  | semmle.label | a [element 2] :  |
-| summaries.rb:85:6:85:6 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:85:6:85:6 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:85:6:85:6 | a [element 1] :  | semmle.label | a [element 1] :  |
 | summaries.rb:85:6:85:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:85:6:85:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:85:6:85:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:85:6:85:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:86:5:86:5 | a [element 1] :  | semmle.label | a [element 1] :  |
-| summaries.rb:86:5:86:5 | a [element 1] :  | semmle.label | a [element 1] :  |
-| summaries.rb:86:5:86:5 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:86:5:86:5 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element 1] :  | semmle.label | call to withElementOne [element 1] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element 1] :  | semmle.label | call to withElementOne [element 1] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element] :  | semmle.label | call to withElementOne [element] :  |
-| summaries.rb:86:5:86:22 | call to withElementOne [element] :  | semmle.label | call to withElementOne [element] :  |
-| summaries.rb:87:6:87:6 | b [element] :  | semmle.label | b [element] :  |
-| summaries.rb:87:6:87:6 | b [element] :  | semmle.label | b [element] :  |
-| summaries.rb:87:6:87:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:87:6:87:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:88:6:88:6 | b [element 1] :  | semmle.label | b [element 1] :  |
-| summaries.rb:88:6:88:6 | b [element 1] :  | semmle.label | b [element 1] :  |
+| summaries.rb:86:6:86:6 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:86:6:86:6 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:86:6:86:6 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:86:6:86:6 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:86:6:86:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:86:6:86:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:87:5:87:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:87:5:87:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:87:5:87:5 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:87:5:87:5 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  | semmle.label | call to withElementOne [element 1] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  | semmle.label | call to withElementOne [element 1] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | semmle.label | call to withElementOne [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | semmle.label | call to withElementOne [element] :  |
 | summaries.rb:88:6:88:6 | b [element] :  | semmle.label | b [element] :  |
 | summaries.rb:88:6:88:6 | b [element] :  | semmle.label | b [element] :  |
 | summaries.rb:88:6:88:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:88:6:88:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:89:6:89:6 | b [element 1] :  | semmle.label | b [element 1] :  |
+| summaries.rb:89:6:89:6 | b [element 1] :  | semmle.label | b [element 1] :  |
 | summaries.rb:89:6:89:6 | b [element] :  | semmle.label | b [element] :  |
 | summaries.rb:89:6:89:6 | b [element] :  | semmle.label | b [element] :  |
 | summaries.rb:89:6:89:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:89:6:89:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:90:5:90:5 | a [element 1] :  | semmle.label | a [element 1] :  |
-| summaries.rb:90:5:90:5 | a [element 1] :  | semmle.label | a [element 1] :  |
-| summaries.rb:90:5:90:29 | call to withExactlyElementOne [element 1] :  | semmle.label | call to withExactlyElementOne [element 1] :  |
-| summaries.rb:90:5:90:29 | call to withExactlyElementOne [element 1] :  | semmle.label | call to withExactlyElementOne [element 1] :  |
-| summaries.rb:92:6:92:6 | c [element 1] :  | semmle.label | c [element 1] :  |
-| summaries.rb:92:6:92:6 | c [element 1] :  | semmle.label | c [element 1] :  |
-| summaries.rb:92:6:92:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:92:6:92:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:94:1:94:1 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
-| summaries.rb:94:1:94:1 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
-| summaries.rb:94:1:94:1 | [post] a [element] :  | semmle.label | [post] a [element] :  |
-| summaries.rb:94:1:94:1 | [post] a [element] :  | semmle.label | [post] a [element] :  |
-| summaries.rb:94:1:94:1 | a [element 2] :  | semmle.label | a [element 2] :  |
-| summaries.rb:94:1:94:1 | a [element 2] :  | semmle.label | a [element 2] :  |
-| summaries.rb:94:1:94:1 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:94:1:94:1 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:95:6:95:6 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:95:6:95:6 | a [element] :  | semmle.label | a [element] :  |
-| summaries.rb:95:6:95:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:95:6:95:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:90:6:90:6 | b [element] :  | semmle.label | b [element] :  |
+| summaries.rb:90:6:90:6 | b [element] :  | semmle.label | b [element] :  |
+| summaries.rb:90:6:90:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:90:6:90:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:91:5:91:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:91:5:91:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | semmle.label | call to withExactlyElementOne [element 1] :  |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | semmle.label | call to withExactlyElementOne [element 1] :  |
+| summaries.rb:93:6:93:6 | c [element 1] :  | semmle.label | c [element 1] :  |
+| summaries.rb:93:6:93:6 | c [element 1] :  | semmle.label | c [element 1] :  |
+| summaries.rb:93:6:93:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:93:6:93:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:95:1:95:1 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
+| summaries.rb:95:1:95:1 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
+| summaries.rb:95:1:95:1 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| summaries.rb:95:1:95:1 | [post] a [element] :  | semmle.label | [post] a [element] :  |
+| summaries.rb:95:1:95:1 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:95:1:95:1 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:95:1:95:1 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:95:1:95:1 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:96:6:96:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:96:6:96:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:96:6:96:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:96:6:96:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:97:6:97:6 | a [element 2] :  | semmle.label | a [element 2] :  |
-| summaries.rb:97:6:97:6 | a [element 2] :  | semmle.label | a [element 2] :  |
 | summaries.rb:97:6:97:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:97:6:97:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:97:6:97:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:97:6:97:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:98:1:98:1 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
-| summaries.rb:98:1:98:1 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
-| summaries.rb:98:1:98:1 | a [element 2] :  | semmle.label | a [element 2] :  |
-| summaries.rb:98:1:98:1 | a [element 2] :  | semmle.label | a [element 2] :  |
-| summaries.rb:101:6:101:6 | a [element 2] :  | semmle.label | a [element 2] :  |
-| summaries.rb:101:6:101:6 | a [element 2] :  | semmle.label | a [element 2] :  |
-| summaries.rb:101:6:101:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:101:6:101:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:104:1:104:1 | [post] x [@value] :  | semmle.label | [post] x [@value] :  |
-| summaries.rb:104:1:104:1 | [post] x [@value] :  | semmle.label | [post] x [@value] :  |
-| summaries.rb:104:13:104:26 | call to source :  | semmle.label | call to source :  |
-| summaries.rb:104:13:104:26 | call to source :  | semmle.label | call to source :  |
-| summaries.rb:105:6:105:6 | x [@value] :  | semmle.label | x [@value] :  |
-| summaries.rb:105:6:105:6 | x [@value] :  | semmle.label | x [@value] :  |
-| summaries.rb:105:6:105:16 | call to get_value | semmle.label | call to get_value |
-| summaries.rb:105:6:105:16 | call to get_value | semmle.label | call to get_value |
-| summaries.rb:115:16:115:22 | [post] tainted :  | semmle.label | [post] tainted :  |
-| summaries.rb:115:16:115:22 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:115:25:115:25 | [post] y :  | semmle.label | [post] y :  |
-| summaries.rb:115:33:115:33 | [post] z :  | semmle.label | [post] z :  |
-| summaries.rb:117:6:117:6 | y | semmle.label | y |
-| summaries.rb:118:6:118:6 | z | semmle.label | z |
-| summaries.rb:121:1:121:1 | [post] x :  | semmle.label | [post] x :  |
-| summaries.rb:121:14:121:20 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:122:6:122:6 | x | semmle.label | x |
-| summaries.rb:124:16:124:22 | tainted | semmle.label | tainted |
-| summaries.rb:124:16:124:22 | tainted | semmle.label | tainted |
-| summaries.rb:125:21:125:27 | tainted | semmle.label | tainted |
-| summaries.rb:125:21:125:27 | tainted | semmle.label | tainted |
-| summaries.rb:128:26:128:32 | tainted | semmle.label | tainted |
-| summaries.rb:128:26:128:32 | tainted | semmle.label | tainted |
-| summaries.rb:130:23:130:29 | tainted | semmle.label | tainted |
-| summaries.rb:130:23:130:29 | tainted | semmle.label | tainted |
-| summaries.rb:133:19:133:25 | tainted | semmle.label | tainted |
-| summaries.rb:133:19:133:25 | tainted | semmle.label | tainted |
-| summaries.rb:134:19:134:25 | tainted | semmle.label | tainted |
-| summaries.rb:134:19:134:25 | tainted | semmle.label | tainted |
-| summaries.rb:138:26:138:32 | tainted | semmle.label | tainted |
-| summaries.rb:138:26:138:32 | tainted | semmle.label | tainted |
-| summaries.rb:140:16:140:22 | tainted | semmle.label | tainted |
-| summaries.rb:140:16:140:22 | tainted | semmle.label | tainted |
-| summaries.rb:143:39:143:45 | tainted | semmle.label | tainted |
-| summaries.rb:143:39:143:45 | tainted | semmle.label | tainted |
+| summaries.rb:98:6:98:6 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:98:6:98:6 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:98:6:98:6 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:98:6:98:6 | a [element] :  | semmle.label | a [element] :  |
+| summaries.rb:98:6:98:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:98:6:98:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:99:1:99:1 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
+| summaries.rb:99:1:99:1 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
+| summaries.rb:99:1:99:1 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:99:1:99:1 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:102:6:102:6 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:102:6:102:6 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:102:6:102:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:102:6:102:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:103:1:103:1 | [post] d [element 1] :  | semmle.label | [post] d [element 1] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 1] :  | semmle.label | [post] d [element 1] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 2] :  | semmle.label | [post] d [element 2] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 2] :  | semmle.label | [post] d [element 2] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 3] :  | semmle.label | [post] d [element 3] :  |
+| summaries.rb:103:1:103:1 | [post] d [element 3] :  | semmle.label | [post] d [element 3] :  |
+| summaries.rb:103:1:103:1 | d [element 1] :  | semmle.label | d [element 1] :  |
+| summaries.rb:103:1:103:1 | d [element 1] :  | semmle.label | d [element 1] :  |
+| summaries.rb:103:1:103:1 | d [element 2] :  | semmle.label | d [element 2] :  |
+| summaries.rb:103:1:103:1 | d [element 2] :  | semmle.label | d [element 2] :  |
+| summaries.rb:103:8:103:22 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:103:8:103:22 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:104:1:104:1 | [post] d [element 3] :  | semmle.label | [post] d [element 3] :  |
+| summaries.rb:104:1:104:1 | [post] d [element 3] :  | semmle.label | [post] d [element 3] :  |
+| summaries.rb:104:1:104:1 | d [element 3] :  | semmle.label | d [element 3] :  |
+| summaries.rb:104:1:104:1 | d [element 3] :  | semmle.label | d [element 3] :  |
+| summaries.rb:106:6:106:6 | d [element 1] :  | semmle.label | d [element 1] :  |
+| summaries.rb:106:6:106:6 | d [element 1] :  | semmle.label | d [element 1] :  |
+| summaries.rb:106:6:106:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:106:6:106:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:107:6:107:6 | d [element 2] :  | semmle.label | d [element 2] :  |
+| summaries.rb:107:6:107:6 | d [element 2] :  | semmle.label | d [element 2] :  |
+| summaries.rb:107:6:107:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:107:6:107:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:108:6:108:6 | d [element 3] :  | semmle.label | d [element 3] :  |
+| summaries.rb:108:6:108:6 | d [element 3] :  | semmle.label | d [element 3] :  |
+| summaries.rb:108:6:108:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:108:6:108:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:111:1:111:1 | [post] x [@value] :  | semmle.label | [post] x [@value] :  |
+| summaries.rb:111:1:111:1 | [post] x [@value] :  | semmle.label | [post] x [@value] :  |
+| summaries.rb:111:13:111:26 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:111:13:111:26 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:112:6:112:6 | x [@value] :  | semmle.label | x [@value] :  |
+| summaries.rb:112:6:112:6 | x [@value] :  | semmle.label | x [@value] :  |
+| summaries.rb:112:6:112:16 | call to get_value | semmle.label | call to get_value |
+| summaries.rb:112:6:112:16 | call to get_value | semmle.label | call to get_value |
+| summaries.rb:122:16:122:22 | [post] tainted :  | semmle.label | [post] tainted :  |
+| summaries.rb:122:16:122:22 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:122:25:122:25 | [post] y :  | semmle.label | [post] y :  |
+| summaries.rb:122:33:122:33 | [post] z :  | semmle.label | [post] z :  |
+| summaries.rb:124:6:124:6 | y | semmle.label | y |
+| summaries.rb:125:6:125:6 | z | semmle.label | z |
+| summaries.rb:128:1:128:1 | [post] x :  | semmle.label | [post] x :  |
+| summaries.rb:128:14:128:20 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:129:6:129:6 | x | semmle.label | x |
+| summaries.rb:131:16:131:22 | tainted | semmle.label | tainted |
+| summaries.rb:131:16:131:22 | tainted | semmle.label | tainted |
+| summaries.rb:132:21:132:27 | tainted | semmle.label | tainted |
+| summaries.rb:132:21:132:27 | tainted | semmle.label | tainted |
+| summaries.rb:135:26:135:32 | tainted | semmle.label | tainted |
+| summaries.rb:135:26:135:32 | tainted | semmle.label | tainted |
+| summaries.rb:137:23:137:29 | tainted | semmle.label | tainted |
+| summaries.rb:137:23:137:29 | tainted | semmle.label | tainted |
+| summaries.rb:140:19:140:25 | tainted | semmle.label | tainted |
+| summaries.rb:140:19:140:25 | tainted | semmle.label | tainted |
+| summaries.rb:141:19:141:25 | tainted | semmle.label | tainted |
+| summaries.rb:141:19:141:25 | tainted | semmle.label | tainted |
+| summaries.rb:145:26:145:32 | tainted | semmle.label | tainted |
+| summaries.rb:145:26:145:32 | tainted | semmle.label | tainted |
+| summaries.rb:147:16:147:22 | tainted | semmle.label | tainted |
+| summaries.rb:147:16:147:22 | tainted | semmle.label | tainted |
+| summaries.rb:150:39:150:45 | tainted | semmle.label | tainted |
+| summaries.rb:150:39:150:45 | tainted | semmle.label | tainted |
 subpaths
 invalidSpecComponent
 #select
@@ -450,65 +508,71 @@ invalidSpecComponent
 | summaries.rb:66:8:66:8 | x | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:66:8:66:8 | x | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
 | summaries.rb:73:8:73:54 | call to preserveTaint | summaries.rb:73:24:73:53 | call to source :  | summaries.rb:73:8:73:54 | call to preserveTaint | $@ | summaries.rb:73:24:73:53 | call to source :  | call to source :  |
 | summaries.rb:76:8:76:57 | call to preserveTaint | summaries.rb:76:26:76:56 | call to source :  | summaries.rb:76:8:76:57 | call to preserveTaint | $@ | summaries.rb:76:26:76:56 | call to source :  | call to source :  |
-| summaries.rb:81:6:81:24 | call to readElementOne | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:81:6:81:24 | call to readElementOne | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:81:6:81:24 | call to readElementOne | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:81:6:81:24 | call to readElementOne | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:81:6:81:24 | call to readElementOne | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:81:6:81:24 | call to readElementOne | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:81:6:81:24 | call to readElementOne | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:81:6:81:24 | call to readElementOne | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:82:6:82:31 | call to readExactlyElementOne | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:82:6:82:31 | call to readExactlyElementOne | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:82:6:82:31 | call to readExactlyElementOne | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:82:6:82:31 | call to readExactlyElementOne | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:83:6:83:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:83:6:83:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:83:6:83:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:83:6:83:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:84:6:84:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:84:6:84:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:84:6:84:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:84:6:84:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:84:6:84:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:84:6:84:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:84:6:84:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:84:6:84:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:85:6:85:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:85:6:85:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
-| summaries.rb:85:6:85:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:85:6:85:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
-| summaries.rb:85:6:85:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:85:6:85:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:85:6:85:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:85:6:85:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:87:6:87:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:87:6:87:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:87:6:87:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:87:6:87:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:88:6:88:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:88:6:88:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:88:6:88:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:88:6:88:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:88:6:88:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:88:6:88:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:88:6:88:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:88:6:88:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:89:6:89:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:89:6:89:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:89:6:89:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:89:6:89:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:92:6:92:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:92:6:92:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:92:6:92:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:92:6:92:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:95:6:95:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:95:6:95:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:95:6:95:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:95:6:95:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:96:6:96:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:96:6:96:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:96:6:96:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:96:6:96:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:97:6:97:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:97:6:97:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
-| summaries.rb:97:6:97:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:97:6:97:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
-| summaries.rb:97:6:97:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:97:6:97:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:97:6:97:9 | ...[...] | summaries.rb:80:13:80:27 | call to source :  | summaries.rb:97:6:97:9 | ...[...] | $@ | summaries.rb:80:13:80:27 | call to source :  | call to source :  |
-| summaries.rb:101:6:101:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:101:6:101:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
-| summaries.rb:101:6:101:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:101:6:101:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
-| summaries.rb:105:6:105:16 | call to get_value | summaries.rb:104:13:104:26 | call to source :  | summaries.rb:105:6:105:16 | call to get_value | $@ | summaries.rb:104:13:104:26 | call to source :  | call to source :  |
-| summaries.rb:105:6:105:16 | call to get_value | summaries.rb:104:13:104:26 | call to source :  | summaries.rb:105:6:105:16 | call to get_value | $@ | summaries.rb:104:13:104:26 | call to source :  | call to source :  |
-| summaries.rb:117:6:117:6 | y | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:117:6:117:6 | y | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:118:6:118:6 | z | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:118:6:118:6 | z | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:122:6:122:6 | x | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:122:6:122:6 | x | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:124:16:124:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:124:16:124:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:124:16:124:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:124:16:124:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:125:21:125:27 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:125:21:125:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:125:21:125:27 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:125:21:125:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:128:26:128:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:128:26:128:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:128:26:128:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:128:26:128:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:130:23:130:29 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:130:23:130:29 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:130:23:130:29 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:130:23:130:29 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:133:19:133:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:133:19:133:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:133:19:133:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:133:19:133:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:134:19:134:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:134:19:134:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:134:19:134:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:134:19:134:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:138:26:138:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:138:26:138:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:138:26:138:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:138:26:138:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:140:16:140:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:140:16:140:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:140:16:140:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:140:16:140:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:143:39:143:45 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:143:39:143:45 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
-| summaries.rb:143:39:143:45 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:143:39:143:45 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:82:6:82:24 | call to readElementOne | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:82:6:82:24 | call to readElementOne | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:82:6:82:24 | call to readElementOne | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:82:6:82:24 | call to readElementOne | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:82:6:82:24 | call to readElementOne | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:82:6:82:24 | call to readElementOne | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:82:6:82:24 | call to readElementOne | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:82:6:82:24 | call to readElementOne | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:83:6:83:31 | call to readExactlyElementOne | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:83:6:83:31 | call to readExactlyElementOne | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:83:6:83:31 | call to readExactlyElementOne | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:83:6:83:31 | call to readExactlyElementOne | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:84:6:84:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:84:6:84:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:84:6:84:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:84:6:84:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:85:6:85:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:85:6:85:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:85:6:85:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:85:6:85:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:85:6:85:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:85:6:85:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:85:6:85:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:85:6:85:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:86:6:86:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:86:6:86:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
+| summaries.rb:86:6:86:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:86:6:86:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
+| summaries.rb:86:6:86:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:86:6:86:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:86:6:86:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:86:6:86:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:88:6:88:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:88:6:88:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:88:6:88:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:88:6:88:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:89:6:89:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:89:6:89:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:89:6:89:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:89:6:89:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:89:6:89:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:89:6:89:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:89:6:89:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:89:6:89:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:90:6:90:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:90:6:90:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:90:6:90:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:90:6:90:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:93:6:93:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:93:6:93:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:93:6:93:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:93:6:93:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:96:6:96:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:96:6:96:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:96:6:96:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:96:6:96:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:97:6:97:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:97:6:97:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:97:6:97:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:97:6:97:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:98:6:98:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:98:6:98:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
+| summaries.rb:98:6:98:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:98:6:98:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
+| summaries.rb:98:6:98:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:98:6:98:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:98:6:98:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:98:6:98:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
+| summaries.rb:102:6:102:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:102:6:102:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
+| summaries.rb:102:6:102:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:102:6:102:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
+| summaries.rb:106:6:106:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:106:6:106:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:106:6:106:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:106:6:106:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
+| summaries.rb:107:6:107:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:107:6:107:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
+| summaries.rb:107:6:107:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:107:6:107:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
+| summaries.rb:108:6:108:9 | ...[...] | summaries.rb:103:8:103:22 | call to source :  | summaries.rb:108:6:108:9 | ...[...] | $@ | summaries.rb:103:8:103:22 | call to source :  | call to source :  |
+| summaries.rb:108:6:108:9 | ...[...] | summaries.rb:103:8:103:22 | call to source :  | summaries.rb:108:6:108:9 | ...[...] | $@ | summaries.rb:103:8:103:22 | call to source :  | call to source :  |
+| summaries.rb:112:6:112:16 | call to get_value | summaries.rb:111:13:111:26 | call to source :  | summaries.rb:112:6:112:16 | call to get_value | $@ | summaries.rb:111:13:111:26 | call to source :  | call to source :  |
+| summaries.rb:112:6:112:16 | call to get_value | summaries.rb:111:13:111:26 | call to source :  | summaries.rb:112:6:112:16 | call to get_value | $@ | summaries.rb:111:13:111:26 | call to source :  | call to source :  |
+| summaries.rb:124:6:124:6 | y | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:124:6:124:6 | y | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:125:6:125:6 | z | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:125:6:125:6 | z | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:129:6:129:6 | x | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:129:6:129:6 | x | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:131:16:131:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:131:16:131:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:131:16:131:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:131:16:131:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:132:21:132:27 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:132:21:132:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:132:21:132:27 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:132:21:132:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:135:26:135:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:135:26:135:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:135:26:135:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:135:26:135:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:137:23:137:29 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:137:23:137:29 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:137:23:137:29 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:137:23:137:29 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:140:19:140:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:140:19:140:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:140:19:140:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:140:19:140:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:141:19:141:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:141:19:141:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:141:19:141:25 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:141:19:141:25 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:145:26:145:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:145:26:145:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:145:26:145:32 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:145:26:145:32 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:147:16:147:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:147:16:147:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:147:16:147:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:147:16:147:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:150:39:150:45 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:150:39:150:45 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:150:39:150:45 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:150:39:150:45 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
 warning
 | CSV type row should have 5 columns but has 2: test;TooFewColumns |
 | CSV type row should have 5 columns but has 8: test;TooManyColumns;;;Member[Foo].Instance;too;many;columns |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -1,6 +1,4 @@
 failures
-| summaries.rb:106:6:106:9 | ...[...] | Unexpected result: hasValueFlow=elem1 |
-| summaries.rb:107:6:107:9 | ...[...] | Unexpected result: hasValueFlow=elem2 |
 edges
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
 | summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
@@ -99,14 +97,10 @@ edges
 | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:87:5:87:5 | a [element 1] :  |
 | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:91:5:91:5 | a [element 1] :  |
 | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:91:5:91:5 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:103:1:103:1 | d [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:103:1:103:1 | d [element 1] :  |
 | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:86:6:86:6 | a [element 2] :  |
 | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:86:6:86:6 | a [element 2] :  |
 | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:95:1:95:1 | a [element 2] :  |
 | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:95:1:95:1 | a [element 2] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:103:1:103:1 | d [element 2] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:103:1:103:1 | d [element 2] :  |
 | summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:82:6:82:6 | a [element] :  |
 | summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:82:6:82:6 | a [element] :  |
 | summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:84:6:84:6 | a [element] :  |
@@ -191,28 +185,14 @@ edges
 | summaries.rb:99:1:99:1 | a [element 2] :  | summaries.rb:99:1:99:1 | [post] a [element 2] :  |
 | summaries.rb:102:6:102:6 | a [element 2] :  | summaries.rb:102:6:102:9 | ...[...] |
 | summaries.rb:102:6:102:6 | a [element 2] :  | summaries.rb:102:6:102:9 | ...[...] |
-| summaries.rb:103:1:103:1 | [post] d [element 1] :  | summaries.rb:106:6:106:6 | d [element 1] :  |
-| summaries.rb:103:1:103:1 | [post] d [element 1] :  | summaries.rb:106:6:106:6 | d [element 1] :  |
-| summaries.rb:103:1:103:1 | [post] d [element 2] :  | summaries.rb:107:6:107:6 | d [element 2] :  |
-| summaries.rb:103:1:103:1 | [post] d [element 2] :  | summaries.rb:107:6:107:6 | d [element 2] :  |
 | summaries.rb:103:1:103:1 | [post] d [element 3] :  | summaries.rb:104:1:104:1 | d [element 3] :  |
 | summaries.rb:103:1:103:1 | [post] d [element 3] :  | summaries.rb:104:1:104:1 | d [element 3] :  |
-| summaries.rb:103:1:103:1 | [post] d [element 3] :  | summaries.rb:108:6:108:6 | d [element 3] :  |
-| summaries.rb:103:1:103:1 | [post] d [element 3] :  | summaries.rb:108:6:108:6 | d [element 3] :  |
-| summaries.rb:103:1:103:1 | d [element 1] :  | summaries.rb:103:1:103:1 | [post] d [element 1] :  |
-| summaries.rb:103:1:103:1 | d [element 1] :  | summaries.rb:103:1:103:1 | [post] d [element 1] :  |
-| summaries.rb:103:1:103:1 | d [element 2] :  | summaries.rb:103:1:103:1 | [post] d [element 2] :  |
-| summaries.rb:103:1:103:1 | d [element 2] :  | summaries.rb:103:1:103:1 | [post] d [element 2] :  |
 | summaries.rb:103:8:103:22 | call to source :  | summaries.rb:103:1:103:1 | [post] d [element 3] :  |
 | summaries.rb:103:8:103:22 | call to source :  | summaries.rb:103:1:103:1 | [post] d [element 3] :  |
 | summaries.rb:104:1:104:1 | [post] d [element 3] :  | summaries.rb:108:6:108:6 | d [element 3] :  |
 | summaries.rb:104:1:104:1 | [post] d [element 3] :  | summaries.rb:108:6:108:6 | d [element 3] :  |
 | summaries.rb:104:1:104:1 | d [element 3] :  | summaries.rb:104:1:104:1 | [post] d [element 3] :  |
 | summaries.rb:104:1:104:1 | d [element 3] :  | summaries.rb:104:1:104:1 | [post] d [element 3] :  |
-| summaries.rb:106:6:106:6 | d [element 1] :  | summaries.rb:106:6:106:9 | ...[...] |
-| summaries.rb:106:6:106:6 | d [element 1] :  | summaries.rb:106:6:106:9 | ...[...] |
-| summaries.rb:107:6:107:6 | d [element 2] :  | summaries.rb:107:6:107:9 | ...[...] |
-| summaries.rb:107:6:107:6 | d [element 2] :  | summaries.rb:107:6:107:9 | ...[...] |
 | summaries.rb:108:6:108:6 | d [element 3] :  | summaries.rb:108:6:108:9 | ...[...] |
 | summaries.rb:108:6:108:6 | d [element 3] :  | summaries.rb:108:6:108:9 | ...[...] |
 | summaries.rb:111:1:111:1 | [post] x [@value] :  | summaries.rb:112:6:112:6 | x [@value] :  |
@@ -407,30 +387,14 @@ nodes
 | summaries.rb:102:6:102:6 | a [element 2] :  | semmle.label | a [element 2] :  |
 | summaries.rb:102:6:102:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:102:6:102:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:103:1:103:1 | [post] d [element 1] :  | semmle.label | [post] d [element 1] :  |
-| summaries.rb:103:1:103:1 | [post] d [element 1] :  | semmle.label | [post] d [element 1] :  |
-| summaries.rb:103:1:103:1 | [post] d [element 2] :  | semmle.label | [post] d [element 2] :  |
-| summaries.rb:103:1:103:1 | [post] d [element 2] :  | semmle.label | [post] d [element 2] :  |
 | summaries.rb:103:1:103:1 | [post] d [element 3] :  | semmle.label | [post] d [element 3] :  |
 | summaries.rb:103:1:103:1 | [post] d [element 3] :  | semmle.label | [post] d [element 3] :  |
-| summaries.rb:103:1:103:1 | d [element 1] :  | semmle.label | d [element 1] :  |
-| summaries.rb:103:1:103:1 | d [element 1] :  | semmle.label | d [element 1] :  |
-| summaries.rb:103:1:103:1 | d [element 2] :  | semmle.label | d [element 2] :  |
-| summaries.rb:103:1:103:1 | d [element 2] :  | semmle.label | d [element 2] :  |
 | summaries.rb:103:8:103:22 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:103:8:103:22 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:104:1:104:1 | [post] d [element 3] :  | semmle.label | [post] d [element 3] :  |
 | summaries.rb:104:1:104:1 | [post] d [element 3] :  | semmle.label | [post] d [element 3] :  |
 | summaries.rb:104:1:104:1 | d [element 3] :  | semmle.label | d [element 3] :  |
 | summaries.rb:104:1:104:1 | d [element 3] :  | semmle.label | d [element 3] :  |
-| summaries.rb:106:6:106:6 | d [element 1] :  | semmle.label | d [element 1] :  |
-| summaries.rb:106:6:106:6 | d [element 1] :  | semmle.label | d [element 1] :  |
-| summaries.rb:106:6:106:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:106:6:106:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:107:6:107:6 | d [element 2] :  | semmle.label | d [element 2] :  |
-| summaries.rb:107:6:107:6 | d [element 2] :  | semmle.label | d [element 2] :  |
-| summaries.rb:107:6:107:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:107:6:107:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:108:6:108:6 | d [element 3] :  | semmle.label | d [element 3] :  |
 | summaries.rb:108:6:108:6 | d [element 3] :  | semmle.label | d [element 3] :  |
 | summaries.rb:108:6:108:9 | ...[...] | semmle.label | ...[...] |
@@ -544,10 +508,6 @@ invalidSpecComponent
 | summaries.rb:98:6:98:9 | ...[...] | summaries.rb:81:13:81:27 | call to source :  | summaries.rb:98:6:98:9 | ...[...] | $@ | summaries.rb:81:13:81:27 | call to source :  | call to source :  |
 | summaries.rb:102:6:102:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:102:6:102:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
 | summaries.rb:102:6:102:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:102:6:102:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
-| summaries.rb:106:6:106:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:106:6:106:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:106:6:106:9 | ...[...] | summaries.rb:79:15:79:29 | call to source :  | summaries.rb:106:6:106:9 | ...[...] | $@ | summaries.rb:79:15:79:29 | call to source :  | call to source :  |
-| summaries.rb:107:6:107:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:107:6:107:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
-| summaries.rb:107:6:107:9 | ...[...] | summaries.rb:79:32:79:46 | call to source :  | summaries.rb:107:6:107:9 | ...[...] | $@ | summaries.rb:79:32:79:46 | call to source :  | call to source :  |
 | summaries.rb:108:6:108:9 | ...[...] | summaries.rb:103:8:103:22 | call to source :  | summaries.rb:108:6:108:9 | ...[...] | $@ | summaries.rb:103:8:103:22 | call to source :  | call to source :  |
 | summaries.rb:108:6:108:9 | ...[...] | summaries.rb:103:8:103:22 | call to source :  | summaries.rb:108:6:108:9 | ...[...] | $@ | summaries.rb:103:8:103:22 | call to source :  | call to source :  |
 | summaries.rb:112:6:112:16 | call to get_value | summaries.rb:111:13:111:26 | call to source :  | summaries.rb:112:6:112:16 | call to get_value | $@ | summaries.rb:111:13:111:26 | call to source :  | call to source :  |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -91,7 +91,8 @@ private class StepsFromModel extends ModelInput::SummaryModelCsv {
         ";any;Method[withoutElementOne];Argument[self].WithoutElement[1];Argument[self];value",
         ";any;Method[withoutExactlyElementOne];Argument[self].WithoutElement[1!];Argument[self];value",
         ";any;Method[readElementOne];Argument[self].Element[1];ReturnValue;value",
-        ";any;Method[readExactlyElementOne];Argument[self].Element[1!];ReturnValue;value"
+        ";any;Method[readExactlyElementOne];Argument[self].Element[1!];ReturnValue;value",
+        ";any;Method[withoutElementOneAndTwo];Argument[self].WithoutElement[1].WithoutElement[2].WithElement[any];Argument[self];value",
       ]
   }
 }

--- a/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
+++ b/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
@@ -77,6 +77,7 @@ Foo.startInNamedParameter(->(foo:) {
 })
 
 a = ["elem0", source("elem1"), source("elem2")]
+d = a
 a[rand()] = source("elem3")
 sink(a.readElementOne(1)) # $ hasValueFlow=elem1 $ hasValueFlow=elem3
 sink(a.readExactlyElementOne(1)) # $ hasValueFlow=elem1
@@ -99,6 +100,12 @@ a.withoutElementOne()
 sink(a[0])
 sink(a[1])
 sink(a[2]) # $ hasValueFlow=elem2
+d[3] = source("elem3")
+d.withoutElementOneAndTwo()
+sink(d[0])
+sink(d[1])
+sink(d[2])
+sink(d[3]) # $ hasValueFlow=elem3
 
 x = Foo.new
 x.set_value(source("attr"))

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
@@ -751,6 +751,27 @@ module Private {
     }
 
     /**
+     * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
+     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * `n` either clears or expects contents.
+     */
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+      viableParam(_, _, _, p) and
+      n = p and
+      clearsOrExcepts = false
+      or
+      exists(Node mid, boolean clearsOrExceptsMid |
+        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+        summaryLocalStep(mid, n, true) and
+        if
+          summaryClearsContent(n, _) or
+          summaryExpectsContent(n, _)
+        then clearsOrExcepts = true
+        else clearsOrExcepts = clearsOrExceptsMid
+      )
+    }
+
+    /**
      * Holds if use-use flow starting from `arg` should be prohibited.
      *
      * This is the case when `arg` is the argument of a call that targets a
@@ -759,15 +780,11 @@ module Private {
      */
     pragma[nomagic]
     predicate prohibitsUseUseFlow(ArgNode arg, SummarizedCallable sc) {
-      exists(ParamNode p, Node mid, ParameterPosition ppos, Node ret |
+      exists(ParamNode p, ParameterPosition ppos, Node ret |
+        paramReachesLocal(p, ret, true) and
         p = summaryArgParam0(_, arg, sc) and
         p.isParameterOf(_, pragma[only_bind_into](ppos)) and
-        summaryLocalStep(p, mid, true) and
-        summaryLocalStep(mid, ret, true) and
         isParameterPostUpdate(ret, _, pragma[only_bind_into](ppos))
-      |
-        summaryClearsContent(mid, _) or
-        summaryExpectsContent(mid, _)
       )
     }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
@@ -752,22 +752,22 @@ module Private {
 
     /**
      * Holds if `p` can reach `n` in a summarized callable, using only value-preserving
-     * local steps. `clearsOrExcepts` records whether any node on the path from `p` to
+     * local steps. `clearsOrExpects` records whether any node on the path from `p` to
      * `n` either clears or expects contents.
      */
-    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExcepts) {
+    private predicate paramReachesLocal(ParamNode p, Node n, boolean clearsOrExpects) {
       viableParam(_, _, _, p) and
       n = p and
-      clearsOrExcepts = false
+      clearsOrExpects = false
       or
-      exists(Node mid, boolean clearsOrExceptsMid |
-        paramReachesLocal(p, mid, clearsOrExceptsMid) and
+      exists(Node mid, boolean clearsOrExpectsMid |
+        paramReachesLocal(p, mid, clearsOrExpectsMid) and
         summaryLocalStep(mid, n, true) and
         if
           summaryClearsContent(n, _) or
           summaryExpectsContent(n, _)
-        then clearsOrExcepts = true
-        else clearsOrExcepts = clearsOrExceptsMid
+        then clearsOrExpects = true
+        else clearsOrExpects = clearsOrExpectsMid
       )
     }
 


### PR DESCRIPTION
Conjunctive `With(out)Content` models-as-data specifications such as
```
input = Argument[self].WithoutElement[0!].WithoutElement[1!] and
output = Argument[self]
```
did not work.

With this PR they do.