### PR TITLE
Tag successfully extracted files queries

### DIFF
--- a/cpp/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
+++ b/cpp/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
@@ -3,6 +3,7 @@
  * @description Lists all files in the source code directory that were extracted without encountering a problem in the file.
  * @kind diagnostic
  * @id cpp/diagnostics/successfully-extracted-files
+ * @tags successfully-extracted-files
  */
 
 import cpp

--- a/csharp/ql/src/Diagnostics/DiagnosticNoExtractionErrors.ql
+++ b/csharp/ql/src/Diagnostics/DiagnosticNoExtractionErrors.ql
@@ -4,6 +4,7 @@
  *              without encountering an extraction or compiler error in the file.
  * @kind diagnostic
  * @id cs/diagnostics/successfully-extracted-files
+ * @tags successfully-extracted-files
  */
 
 import csharp

--- a/go/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
+++ b/go/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
@@ -3,6 +3,7 @@
  * @name Successfully analyzed files
  * @description List all files that were successfully extracted.
  * @kind diagnostic
+ * @tags successfully-extracted-files
  */
 
 import go

--- a/java/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
+++ b/java/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
@@ -4,6 +4,7 @@
  *              were extracted without encountering an error in the file.
  * @kind diagnostic
  * @id java/diagnostics/successfully-extracted-files
+ * @tags successfully-extracted-files
  */
 
 import java

--- a/javascript/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
+++ b/javascript/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
@@ -3,6 +3,7 @@
  * @description Lists all files in the source code directory that were extracted without encountering an error in the file.
  * @kind diagnostic
  * @id js/diagnostics/successfully-extracted-files
+ * @tags successfully-extracted-files
  */
 
 import javascript

--- a/python/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
+++ b/python/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
@@ -4,6 +4,7 @@
  *   without encountering an error.
  * @kind diagnostic
  * @id py/diagnostics/successfully-extracted-files
+ * @tags successfully-extracted-files
  */
 
 import python

--- a/ql/ql/src/queries/diagnostics/SuccessfullyExtractedFiles.ql
+++ b/ql/ql/src/queries/diagnostics/SuccessfullyExtractedFiles.ql
@@ -4,6 +4,7 @@
  *   without encountering an error in the file.
  * @kind diagnostic
  * @id ql/diagnostics/successfully-extracted-files
+ * @tags successfully-extracted-files
  */
 
 import ql

--- a/ruby/ql/src/queries/diagnostics/SuccessfullyExtractedFiles.ql
+++ b/ruby/ql/src/queries/diagnostics/SuccessfullyExtractedFiles.ql
@@ -4,6 +4,7 @@
  *   without encountering an error in the file.
  * @kind diagnostic
  * @id rb/diagnostics/successfully-extracted-files
+ * @tags successfully-extracted-files
  */
 
 import codeql.ruby.AST


### PR DESCRIPTION
Tag the successfully extracted files queries with `successfully-extracted-files` to make them easier to identify programmatically in a language-independent way.  This follows the prior art for lines of code queries, which are tagged `lines-of-code` (see https://github.com/github/codeql/pull/5902).