### PR TITLE
RB: change the summary for reject() to always flow to the first block parameter

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -105,7 +105,9 @@ private module Cached {
     exists(DataFlow::ContentSet c | readStep(nodeFrom, c, nodeTo) |
       c.isSingleton(any(DataFlow::Content::ElementContent ec))
       or
-      c.isAnyElement()
+      c.isAnyElement() // TODO: This one!
+      or
+      c.isElementLowerBound(0) // any element in an array
     )
   }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
@@ -1222,6 +1222,9 @@ module Array {
         input = "Argument[self].WithoutElement[0..!].WithElement[any]" and
         output = ["ReturnValue", "Argument[self]"]
         or
+        input = "Argument[self].Element[0..!]" and
+        output = "Argument[block].Parameter[0]"
+        or
         input = "Argument[self].Element[any]" and
         output = "Argument[block].Parameter[" + lastBlockParam + "]"
       ) and
@@ -2437,6 +2440,9 @@ module Enumerable {
         or
         input = "Argument[self].Element[any]" and
         output = "Argument[block].Parameter[" + lastBlockParam + "]"
+        or
+        input = "Argument[self].Element[0..!]" and
+        output = "Argument[block].Parameter[0]"
       ) and
       preservesValue = true
     }

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -3435,6 +3435,24 @@ edges
 | array_flow.rb:1631:10:1631:10 | a [element 0] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
 | array_flow.rb:1631:10:1631:10 | a [element] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
 | array_flow.rb:1631:10:1631:10 | a [element] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
+| array_flow.rb:1635:16:1635:25 | call to source :  | array_flow.rb:1636:5:1636:5 | a [element 2] :  |
+| array_flow.rb:1635:16:1635:25 | call to source :  | array_flow.rb:1636:5:1636:5 | a [element 2] :  |
+| array_flow.rb:1636:5:1636:5 | a [element 2] :  | array_flow.rb:1636:18:1636:18 | x :  |
+| array_flow.rb:1636:5:1636:5 | a [element 2] :  | array_flow.rb:1636:18:1636:18 | x :  |
+| array_flow.rb:1636:18:1636:18 | x :  | array_flow.rb:1637:14:1637:14 | x |
+| array_flow.rb:1636:18:1636:18 | x :  | array_flow.rb:1637:14:1637:14 | x |
+| array_flow.rb:1640:16:1640:25 | call to source :  | array_flow.rb:1641:5:1641:5 | b [element 2] :  |
+| array_flow.rb:1640:16:1640:25 | call to source :  | array_flow.rb:1641:5:1641:5 | b [element 2] :  |
+| array_flow.rb:1641:5:1641:5 | b [element 2] :  | array_flow.rb:1641:18:1641:18 | x :  |
+| array_flow.rb:1641:5:1641:5 | b [element 2] :  | array_flow.rb:1641:18:1641:18 | x :  |
+| array_flow.rb:1641:18:1641:18 | x :  | array_flow.rb:1642:14:1642:14 | x |
+| array_flow.rb:1641:18:1641:18 | x :  | array_flow.rb:1642:14:1642:14 | x |
+| array_flow.rb:1646:16:1646:25 | call to source :  | array_flow.rb:1647:5:1647:5 | c [element 2] :  |
+| array_flow.rb:1646:16:1646:25 | call to source :  | array_flow.rb:1647:5:1647:5 | c [element 2] :  |
+| array_flow.rb:1647:5:1647:5 | c [element 2] :  | array_flow.rb:1647:19:1647:19 | x :  |
+| array_flow.rb:1647:5:1647:5 | c [element 2] :  | array_flow.rb:1647:19:1647:19 | x :  |
+| array_flow.rb:1647:19:1647:19 | x :  | array_flow.rb:1648:14:1648:14 | x |
+| array_flow.rb:1647:19:1647:19 | x :  | array_flow.rb:1648:14:1648:14 | x |
 nodes
 | array_flow.rb:2:9:2:20 | * ... [element 0] :  | semmle.label | * ... [element 0] :  |
 | array_flow.rb:2:9:2:20 | * ... [element 0] :  | semmle.label | * ... [element 0] :  |
@@ -7122,6 +7140,30 @@ nodes
 | array_flow.rb:1631:10:1631:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1631:10:1631:15 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1631:10:1631:15 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1635:16:1635:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1635:16:1635:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1636:5:1636:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1636:5:1636:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1636:18:1636:18 | x :  | semmle.label | x :  |
+| array_flow.rb:1636:18:1636:18 | x :  | semmle.label | x :  |
+| array_flow.rb:1637:14:1637:14 | x | semmle.label | x |
+| array_flow.rb:1637:14:1637:14 | x | semmle.label | x |
+| array_flow.rb:1640:16:1640:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1640:16:1640:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1641:5:1641:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1641:5:1641:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1641:18:1641:18 | x :  | semmle.label | x :  |
+| array_flow.rb:1641:18:1641:18 | x :  | semmle.label | x :  |
+| array_flow.rb:1642:14:1642:14 | x | semmle.label | x |
+| array_flow.rb:1642:14:1642:14 | x | semmle.label | x |
+| array_flow.rb:1646:16:1646:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1646:16:1646:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1647:5:1647:5 | c [element 2] :  | semmle.label | c [element 2] :  |
+| array_flow.rb:1647:5:1647:5 | c [element 2] :  | semmle.label | c [element 2] :  |
+| array_flow.rb:1647:19:1647:19 | x :  | semmle.label | x :  |
+| array_flow.rb:1647:19:1647:19 | x :  | semmle.label | x :  |
+| array_flow.rb:1648:14:1648:14 | x | semmle.label | x |
+| array_flow.rb:1648:14:1648:14 | x | semmle.label | x |
 subpaths
 #select
 | array_flow.rb:3:10:3:13 | ...[...] | array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:3:10:3:13 | ...[...] | $@ | array_flow.rb:2:10:2:20 | call to source :  | call to source :  |
@@ -7820,3 +7862,6 @@ subpaths
 | array_flow.rb:1631:10:1631:15 | ...[...] | array_flow.rb:1622:16:1622:28 | call to source :  | array_flow.rb:1631:10:1631:15 | ...[...] | $@ | array_flow.rb:1622:16:1622:28 | call to source :  | call to source :  |
 | array_flow.rb:1631:10:1631:15 | ...[...] | array_flow.rb:1624:14:1624:26 | call to source :  | array_flow.rb:1631:10:1631:15 | ...[...] | $@ | array_flow.rb:1624:14:1624:26 | call to source :  | call to source :  |
 | array_flow.rb:1631:10:1631:15 | ...[...] | array_flow.rb:1626:16:1626:28 | call to source :  | array_flow.rb:1631:10:1631:15 | ...[...] | $@ | array_flow.rb:1626:16:1626:28 | call to source :  | call to source :  |
+| array_flow.rb:1637:14:1637:14 | x | array_flow.rb:1635:16:1635:25 | call to source :  | array_flow.rb:1637:14:1637:14 | x | $@ | array_flow.rb:1635:16:1635:25 | call to source :  | call to source :  |
+| array_flow.rb:1642:14:1642:14 | x | array_flow.rb:1640:16:1640:25 | call to source :  | array_flow.rb:1642:14:1642:14 | x | $@ | array_flow.rb:1640:16:1640:25 | call to source :  | call to source :  |
+| array_flow.rb:1648:14:1648:14 | x | array_flow.rb:1646:16:1646:25 | call to source :  | array_flow.rb:1648:14:1648:14 | x | $@ | array_flow.rb:1646:16:1646:25 | call to source :  | call to source :  |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -1630,3 +1630,23 @@ def m137
     # unknown read
     sink(a[1.0]) # $ hasValueFlow=137.1 $ hasValueFlow=137.2 $ hasValueFlow=137.3 $ hasValueFlow=137.4
 end
+
+def m138
+    a = [0, 1, source(95)]
+    a.reject do |x, *|
+        sink x
+        x > 10
+    end
+    b = [0, 1, source(96)]
+    b.reject do |x, y, *|
+        sink x
+        sink y
+        x > 10
+    end
+    c = [0, 1, source(97)]
+    c.reject! do |x, y, *|
+        sink x
+        sink y
+        x > 10
+    end
+end

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -1634,18 +1634,18 @@ end
 def m138
     a = [0, 1, source(95)]
     a.reject do |x, *|
-        sink x
+        sink x # $ hasValueFlow=95
         x > 10
     end
     b = [0, 1, source(96)]
     b.reject do |x, y, *|
-        sink x
+        sink x # $ hasValueFlow=96
         sink y
         x > 10
     end
     c = [0, 1, source(97)]
     c.reject! do |x, y, *|
-        sink x
+        sink x # $ hasValueFlow=97
         sink y
         x > 10
     end

--- a/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.expected
@@ -16,6 +16,9 @@ edges
 | CommandInjection.rb:82:22:82:25 | args :  | CommandInjection.rb:82:22:82:37 | ...[...] :  |
 | CommandInjection.rb:82:22:82:37 | ...[...] :  | CommandInjection.rb:82:14:82:39 | "echo #{...}" |
 | CommandInjection.rb:93:25:93:30 | my_arr :  | CommandInjection.rb:94:14:94:29 | "echo #{...}" |
+| CommandInjection.rb:93:25:93:30 | my_arr :  | CommandInjection.rb:95:7:95:12 | my_arr :  |
+| CommandInjection.rb:95:7:95:12 | my_arr :  | CommandInjection.rb:95:25:95:25 | n :  |
+| CommandInjection.rb:95:25:95:25 | n :  | CommandInjection.rb:96:16:96:26 | "echo #{...}" |
 nodes
 | CommandInjection.rb:6:15:6:20 | call to params :  | semmle.label | call to params :  |
 | CommandInjection.rb:6:15:6:26 | ...[...] :  | semmle.label | ...[...] :  |
@@ -40,6 +43,9 @@ nodes
 | CommandInjection.rb:82:22:82:37 | ...[...] :  | semmle.label | ...[...] :  |
 | CommandInjection.rb:93:25:93:30 | my_arr :  | semmle.label | my_arr :  |
 | CommandInjection.rb:94:14:94:29 | "echo #{...}" | semmle.label | "echo #{...}" |
+| CommandInjection.rb:95:7:95:12 | my_arr :  | semmle.label | my_arr :  |
+| CommandInjection.rb:95:25:95:25 | n :  | semmle.label | n :  |
+| CommandInjection.rb:96:16:96:26 | "echo #{...}" | semmle.label | "echo #{...}" |
 subpaths
 #select
 | CommandInjection.rb:7:10:7:15 | #{...} | CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:7:10:7:15 | #{...} | This command depends on a $@. | CommandInjection.rb:6:15:6:20 | call to params | user-provided value |
@@ -55,3 +61,4 @@ subpaths
 | CommandInjection.rb:73:14:73:34 | "echo #{...}" | CommandInjection.rb:72:23:72:33 | blah_number :  | CommandInjection.rb:73:14:73:34 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:72:23:72:33 | blah_number | user-provided value |
 | CommandInjection.rb:82:14:82:39 | "echo #{...}" | CommandInjection.rb:81:20:81:25 | **args :  | CommandInjection.rb:82:14:82:39 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:81:20:81:25 | **args | user-provided value |
 | CommandInjection.rb:94:14:94:29 | "echo #{...}" | CommandInjection.rb:93:25:93:30 | my_arr :  | CommandInjection.rb:94:14:94:29 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:93:25:93:30 | my_arr | user-provided value |
+| CommandInjection.rb:96:16:96:26 | "echo #{...}" | CommandInjection.rb:93:25:93:30 | my_arr :  | CommandInjection.rb:96:16:96:26 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:93:25:93:30 | my_arr | user-provided value |

--- a/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.expected
@@ -15,6 +15,7 @@ edges
 | CommandInjection.rb:81:20:81:25 | **args :  | CommandInjection.rb:82:22:82:25 | args :  |
 | CommandInjection.rb:82:22:82:25 | args :  | CommandInjection.rb:82:22:82:37 | ...[...] :  |
 | CommandInjection.rb:82:22:82:37 | ...[...] :  | CommandInjection.rb:82:14:82:39 | "echo #{...}" |
+| CommandInjection.rb:93:25:93:30 | my_arr :  | CommandInjection.rb:94:14:94:29 | "echo #{...}" |
 nodes
 | CommandInjection.rb:6:15:6:20 | call to params :  | semmle.label | call to params :  |
 | CommandInjection.rb:6:15:6:26 | ...[...] :  | semmle.label | ...[...] :  |
@@ -37,6 +38,8 @@ nodes
 | CommandInjection.rb:82:14:82:39 | "echo #{...}" | semmle.label | "echo #{...}" |
 | CommandInjection.rb:82:22:82:25 | args :  | semmle.label | args :  |
 | CommandInjection.rb:82:22:82:37 | ...[...] :  | semmle.label | ...[...] :  |
+| CommandInjection.rb:93:25:93:30 | my_arr :  | semmle.label | my_arr :  |
+| CommandInjection.rb:94:14:94:29 | "echo #{...}" | semmle.label | "echo #{...}" |
 subpaths
 #select
 | CommandInjection.rb:7:10:7:15 | #{...} | CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:7:10:7:15 | #{...} | This command depends on a $@. | CommandInjection.rb:6:15:6:20 | call to params | user-provided value |
@@ -51,3 +54,4 @@ subpaths
 | CommandInjection.rb:65:14:65:29 | "echo #{...}" | CommandInjection.rb:64:18:64:23 | number :  | CommandInjection.rb:65:14:65:29 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:64:18:64:23 | number | user-provided value |
 | CommandInjection.rb:73:14:73:34 | "echo #{...}" | CommandInjection.rb:72:23:72:33 | blah_number :  | CommandInjection.rb:73:14:73:34 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:72:23:72:33 | blah_number | user-provided value |
 | CommandInjection.rb:82:14:82:39 | "echo #{...}" | CommandInjection.rb:81:20:81:25 | **args :  | CommandInjection.rb:82:14:82:39 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:81:20:81:25 | **args | user-provided value |
+| CommandInjection.rb:94:14:94:29 | "echo #{...}" | CommandInjection.rb:93:25:93:30 | my_arr :  | CommandInjection.rb:94:14:94:29 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:93:25:93:30 | my_arr | user-provided value |

--- a/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.rb
+++ b/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.rb
@@ -93,7 +93,7 @@ module Types
     def custom_method_2(my_arr:, number: nil)
       system("echo #{my_arr}") # NOT OK
       my_arr.reject do |n, *|
-        system("echo #{n}") # NOT OK - but not flagged
+        system("echo #{n}") # NOT OK
       end
     end
   end

--- a/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.rb
+++ b/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.rb
@@ -86,5 +86,15 @@ module Types
     def foo(arg)
       system("echo #{arg}") # OK, this is just a random method, not a resolver method
     end
+
+    field :with_method, String, null: false, description: "A field with a custom resolver method", resolver_method: :custom_method_2 do
+      argument :my_arr, [String], "An array of strings", required: true
+    end
+    def custom_method_2(my_arr:, number: nil)
+      system("echo #{my_arr}") # NOT OK
+      my_arr.reject do |n, *|
+        system("echo #{n}") # NOT OK - but not flagged
+      end
+    end
   end
 end


### PR DESCRIPTION
Gets a TP/TN for CVE-2021-31799 (together with https://github.com/github/codeql/pull/10680).  

The summary for `reject()` would propagate flow from array-elements to the last parameter of the block.  
However, the `reject()` method on Arrays always sends those elements to the first parameter.   

In the vast majority of cases that is not an issue (there is usually exactly one parameter when `reject` is used with arrays).  
But [that is not the case in rdoc](https://github.com/ruby/rdoc/blob/06112d5c3479fe3f96907cae379d400acf89b295/lib/rdoc/rdoc.rb#L443).  

I will take a look all the other flow-summaries for arrays that use the `lastBlockParam()` utility predicate. 
But only after I get a 👍 on how I've changed `reject()`.   
So this PR is ready-for-review, but not ready-for-merge.