### PR TITLE
RB: use xl runners for the ruby language tests

### DIFF
--- a/.github/workflows/ruby-qltest.yml
+++ b/.github/workflows/ruby-qltest.yml
@@ -65,7 +65,7 @@ jobs:
            xargs codeql execute upgrades testdb
           diff -q testdb/ruby.dbscheme downgrades/initial/ruby.dbscheme
   qltest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The other languages are using XL runners, so why shouldn't ruby? 

Test time goes from 16 minutes to 14 minutes... 
No significant diff, closing.  