### PR TITLE
C++: Tune cpp/unterminated-variadic-call

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-121/UnterminatedVarargsCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-121/UnterminatedVarargsCall.ql
@@ -67,11 +67,7 @@ class VarargsFunction extends Function {
     not exists(FunctionCall fc, int index | this.nonTrailingVarArgValue(fc, index) = result)
   }
 
-  predicate isWhitelisted() {
-    this.hasGlobalName("open") or
-    this.hasGlobalName("fcntl") or
-    this.hasGlobalName("ptrace")
-  }
+  predicate isWhitelisted() { this.hasGlobalName(["open", "fcntl", "ptrace", "mremap"]) }
 }
 
 from VarargsFunction f, FunctionCall fc, string terminator, int cnt, int totalCount

--- a/cpp/ql/src/Security/CWE/CWE-121/UnterminatedVarargsCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-121/UnterminatedVarargsCall.ql
@@ -60,11 +60,11 @@ class VarargsFunction extends Function {
     // the terminator is 0 or -1
     result = ["0", "-1"] and
     // at least 80% of calls have the terminator
-    cnt = trailingArgValueCount(result) and
-    totalCount = totalCount() and
+    cnt = this.trailingArgValueCount(result) and
+    totalCount = this.totalCount() and
     100 * cnt / totalCount >= 80 and
     // terminator value is not used in a non-terminating position
-    not exists(FunctionCall fc, int index | nonTrailingVarArgValue(fc, index) = result)
+    not exists(FunctionCall fc, int index | this.nonTrailingVarArgValue(fc, index) = result)
   }
 
   predicate isWhitelisted() {

--- a/cpp/ql/src/change-notes/2022-10-06-unterminated-variadic-call.md
+++ b/cpp/ql/src/change-notes/2022-10-06-unterminated-variadic-call.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Unterminated variadic call" (`cpp/unterminated-variadic-call`) query has been tuned to produce fewer false positive results.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/UnterminatedVarargsCall.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/UnterminatedVarargsCall.expected
@@ -1,2 +1,9 @@
-| more_tests.cpp:23:2:23:12 | call to myFunction2 | Calls to $@ should use the value -1 as a terminator (4 of 5 calls do). | more_tests.cpp:5:6:5:16 | myFunction2 | myFunction2 |
+| more_tests.cpp:25:2:25:12 | call to myFunction2 | Calls to $@ should use the value -1 as a terminator (5 of 6 calls do). | more_tests.cpp:5:6:5:16 | myFunction2 | myFunction2 |
+| more_tests.cpp:39:2:39:12 | call to myFunction4 | Calls to $@ should use the value 0 as a terminator (5 of 6 calls do). | more_tests.cpp:7:6:7:16 | myFunction4 | myFunction4 |
+| more_tests.cpp:49:2:49:12 | call to myFunction6 | Calls to $@ should use the value 0 as a terminator (5 of 6 calls do). | more_tests.cpp:9:6:9:16 | myFunction6 | myFunction6 |
+| more_tests.cpp:64:2:64:12 | call to myFunction7 | Calls to $@ should use the value 0 as a terminator (9 of 11 calls do). | more_tests.cpp:10:6:10:16 | myFunction7 | myFunction7 |
+| more_tests.cpp:65:2:65:12 | call to myFunction7 | Calls to $@ should use the value 0 as a terminator (9 of 11 calls do). | more_tests.cpp:10:6:10:16 | myFunction7 | myFunction7 |
 | tests.c:34:2:34:3 | call to f1 | Calls to $@ should use the value 0 as a terminator (4 of 5 calls do). | tests.c:4:6:4:7 | f1 | f1 |
+| tests.c:78:2:78:3 | call to f6 | Calls to $@ should use the value -1 as a terminator (10 of 12 calls do). | tests.c:24:6:24:7 | f6 | f6 |
+| tests.c:79:2:79:3 | call to f6 | Calls to $@ should use the value -1 as a terminator (10 of 12 calls do). | tests.c:24:6:24:7 | f6 | f6 |
+| tests.c:84:2:84:3 | call to f7 | Calls to $@ should use the value 0 as a terminator (12 of 13 calls do). | tests.c:28:6:28:7 | f7 | f7 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/UnterminatedVarargsCall.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/UnterminatedVarargsCall.expected
@@ -1,9 +1,2 @@
-| more_tests.cpp:23:2:23:12 | call to myFunction2 | Calls to $@ should use the value -1 as a terminator (4 calls do). | more_tests.cpp:5:6:5:16 | myFunction2 | myFunction2 |
-| more_tests.cpp:34:2:34:12 | call to myFunction4 | Calls to $@ should use the value 0 as a terminator (3 calls do). | more_tests.cpp:7:6:7:16 | myFunction4 | myFunction4 |
-| more_tests.cpp:44:2:44:12 | call to myFunction6 | Calls to $@ should use the value 0 as a terminator (3 calls do). | more_tests.cpp:9:6:9:16 | myFunction6 | myFunction6 |
-| more_tests.cpp:55:2:55:12 | call to myFunction7 | Calls to $@ should use the value 0 as a terminator (7 calls do). | more_tests.cpp:10:6:10:16 | myFunction7 | myFunction7 |
-| more_tests.cpp:56:2:56:12 | call to myFunction7 | Calls to $@ should use the value 0 as a terminator (7 calls do). | more_tests.cpp:10:6:10:16 | myFunction7 | myFunction7 |
-| tests.c:34:2:34:3 | call to f1 | Calls to $@ should use the value 0 as a terminator (4 calls do). | tests.c:4:6:4:7 | f1 | f1 |
-| tests.c:67:2:67:3 | call to f6 | Calls to $@ should use the value -1 as a terminator (3 calls do). | tests.c:24:6:24:7 | f6 | f6 |
-| tests.c:68:2:68:3 | call to f6 | Calls to $@ should use the value -1 as a terminator (3 calls do). | tests.c:24:6:24:7 | f6 | f6 |
-| tests.c:73:2:73:3 | call to f7 | Calls to $@ should use the value 0 as a terminator (3 calls do). | tests.c:28:6:28:7 | f7 | f7 |
+| more_tests.cpp:23:2:23:12 | call to myFunction2 | Calls to $@ should use the value -1 as a terminator (4 of 5 calls do). | more_tests.cpp:5:6:5:16 | myFunction2 | myFunction2 |
+| tests.c:34:2:34:3 | call to f1 | Calls to $@ should use the value 0 as a terminator (4 of 5 calls do). | tests.c:4:6:4:7 | f1 | f1 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/more_tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/more_tests.cpp
@@ -14,24 +14,29 @@ int main()
 	int x;
 
 	myFunction1("%i", 0); // GOOD: not common enough to be assumed a terminator
+	myFunction1("%i", 0);
 	myFunction1("%i", x);
 
 	myFunction2(-1);
 	myFunction2(0, -1);
 	myFunction2(0, 1, -1);
 	myFunction2(0, 1, 2, -1);
-	myFunction2(0, 1, 2, 3); // BAD: missing terminator [NOT DETECTED]
+	myFunction2(0, 1, 2, 3, -1);
+	myFunction2(0, 1, 2, 3, 4); // BAD: missing terminator
 
 	myFunction3(-1);
 	myFunction3(0, -1);
 	myFunction3(-1, 1, -1); // GOOD: -1 isn't a terminator because it's used in a non-terminal position
 	myFunction3(0, 1, 2, -1);
-	myFunction3(0, 1, 2, 3);
+	myFunction3(0, 1, 2, 3, -1);
+	myFunction3(0, 1, 2, 3, 4);
 
 	myFunction4(x, x, 0);
 	myFunction4(0, x, 1, 0);
 	myFunction4(0, 0, 1, 1, 0);
-	myFunction4(x, 0, 1, 1, 1); // BAD: missing terminator [NOT DETECTED]
+	myFunction4(0, x, 1, 1, 1, 0);
+	myFunction4(0, 0, 1, 1, 1, 1, 0);
+	myFunction4(x, 0, 1, 1, 1, 1, 1); // BAD: missing terminator
 
 	myFunction5('a', 'b', 'c', 0); // GOOD: ambiguous terminator
 	myFunction5('a', 'b', 'c', 0);
@@ -41,19 +46,23 @@ int main()
 	myFunction5('a', 'b', 'c', -1);
 
 	myFunction6(0.0);
-	myFunction6(1.0); // BAD: missing terminator [NOT DETECTED]
+	myFunction6(1.0); // BAD: missing terminator
 	myFunction6(1.0, 2.0, 0.0);
 	myFunction6(1.0, 2.0, 3.0, 0.0);
+	myFunction6(1.0, 2.0, 3.0, 4.0, 0.0);
+	myFunction6(1.0, 2.0, 3.0, 4.0, 5.0, 0.0);
 
 	myFunction7(NULL);
 	myFunction7("hello", "world", NULL);
 	myFunction7("apple", "banana", "pear", "mango", NULL);
 	myFunction7("dog", "cat", "elephant", "badger", "fish", NULL);
 	myFunction7("one", "two", "three", 0);
+	myFunction7("four", "five", "six", 0);
+	myFunction7("seven", "eight", "nine", 0);
 	myFunction7("alpha", "beta", "gamma", 0);
 	myFunction7("", 0);
-	myFunction7("yes", "no"); // BAD: missing terminator [NOT DETECTED]
-	myFunction7(); // BAD: missing terminator [NOT DETECTED]
+	myFunction7("yes", "no"); // BAD: missing terminator
+	myFunction7(); // BAD: missing terminator
 
 	return 0;
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/more_tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/more_tests.cpp
@@ -13,27 +13,27 @@ int main()
 {
 	int x;
 
-	myFunction1("%i", 0); // not common enough to be assumed a terminator
+	myFunction1("%i", 0); // GOOD: not common enough to be assumed a terminator
 	myFunction1("%i", x);
 
 	myFunction2(-1);
 	myFunction2(0, -1);
 	myFunction2(0, 1, -1);
 	myFunction2(0, 1, 2, -1);
-	myFunction2(0, 1, 2, 3); // missing terminator
+	myFunction2(0, 1, 2, 3); // BAD: missing terminator [NOT DETECTED]
 
 	myFunction3(-1);
 	myFunction3(0, -1);
-	myFunction3(-1, 1, -1); // -1 isn't a terminator because it's used in a non-terminal position
+	myFunction3(-1, 1, -1); // GOOD: -1 isn't a terminator because it's used in a non-terminal position
 	myFunction3(0, 1, 2, -1);
 	myFunction3(0, 1, 2, 3);
 
 	myFunction4(x, x, 0);
 	myFunction4(0, x, 1, 0);
 	myFunction4(0, 0, 1, 1, 0);
-	myFunction4(x, 0, 1, 1, 1); // missing terminator
+	myFunction4(x, 0, 1, 1, 1); // BAD: missing terminator [NOT DETECTED]
 
-	myFunction5('a', 'b', 'c', 0); // ambiguous terminator
+	myFunction5('a', 'b', 'c', 0); // GOOD: ambiguous terminator
 	myFunction5('a', 'b', 'c', 0);
 	myFunction5('a', 'b', 'c', 0);
 	myFunction5('a', 'b', 'c', -1);
@@ -41,7 +41,7 @@ int main()
 	myFunction5('a', 'b', 'c', -1);
 
 	myFunction6(0.0);
-	myFunction6(1.0); // missing terminator
+	myFunction6(1.0); // BAD: missing terminator [NOT DETECTED]
 	myFunction6(1.0, 2.0, 0.0);
 	myFunction6(1.0, 2.0, 3.0, 0.0);
 
@@ -52,8 +52,8 @@ int main()
 	myFunction7("one", "two", "three", 0);
 	myFunction7("alpha", "beta", "gamma", 0);
 	myFunction7("", 0);
-	myFunction7("yes", "no"); // missing terminator
-	myFunction7(); // missing terminator
+	myFunction7("yes", "no"); // BAD: missing terminator [NOT DETECTED]
+	myFunction7(); // BAD: missing terminator [NOT DETECTED]
 
 	return 0;
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/tests.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/tests.c
@@ -64,13 +64,13 @@ int main(int argc, char *argv[])
 	f6("fsdf", 3, 8, -1);
 	f6("a", 7, 9, 10, -1);
 	f6("a", 1, 22, 6, 17, 2, -1);
-	f6("fgasfgas", 5, 6, argc); // BAD: not (necessarily) terminated with -1
-	f6("sadfsaf"); // BAD: not terminated with -1
+	f6("fgasfgas", 5, 6, argc); // BAD: not (necessarily) terminated with -1 [NOT DETECTED]
+	f6("sadfsaf"); // BAD: not terminated with -1 [NOT DETECTED]
 
 	f7("", 0);
 	f7("", 0);
 	f7("", 0);
-	f7(""); // BAD: not terminated with 0
+	f7(""); // BAD: not terminated with 0 [NOT DETECTED]
 
 	return 0;
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/tests.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-121/semmle/tests/tests.c
@@ -42,11 +42,15 @@ int main(int argc, char *argv[])
 
 	// GOOD: 0 is not common enough to be sure it's a terminator
 	f3("", 0);
+	f3("", 0);
 	f3("", 10);
 
 	// GOOD: -1 is not common enough to be sure it's a terminator
 	f4("", 0);
 	f4("", 0);
+	f4("", -1);
+	f4("", -1);
+	f4("", -1);
 	f4("", -1);
 	f4("", -1);
 	f4("", -1);
@@ -61,16 +65,32 @@ int main(int argc, char *argv[])
 	f5("", 0);
 	f5("", 10);
 	
-	f6("fsdf", 3, 8, -1);
-	f6("a", 7, 9, 10, -1);
-	f6("a", 1, 22, 6, 17, 2, -1);
-	f6("fgasfgas", 5, 6, argc); // BAD: not (necessarily) terminated with -1 [NOT DETECTED]
-	f6("sadfsaf"); // BAD: not terminated with -1 [NOT DETECTED]
+	f6("a", 3, 8, -1);
+	f6("b", 7, 9, 10, -1);
+	f6("c", 1, 22, 6, 17, 2, -1);
+	f6("d", 1, -1);
+	f6("e", 1, 2, -1);
+	f6("f", 1, 2, 3, -1);
+	f6("g", 1, 2, 3, 4, -1);
+	f6("h", 5, -1);
+	f6("i", 5, 6, -1);
+	f6("j", 5, 6, 7, -1);
+	f6("k", 5, 6, argc); // BAD: not (necessarily) terminated with -1
+	f6("l"); // BAD: not terminated with -1
 
 	f7("", 0);
 	f7("", 0);
 	f7("", 0);
-	f7(""); // BAD: not terminated with 0 [NOT DETECTED]
+	f7(""); // BAD: not terminated with 0
+	f7("", 0);
+	f7("", 0);
+	f7("", 0);
+	f7("", 0);
+	f7("", 0);
+	f7("", 0);
+	f7("", 0);
+	f7("", 0);
+	f7("", 0);
 
 	return 0;
 }


### PR DESCRIPTION
`cpp/unterminated-variadic-call` is a heuristic query - it looks for cases where a variadic call looks like its missing a sentinel to end the variadic arguments (such as a `0` at the end) by comparing with other calls to the same variadic function.  The threshold of calls required to establish such a pattern is currently just 50%, with many real-world false positive results being backed by only 50-70% of calls as evidence - while the query has `@precision medium`.

This PR increases the threshold from 50% to 80%, greatly improving precision, though there will still be some false positive results even after the change.  The query `@precision` is left at `medium`, but I feel it's a more honest `medium` now whereas before this change it should perhaps have been `low`.  The alert message has been slightly expanded to help users understand why the result is being generated.