### PR TITLE
Ruby: Take overrides into account for singleton methods defined on modules

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -736,6 +736,10 @@ private predicate singletonMethodOnModule(MethodBase method, string name, Module
   )
 }
 
+/**
+ * Holds if `method` is a singleton method named `name`, defined on module
+ * `m`, or any transitive base class of `m`.
+ */
 pragma[nomagic]
 private MethodBase lookupSingletonMethod(Module m, string name) {
   singletonMethodOnModule(result, name, m)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -389,7 +389,7 @@ private module Cached {
         // ```
         exists(DataFlow::Node sourceNode, Module m |
           flowsToMethodCall(call, sourceNode, method) and
-          singletonMethodOnModule(result, method, m)
+          result = lookupSingletonMethod(m, method)
         |
           // ```rb
           // def C.singleton; end # <- result
@@ -725,12 +725,31 @@ private predicate singletonMethodOnModule(MethodBase method, string name, Module
     selfInModule(object.(SelfVariableReadAccess).getVariable(), m)
   )
   or
-  flowsToSingletonMethodObject(trackModuleAccess(m), method, name)
+  exists(DataFlow::LocalSourceNode sourceNode |
+    m = resolveConstantReadAccess(sourceNode.asExpr().getExpr()) and
+    flowsToSingletonMethodObject(sourceNode, method, name)
+  )
   or
   exists(Module other |
     extendCallModule(m, other) and
     method = lookupMethod(other, name)
   )
+}
+
+pragma[nomagic]
+private MethodBase lookupSingletonMethod(Module m, string name) {
+  singletonMethodOnModule(result, name, m)
+  or
+  // cannot be part of `singletonMethodOnModule` because it would introduce
+  // negative recursion below
+  exists(DataFlow::LocalSourceNode sourceNode |
+    sourceNode = trackModuleAccess(m) and
+    not m = resolveConstantReadAccess(sourceNode.asExpr().getExpr()) and
+    flowsToSingletonMethodObject(sourceNode, result, name)
+  )
+  or
+  not singletonMethodOnModule(_, name, m) and
+  result = lookupSingletonMethod(m.getSuperClass(), name)
 }
 
 /**

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -89,25 +89,25 @@ calls.rb:
 #  377| SingletonOverride1
 #-----| super -> Object
 
-#  402| SingletonOverride2
+#  404| SingletonOverride2
 #-----| super -> SingletonOverride1
 
-#  417| ConditionalInstanceMethods
+#  421| ConditionalInstanceMethods
 #-----| super -> Object
 
-#  480| ExtendSingletonMethod
+#  484| ExtendSingletonMethod
 
-#  490| ExtendSingletonMethod2
+#  494| ExtendSingletonMethod2
 
-#  496| ExtendSingletonMethod3
+#  500| ExtendSingletonMethod3
 
-#  509| ProtectedMethodInModule
+#  513| ProtectedMethodInModule
 
-#  515| ProtectedMethods
+#  519| ProtectedMethods
 #-----| super -> Object
 #-----| include -> ProtectedMethodInModule
 
-#  534| ProtectedMethodsSub
+#  538| ProtectedMethodsSub
 #-----| super -> ProtectedMethods
 
 hello.rb:

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -161,6 +161,8 @@ getTarget
 | calls.rb:412:9:412:44 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:416:1:416:29 | call to singleton1 | calls.rb:406:9:408:11 | singleton1 |
 | calls.rb:417:1:417:29 | call to singleton2 | calls.rb:411:5:413:7 | singleton2 |
+| calls.rb:418:1:418:34 | call to call_singleton1 | calls.rb:383:9:385:11 | call_singleton1 |
+| calls.rb:419:1:419:34 | call to call_singleton2 | calls.rb:392:5:394:7 | call_singleton2 |
 | calls.rb:424:13:424:48 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:429:9:429:44 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:432:13:432:48 | call to puts | calls.rb:102:5:102:30 | puts |
@@ -290,8 +292,6 @@ unresolvedCall
 | calls.rb:274:1:274:14 | call to singleton_g |
 | calls.rb:276:1:276:14 | call to singleton_g |
 | calls.rb:313:9:313:20 | call to instance |
-| calls.rb:418:1:418:34 | call to call_singleton1 |
-| calls.rb:419:1:419:34 | call to call_singleton2 |
 | calls.rb:422:8:422:13 | call to rand |
 | calls.rb:422:8:422:17 | ... > ... |
 | calls.rb:439:9:439:10 | call to m3 |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -148,67 +148,71 @@ getTarget
 | calls.rb:375:1:375:11 | call to instance | calls.rb:368:5:370:7 | instance |
 | calls.rb:380:13:380:48 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:384:13:384:22 | call to singleton1 | calls.rb:379:9:381:11 | singleton1 |
-| calls.rb:384:13:384:22 | call to singleton1 | calls.rb:404:9:406:11 | singleton1 |
+| calls.rb:384:13:384:22 | call to singleton1 | calls.rb:406:9:408:11 | singleton1 |
 | calls.rb:389:9:389:44 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:393:9:393:18 | call to singleton2 | calls.rb:388:5:390:7 | singleton2 |
-| calls.rb:393:9:393:18 | call to singleton2 | calls.rb:409:5:411:7 | singleton2 |
+| calls.rb:393:9:393:18 | call to singleton2 | calls.rb:411:5:413:7 | singleton2 |
 | calls.rb:396:5:396:14 | call to singleton2 | calls.rb:388:5:390:7 | singleton2 |
-| calls.rb:399:1:399:34 | call to call_singleton1 | calls.rb:383:9:385:11 | call_singleton1 |
-| calls.rb:400:1:400:34 | call to call_singleton2 | calls.rb:392:5:394:7 | call_singleton2 |
-| calls.rb:405:13:405:48 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:410:9:410:44 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:420:13:420:48 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:425:9:425:44 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:428:13:428:48 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:431:17:431:52 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:439:9:443:11 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:439:9:443:15 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:441:17:441:40 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:447:1:447:30 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:447:1:447:33 | call to m1 | calls.rb:419:9:421:11 | m1 |
-| calls.rb:448:1:448:30 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:449:1:449:30 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:449:1:449:33 | call to m2 | calls.rb:424:5:436:7 | m2 |
-| calls.rb:450:1:450:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:399:1:399:29 | call to singleton1 | calls.rb:379:9:381:11 | singleton1 |
+| calls.rb:400:1:400:29 | call to singleton2 | calls.rb:388:5:390:7 | singleton2 |
+| calls.rb:401:1:401:34 | call to call_singleton1 | calls.rb:383:9:385:11 | call_singleton1 |
+| calls.rb:402:1:402:34 | call to call_singleton2 | calls.rb:392:5:394:7 | call_singleton2 |
+| calls.rb:407:13:407:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:412:9:412:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:416:1:416:29 | call to singleton1 | calls.rb:406:9:408:11 | singleton1 |
+| calls.rb:417:1:417:29 | call to singleton2 | calls.rb:411:5:413:7 | singleton2 |
+| calls.rb:424:13:424:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:429:9:429:44 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:432:13:432:48 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:435:17:435:52 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:443:9:447:11 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:443:9:447:15 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:445:17:445:40 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:451:1:451:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:451:1:451:33 | call to m1 | calls.rb:423:9:425:11 | m1 |
 | calls.rb:452:1:452:30 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:454:27:472:3 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:457:13:457:22 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:461:5:465:7 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:461:5:465:11 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:463:13:463:22 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:469:13:469:27 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:474:1:474:27 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:475:1:475:27 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:476:1:476:27 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:477:1:477:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:453:1:453:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:453:1:453:33 | call to m2 | calls.rb:428:5:440:7 | m2 |
+| calls.rb:454:1:454:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:455:1:455:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:456:1:456:30 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:458:27:476:3 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:461:13:461:22 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:465:5:469:7 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:465:5:469:11 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:467:13:467:22 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:473:13:473:27 | call to puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:478:1:478:27 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:488:1:488:31 | call to singleton | calls.rb:481:5:483:7 | singleton |
-| calls.rb:494:1:494:32 | call to singleton | calls.rb:481:5:483:7 | singleton |
-| calls.rb:501:1:501:32 | call to singleton | calls.rb:481:5:483:7 | singleton |
-| calls.rb:507:1:507:13 | call to singleton | calls.rb:481:5:483:7 | singleton |
-| calls.rb:516:5:516:35 | call to include | calls.rb:108:5:110:7 | include |
-| calls.rb:519:9:519:35 | call to puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:523:9:523:11 | call to foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:524:9:524:11 | call to bar | calls.rb:518:15:520:7 | bar |
-| calls.rb:525:9:525:28 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:525:9:525:32 | call to foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:526:9:526:28 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:526:9:526:32 | call to bar | calls.rb:518:15:520:7 | bar |
-| calls.rb:530:1:530:20 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:531:1:531:20 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:532:1:532:20 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:532:1:532:24 | call to baz | calls.rb:522:5:527:7 | baz |
-| calls.rb:536:9:536:11 | call to foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:537:9:537:31 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:537:9:537:35 | call to foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:541:1:541:23 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:542:1:542:23 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:543:1:543:23 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:543:1:543:27 | call to baz | calls.rb:535:5:538:7 | baz |
-| calls.rb:545:2:545:6 | call to new | calls.rb:117:5:117:16 | new |
-| calls.rb:545:20:545:24 | call to baz | calls.rb:51:5:57:7 | baz |
-| calls.rb:546:26:546:37 | call to capitalize | calls.rb:97:5:97:23 | capitalize |
+| calls.rb:479:1:479:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:480:1:480:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:481:1:481:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:482:1:482:27 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:492:1:492:31 | call to singleton | calls.rb:485:5:487:7 | singleton |
+| calls.rb:498:1:498:32 | call to singleton | calls.rb:485:5:487:7 | singleton |
+| calls.rb:505:1:505:32 | call to singleton | calls.rb:485:5:487:7 | singleton |
+| calls.rb:511:1:511:13 | call to singleton | calls.rb:485:5:487:7 | singleton |
+| calls.rb:520:5:520:35 | call to include | calls.rb:108:5:110:7 | include |
+| calls.rb:523:9:523:35 | call to puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:527:9:527:11 | call to foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:528:9:528:11 | call to bar | calls.rb:522:15:524:7 | bar |
+| calls.rb:529:9:529:28 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:529:9:529:32 | call to foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:530:9:530:28 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:530:9:530:32 | call to bar | calls.rb:522:15:524:7 | bar |
+| calls.rb:534:1:534:20 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:535:1:535:20 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:536:1:536:20 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:536:1:536:24 | call to baz | calls.rb:526:5:531:7 | baz |
+| calls.rb:540:9:540:11 | call to foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:541:9:541:31 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:541:9:541:35 | call to foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:545:1:545:23 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:546:1:546:23 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:547:1:547:23 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:547:1:547:27 | call to baz | calls.rb:539:5:542:7 | baz |
+| calls.rb:549:2:549:6 | call to new | calls.rb:117:5:117:16 | new |
+| calls.rb:549:20:549:24 | call to baz | calls.rb:51:5:57:7 | baz |
+| calls.rb:550:26:550:37 | call to capitalize | calls.rb:97:5:97:23 | capitalize |
 | hello.rb:12:5:12:24 | call to include | calls.rb:108:5:110:7 | include |
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
@@ -286,46 +290,46 @@ unresolvedCall
 | calls.rb:274:1:274:14 | call to singleton_g |
 | calls.rb:276:1:276:14 | call to singleton_g |
 | calls.rb:313:9:313:20 | call to instance |
-| calls.rb:414:1:414:34 | call to call_singleton1 |
-| calls.rb:415:1:415:34 | call to call_singleton2 |
-| calls.rb:418:8:418:13 | call to rand |
-| calls.rb:418:8:418:17 | ... > ... |
-| calls.rb:435:9:435:10 | call to m3 |
-| calls.rb:438:8:438:13 | call to rand |
-| calls.rb:438:8:438:17 | ... > ... |
-| calls.rb:439:9:443:18 | call to m5 |
-| calls.rb:448:1:448:33 | call to m3 |
-| calls.rb:450:1:450:33 | call to m3 |
-| calls.rb:451:1:451:33 | call to m4 |
-| calls.rb:452:1:452:33 | call to m5 |
-| calls.rb:455:5:455:11 | call to [] |
-| calls.rb:455:5:459:7 | call to each |
-| calls.rb:461:5:465:15 | call to bar |
-| calls.rb:467:5:467:11 | call to [] |
-| calls.rb:467:5:471:7 | call to each |
-| calls.rb:468:9:470:11 | call to define_method |
-| calls.rb:474:1:474:31 | call to foo |
-| calls.rb:475:1:475:31 | call to bar |
-| calls.rb:476:1:476:33 | call to baz_0 |
-| calls.rb:477:1:477:33 | call to baz_1 |
-| calls.rb:478:1:478:33 | call to baz_2 |
-| calls.rb:482:9:482:46 | call to puts |
-| calls.rb:485:5:485:15 | call to extend |
-| calls.rb:491:5:491:32 | call to extend |
-| calls.rb:499:1:499:51 | call to extend |
-| calls.rb:504:1:504:13 | call to singleton |
-| calls.rb:505:1:505:32 | call to extend |
-| calls.rb:510:5:512:7 | call to protected |
-| calls.rb:511:9:511:42 | call to puts |
-| calls.rb:518:5:520:7 | call to protected |
-| calls.rb:530:1:530:24 | call to foo |
-| calls.rb:531:1:531:24 | call to bar |
-| calls.rb:541:1:541:27 | call to foo |
-| calls.rb:542:1:542:27 | call to bar |
-| calls.rb:545:1:545:7 | call to [] |
-| calls.rb:545:1:545:26 | call to each |
-| calls.rb:546:1:546:13 | call to [] |
-| calls.rb:546:1:546:39 | call to each |
+| calls.rb:418:1:418:34 | call to call_singleton1 |
+| calls.rb:419:1:419:34 | call to call_singleton2 |
+| calls.rb:422:8:422:13 | call to rand |
+| calls.rb:422:8:422:17 | ... > ... |
+| calls.rb:439:9:439:10 | call to m3 |
+| calls.rb:442:8:442:13 | call to rand |
+| calls.rb:442:8:442:17 | ... > ... |
+| calls.rb:443:9:447:18 | call to m5 |
+| calls.rb:452:1:452:33 | call to m3 |
+| calls.rb:454:1:454:33 | call to m3 |
+| calls.rb:455:1:455:33 | call to m4 |
+| calls.rb:456:1:456:33 | call to m5 |
+| calls.rb:459:5:459:11 | call to [] |
+| calls.rb:459:5:463:7 | call to each |
+| calls.rb:465:5:469:15 | call to bar |
+| calls.rb:471:5:471:11 | call to [] |
+| calls.rb:471:5:475:7 | call to each |
+| calls.rb:472:9:474:11 | call to define_method |
+| calls.rb:478:1:478:31 | call to foo |
+| calls.rb:479:1:479:31 | call to bar |
+| calls.rb:480:1:480:33 | call to baz_0 |
+| calls.rb:481:1:481:33 | call to baz_1 |
+| calls.rb:482:1:482:33 | call to baz_2 |
+| calls.rb:486:9:486:46 | call to puts |
+| calls.rb:489:5:489:15 | call to extend |
+| calls.rb:495:5:495:32 | call to extend |
+| calls.rb:503:1:503:51 | call to extend |
+| calls.rb:508:1:508:13 | call to singleton |
+| calls.rb:509:1:509:32 | call to extend |
+| calls.rb:514:5:516:7 | call to protected |
+| calls.rb:515:9:515:42 | call to puts |
+| calls.rb:522:5:524:7 | call to protected |
+| calls.rb:534:1:534:24 | call to foo |
+| calls.rb:535:1:535:24 | call to bar |
+| calls.rb:545:1:545:27 | call to foo |
+| calls.rb:546:1:546:27 | call to bar |
+| calls.rb:549:1:549:7 | call to [] |
+| calls.rb:549:1:549:26 | call to each |
+| calls.rb:550:1:550:13 | call to [] |
+| calls.rb:550:1:550:39 | call to each |
 | hello.rb:20:16:20:26 | ... + ... |
 | hello.rb:20:16:20:34 | ... + ... |
 | hello.rb:20:16:20:40 | ... + ... |
@@ -351,8 +355,8 @@ privateMethod
 | calls.rb:278:1:286:3 | create |
 | calls.rb:343:1:359:3 | pattern_dispatch |
 | calls.rb:367:1:371:3 | add_singleton |
-| calls.rb:456:9:458:11 | foo |
-| calls.rb:462:9:464:11 | bar |
+| calls.rb:460:9:462:11 | foo |
+| calls.rb:466:9:468:11 | bar |
 | private.rb:2:11:3:5 | private1 |
 | private.rb:8:3:9:5 | private2 |
 | private.rb:14:3:15:5 | private3 |
@@ -417,16 +421,16 @@ publicMethod
 | calls.rb:383:9:385:11 | call_singleton1 |
 | calls.rb:388:5:390:7 | singleton2 |
 | calls.rb:392:5:394:7 | call_singleton2 |
-| calls.rb:404:9:406:11 | singleton1 |
-| calls.rb:409:5:411:7 | singleton2 |
-| calls.rb:419:9:421:11 | m1 |
-| calls.rb:424:5:436:7 | m2 |
-| calls.rb:427:9:433:11 | m3 |
-| calls.rb:430:13:432:15 | m4 |
-| calls.rb:440:13:442:15 | m5 |
-| calls.rb:481:5:483:7 | singleton |
-| calls.rb:522:5:527:7 | baz |
-| calls.rb:535:5:538:7 | baz |
+| calls.rb:406:9:408:11 | singleton1 |
+| calls.rb:411:5:413:7 | singleton2 |
+| calls.rb:423:9:425:11 | m1 |
+| calls.rb:428:5:440:7 | m2 |
+| calls.rb:431:9:437:11 | m3 |
+| calls.rb:434:13:436:15 | m4 |
+| calls.rb:444:13:446:15 | m5 |
+| calls.rb:485:5:487:7 | singleton |
+| calls.rb:526:5:531:7 | baz |
+| calls.rb:539:5:542:7 | baz |
 | hello.rb:2:5:4:7 | hello |
 | hello.rb:5:5:7:7 | world |
 | hello.rb:13:5:15:7 | message |
@@ -443,7 +447,7 @@ publicMethod
 | private.rb:66:3:67:5 | public |
 | private.rb:91:3:93:5 | call_m1 |
 protectedMethod
-| calls.rb:510:15:512:7 | foo |
-| calls.rb:518:15:520:7 | bar |
+| calls.rb:514:15:516:7 | foo |
+| calls.rb:522:15:524:7 | bar |
 | private.rb:32:3:33:5 | protected1 |
 | private.rb:35:3:36:5 | protected2 |

--- a/ruby/ql/test/library-tests/modules/calls.rb
+++ b/ruby/ql/test/library-tests/modules/calls.rb
@@ -396,6 +396,8 @@ class SingletonOverride1
     singleton2
 end
 
+SingletonOverride1.singleton1
+SingletonOverride1.singleton2
 SingletonOverride1.call_singleton1
 SingletonOverride1.call_singleton2
 
@@ -411,6 +413,8 @@ class SingletonOverride2 < SingletonOverride1
     end
 end
 
+SingletonOverride2.singleton1
+SingletonOverride2.singleton2
 SingletonOverride2.call_singleton1
 SingletonOverride2.call_singleton2
 

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -36,13 +36,13 @@ getMethod
 | calls.rb:325:1:329:3 | C1 | instance | calls.rb:326:5:328:7 | instance |
 | calls.rb:331:1:335:3 | C2 | instance | calls.rb:332:5:334:7 | instance |
 | calls.rb:337:1:341:3 | C3 | instance | calls.rb:338:5:340:7 | instance |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | m1 | calls.rb:419:9:421:11 | m1 |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | m2 | calls.rb:424:5:436:7 | m2 |
-| calls.rb:480:1:486:3 | ExtendSingletonMethod | singleton | calls.rb:481:5:483:7 | singleton |
-| calls.rb:509:1:513:3 | ProtectedMethodInModule | foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:515:1:528:3 | ProtectedMethods | bar | calls.rb:518:15:520:7 | bar |
-| calls.rb:515:1:528:3 | ProtectedMethods | baz | calls.rb:522:5:527:7 | baz |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | baz | calls.rb:535:5:538:7 | baz |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | m1 | calls.rb:423:9:425:11 | m1 |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | m2 | calls.rb:428:5:440:7 | m2 |
+| calls.rb:484:1:490:3 | ExtendSingletonMethod | singleton | calls.rb:485:5:487:7 | singleton |
+| calls.rb:513:1:517:3 | ProtectedMethodInModule | foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:519:1:532:3 | ProtectedMethods | bar | calls.rb:522:15:524:7 | bar |
+| calls.rb:519:1:532:3 | ProtectedMethods | baz | calls.rb:526:5:531:7 | baz |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | baz | calls.rb:539:5:542:7 | baz |
 | hello.rb:1:1:8:3 | EnglishWords | hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
@@ -326,68 +326,68 @@ lookupMethod
 | calls.rb:377:1:397:3 | SingletonOverride1 | private_on_main | calls.rb:185:1:186:3 | private_on_main |
 | calls.rb:377:1:397:3 | SingletonOverride1 | puts | calls.rb:102:5:102:30 | puts |
 | calls.rb:377:1:397:3 | SingletonOverride1 | to_s | calls.rb:172:5:173:7 | to_s |
-| calls.rb:402:1:412:3 | SingletonOverride2 | add_singleton | calls.rb:367:1:371:3 | add_singleton |
-| calls.rb:402:1:412:3 | SingletonOverride2 | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:402:1:412:3 | SingletonOverride2 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:402:1:412:3 | SingletonOverride2 | create | calls.rb:278:1:286:3 | create |
-| calls.rb:402:1:412:3 | SingletonOverride2 | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:402:1:412:3 | SingletonOverride2 | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:402:1:412:3 | SingletonOverride2 | funny | calls.rb:140:1:142:3 | funny |
-| calls.rb:402:1:412:3 | SingletonOverride2 | indirect | calls.rb:158:1:160:3 | indirect |
-| calls.rb:402:1:412:3 | SingletonOverride2 | new | calls.rb:117:5:117:16 | new |
-| calls.rb:402:1:412:3 | SingletonOverride2 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:402:1:412:3 | SingletonOverride2 | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
-| calls.rb:402:1:412:3 | SingletonOverride2 | private_on_main | calls.rb:185:1:186:3 | private_on_main |
-| calls.rb:402:1:412:3 | SingletonOverride2 | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:402:1:412:3 | SingletonOverride2 | to_s | calls.rb:172:5:173:7 | to_s |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | add_singleton | calls.rb:367:1:371:3 | add_singleton |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | create | calls.rb:278:1:286:3 | create |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | foo | calls.rb:1:1:3:3 | foo |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | foo | calls.rb:85:1:89:3 | foo |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | funny | calls.rb:140:1:142:3 | funny |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | indirect | calls.rb:158:1:160:3 | indirect |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | m1 | calls.rb:419:9:421:11 | m1 |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | m2 | calls.rb:424:5:436:7 | m2 |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | new | calls.rb:117:5:117:16 | new |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | private_on_main | calls.rb:185:1:186:3 | private_on_main |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | to_s | calls.rb:172:5:173:7 | to_s |
-| calls.rb:480:1:486:3 | ExtendSingletonMethod | singleton | calls.rb:481:5:483:7 | singleton |
-| calls.rb:509:1:513:3 | ProtectedMethodInModule | foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:515:1:528:3 | ProtectedMethods | add_singleton | calls.rb:367:1:371:3 | add_singleton |
-| calls.rb:515:1:528:3 | ProtectedMethods | bar | calls.rb:518:15:520:7 | bar |
-| calls.rb:515:1:528:3 | ProtectedMethods | baz | calls.rb:522:5:527:7 | baz |
-| calls.rb:515:1:528:3 | ProtectedMethods | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:515:1:528:3 | ProtectedMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:515:1:528:3 | ProtectedMethods | create | calls.rb:278:1:286:3 | create |
-| calls.rb:515:1:528:3 | ProtectedMethods | foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:515:1:528:3 | ProtectedMethods | funny | calls.rb:140:1:142:3 | funny |
-| calls.rb:515:1:528:3 | ProtectedMethods | indirect | calls.rb:158:1:160:3 | indirect |
-| calls.rb:515:1:528:3 | ProtectedMethods | new | calls.rb:117:5:117:16 | new |
-| calls.rb:515:1:528:3 | ProtectedMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:515:1:528:3 | ProtectedMethods | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
-| calls.rb:515:1:528:3 | ProtectedMethods | private_on_main | calls.rb:185:1:186:3 | private_on_main |
-| calls.rb:515:1:528:3 | ProtectedMethods | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:515:1:528:3 | ProtectedMethods | to_s | calls.rb:172:5:173:7 | to_s |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | add_singleton | calls.rb:367:1:371:3 | add_singleton |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | bar | calls.rb:518:15:520:7 | bar |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | baz | calls.rb:535:5:538:7 | baz |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | call_block | calls.rb:81:1:83:3 | call_block |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | create | calls.rb:278:1:286:3 | create |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | funny | calls.rb:140:1:142:3 | funny |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | indirect | calls.rb:158:1:160:3 | indirect |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | new | calls.rb:117:5:117:16 | new |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | optional_arg | calls.rb:76:1:79:3 | optional_arg |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | private_on_main | calls.rb:185:1:186:3 | private_on_main |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | puts | calls.rb:102:5:102:30 | puts |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:404:1:414:3 | SingletonOverride2 | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:404:1:414:3 | SingletonOverride2 | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:404:1:414:3 | SingletonOverride2 | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:404:1:414:3 | SingletonOverride2 | create | calls.rb:278:1:286:3 | create |
+| calls.rb:404:1:414:3 | SingletonOverride2 | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:404:1:414:3 | SingletonOverride2 | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:404:1:414:3 | SingletonOverride2 | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:404:1:414:3 | SingletonOverride2 | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:404:1:414:3 | SingletonOverride2 | new | calls.rb:117:5:117:16 | new |
+| calls.rb:404:1:414:3 | SingletonOverride2 | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:404:1:414:3 | SingletonOverride2 | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:404:1:414:3 | SingletonOverride2 | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:404:1:414:3 | SingletonOverride2 | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:404:1:414:3 | SingletonOverride2 | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | create | calls.rb:278:1:286:3 | create |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | foo | calls.rb:1:1:3:3 | foo |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | foo | calls.rb:85:1:89:3 | foo |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | m1 | calls.rb:423:9:425:11 | m1 |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | m2 | calls.rb:428:5:440:7 | m2 |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | new | calls.rb:117:5:117:16 | new |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:484:1:490:3 | ExtendSingletonMethod | singleton | calls.rb:485:5:487:7 | singleton |
+| calls.rb:513:1:517:3 | ProtectedMethodInModule | foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:519:1:532:3 | ProtectedMethods | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:519:1:532:3 | ProtectedMethods | bar | calls.rb:522:15:524:7 | bar |
+| calls.rb:519:1:532:3 | ProtectedMethods | baz | calls.rb:526:5:531:7 | baz |
+| calls.rb:519:1:532:3 | ProtectedMethods | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:519:1:532:3 | ProtectedMethods | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:519:1:532:3 | ProtectedMethods | create | calls.rb:278:1:286:3 | create |
+| calls.rb:519:1:532:3 | ProtectedMethods | foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:519:1:532:3 | ProtectedMethods | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:519:1:532:3 | ProtectedMethods | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:519:1:532:3 | ProtectedMethods | new | calls.rb:117:5:117:16 | new |
+| calls.rb:519:1:532:3 | ProtectedMethods | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:519:1:532:3 | ProtectedMethods | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:519:1:532:3 | ProtectedMethods | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:519:1:532:3 | ProtectedMethods | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:519:1:532:3 | ProtectedMethods | to_s | calls.rb:172:5:173:7 | to_s |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | add_singleton | calls.rb:367:1:371:3 | add_singleton |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | bar | calls.rb:522:15:524:7 | bar |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | baz | calls.rb:539:5:542:7 | baz |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | call_block | calls.rb:81:1:83:3 | call_block |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | call_instance_m | calls.rb:39:1:41:3 | call_instance_m |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | create | calls.rb:278:1:286:3 | create |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | funny | calls.rb:140:1:142:3 | funny |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | indirect | calls.rb:158:1:160:3 | indirect |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | new | calls.rb:117:5:117:16 | new |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | optional_arg | calls.rb:76:1:79:3 | optional_arg |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | pattern_dispatch | calls.rb:343:1:359:3 | pattern_dispatch |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | private_on_main | calls.rb:185:1:186:3 | private_on_main |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | puts | calls.rb:102:5:102:30 | puts |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | to_s | calls.rb:172:5:173:7 | to_s |
 | file://:0:0:0:0 | Class | include | calls.rb:108:5:110:7 | include |
 | file://:0:0:0:0 | Class | module_eval | calls.rb:107:5:107:24 | module_eval |
 | file://:0:0:0:0 | Class | new | calls.rb:117:5:117:16 | new |
@@ -765,73 +765,73 @@ enclosingMethod
 | calls.rb:389:15:389:43 | SingletonOverride1#singleton2 | calls.rb:388:5:390:7 | singleton2 |
 | calls.rb:393:9:393:18 | call to singleton2 | calls.rb:392:5:394:7 | call_singleton2 |
 | calls.rb:393:9:393:18 | self | calls.rb:392:5:394:7 | call_singleton2 |
-| calls.rb:405:13:405:48 | call to puts | calls.rb:404:9:406:11 | singleton1 |
-| calls.rb:405:13:405:48 | self | calls.rb:404:9:406:11 | singleton1 |
-| calls.rb:405:18:405:48 | "SingletonOverride2#singleton1" | calls.rb:404:9:406:11 | singleton1 |
-| calls.rb:405:19:405:47 | SingletonOverride2#singleton1 | calls.rb:404:9:406:11 | singleton1 |
-| calls.rb:410:9:410:44 | call to puts | calls.rb:409:5:411:7 | singleton2 |
-| calls.rb:410:9:410:44 | self | calls.rb:409:5:411:7 | singleton2 |
-| calls.rb:410:14:410:44 | "SingletonOverride2#singleton2" | calls.rb:409:5:411:7 | singleton2 |
-| calls.rb:410:15:410:43 | SingletonOverride2#singleton2 | calls.rb:409:5:411:7 | singleton2 |
-| calls.rb:420:13:420:48 | call to puts | calls.rb:419:9:421:11 | m1 |
-| calls.rb:420:13:420:48 | self | calls.rb:419:9:421:11 | m1 |
-| calls.rb:420:18:420:48 | "ConditionalInstanceMethods#m1" | calls.rb:419:9:421:11 | m1 |
-| calls.rb:420:19:420:47 | ConditionalInstanceMethods#m1 | calls.rb:419:9:421:11 | m1 |
-| calls.rb:425:9:425:44 | call to puts | calls.rb:424:5:436:7 | m2 |
-| calls.rb:425:9:425:44 | self | calls.rb:424:5:436:7 | m2 |
-| calls.rb:425:14:425:44 | "ConditionalInstanceMethods#m2" | calls.rb:424:5:436:7 | m2 |
-| calls.rb:425:15:425:43 | ConditionalInstanceMethods#m2 | calls.rb:424:5:436:7 | m2 |
-| calls.rb:427:9:433:11 | m3 | calls.rb:424:5:436:7 | m2 |
-| calls.rb:428:13:428:48 | call to puts | calls.rb:427:9:433:11 | m3 |
-| calls.rb:428:13:428:48 | self | calls.rb:427:9:433:11 | m3 |
-| calls.rb:428:18:428:48 | "ConditionalInstanceMethods#m3" | calls.rb:427:9:433:11 | m3 |
-| calls.rb:428:19:428:47 | ConditionalInstanceMethods#m3 | calls.rb:427:9:433:11 | m3 |
-| calls.rb:430:13:432:15 | m4 | calls.rb:427:9:433:11 | m3 |
-| calls.rb:431:17:431:52 | call to puts | calls.rb:430:13:432:15 | m4 |
-| calls.rb:431:17:431:52 | self | calls.rb:430:13:432:15 | m4 |
-| calls.rb:431:22:431:52 | "ConditionalInstanceMethods#m4" | calls.rb:430:13:432:15 | m4 |
-| calls.rb:431:23:431:51 | ConditionalInstanceMethods#m4 | calls.rb:430:13:432:15 | m4 |
-| calls.rb:435:9:435:10 | call to m3 | calls.rb:424:5:436:7 | m2 |
-| calls.rb:435:9:435:10 | self | calls.rb:424:5:436:7 | m2 |
-| calls.rb:441:17:441:40 | call to puts | calls.rb:440:13:442:15 | m5 |
-| calls.rb:441:17:441:40 | self | calls.rb:440:13:442:15 | m5 |
-| calls.rb:441:22:441:40 | "AnonymousClass#m5" | calls.rb:440:13:442:15 | m5 |
-| calls.rb:441:23:441:39 | AnonymousClass#m5 | calls.rb:440:13:442:15 | m5 |
-| calls.rb:457:13:457:22 | call to puts | calls.rb:456:9:458:11 | foo |
-| calls.rb:457:13:457:22 | self | calls.rb:456:9:458:11 | foo |
-| calls.rb:457:18:457:22 | "foo" | calls.rb:456:9:458:11 | foo |
-| calls.rb:457:19:457:21 | foo | calls.rb:456:9:458:11 | foo |
-| calls.rb:463:13:463:22 | call to puts | calls.rb:462:9:464:11 | bar |
-| calls.rb:463:13:463:22 | self | calls.rb:462:9:464:11 | bar |
-| calls.rb:463:18:463:22 | "bar" | calls.rb:462:9:464:11 | bar |
-| calls.rb:463:19:463:21 | bar | calls.rb:462:9:464:11 | bar |
-| calls.rb:482:9:482:46 | call to puts | calls.rb:481:5:483:7 | singleton |
-| calls.rb:482:9:482:46 | self | calls.rb:481:5:483:7 | singleton |
-| calls.rb:482:14:482:46 | "ExtendSingletonMethod#singleton" | calls.rb:481:5:483:7 | singleton |
-| calls.rb:482:15:482:45 | ExtendSingletonMethod#singleton | calls.rb:481:5:483:7 | singleton |
-| calls.rb:511:9:511:42 | call to puts | calls.rb:510:15:512:7 | foo |
-| calls.rb:511:9:511:42 | self | calls.rb:510:15:512:7 | foo |
-| calls.rb:511:14:511:42 | "ProtectedMethodInModule#foo" | calls.rb:510:15:512:7 | foo |
-| calls.rb:511:15:511:41 | ProtectedMethodInModule#foo | calls.rb:510:15:512:7 | foo |
-| calls.rb:519:9:519:35 | call to puts | calls.rb:518:15:520:7 | bar |
-| calls.rb:519:9:519:35 | self | calls.rb:518:15:520:7 | bar |
-| calls.rb:519:14:519:35 | "ProtectedMethods#bar" | calls.rb:518:15:520:7 | bar |
-| calls.rb:519:15:519:34 | ProtectedMethods#bar | calls.rb:518:15:520:7 | bar |
-| calls.rb:523:9:523:11 | call to foo | calls.rb:522:5:527:7 | baz |
-| calls.rb:523:9:523:11 | self | calls.rb:522:5:527:7 | baz |
-| calls.rb:524:9:524:11 | call to bar | calls.rb:522:5:527:7 | baz |
-| calls.rb:524:9:524:11 | self | calls.rb:522:5:527:7 | baz |
-| calls.rb:525:9:525:24 | ProtectedMethods | calls.rb:522:5:527:7 | baz |
-| calls.rb:525:9:525:28 | call to new | calls.rb:522:5:527:7 | baz |
-| calls.rb:525:9:525:32 | call to foo | calls.rb:522:5:527:7 | baz |
-| calls.rb:526:9:526:24 | ProtectedMethods | calls.rb:522:5:527:7 | baz |
-| calls.rb:526:9:526:28 | call to new | calls.rb:522:5:527:7 | baz |
-| calls.rb:526:9:526:32 | call to bar | calls.rb:522:5:527:7 | baz |
-| calls.rb:536:9:536:11 | call to foo | calls.rb:535:5:538:7 | baz |
-| calls.rb:536:9:536:11 | self | calls.rb:535:5:538:7 | baz |
-| calls.rb:537:9:537:27 | ProtectedMethodsSub | calls.rb:535:5:538:7 | baz |
-| calls.rb:537:9:537:31 | call to new | calls.rb:535:5:538:7 | baz |
-| calls.rb:537:9:537:35 | call to foo | calls.rb:535:5:538:7 | baz |
+| calls.rb:407:13:407:48 | call to puts | calls.rb:406:9:408:11 | singleton1 |
+| calls.rb:407:13:407:48 | self | calls.rb:406:9:408:11 | singleton1 |
+| calls.rb:407:18:407:48 | "SingletonOverride2#singleton1" | calls.rb:406:9:408:11 | singleton1 |
+| calls.rb:407:19:407:47 | SingletonOverride2#singleton1 | calls.rb:406:9:408:11 | singleton1 |
+| calls.rb:412:9:412:44 | call to puts | calls.rb:411:5:413:7 | singleton2 |
+| calls.rb:412:9:412:44 | self | calls.rb:411:5:413:7 | singleton2 |
+| calls.rb:412:14:412:44 | "SingletonOverride2#singleton2" | calls.rb:411:5:413:7 | singleton2 |
+| calls.rb:412:15:412:43 | SingletonOverride2#singleton2 | calls.rb:411:5:413:7 | singleton2 |
+| calls.rb:424:13:424:48 | call to puts | calls.rb:423:9:425:11 | m1 |
+| calls.rb:424:13:424:48 | self | calls.rb:423:9:425:11 | m1 |
+| calls.rb:424:18:424:48 | "ConditionalInstanceMethods#m1" | calls.rb:423:9:425:11 | m1 |
+| calls.rb:424:19:424:47 | ConditionalInstanceMethods#m1 | calls.rb:423:9:425:11 | m1 |
+| calls.rb:429:9:429:44 | call to puts | calls.rb:428:5:440:7 | m2 |
+| calls.rb:429:9:429:44 | self | calls.rb:428:5:440:7 | m2 |
+| calls.rb:429:14:429:44 | "ConditionalInstanceMethods#m2" | calls.rb:428:5:440:7 | m2 |
+| calls.rb:429:15:429:43 | ConditionalInstanceMethods#m2 | calls.rb:428:5:440:7 | m2 |
+| calls.rb:431:9:437:11 | m3 | calls.rb:428:5:440:7 | m2 |
+| calls.rb:432:13:432:48 | call to puts | calls.rb:431:9:437:11 | m3 |
+| calls.rb:432:13:432:48 | self | calls.rb:431:9:437:11 | m3 |
+| calls.rb:432:18:432:48 | "ConditionalInstanceMethods#m3" | calls.rb:431:9:437:11 | m3 |
+| calls.rb:432:19:432:47 | ConditionalInstanceMethods#m3 | calls.rb:431:9:437:11 | m3 |
+| calls.rb:434:13:436:15 | m4 | calls.rb:431:9:437:11 | m3 |
+| calls.rb:435:17:435:52 | call to puts | calls.rb:434:13:436:15 | m4 |
+| calls.rb:435:17:435:52 | self | calls.rb:434:13:436:15 | m4 |
+| calls.rb:435:22:435:52 | "ConditionalInstanceMethods#m4" | calls.rb:434:13:436:15 | m4 |
+| calls.rb:435:23:435:51 | ConditionalInstanceMethods#m4 | calls.rb:434:13:436:15 | m4 |
+| calls.rb:439:9:439:10 | call to m3 | calls.rb:428:5:440:7 | m2 |
+| calls.rb:439:9:439:10 | self | calls.rb:428:5:440:7 | m2 |
+| calls.rb:445:17:445:40 | call to puts | calls.rb:444:13:446:15 | m5 |
+| calls.rb:445:17:445:40 | self | calls.rb:444:13:446:15 | m5 |
+| calls.rb:445:22:445:40 | "AnonymousClass#m5" | calls.rb:444:13:446:15 | m5 |
+| calls.rb:445:23:445:39 | AnonymousClass#m5 | calls.rb:444:13:446:15 | m5 |
+| calls.rb:461:13:461:22 | call to puts | calls.rb:460:9:462:11 | foo |
+| calls.rb:461:13:461:22 | self | calls.rb:460:9:462:11 | foo |
+| calls.rb:461:18:461:22 | "foo" | calls.rb:460:9:462:11 | foo |
+| calls.rb:461:19:461:21 | foo | calls.rb:460:9:462:11 | foo |
+| calls.rb:467:13:467:22 | call to puts | calls.rb:466:9:468:11 | bar |
+| calls.rb:467:13:467:22 | self | calls.rb:466:9:468:11 | bar |
+| calls.rb:467:18:467:22 | "bar" | calls.rb:466:9:468:11 | bar |
+| calls.rb:467:19:467:21 | bar | calls.rb:466:9:468:11 | bar |
+| calls.rb:486:9:486:46 | call to puts | calls.rb:485:5:487:7 | singleton |
+| calls.rb:486:9:486:46 | self | calls.rb:485:5:487:7 | singleton |
+| calls.rb:486:14:486:46 | "ExtendSingletonMethod#singleton" | calls.rb:485:5:487:7 | singleton |
+| calls.rb:486:15:486:45 | ExtendSingletonMethod#singleton | calls.rb:485:5:487:7 | singleton |
+| calls.rb:515:9:515:42 | call to puts | calls.rb:514:15:516:7 | foo |
+| calls.rb:515:9:515:42 | self | calls.rb:514:15:516:7 | foo |
+| calls.rb:515:14:515:42 | "ProtectedMethodInModule#foo" | calls.rb:514:15:516:7 | foo |
+| calls.rb:515:15:515:41 | ProtectedMethodInModule#foo | calls.rb:514:15:516:7 | foo |
+| calls.rb:523:9:523:35 | call to puts | calls.rb:522:15:524:7 | bar |
+| calls.rb:523:9:523:35 | self | calls.rb:522:15:524:7 | bar |
+| calls.rb:523:14:523:35 | "ProtectedMethods#bar" | calls.rb:522:15:524:7 | bar |
+| calls.rb:523:15:523:34 | ProtectedMethods#bar | calls.rb:522:15:524:7 | bar |
+| calls.rb:527:9:527:11 | call to foo | calls.rb:526:5:531:7 | baz |
+| calls.rb:527:9:527:11 | self | calls.rb:526:5:531:7 | baz |
+| calls.rb:528:9:528:11 | call to bar | calls.rb:526:5:531:7 | baz |
+| calls.rb:528:9:528:11 | self | calls.rb:526:5:531:7 | baz |
+| calls.rb:529:9:529:24 | ProtectedMethods | calls.rb:526:5:531:7 | baz |
+| calls.rb:529:9:529:28 | call to new | calls.rb:526:5:531:7 | baz |
+| calls.rb:529:9:529:32 | call to foo | calls.rb:526:5:531:7 | baz |
+| calls.rb:530:9:530:24 | ProtectedMethods | calls.rb:526:5:531:7 | baz |
+| calls.rb:530:9:530:28 | call to new | calls.rb:526:5:531:7 | baz |
+| calls.rb:530:9:530:32 | call to bar | calls.rb:526:5:531:7 | baz |
+| calls.rb:540:9:540:11 | call to foo | calls.rb:539:5:542:7 | baz |
+| calls.rb:540:9:540:11 | self | calls.rb:539:5:542:7 | baz |
+| calls.rb:541:9:541:27 | ProtectedMethodsSub | calls.rb:539:5:542:7 | baz |
+| calls.rb:541:9:541:31 | call to new | calls.rb:539:5:542:7 | baz |
+| calls.rb:541:9:541:35 | call to foo | calls.rb:539:5:542:7 | baz |
 | hello.rb:3:9:3:22 | return | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:16:3:22 | "hello" | hello.rb:2:5:4:7 | hello |
 | hello.rb:3:17:3:21 | hello | hello.rb:2:5:4:7 | hello |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -18,14 +18,14 @@ getModule
 | calls.rb:331:1:335:3 | C2 |
 | calls.rb:337:1:341:3 | C3 |
 | calls.rb:377:1:397:3 | SingletonOverride1 |
-| calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:490:1:492:3 | ExtendSingletonMethod2 |
-| calls.rb:496:1:497:3 | ExtendSingletonMethod3 |
-| calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub |
+| calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:494:1:496:3 | ExtendSingletonMethod2 |
+| calls.rb:500:1:501:3 | ExtendSingletonMethod3 |
+| calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub |
 | file://:0:0:0:0 | BasicObject |
 | file://:0:0:0:0 | Class |
 | file://:0:0:0:0 | Complex |
@@ -84,7 +84,7 @@ getADeclaration
 | calls.rb:96:1:98:3 | String | calls.rb:96:1:98:3 | String |
 | calls.rb:100:1:103:3 | Kernel | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:105:1:113:3 | Module | calls.rb:105:1:113:3 | Module |
-| calls.rb:115:1:118:3 | Object | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:115:1:118:3 | Object | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:115:1:118:3 | Object | calls.rb:115:1:118:3 | Object |
 | calls.rb:115:1:118:3 | Object | hello.rb:1:1:22:3 | hello.rb |
 | calls.rb:115:1:118:3 | Object | modules.rb:1:1:129:4 | modules.rb |
@@ -102,14 +102,14 @@ getADeclaration
 | calls.rb:331:1:335:3 | C2 | calls.rb:331:1:335:3 | C2 |
 | calls.rb:337:1:341:3 | C3 | calls.rb:337:1:341:3 | C3 |
 | calls.rb:377:1:397:3 | SingletonOverride1 | calls.rb:377:1:397:3 | SingletonOverride1 |
-| calls.rb:402:1:412:3 | SingletonOverride2 | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:480:1:486:3 | ExtendSingletonMethod | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:490:1:492:3 | ExtendSingletonMethod2 | calls.rb:490:1:492:3 | ExtendSingletonMethod2 |
-| calls.rb:496:1:497:3 | ExtendSingletonMethod3 | calls.rb:496:1:497:3 | ExtendSingletonMethod3 |
-| calls.rb:509:1:513:3 | ProtectedMethodInModule | calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:515:1:528:3 | ProtectedMethods | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | calls.rb:534:1:539:3 | ProtectedMethodsSub |
+| calls.rb:404:1:414:3 | SingletonOverride2 | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:484:1:490:3 | ExtendSingletonMethod | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:494:1:496:3 | ExtendSingletonMethod2 | calls.rb:494:1:496:3 | ExtendSingletonMethod2 |
+| calls.rb:500:1:501:3 | ExtendSingletonMethod3 | calls.rb:500:1:501:3 | ExtendSingletonMethod3 |
+| calls.rb:513:1:517:3 | ProtectedMethodInModule | calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:519:1:532:3 | ProtectedMethods | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | calls.rb:538:1:543:3 | ProtectedMethodsSub |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
@@ -171,10 +171,10 @@ getSuperClass
 | calls.rb:331:1:335:3 | C2 | calls.rb:325:1:329:3 | C1 |
 | calls.rb:337:1:341:3 | C3 | calls.rb:331:1:335:3 | C2 |
 | calls.rb:377:1:397:3 | SingletonOverride1 | calls.rb:115:1:118:3 | Object |
-| calls.rb:402:1:412:3 | SingletonOverride2 | calls.rb:377:1:397:3 | SingletonOverride1 |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | calls.rb:115:1:118:3 | Object |
-| calls.rb:515:1:528:3 | ProtectedMethods | calls.rb:115:1:118:3 | Object |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | calls.rb:515:1:528:3 | ProtectedMethods |
+| calls.rb:404:1:414:3 | SingletonOverride2 | calls.rb:377:1:397:3 | SingletonOverride1 |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | calls.rb:115:1:118:3 | Object |
+| calls.rb:519:1:532:3 | ProtectedMethods | calls.rb:115:1:118:3 | Object |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | calls.rb:519:1:532:3 | ProtectedMethods |
 | file://:0:0:0:0 | Class | calls.rb:105:1:113:3 | Module |
 | file://:0:0:0:0 | Complex | file://:0:0:0:0 | Numeric |
 | file://:0:0:0:0 | FalseClass | calls.rb:115:1:118:3 | Object |
@@ -206,7 +206,7 @@ getAPrependedModule
 getAnIncludedModule
 | calls.rb:43:1:58:3 | C | calls.rb:21:1:34:3 | M |
 | calls.rb:115:1:118:3 | Object | calls.rb:100:1:103:3 | Kernel |
-| calls.rb:515:1:528:3 | ProtectedMethods | calls.rb:509:1:513:3 | ProtectedMethodInModule |
+| calls.rb:519:1:532:3 | ProtectedMethods | calls.rb:513:1:517:3 | ProtectedMethodInModule |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:1:1:8:3 | EnglishWords |
 | modules.rb:88:1:93:3 | IncludeTest | modules.rb:63:1:81:3 | Test |
 | modules.rb:95:1:99:3 | IncludeTest2 | modules.rb:63:1:81:3 | Test |
@@ -258,41 +258,45 @@ resolveConstantReadAccess
 | calls.rb:373:6:373:7 | C1 | C1 |
 | calls.rb:399:1:399:18 | SingletonOverride1 | SingletonOverride1 |
 | calls.rb:400:1:400:18 | SingletonOverride1 | SingletonOverride1 |
-| calls.rb:402:28:402:45 | SingletonOverride1 | SingletonOverride1 |
-| calls.rb:414:1:414:18 | SingletonOverride2 | SingletonOverride2 |
-| calls.rb:415:1:415:18 | SingletonOverride2 | SingletonOverride2 |
-| calls.rb:439:9:439:13 | Class | Class |
-| calls.rb:447:1:447:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:448:1:448:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:449:1:449:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:450:1:450:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:401:1:401:18 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:402:1:402:18 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:404:28:404:45 | SingletonOverride1 | SingletonOverride1 |
+| calls.rb:416:1:416:18 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:417:1:417:18 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:418:1:418:18 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:419:1:419:18 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:443:9:443:13 | Class | Class |
 | calls.rb:451:1:451:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
 | calls.rb:452:1:452:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:454:27:454:31 | Class | Class |
-| calls.rb:455:5:455:11 | Array | Array |
-| calls.rb:461:5:461:9 | Class | Class |
-| calls.rb:467:5:467:11 | Array | Array |
-| calls.rb:488:1:488:21 | ExtendSingletonMethod | ExtendSingletonMethod |
-| calls.rb:491:12:491:32 | ExtendSingletonMethod | ExtendSingletonMethod |
-| calls.rb:494:1:494:22 | ExtendSingletonMethod2 | ExtendSingletonMethod2 |
-| calls.rb:499:1:499:22 | ExtendSingletonMethod3 | ExtendSingletonMethod3 |
-| calls.rb:499:31:499:51 | ExtendSingletonMethod | ExtendSingletonMethod |
-| calls.rb:501:1:501:22 | ExtendSingletonMethod3 | ExtendSingletonMethod3 |
-| calls.rb:505:12:505:32 | ExtendSingletonMethod | ExtendSingletonMethod |
-| calls.rb:516:13:516:35 | ProtectedMethodInModule | ProtectedMethodInModule |
-| calls.rb:525:9:525:24 | ProtectedMethods | ProtectedMethods |
-| calls.rb:526:9:526:24 | ProtectedMethods | ProtectedMethods |
-| calls.rb:530:1:530:16 | ProtectedMethods | ProtectedMethods |
-| calls.rb:531:1:531:16 | ProtectedMethods | ProtectedMethods |
-| calls.rb:532:1:532:16 | ProtectedMethods | ProtectedMethods |
-| calls.rb:534:29:534:44 | ProtectedMethods | ProtectedMethods |
-| calls.rb:537:9:537:27 | ProtectedMethodsSub | ProtectedMethodsSub |
-| calls.rb:541:1:541:19 | ProtectedMethodsSub | ProtectedMethodsSub |
-| calls.rb:542:1:542:19 | ProtectedMethodsSub | ProtectedMethodsSub |
-| calls.rb:543:1:543:19 | ProtectedMethodsSub | ProtectedMethodsSub |
-| calls.rb:545:1:545:7 | Array | Array |
-| calls.rb:545:2:545:2 | C | C |
-| calls.rb:546:1:546:13 | Array | Array |
+| calls.rb:453:1:453:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:454:1:454:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:455:1:455:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:456:1:456:26 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:458:27:458:31 | Class | Class |
+| calls.rb:459:5:459:11 | Array | Array |
+| calls.rb:465:5:465:9 | Class | Class |
+| calls.rb:471:5:471:11 | Array | Array |
+| calls.rb:492:1:492:21 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:495:12:495:32 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:498:1:498:22 | ExtendSingletonMethod2 | ExtendSingletonMethod2 |
+| calls.rb:503:1:503:22 | ExtendSingletonMethod3 | ExtendSingletonMethod3 |
+| calls.rb:503:31:503:51 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:505:1:505:22 | ExtendSingletonMethod3 | ExtendSingletonMethod3 |
+| calls.rb:509:12:509:32 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:520:13:520:35 | ProtectedMethodInModule | ProtectedMethodInModule |
+| calls.rb:529:9:529:24 | ProtectedMethods | ProtectedMethods |
+| calls.rb:530:9:530:24 | ProtectedMethods | ProtectedMethods |
+| calls.rb:534:1:534:16 | ProtectedMethods | ProtectedMethods |
+| calls.rb:535:1:535:16 | ProtectedMethods | ProtectedMethods |
+| calls.rb:536:1:536:16 | ProtectedMethods | ProtectedMethods |
+| calls.rb:538:29:538:44 | ProtectedMethods | ProtectedMethods |
+| calls.rb:541:9:541:27 | ProtectedMethodsSub | ProtectedMethodsSub |
+| calls.rb:545:1:545:19 | ProtectedMethodsSub | ProtectedMethodsSub |
+| calls.rb:546:1:546:19 | ProtectedMethodsSub | ProtectedMethodsSub |
+| calls.rb:547:1:547:19 | ProtectedMethodsSub | ProtectedMethodsSub |
+| calls.rb:549:1:549:7 | Array | Array |
+| calls.rb:549:2:549:2 | C | C |
+| calls.rb:550:1:550:13 | Array | Array |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
 | modules.rb:48:8:48:10 | Foo | Foo |
@@ -348,15 +352,15 @@ resolveConstantWriteAccess
 | calls.rb:331:1:335:3 | C2 | C2 |
 | calls.rb:337:1:341:3 | C3 | C3 |
 | calls.rb:377:1:397:3 | SingletonOverride1 | SingletonOverride1 |
-| calls.rb:402:1:412:3 | SingletonOverride2 | SingletonOverride2 |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | ConditionalInstanceMethods |
-| calls.rb:454:1:454:23 | EsotericInstanceMethods | EsotericInstanceMethods |
-| calls.rb:480:1:486:3 | ExtendSingletonMethod | ExtendSingletonMethod |
-| calls.rb:490:1:492:3 | ExtendSingletonMethod2 | ExtendSingletonMethod2 |
-| calls.rb:496:1:497:3 | ExtendSingletonMethod3 | ExtendSingletonMethod3 |
-| calls.rb:509:1:513:3 | ProtectedMethodInModule | ProtectedMethodInModule |
-| calls.rb:515:1:528:3 | ProtectedMethods | ProtectedMethods |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | ProtectedMethodsSub |
+| calls.rb:404:1:414:3 | SingletonOverride2 | SingletonOverride2 |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | ConditionalInstanceMethods |
+| calls.rb:458:1:458:23 | EsotericInstanceMethods | EsotericInstanceMethods |
+| calls.rb:484:1:490:3 | ExtendSingletonMethod | ExtendSingletonMethod |
+| calls.rb:494:1:496:3 | ExtendSingletonMethod2 | ExtendSingletonMethod2 |
+| calls.rb:500:1:501:3 | ExtendSingletonMethod3 | ExtendSingletonMethod3 |
+| calls.rb:513:1:517:3 | ProtectedMethodInModule | ProtectedMethodInModule |
+| calls.rb:519:1:532:3 | ProtectedMethods | ProtectedMethods |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | ProtectedMethodsSub |
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |
@@ -411,32 +415,32 @@ resolveConstantWriteAccess
 | private.rb:82:1:94:3 | PrivateOverride1 | PrivateOverride1 |
 | private.rb:96:1:102:3 | PrivateOverride2 | PrivateOverride2 |
 enclosingModule
-| calls.rb:1:1:3:3 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:2:5:2:14 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:2:11:2:13 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:5:1:5:3 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:7:1:9:3 | bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:7:5:7:8 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:8:5:8:15 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:11:1:11:4 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:13:1:15:3 | bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:13:5:13:8 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:14:5:14:15 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:17:1:17:4 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:19:1:19:4 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:21:1:34:3 | M | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:1:1:3:3 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:2:5:2:14 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:2:10:2:14 | "foo" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:2:11:2:13 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:5:1:5:3 | call to foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:5:1:5:3 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:7:1:9:3 | bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:7:5:7:8 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:8:5:8:15 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:8:5:8:15 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:8:10:8:15 | "bar1" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:8:11:8:14 | bar1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:11:1:11:4 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:11:1:11:8 | call to bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:13:1:15:3 | bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:13:5:13:8 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:14:5:14:15 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:14:5:14:15 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:14:10:14:15 | "bar2" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:14:11:14:14 | bar2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:17:1:17:4 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:17:1:17:8 | call to bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:19:1:19:4 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:19:1:19:8 | call to foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:21:1:34:3 | M | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:22:5:24:7 | instance_m | calls.rb:21:1:34:3 | M |
 | calls.rb:23:9:23:19 | call to singleton_m | calls.rb:21:1:34:3 | M |
 | calls.rb:23:9:23:19 | self | calls.rb:21:1:34:3 | M |
@@ -452,14 +456,14 @@ enclosingModule
 | calls.rb:32:5:32:15 | self | calls.rb:21:1:34:3 | M |
 | calls.rb:33:5:33:8 | self | calls.rb:21:1:34:3 | M |
 | calls.rb:33:5:33:20 | call to singleton_m | calls.rb:21:1:34:3 | M |
-| calls.rb:36:1:36:1 | M | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:37:1:37:1 | M | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:40:5:40:14 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:43:1:58:3 | C | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:36:1:36:1 | M | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:36:1:36:12 | call to instance_m | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:37:1:37:1 | M | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:37:1:37:13 | call to singleton_m | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:39:1:41:3 | call_instance_m | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:40:5:40:14 | call to instance_m | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:40:5:40:14 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:43:1:58:3 | C | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:44:5:44:13 | call to include | calls.rb:43:1:58:3 | C |
 | calls.rb:44:5:44:13 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:44:13:44:13 | M | calls.rb:43:1:58:3 | C |
@@ -480,66 +484,66 @@ enclosingModule
 | calls.rb:55:9:55:19 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:56:9:56:12 | self | calls.rb:43:1:58:3 | C |
 | calls.rb:56:9:56:24 | call to singleton_m | calls.rb:43:1:58:3 | C |
-| calls.rb:60:1:60:1 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:60:5:60:5 | C | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:61:1:61:1 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:62:1:62:1 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:63:1:63:1 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:65:1:69:3 | D | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:65:11:65:11 | C | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:60:1:60:1 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:60:1:60:9 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:60:5:60:5 | C | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:60:5:60:9 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:61:1:61:1 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:61:1:61:5 | call to baz | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:62:1:62:1 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:62:1:62:13 | call to singleton_m | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:63:1:63:1 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:63:1:63:12 | call to instance_m | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:65:1:69:3 | D | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:65:11:65:11 | C | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:66:5:68:7 | baz | calls.rb:65:1:69:3 | D |
 | calls.rb:67:9:67:13 | call to super | calls.rb:65:1:69:3 | D |
-| calls.rb:71:1:71:1 | d | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:71:5:71:5 | D | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:72:1:72:1 | d | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:73:1:73:1 | d | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:74:1:74:1 | d | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:76:18:76:18 | a | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:76:18:76:18 | a | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:76:25:76:25 | b | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:76:25:76:25 | b | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:77:5:77:5 | a | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:78:5:78:5 | b | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:85:1:89:3 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:86:5:86:7 | var | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:87:5:87:7 | var | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:88:5:88:29 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:88:19:88:19 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:88:19:88:19 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:88:22:88:24 | var | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:88:26:88:26 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:71:1:71:1 | d | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:71:1:71:9 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:71:5:71:5 | D | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:71:5:71:9 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:72:1:72:1 | d | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:72:1:72:5 | call to baz | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:73:1:73:1 | d | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:73:1:73:13 | call to singleton_m | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:74:1:74:1 | d | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:74:1:74:12 | call to instance_m | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:76:1:79:3 | optional_arg | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:76:18:76:18 | a | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:76:22:76:22 | 4 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:76:25:76:25 | b | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:76:28:76:28 | 5 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:77:5:77:5 | a | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:77:5:77:16 | call to bit_length | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:78:5:78:5 | b | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:78:5:78:16 | call to bit_length | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:81:1:83:3 | call_block | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:82:5:82:11 | yield ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:82:11:82:11 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:85:1:89:3 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:86:5:86:7 | var | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:86:5:86:18 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:86:11:86:14 | Hash | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:86:11:86:18 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:87:5:87:7 | var | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:87:5:87:10 | ...[...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:87:9:87:9 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:88:5:88:29 | call to call_block | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:88:5:88:29 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:88:16:88:29 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:88:19:88:19 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:88:22:88:24 | var | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:88:22:88:27 | ...[...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:88:26:88:26 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:91:1:94:3 | Integer | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:92:5:92:23 | bit_length | calls.rb:91:1:94:3 | Integer |
 | calls.rb:93:5:93:16 | abs | calls.rb:91:1:94:3 | Integer |
-| calls.rb:96:1:98:3 | String | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:96:1:98:3 | String | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:97:5:97:23 | capitalize | calls.rb:96:1:98:3 | String |
-| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:100:1:103:3 | Kernel | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:101:5:101:25 | alias ... | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:101:11:101:19 | :old_puts | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:101:11:101:19 | old_puts | calls.rb:100:1:103:3 | Kernel |
@@ -551,7 +555,7 @@ enclosingModule
 | calls.rb:102:17:102:26 | call to old_puts | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:102:17:102:26 | self | calls.rb:100:1:103:3 | Kernel |
 | calls.rb:102:26:102:26 | x | calls.rb:100:1:103:3 | Kernel |
-| calls.rb:105:1:113:3 | Module | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:105:1:113:3 | Module | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:106:5:106:31 | alias ... | calls.rb:105:1:113:3 | Module |
 | calls.rb:106:11:106:22 | :old_include | calls.rb:105:1:113:3 | Module |
 | calls.rb:106:11:106:22 | old_include | calls.rb:105:1:113:3 | Module |
@@ -566,13 +570,13 @@ enclosingModule
 | calls.rb:109:21:109:21 | x | calls.rb:105:1:113:3 | Module |
 | calls.rb:111:5:111:20 | prepend | calls.rb:105:1:113:3 | Module |
 | calls.rb:112:5:112:20 | private | calls.rb:105:1:113:3 | Module |
-| calls.rb:115:1:118:3 | Object | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:115:16:115:21 | Module | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:115:1:118:3 | Object | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:115:16:115:21 | Module | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:116:5:116:18 | call to include | calls.rb:115:1:118:3 | Object |
 | calls.rb:116:5:116:18 | self | calls.rb:115:1:118:3 | Object |
 | calls.rb:116:13:116:18 | Kernel | calls.rb:115:1:118:3 | Object |
 | calls.rb:117:5:117:16 | new | calls.rb:115:1:118:3 | Object |
-| calls.rb:120:1:123:3 | Hash | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:120:1:123:3 | Hash | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:121:5:121:25 | alias ... | calls.rb:120:1:123:3 | Hash |
 | calls.rb:121:11:121:21 | :old_lookup | calls.rb:120:1:123:3 | Hash |
 | calls.rb:121:11:121:21 | old_lookup | calls.rb:120:1:123:3 | Hash |
@@ -584,7 +588,7 @@ enclosingModule
 | calls.rb:122:15:122:27 | call to old_lookup | calls.rb:120:1:123:3 | Hash |
 | calls.rb:122:15:122:27 | self | calls.rb:120:1:123:3 | Hash |
 | calls.rb:122:26:122:26 | x | calls.rb:120:1:123:3 | Hash |
-| calls.rb:125:1:138:3 | Array | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:125:1:138:3 | Array | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:126:3:126:23 | alias ... | calls.rb:125:1:138:3 | Array |
 | calls.rb:126:9:126:19 | :old_lookup | calls.rb:125:1:138:3 | Array |
 | calls.rb:126:9:126:19 | old_lookup | calls.rb:125:1:138:3 | Array |
@@ -620,130 +624,130 @@ enclosingModule
 | calls.rb:135:9:135:14 | ... = ... | calls.rb:125:1:138:3 | Array |
 | calls.rb:135:11:135:12 | ... + ... | calls.rb:125:1:138:3 | Array |
 | calls.rb:135:14:135:14 | 1 | calls.rb:125:1:138:3 | Array |
-| calls.rb:140:1:142:3 | funny | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:141:5:141:20 | yield ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:141:11:141:20 | "prefix: " | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:141:12:141:19 | prefix:  | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:1:144:30 | call to funny | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:1:144:30 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:7:144:30 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:10:144:10 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:10:144:10 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:13:144:29 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:13:144:29 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:18:144:18 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:144:18:144:29 | call to capitalize | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:146:1:146:3 | "a" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:146:1:146:14 | call to capitalize | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:146:2:146:2 | a | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:147:1:147:1 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:147:1:147:12 | call to bit_length | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:148:1:148:1 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:148:1:148:5 | call to abs | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:1:150:13 | Array | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:1:150:13 | [...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:1:150:13 | call to [] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:1:150:62 | call to foreach | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:2:150:4 | "a" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:3:150:3 | a | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:6:150:8 | "b" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:7:150:7 | b | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:10:150:12 | "c" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:11:150:11 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:23:150:62 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:26:150:26 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:26:150:26 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:29:150:29 | v | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:29:150:29 | v | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:32:150:61 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:32:150:61 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:37:150:61 | "#{...} -> #{...}" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:38:150:41 | #{...} | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:40:150:40 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:42:150:45 |  ->  | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:46:150:60 | #{...} | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:48:150:48 | v | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:150:48:150:59 | call to capitalize | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:1:152:7 | Array | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:1:152:7 | [...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:1:152:7 | call to [] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:1:152:35 | call to foreach | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:2:152:2 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:4:152:4 | 2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:6:152:6 | 3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:17:152:35 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:20:152:20 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:20:152:20 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:23:152:23 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:152:23:152:34 | call to bit_length | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:1:154:7 | Array | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:1:154:7 | [...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:1:154:7 | call to [] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:1:154:40 | call to foreach | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:2:154:2 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:4:154:4 | 2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:6:154:6 | 3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:17:154:40 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:20:154:20 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:20:154:20 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:23:154:39 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:23:154:39 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:28:154:28 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:154:28:154:39 | call to capitalize | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:1:156:8 | Array | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:1:156:8 | [...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:1:156:8 | call to [] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:1:156:37 | call to foreach | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:2:156:2 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:4:156:5 | - ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:5:156:5 | 2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:7:156:7 | 3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:18:156:37 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:21:156:21 | _ | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:21:156:21 | _ | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:24:156:24 | v | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:24:156:24 | v | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:27:156:36 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:27:156:36 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:32:156:32 | v | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:156:32:156:36 | call to abs | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:158:1:160:3 | indirect | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:158:14:158:15 | &b | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:158:15:158:15 | b | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:159:5:159:17 | call to call_block | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:159:5:159:17 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:159:16:159:17 | &... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:159:17:159:17 | b | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:162:1:162:28 | call to indirect | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:162:1:162:28 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:162:10:162:28 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:162:13:162:13 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:162:13:162:13 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:162:16:162:16 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:162:16:162:27 | call to bit_length | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:165:1:169:3 | S | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:140:1:142:3 | funny | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:141:5:141:20 | yield ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:141:11:141:20 | "prefix: " | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:141:12:141:19 | prefix:  | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:1:144:30 | call to funny | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:1:144:30 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:7:144:30 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:10:144:10 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:10:144:10 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:13:144:29 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:13:144:29 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:18:144:18 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:144:18:144:29 | call to capitalize | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:146:1:146:3 | "a" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:146:1:146:14 | call to capitalize | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:146:2:146:2 | a | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:147:1:147:1 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:147:1:147:12 | call to bit_length | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:148:1:148:1 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:148:1:148:5 | call to abs | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:1:150:13 | Array | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:1:150:13 | [...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:1:150:13 | call to [] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:1:150:62 | call to foreach | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:2:150:4 | "a" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:3:150:3 | a | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:6:150:8 | "b" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:7:150:7 | b | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:10:150:12 | "c" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:11:150:11 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:23:150:62 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:26:150:26 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:26:150:26 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:29:150:29 | v | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:29:150:29 | v | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:32:150:61 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:32:150:61 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:37:150:61 | "#{...} -> #{...}" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:38:150:41 | #{...} | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:40:150:40 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:42:150:45 |  ->  | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:46:150:60 | #{...} | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:48:150:48 | v | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:150:48:150:59 | call to capitalize | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:1:152:7 | Array | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:1:152:7 | [...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:1:152:7 | call to [] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:1:152:35 | call to foreach | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:2:152:2 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:4:152:4 | 2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:6:152:6 | 3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:17:152:35 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:20:152:20 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:20:152:20 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:23:152:23 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:152:23:152:34 | call to bit_length | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:1:154:7 | Array | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:1:154:7 | [...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:1:154:7 | call to [] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:1:154:40 | call to foreach | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:2:154:2 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:4:154:4 | 2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:6:154:6 | 3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:17:154:40 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:20:154:20 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:20:154:20 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:23:154:39 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:23:154:39 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:28:154:28 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:154:28:154:39 | call to capitalize | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:1:156:8 | Array | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:1:156:8 | [...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:1:156:8 | call to [] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:1:156:37 | call to foreach | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:2:156:2 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:4:156:5 | - ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:5:156:5 | 2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:7:156:7 | 3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:18:156:37 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:21:156:21 | _ | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:21:156:21 | _ | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:24:156:24 | v | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:24:156:24 | v | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:27:156:36 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:27:156:36 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:32:156:32 | v | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:156:32:156:36 | call to abs | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:158:1:160:3 | indirect | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:158:14:158:15 | &b | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:158:15:158:15 | b | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:159:5:159:17 | call to call_block | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:159:5:159:17 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:159:16:159:17 | &... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:159:17:159:17 | b | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:162:1:162:28 | call to indirect | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:162:1:162:28 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:162:10:162:28 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:162:13:162:13 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:162:13:162:13 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:162:16:162:16 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:162:16:162:27 | call to bit_length | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:165:1:169:3 | S | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:166:5:168:7 | s_method | calls.rb:165:1:169:3 | S |
 | calls.rb:167:9:167:12 | self | calls.rb:165:1:169:3 | S |
 | calls.rb:167:9:167:17 | call to to_s | calls.rb:165:1:169:3 | S |
-| calls.rb:171:1:174:3 | A | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:171:11:171:11 | S | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:171:1:174:3 | A | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:171:11:171:11 | S | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:172:5:173:7 | to_s | calls.rb:171:1:174:3 | A |
-| calls.rb:176:1:179:3 | B | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:176:11:176:11 | S | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:176:1:179:3 | B | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:176:11:176:11 | S | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:177:5:178:7 | to_s | calls.rb:176:1:179:3 | B |
-| calls.rb:181:1:181:1 | S | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:181:1:181:5 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:181:1:181:14 | call to s_method | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:182:1:182:1 | A | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:182:1:182:5 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:182:1:182:14 | call to s_method | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:183:1:183:1 | B | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:183:1:183:5 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:183:1:183:14 | call to s_method | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:185:1:186:3 | private_on_main | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:188:1:188:15 | call to private_on_main | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:188:1:188:15 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:190:1:226:3 | Singletons | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:181:1:181:1 | S | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:181:1:181:5 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:181:1:181:14 | call to s_method | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:182:1:182:1 | A | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:182:1:182:5 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:182:1:182:14 | call to s_method | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:183:1:183:1 | B | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:183:1:183:5 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:183:1:183:14 | call to s_method | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:185:1:186:3 | private_on_main | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:188:1:188:15 | call to private_on_main | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:188:1:188:15 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:190:1:226:3 | Singletons | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:191:5:194:7 | singleton_a | calls.rb:190:1:226:3 | Singletons |
 | calls.rb:191:9:191:12 | self | calls.rb:190:1:226:3 | Singletons |
 | calls.rb:192:9:192:26 | call to puts | calls.rb:190:1:226:3 | Singletons |
@@ -793,126 +797,126 @@ enclosingModule
 | calls.rb:223:5:225:7 | call_singleton_g | calls.rb:190:1:226:3 | Singletons |
 | calls.rb:224:9:224:12 | self | calls.rb:190:1:226:3 | Singletons |
 | calls.rb:224:9:224:24 | call to singleton_g | calls.rb:190:1:226:3 | Singletons |
-| calls.rb:228:1:228:10 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:228:1:228:22 | call to singleton_a | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:229:1:229:10 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:229:1:229:22 | call to singleton_f | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:231:1:231:19 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:231:6:231:15 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:231:6:231:19 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:233:1:233:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:233:1:233:11 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:234:1:234:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:234:1:234:14 | call to singleton_e | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:236:1:238:3 | singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:236:5:236:6 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:237:5:237:24 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:237:5:237:24 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:237:10:237:24 | "singleton_g_1" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:237:11:237:23 | singleton_g_1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:240:1:240:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:240:1:240:14 | call to singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:241:1:241:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:241:1:241:19 | call to call_singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:243:1:245:3 | singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:243:5:243:6 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:244:5:244:24 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:244:5:244:24 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:244:10:244:24 | "singleton_g_2" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:244:11:244:23 | singleton_g_2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:247:1:247:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:247:1:247:14 | call to singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:248:1:248:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:248:1:248:19 | call to call_singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:250:1:254:3 | class << ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:250:10:250:11 | c1 | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:228:1:228:10 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:228:1:228:22 | call to singleton_a | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:229:1:229:10 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:229:1:229:22 | call to singleton_f | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:231:1:231:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:231:1:231:19 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:231:6:231:15 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:231:6:231:19 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:233:1:233:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:233:1:233:11 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:234:1:234:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:234:1:234:14 | call to singleton_e | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:236:1:238:3 | singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:236:5:236:6 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:237:5:237:24 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:237:5:237:24 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:237:10:237:24 | "singleton_g_1" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:237:11:237:23 | singleton_g_1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:240:1:240:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:240:1:240:14 | call to singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:241:1:241:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:241:1:241:19 | call to call_singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:243:1:245:3 | singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:243:5:243:6 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:244:5:244:24 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:244:5:244:24 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:244:10:244:24 | "singleton_g_2" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:244:11:244:23 | singleton_g_2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:247:1:247:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:247:1:247:14 | call to singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:248:1:248:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:248:1:248:19 | call to call_singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:250:1:254:3 | class << ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:250:10:250:11 | c1 | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:251:5:253:7 | singleton_g | calls.rb:250:1:254:3 | class << ... |
 | calls.rb:252:9:252:28 | call to puts | calls.rb:250:1:254:3 | class << ... |
 | calls.rb:252:9:252:28 | self | calls.rb:250:1:254:3 | class << ... |
 | calls.rb:252:14:252:28 | "singleton_g_3" | calls.rb:250:1:254:3 | class << ... |
 | calls.rb:252:15:252:27 | singleton_g_3 | calls.rb:250:1:254:3 | class << ... |
-| calls.rb:256:1:256:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:256:1:256:14 | call to singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:257:1:257:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:257:1:257:19 | call to call_singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:259:1:259:2 | c2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:259:1:259:19 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:259:6:259:15 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:259:6:259:19 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:260:1:260:2 | c2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:260:1:260:14 | call to singleton_e | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:261:1:261:2 | c2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:263:1:263:4 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:263:1:263:8 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:265:1:265:16 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:265:1:265:16 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:265:6:265:16 | "top-level" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:265:7:265:15 | top-level | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:267:1:269:3 | singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:267:5:267:14 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:268:5:268:22 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:268:5:268:22 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:268:10:268:22 | "singleton_g" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:268:11:268:21 | singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:271:1:271:10 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:271:1:271:22 | call to singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:272:1:272:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:272:1:272:14 | call to singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:273:1:273:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:273:1:273:19 | call to call_singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:274:1:274:2 | c2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:274:1:274:14 | call to singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:275:1:275:2 | c3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:275:1:275:19 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:275:6:275:15 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:275:6:275:19 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:276:1:276:2 | c3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:276:1:276:14 | call to singleton_g | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:278:1:286:3 | create | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:278:12:278:15 | type | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:278:12:278:15 | type | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:279:5:279:8 | type | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:279:5:279:12 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:279:5:279:21 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:281:5:283:7 | singleton_h | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:281:9:281:12 | type | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:282:9:282:26 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:282:9:282:26 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:282:14:282:26 | "singleton_h" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:282:15:282:25 | singleton_h | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:285:5:285:8 | type | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:285:5:285:20 | call to singleton_h | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:288:1:288:17 | call to create | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:288:1:288:17 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:288:8:288:17 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:289:1:289:10 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:289:1:289:22 | call to singleton_h | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:291:1:291:1 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:291:1:291:14 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:291:5:291:14 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:293:1:297:3 | class << ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:293:10:293:10 | x | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:256:1:256:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:256:1:256:14 | call to singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:257:1:257:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:257:1:257:19 | call to call_singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:259:1:259:2 | c2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:259:1:259:19 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:259:6:259:15 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:259:6:259:19 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:260:1:260:2 | c2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:260:1:260:14 | call to singleton_e | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:261:1:261:2 | c2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:261:1:261:14 | call to singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:263:1:263:4 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:263:1:263:8 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:265:1:265:16 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:265:1:265:16 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:265:6:265:16 | "top-level" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:265:7:265:15 | top-level | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:267:1:269:3 | singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:267:5:267:14 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:268:5:268:22 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:268:5:268:22 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:268:10:268:22 | "singleton_g" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:268:11:268:21 | singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:271:1:271:10 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:271:1:271:22 | call to singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:272:1:272:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:272:1:272:14 | call to singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:273:1:273:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:273:1:273:19 | call to call_singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:274:1:274:2 | c2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:274:1:274:14 | call to singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:275:1:275:2 | c3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:275:1:275:19 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:275:6:275:15 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:275:6:275:19 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:276:1:276:2 | c3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:276:1:276:14 | call to singleton_g | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:278:1:286:3 | create | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:278:12:278:15 | type | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:278:12:278:15 | type | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:279:5:279:8 | type | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:279:5:279:12 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:279:5:279:21 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:281:5:283:7 | singleton_h | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:281:9:281:12 | type | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:282:9:282:26 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:282:9:282:26 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:282:14:282:26 | "singleton_h" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:282:15:282:25 | singleton_h | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:285:5:285:8 | type | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:285:5:285:20 | call to singleton_h | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:288:1:288:17 | call to create | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:288:1:288:17 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:288:8:288:17 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:289:1:289:10 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:289:1:289:22 | call to singleton_h | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:291:1:291:1 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:291:1:291:14 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:291:5:291:14 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:293:1:297:3 | class << ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:293:10:293:10 | x | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:294:5:296:7 | singleton_i | calls.rb:293:1:297:3 | class << ... |
 | calls.rb:295:9:295:26 | call to puts | calls.rb:293:1:297:3 | class << ... |
 | calls.rb:295:9:295:26 | self | calls.rb:293:1:297:3 | class << ... |
 | calls.rb:295:14:295:26 | "singleton_i" | calls.rb:293:1:297:3 | class << ... |
 | calls.rb:295:15:295:25 | singleton_i | calls.rb:293:1:297:3 | class << ... |
-| calls.rb:299:1:299:1 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:299:1:299:13 | call to singleton_i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:300:1:300:10 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:300:1:300:22 | call to singleton_i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:302:1:306:3 | class << ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:302:10:302:19 | Singletons | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:299:1:299:1 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:299:1:299:13 | call to singleton_i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:300:1:300:10 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:300:1:300:22 | call to singleton_i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:302:1:306:3 | class << ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:302:10:302:19 | Singletons | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:303:5:305:7 | singleton_j | calls.rb:302:1:306:3 | class << ... |
 | calls.rb:304:9:304:26 | call to puts | calls.rb:302:1:306:3 | class << ... |
 | calls.rb:304:9:304:26 | self | calls.rb:302:1:306:3 | class << ... |
 | calls.rb:304:14:304:26 | "singleton_j" | calls.rb:302:1:306:3 | class << ... |
 | calls.rb:304:15:304:25 | singleton_j | calls.rb:302:1:306:3 | class << ... |
-| calls.rb:308:1:308:10 | Singletons | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:308:1:308:22 | call to singleton_j | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:310:1:321:3 | SelfNew | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:308:1:308:10 | Singletons | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:308:1:308:22 | call to singleton_j | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:310:1:321:3 | SelfNew | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:311:5:314:7 | instance | calls.rb:310:1:321:3 | SelfNew |
 | calls.rb:312:9:312:31 | call to puts | calls.rb:310:1:321:3 | SelfNew |
 | calls.rb:312:9:312:31 | self | calls.rb:310:1:321:3 | SelfNew |
@@ -929,110 +933,110 @@ enclosingModule
 | calls.rb:320:5:320:7 | call to new | calls.rb:310:1:321:3 | SelfNew |
 | calls.rb:320:5:320:7 | self | calls.rb:310:1:321:3 | SelfNew |
 | calls.rb:320:5:320:16 | call to instance | calls.rb:310:1:321:3 | SelfNew |
-| calls.rb:323:1:323:7 | SelfNew | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:323:1:323:17 | call to singleton | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:325:1:329:3 | C1 | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:323:1:323:7 | SelfNew | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:323:1:323:17 | call to singleton | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:325:1:329:3 | C1 | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:326:5:328:7 | instance | calls.rb:325:1:329:3 | C1 |
 | calls.rb:327:9:327:26 | call to puts | calls.rb:325:1:329:3 | C1 |
 | calls.rb:327:9:327:26 | self | calls.rb:325:1:329:3 | C1 |
 | calls.rb:327:14:327:26 | "C1#instance" | calls.rb:325:1:329:3 | C1 |
 | calls.rb:327:15:327:25 | C1#instance | calls.rb:325:1:329:3 | C1 |
-| calls.rb:331:1:335:3 | C2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:331:12:331:13 | C1 | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:331:1:335:3 | C2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:331:12:331:13 | C1 | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:332:5:334:7 | instance | calls.rb:331:1:335:3 | C2 |
 | calls.rb:333:9:333:26 | call to puts | calls.rb:331:1:335:3 | C2 |
 | calls.rb:333:9:333:26 | self | calls.rb:331:1:335:3 | C2 |
 | calls.rb:333:14:333:26 | "C2#instance" | calls.rb:331:1:335:3 | C2 |
 | calls.rb:333:15:333:25 | C2#instance | calls.rb:331:1:335:3 | C2 |
-| calls.rb:337:1:341:3 | C3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:337:12:337:13 | C2 | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:337:1:341:3 | C3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:337:12:337:13 | C2 | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:338:5:340:7 | instance | calls.rb:337:1:341:3 | C3 |
 | calls.rb:339:9:339:26 | call to puts | calls.rb:337:1:341:3 | C3 |
 | calls.rb:339:9:339:26 | self | calls.rb:337:1:341:3 | C3 |
 | calls.rb:339:14:339:26 | "C3#instance" | calls.rb:337:1:341:3 | C3 |
 | calls.rb:339:15:339:25 | C3#instance | calls.rb:337:1:341:3 | C3 |
-| calls.rb:343:1:359:3 | pattern_dispatch | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:343:22:343:22 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:343:22:343:22 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:344:5:352:7 | case ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:344:10:344:10 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:345:5:346:18 | when ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:345:10:345:11 | C3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:345:12:346:18 | then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:346:9:346:9 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:346:9:346:18 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:347:5:348:18 | when ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:347:10:347:11 | C2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:347:12:348:18 | then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:348:9:348:9 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:348:9:348:18 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:349:5:350:18 | when ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:349:10:349:11 | C1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:349:12:350:18 | then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:350:9:350:9 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:350:9:350:18 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:351:5:351:8 | else ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:354:5:358:7 | case ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:354:10:354:10 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:355:9:355:29 | in ... then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:355:12:355:13 | C3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:355:15:355:29 | then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:355:20:355:20 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:355:20:355:29 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:356:9:356:36 | in ... then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:356:12:356:13 | C2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:356:12:356:19 | ... => ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:356:18:356:19 | c2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:356:21:356:36 | then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:356:26:356:27 | c2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:356:26:356:36 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:357:9:357:36 | in ... then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:357:12:357:13 | C1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:357:12:357:19 | ... => ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:357:18:357:19 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:357:21:357:36 | then ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:357:26:357:27 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:357:26:357:36 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:361:1:361:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:361:1:361:11 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:361:6:361:7 | C1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:361:6:361:11 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:362:1:362:2 | c1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:362:1:362:11 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:363:1:363:25 | call to pattern_dispatch | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:363:1:363:25 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:363:18:363:25 | ( ... ) | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:363:19:363:20 | C1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:363:19:363:24 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:364:1:364:25 | call to pattern_dispatch | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:364:1:364:25 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:364:18:364:25 | ( ... ) | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:364:19:364:20 | C2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:364:19:364:24 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:365:1:365:25 | call to pattern_dispatch | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:365:1:365:25 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:365:18:365:25 | ( ... ) | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:365:19:365:20 | C3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:365:19:365:24 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:367:1:371:3 | add_singleton | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:367:19:367:19 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:367:19:367:19 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:368:5:370:7 | instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:368:9:368:9 | x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:369:9:369:28 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:369:9:369:28 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:369:14:369:28 | "instance_on x" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:369:15:369:27 | instance_on x | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:373:1:373:2 | c3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:373:1:373:11 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:373:6:373:7 | C1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:373:6:373:11 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:374:1:374:16 | call to add_singleton | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:374:1:374:16 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:374:15:374:16 | c3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:375:1:375:2 | c3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:375:1:375:11 | call to instance | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:377:1:397:3 | SingletonOverride1 | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:343:1:359:3 | pattern_dispatch | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:343:22:343:22 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:343:22:343:22 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:344:5:352:7 | case ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:344:10:344:10 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:345:5:346:18 | when ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:345:10:345:11 | C3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:345:12:346:18 | then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:346:9:346:9 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:346:9:346:18 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:347:5:348:18 | when ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:347:10:347:11 | C2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:347:12:348:18 | then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:348:9:348:9 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:348:9:348:18 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:349:5:350:18 | when ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:349:10:349:11 | C1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:349:12:350:18 | then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:350:9:350:9 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:350:9:350:18 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:351:5:351:8 | else ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:354:5:358:7 | case ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:354:10:354:10 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:355:9:355:29 | in ... then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:355:12:355:13 | C3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:355:15:355:29 | then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:355:20:355:20 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:355:20:355:29 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:356:9:356:36 | in ... then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:356:12:356:13 | C2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:356:12:356:19 | ... => ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:356:18:356:19 | c2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:356:21:356:36 | then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:356:26:356:27 | c2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:356:26:356:36 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:357:9:357:36 | in ... then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:357:12:357:13 | C1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:357:12:357:19 | ... => ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:357:18:357:19 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:357:21:357:36 | then ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:357:26:357:27 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:357:26:357:36 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:361:1:361:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:361:1:361:11 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:361:6:361:7 | C1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:361:6:361:11 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:362:1:362:2 | c1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:362:1:362:11 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:363:1:363:25 | call to pattern_dispatch | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:363:1:363:25 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:363:18:363:25 | ( ... ) | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:363:19:363:20 | C1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:363:19:363:24 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:364:1:364:25 | call to pattern_dispatch | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:364:1:364:25 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:364:18:364:25 | ( ... ) | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:364:19:364:20 | C2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:364:19:364:24 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:365:1:365:25 | call to pattern_dispatch | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:365:1:365:25 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:365:18:365:25 | ( ... ) | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:365:19:365:20 | C3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:365:19:365:24 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:367:1:371:3 | add_singleton | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:367:19:367:19 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:367:19:367:19 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:368:5:370:7 | instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:368:9:368:9 | x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:369:9:369:28 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:369:9:369:28 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:369:14:369:28 | "instance_on x" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:369:15:369:27 | instance_on x | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:373:1:373:2 | c3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:373:1:373:11 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:373:6:373:7 | C1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:373:6:373:11 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:374:1:374:16 | call to add_singleton | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:374:1:374:16 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:374:15:374:16 | c3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:375:1:375:2 | c3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:375:1:375:11 | call to instance | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:377:1:397:3 | SingletonOverride1 | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:378:5:386:7 | class << ... | calls.rb:377:1:397:3 | SingletonOverride1 |
 | calls.rb:378:14:378:17 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
 | calls.rb:379:9:381:11 | singleton1 | calls.rb:378:5:386:7 | class << ... |
@@ -1055,274 +1059,282 @@ enclosingModule
 | calls.rb:393:9:393:18 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
 | calls.rb:396:5:396:14 | call to singleton2 | calls.rb:377:1:397:3 | SingletonOverride1 |
 | calls.rb:396:5:396:14 | self | calls.rb:377:1:397:3 | SingletonOverride1 |
-| calls.rb:399:1:399:18 | SingletonOverride1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:399:1:399:34 | call to call_singleton1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:400:1:400:18 | SingletonOverride1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:400:1:400:34 | call to call_singleton2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:402:1:412:3 | SingletonOverride2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:402:28:402:45 | SingletonOverride1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:403:5:407:7 | class << ... | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:403:14:403:17 | self | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:404:9:406:11 | singleton1 | calls.rb:403:5:407:7 | class << ... |
-| calls.rb:405:13:405:48 | call to puts | calls.rb:403:5:407:7 | class << ... |
-| calls.rb:405:13:405:48 | self | calls.rb:403:5:407:7 | class << ... |
-| calls.rb:405:18:405:48 | "SingletonOverride2#singleton1" | calls.rb:403:5:407:7 | class << ... |
-| calls.rb:405:19:405:47 | SingletonOverride2#singleton1 | calls.rb:403:5:407:7 | class << ... |
-| calls.rb:409:5:411:7 | singleton2 | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:409:9:409:12 | self | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:410:9:410:44 | call to puts | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:410:9:410:44 | self | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:410:14:410:44 | "SingletonOverride2#singleton2" | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:410:15:410:43 | SingletonOverride2#singleton2 | calls.rb:402:1:412:3 | SingletonOverride2 |
-| calls.rb:414:1:414:18 | SingletonOverride2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:414:1:414:34 | call to call_singleton1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:415:1:415:18 | SingletonOverride2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:415:1:415:34 | call to call_singleton2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:417:1:445:3 | ConditionalInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:418:5:422:7 | if ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:418:8:418:13 | call to rand | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:418:8:418:13 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:418:8:418:17 | ... > ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:418:17:418:17 | 0 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:418:19:421:11 | then ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:419:9:421:11 | m1 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:420:13:420:48 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:420:13:420:48 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:420:18:420:48 | "ConditionalInstanceMethods#m1" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:420:19:420:47 | ConditionalInstanceMethods#m1 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:424:5:436:7 | m2 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:425:9:425:44 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:425:9:425:44 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:425:14:425:44 | "ConditionalInstanceMethods#m2" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:425:15:425:43 | ConditionalInstanceMethods#m2 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:427:9:433:11 | m3 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:428:13:428:48 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:428:13:428:48 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:428:18:428:48 | "ConditionalInstanceMethods#m3" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:428:19:428:47 | ConditionalInstanceMethods#m3 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:430:13:432:15 | m4 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:431:17:431:52 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:431:17:431:52 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:431:22:431:52 | "ConditionalInstanceMethods#m4" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:431:23:431:51 | ConditionalInstanceMethods#m4 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:435:9:435:10 | call to m3 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:435:9:435:10 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:438:5:444:7 | if ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:438:8:438:13 | call to rand | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:438:8:438:13 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:438:8:438:17 | ... > ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:438:17:438:17 | 0 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:438:19:443:18 | then ... | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:439:9:439:13 | Class | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:439:9:443:11 | call to new | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:439:9:443:15 | call to new | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:439:9:443:18 | call to m5 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:439:19:443:11 | do ... end | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:440:13:442:15 | m5 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:441:17:441:40 | call to puts | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:441:17:441:40 | self | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:441:22:441:40 | "AnonymousClass#m5" | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:441:23:441:39 | AnonymousClass#m5 | calls.rb:417:1:445:3 | ConditionalInstanceMethods |
-| calls.rb:447:1:447:26 | ConditionalInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:447:1:447:30 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:447:1:447:33 | call to m1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:448:1:448:26 | ConditionalInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:448:1:448:30 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:448:1:448:33 | call to m3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:449:1:449:26 | ConditionalInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:449:1:449:30 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:449:1:449:33 | call to m2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:450:1:450:26 | ConditionalInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:450:1:450:30 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:450:1:450:33 | call to m3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:451:1:451:26 | ConditionalInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:451:1:451:30 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:451:1:451:33 | call to m4 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:452:1:452:26 | ConditionalInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:452:1:452:30 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:452:1:452:33 | call to m5 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:454:1:454:23 | EsotericInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:454:1:472:3 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:454:27:454:31 | Class | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:454:27:472:3 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:454:37:472:3 | do ... end | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:455:5:455:11 | Array | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:455:5:455:11 | [...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:455:5:455:11 | call to [] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:455:5:459:7 | call to each | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:455:6:455:6 | 0 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:455:8:455:8 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:455:10:455:10 | 2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:455:18:459:7 | do ... end | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:456:9:458:11 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:457:13:457:22 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:457:13:457:22 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:457:18:457:22 | "foo" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:457:19:457:21 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:461:5:461:9 | Class | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:461:5:465:7 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:461:5:465:11 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:461:5:465:15 | call to bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:461:15:465:7 | do ... end | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:462:9:464:11 | bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:463:13:463:22 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:463:13:463:22 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:463:18:463:22 | "bar" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:463:19:463:21 | bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:5:467:11 | Array | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:5:467:11 | [...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:5:467:11 | call to [] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:5:471:7 | call to each | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:6:467:6 | 0 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:8:467:8 | 1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:10:467:10 | 2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:18:471:7 | do ... end | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:22:467:22 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:467:22:467:22 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:468:9:470:11 | call to define_method | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:468:9:470:11 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:468:23:468:32 | "baz_#{...}" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:468:24:468:27 | baz_ | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:468:28:468:31 | #{...} | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:468:30:468:30 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:468:35:470:11 | do ... end | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:469:13:469:27 | call to puts | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:469:13:469:27 | self | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:469:18:469:27 | "baz_#{...}" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:469:19:469:22 | baz_ | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:469:23:469:26 | #{...} | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:469:25:469:25 | i | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:474:1:474:23 | EsotericInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:474:1:474:27 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:474:1:474:31 | call to foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:475:1:475:23 | EsotericInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:475:1:475:27 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:475:1:475:31 | call to bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:476:1:476:23 | EsotericInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:476:1:476:27 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:476:1:476:33 | call to baz_0 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:477:1:477:23 | EsotericInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:477:1:477:27 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:477:1:477:33 | call to baz_1 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:478:1:478:23 | EsotericInstanceMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:478:1:478:27 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:478:1:478:33 | call to baz_2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:480:1:486:3 | ExtendSingletonMethod | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:481:5:483:7 | singleton | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:482:9:482:46 | call to puts | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:482:9:482:46 | self | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:482:14:482:46 | "ExtendSingletonMethod#singleton" | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:482:15:482:45 | ExtendSingletonMethod#singleton | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:485:5:485:15 | call to extend | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:485:5:485:15 | self | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:485:12:485:15 | self | calls.rb:480:1:486:3 | ExtendSingletonMethod |
-| calls.rb:488:1:488:21 | ExtendSingletonMethod | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:488:1:488:31 | call to singleton | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:490:1:492:3 | ExtendSingletonMethod2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:491:5:491:32 | call to extend | calls.rb:490:1:492:3 | ExtendSingletonMethod2 |
-| calls.rb:491:5:491:32 | self | calls.rb:490:1:492:3 | ExtendSingletonMethod2 |
-| calls.rb:491:12:491:32 | ExtendSingletonMethod | calls.rb:490:1:492:3 | ExtendSingletonMethod2 |
-| calls.rb:494:1:494:22 | ExtendSingletonMethod2 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:494:1:494:32 | call to singleton | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:496:1:497:3 | ExtendSingletonMethod3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:499:1:499:22 | ExtendSingletonMethod3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:499:1:499:51 | call to extend | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:499:31:499:51 | ExtendSingletonMethod | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:501:1:501:22 | ExtendSingletonMethod3 | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:501:1:501:32 | call to singleton | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:503:1:503:3 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:503:1:503:13 | ... = ... | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:503:7:503:13 | "hello" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:503:8:503:12 | hello | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:504:1:504:3 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:504:1:504:13 | call to singleton | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:505:1:505:3 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:505:1:505:32 | call to extend | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:505:12:505:32 | ExtendSingletonMethod | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:507:1:507:3 | foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:507:1:507:13 | call to singleton | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:509:1:513:3 | ProtectedMethodInModule | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:510:5:512:7 | call to protected | calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:510:5:512:7 | self | calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:510:15:512:7 | foo | calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:511:9:511:42 | call to puts | calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:511:9:511:42 | self | calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:511:14:511:42 | "ProtectedMethodInModule#foo" | calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:511:15:511:41 | ProtectedMethodInModule#foo | calls.rb:509:1:513:3 | ProtectedMethodInModule |
-| calls.rb:515:1:528:3 | ProtectedMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:516:5:516:35 | call to include | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:516:5:516:35 | self | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:516:13:516:35 | ProtectedMethodInModule | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:518:5:520:7 | call to protected | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:518:5:520:7 | self | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:518:15:520:7 | bar | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:519:9:519:35 | call to puts | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:519:9:519:35 | self | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:519:14:519:35 | "ProtectedMethods#bar" | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:519:15:519:34 | ProtectedMethods#bar | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:522:5:527:7 | baz | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:523:9:523:11 | call to foo | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:523:9:523:11 | self | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:524:9:524:11 | call to bar | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:524:9:524:11 | self | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:525:9:525:24 | ProtectedMethods | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:525:9:525:28 | call to new | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:525:9:525:32 | call to foo | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:526:9:526:24 | ProtectedMethods | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:526:9:526:28 | call to new | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:526:9:526:32 | call to bar | calls.rb:515:1:528:3 | ProtectedMethods |
-| calls.rb:530:1:530:16 | ProtectedMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:530:1:530:20 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:530:1:530:24 | call to foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:531:1:531:16 | ProtectedMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:531:1:531:20 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:531:1:531:24 | call to bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:532:1:532:16 | ProtectedMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:532:1:532:20 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:532:1:532:24 | call to baz | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:534:1:539:3 | ProtectedMethodsSub | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:534:29:534:44 | ProtectedMethods | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:535:5:538:7 | baz | calls.rb:534:1:539:3 | ProtectedMethodsSub |
-| calls.rb:536:9:536:11 | call to foo | calls.rb:534:1:539:3 | ProtectedMethodsSub |
-| calls.rb:536:9:536:11 | self | calls.rb:534:1:539:3 | ProtectedMethodsSub |
-| calls.rb:537:9:537:27 | ProtectedMethodsSub | calls.rb:534:1:539:3 | ProtectedMethodsSub |
-| calls.rb:537:9:537:31 | call to new | calls.rb:534:1:539:3 | ProtectedMethodsSub |
-| calls.rb:537:9:537:35 | call to foo | calls.rb:534:1:539:3 | ProtectedMethodsSub |
-| calls.rb:541:1:541:19 | ProtectedMethodsSub | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:541:1:541:23 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:541:1:541:27 | call to foo | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:542:1:542:19 | ProtectedMethodsSub | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:542:1:542:23 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:542:1:542:27 | call to bar | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:543:1:543:19 | ProtectedMethodsSub | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:543:1:543:23 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:543:1:543:27 | call to baz | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:1:545:7 | Array | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:1:545:7 | [...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:1:545:7 | call to [] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:1:545:26 | call to each | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:2:545:2 | C | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:2:545:6 | call to new | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:14:545:26 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:17:545:17 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:17:545:17 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:20:545:20 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:545:20:545:24 | call to baz | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:1:546:13 | Array | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:1:546:13 | [...] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:1:546:13 | call to [] | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:1:546:39 | call to each | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:2:546:4 | "a" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:3:546:3 | a | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:6:546:8 | "b" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:7:546:7 | b | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:10:546:12 | "c" | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:11:546:11 | c | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:20:546:39 | { ... } | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:23:546:23 | s | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:23:546:23 | s | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:26:546:26 | s | calls.rb:1:1:546:40 | calls.rb |
-| calls.rb:546:26:546:37 | call to capitalize | calls.rb:1:1:546:40 | calls.rb |
+| calls.rb:399:1:399:18 | SingletonOverride1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:399:1:399:29 | call to singleton1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:400:1:400:18 | SingletonOverride1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:400:1:400:29 | call to singleton2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:401:1:401:18 | SingletonOverride1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:401:1:401:34 | call to call_singleton1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:402:1:402:18 | SingletonOverride1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:402:1:402:34 | call to call_singleton2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:404:1:414:3 | SingletonOverride2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:404:28:404:45 | SingletonOverride1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:405:5:409:7 | class << ... | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:405:14:405:17 | self | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:406:9:408:11 | singleton1 | calls.rb:405:5:409:7 | class << ... |
+| calls.rb:407:13:407:48 | call to puts | calls.rb:405:5:409:7 | class << ... |
+| calls.rb:407:13:407:48 | self | calls.rb:405:5:409:7 | class << ... |
+| calls.rb:407:18:407:48 | "SingletonOverride2#singleton1" | calls.rb:405:5:409:7 | class << ... |
+| calls.rb:407:19:407:47 | SingletonOverride2#singleton1 | calls.rb:405:5:409:7 | class << ... |
+| calls.rb:411:5:413:7 | singleton2 | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:411:9:411:12 | self | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:412:9:412:44 | call to puts | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:412:9:412:44 | self | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:412:14:412:44 | "SingletonOverride2#singleton2" | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:412:15:412:43 | SingletonOverride2#singleton2 | calls.rb:404:1:414:3 | SingletonOverride2 |
+| calls.rb:416:1:416:18 | SingletonOverride2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:416:1:416:29 | call to singleton1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:417:1:417:18 | SingletonOverride2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:417:1:417:29 | call to singleton2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:418:1:418:18 | SingletonOverride2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:418:1:418:34 | call to call_singleton1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:419:1:419:18 | SingletonOverride2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:419:1:419:34 | call to call_singleton2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:421:1:449:3 | ConditionalInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:422:5:426:7 | if ... | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:422:8:422:13 | call to rand | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:422:8:422:13 | self | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:422:8:422:17 | ... > ... | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:422:17:422:17 | 0 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:422:19:425:11 | then ... | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:423:9:425:11 | m1 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:424:13:424:48 | call to puts | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:424:13:424:48 | self | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:424:18:424:48 | "ConditionalInstanceMethods#m1" | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:424:19:424:47 | ConditionalInstanceMethods#m1 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:428:5:440:7 | m2 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:429:9:429:44 | call to puts | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:429:9:429:44 | self | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:429:14:429:44 | "ConditionalInstanceMethods#m2" | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:429:15:429:43 | ConditionalInstanceMethods#m2 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:431:9:437:11 | m3 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:432:13:432:48 | call to puts | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:432:13:432:48 | self | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:432:18:432:48 | "ConditionalInstanceMethods#m3" | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:432:19:432:47 | ConditionalInstanceMethods#m3 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:434:13:436:15 | m4 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:435:17:435:52 | call to puts | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:435:17:435:52 | self | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:435:22:435:52 | "ConditionalInstanceMethods#m4" | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:435:23:435:51 | ConditionalInstanceMethods#m4 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:439:9:439:10 | call to m3 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:439:9:439:10 | self | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:442:5:448:7 | if ... | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:442:8:442:13 | call to rand | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:442:8:442:13 | self | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:442:8:442:17 | ... > ... | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:442:17:442:17 | 0 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:442:19:447:18 | then ... | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:443:9:443:13 | Class | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:443:9:447:11 | call to new | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:443:9:447:15 | call to new | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:443:9:447:18 | call to m5 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:443:19:447:11 | do ... end | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:444:13:446:15 | m5 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:445:17:445:40 | call to puts | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:445:17:445:40 | self | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:445:22:445:40 | "AnonymousClass#m5" | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:445:23:445:39 | AnonymousClass#m5 | calls.rb:421:1:449:3 | ConditionalInstanceMethods |
+| calls.rb:451:1:451:26 | ConditionalInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:451:1:451:30 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:451:1:451:33 | call to m1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:452:1:452:26 | ConditionalInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:452:1:452:30 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:452:1:452:33 | call to m3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:453:1:453:26 | ConditionalInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:453:1:453:30 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:453:1:453:33 | call to m2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:454:1:454:26 | ConditionalInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:454:1:454:30 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:454:1:454:33 | call to m3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:455:1:455:26 | ConditionalInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:455:1:455:30 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:455:1:455:33 | call to m4 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:456:1:456:26 | ConditionalInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:456:1:456:30 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:456:1:456:33 | call to m5 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:458:1:458:23 | EsotericInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:458:1:476:3 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:458:27:458:31 | Class | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:458:27:476:3 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:458:37:476:3 | do ... end | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:459:5:459:11 | Array | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:459:5:459:11 | [...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:459:5:459:11 | call to [] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:459:5:463:7 | call to each | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:459:6:459:6 | 0 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:459:8:459:8 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:459:10:459:10 | 2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:459:18:463:7 | do ... end | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:460:9:462:11 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:461:13:461:22 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:461:13:461:22 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:461:18:461:22 | "foo" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:461:19:461:21 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:465:5:465:9 | Class | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:465:5:469:7 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:465:5:469:11 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:465:5:469:15 | call to bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:465:15:469:7 | do ... end | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:466:9:468:11 | bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:467:13:467:22 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:467:13:467:22 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:467:18:467:22 | "bar" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:467:19:467:21 | bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:5:471:11 | Array | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:5:471:11 | [...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:5:471:11 | call to [] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:5:475:7 | call to each | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:6:471:6 | 0 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:8:471:8 | 1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:10:471:10 | 2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:18:475:7 | do ... end | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:22:471:22 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:471:22:471:22 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:472:9:474:11 | call to define_method | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:472:9:474:11 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:472:23:472:32 | "baz_#{...}" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:472:24:472:27 | baz_ | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:472:28:472:31 | #{...} | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:472:30:472:30 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:472:35:474:11 | do ... end | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:473:13:473:27 | call to puts | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:473:13:473:27 | self | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:473:18:473:27 | "baz_#{...}" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:473:19:473:22 | baz_ | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:473:23:473:26 | #{...} | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:473:25:473:25 | i | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:478:1:478:23 | EsotericInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:478:1:478:27 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:478:1:478:31 | call to foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:479:1:479:23 | EsotericInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:479:1:479:27 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:479:1:479:31 | call to bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:480:1:480:23 | EsotericInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:480:1:480:27 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:480:1:480:33 | call to baz_0 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:481:1:481:23 | EsotericInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:481:1:481:27 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:481:1:481:33 | call to baz_1 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:482:1:482:23 | EsotericInstanceMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:482:1:482:27 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:482:1:482:33 | call to baz_2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:484:1:490:3 | ExtendSingletonMethod | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:485:5:487:7 | singleton | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:486:9:486:46 | call to puts | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:486:9:486:46 | self | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:486:14:486:46 | "ExtendSingletonMethod#singleton" | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:486:15:486:45 | ExtendSingletonMethod#singleton | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:489:5:489:15 | call to extend | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:489:5:489:15 | self | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:489:12:489:15 | self | calls.rb:484:1:490:3 | ExtendSingletonMethod |
+| calls.rb:492:1:492:21 | ExtendSingletonMethod | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:492:1:492:31 | call to singleton | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:494:1:496:3 | ExtendSingletonMethod2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:495:5:495:32 | call to extend | calls.rb:494:1:496:3 | ExtendSingletonMethod2 |
+| calls.rb:495:5:495:32 | self | calls.rb:494:1:496:3 | ExtendSingletonMethod2 |
+| calls.rb:495:12:495:32 | ExtendSingletonMethod | calls.rb:494:1:496:3 | ExtendSingletonMethod2 |
+| calls.rb:498:1:498:22 | ExtendSingletonMethod2 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:498:1:498:32 | call to singleton | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:500:1:501:3 | ExtendSingletonMethod3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:503:1:503:22 | ExtendSingletonMethod3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:503:1:503:51 | call to extend | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:503:31:503:51 | ExtendSingletonMethod | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:505:1:505:22 | ExtendSingletonMethod3 | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:505:1:505:32 | call to singleton | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:507:1:507:3 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:507:1:507:13 | ... = ... | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:507:7:507:13 | "hello" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:507:8:507:12 | hello | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:508:1:508:3 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:508:1:508:13 | call to singleton | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:509:1:509:3 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:509:1:509:32 | call to extend | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:509:12:509:32 | ExtendSingletonMethod | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:511:1:511:3 | foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:511:1:511:13 | call to singleton | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:513:1:517:3 | ProtectedMethodInModule | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:514:5:516:7 | call to protected | calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:514:5:516:7 | self | calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:514:15:516:7 | foo | calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:515:9:515:42 | call to puts | calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:515:9:515:42 | self | calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:515:14:515:42 | "ProtectedMethodInModule#foo" | calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:515:15:515:41 | ProtectedMethodInModule#foo | calls.rb:513:1:517:3 | ProtectedMethodInModule |
+| calls.rb:519:1:532:3 | ProtectedMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:520:5:520:35 | call to include | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:520:5:520:35 | self | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:520:13:520:35 | ProtectedMethodInModule | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:522:5:524:7 | call to protected | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:522:5:524:7 | self | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:522:15:524:7 | bar | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:523:9:523:35 | call to puts | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:523:9:523:35 | self | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:523:14:523:35 | "ProtectedMethods#bar" | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:523:15:523:34 | ProtectedMethods#bar | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:526:5:531:7 | baz | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:527:9:527:11 | call to foo | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:527:9:527:11 | self | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:528:9:528:11 | call to bar | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:528:9:528:11 | self | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:529:9:529:24 | ProtectedMethods | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:529:9:529:28 | call to new | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:529:9:529:32 | call to foo | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:530:9:530:24 | ProtectedMethods | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:530:9:530:28 | call to new | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:530:9:530:32 | call to bar | calls.rb:519:1:532:3 | ProtectedMethods |
+| calls.rb:534:1:534:16 | ProtectedMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:534:1:534:20 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:534:1:534:24 | call to foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:535:1:535:16 | ProtectedMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:535:1:535:20 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:535:1:535:24 | call to bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:536:1:536:16 | ProtectedMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:536:1:536:20 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:536:1:536:24 | call to baz | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:538:1:543:3 | ProtectedMethodsSub | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:538:29:538:44 | ProtectedMethods | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:539:5:542:7 | baz | calls.rb:538:1:543:3 | ProtectedMethodsSub |
+| calls.rb:540:9:540:11 | call to foo | calls.rb:538:1:543:3 | ProtectedMethodsSub |
+| calls.rb:540:9:540:11 | self | calls.rb:538:1:543:3 | ProtectedMethodsSub |
+| calls.rb:541:9:541:27 | ProtectedMethodsSub | calls.rb:538:1:543:3 | ProtectedMethodsSub |
+| calls.rb:541:9:541:31 | call to new | calls.rb:538:1:543:3 | ProtectedMethodsSub |
+| calls.rb:541:9:541:35 | call to foo | calls.rb:538:1:543:3 | ProtectedMethodsSub |
+| calls.rb:545:1:545:19 | ProtectedMethodsSub | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:545:1:545:23 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:545:1:545:27 | call to foo | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:546:1:546:19 | ProtectedMethodsSub | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:546:1:546:23 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:546:1:546:27 | call to bar | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:547:1:547:19 | ProtectedMethodsSub | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:547:1:547:23 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:547:1:547:27 | call to baz | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:1:549:7 | Array | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:1:549:7 | [...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:1:549:7 | call to [] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:1:549:26 | call to each | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:2:549:2 | C | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:2:549:6 | call to new | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:14:549:26 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:17:549:17 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:17:549:17 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:20:549:20 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:549:20:549:24 | call to baz | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:1:550:13 | Array | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:1:550:13 | [...] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:1:550:13 | call to [] | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:1:550:39 | call to each | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:2:550:4 | "a" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:3:550:3 | a | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:6:550:8 | "b" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:7:550:7 | b | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:10:550:12 | "c" | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:11:550:11 | c | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:20:550:39 | { ... } | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:23:550:23 | s | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:23:550:23 | s | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:26:550:26 | s | calls.rb:1:1:550:40 | calls.rb |
+| calls.rb:550:26:550:37 | call to capitalize | calls.rb:1:1:550:40 | calls.rb |
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:22:3 | hello.rb |
 | hello.rb:2:5:4:7 | hello | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:3:9:3:22 | return | hello.rb:1:1:8:3 | EnglishWords |

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -85,24 +85,24 @@ calls.rb:
 #  377| SingletonOverride1
 #-----|  -> Object
 
-#  402| SingletonOverride2
+#  404| SingletonOverride2
 #-----|  -> SingletonOverride1
 
-#  417| ConditionalInstanceMethods
+#  421| ConditionalInstanceMethods
 #-----|  -> Object
 
-#  480| ExtendSingletonMethod
+#  484| ExtendSingletonMethod
 
-#  490| ExtendSingletonMethod2
+#  494| ExtendSingletonMethod2
 
-#  496| ExtendSingletonMethod3
+#  500| ExtendSingletonMethod3
 
-#  509| ProtectedMethodInModule
+#  513| ProtectedMethodInModule
 
-#  515| ProtectedMethods
+#  519| ProtectedMethods
 #-----|  -> Object
 
-#  534| ProtectedMethodsSub
+#  538| ProtectedMethodsSub
 #-----|  -> ProtectedMethods
 
 hello.rb:


### PR DESCRIPTION
We were previously not handling cases like this:

```rb
class A
    def self.singleton; end
end

class B < A
end
B.singleton # should resolve to B#singleton

class C < A
    def self.singleton; end
end
C.singleton # should resolve to C#singleton
```

DCA shows 20k new call edges, and those I sampled looked legit.