### PR TITLE
C++: Fix `getType` for experimental IR dataflow

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -465,20 +465,20 @@ predicate clearsContent(Node n, Content c) {
 predicate expectsContent(Node n, ContentSet c) { none() }
 
 /** Gets the type of `n` used for type pruning. */
-IRType getNodeType(Node n) {
+DataFlowType getNodeType(Node n) {
   suppressUnusedNode(n) and
-  result instanceof IRVoidType // stub implementation
+  result instanceof VoidType // stub implementation
 }
 
 /** Gets a string representation of a type returned by `getNodeType`. */
-string ppReprType(IRType t) { none() } // stub implementation
+string ppReprType(DataFlowType t) { none() } // stub implementation
 
 /**
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
 pragma[inline]
-predicate compatibleTypes(IRType t1, IRType t2) {
+predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
   any() // stub implementation
 }
 
@@ -502,7 +502,7 @@ class DataFlowCallable = Cpp::Declaration;
 
 class DataFlowExpr = Expr;
 
-class DataFlowType = IRType;
+class DataFlowType = Type;
 
 /** A function call relevant for data flow. */
 class DataFlowCall extends CallInstruction {

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -137,7 +137,7 @@ private newtype TReturnKind =
     exists(IndirectReturnNode return, ReturnIndirectionInstruction returnInd |
       returnInd.hasIndex(argumentIndex) and
       return.getAddressOperand() = returnInd.getSourceAddressOperand() and
-      indirectionIndex = return.getIndirectionIndex() - 1 // We subtract one because the return loads the value.
+      indirectionIndex = return.getIndirectionIndex()
     )
   }
 
@@ -197,7 +197,7 @@ class ReturnIndirectionNode extends IndirectReturnNode, ReturnNode {
     exists(int argumentIndex, ReturnIndirectionInstruction returnInd |
       returnInd.hasIndex(argumentIndex) and
       this.getAddressOperand() = returnInd.getSourceAddressOperand() and
-      result = TIndirectReturnKind(argumentIndex, this.getIndirectionIndex() - 1) and
+      result = TIndirectReturnKind(argumentIndex, this.getIndirectionIndex()) and
       hasNonInitializeParameterDef(returnInd.getIRVariable())
     )
     or
@@ -365,7 +365,7 @@ predicate jumpStep(Node n1, Node n2) {
 predicate storeStep(Node node1, Content c, PostFieldUpdateNode node2) {
   exists(int indirectionIndex1, int numberOfLoads, StoreInstruction store |
     nodeHasInstruction(node1, store, pragma[only_bind_into](indirectionIndex1)) and
-    node2.getIndirectionIndex() = 0 and
+    node2.getIndirectionIndex() = 1 and
     numberOfLoadsFromOperand(node2.getFieldAddress(), store.getDestinationAddressOperand(),
       numberOfLoads)
   |

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/ModelUtil.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/ModelUtil.qll
@@ -41,7 +41,7 @@ Node callOutput(CallInstruction call, FunctionOutput output) {
   // The side effect of a call on the value pointed to by an argument or qualifier
   exists(int index, int indirectionIndex |
     result.(IndirectArgumentOutNode).getArgumentIndex() = index and
-    result.(IndirectArgumentOutNode).getIndirectionIndex() + 1 = indirectionIndex and
+    result.(IndirectArgumentOutNode).getIndirectionIndex() = indirectionIndex and
     result.(IndirectArgumentOutNode).getCallInstruction() = call and
     output.isParameterDerefOrQualifierObject(index, indirectionIndex)
   )

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -11,7 +11,9 @@ private import DataFlowUtil
  * corresponding `(Indirect)OperandNode`.
  */
 predicate ignoreOperand(Operand operand) {
-  operand = any(Instruction instr | ignoreInstruction(instr)).getAnOperand()
+  operand = any(Instruction instr | ignoreInstruction(instr)).getAnOperand() or
+  operand = any(Instruction instr | ignoreInstruction(instr)).getAUse() or
+  operand instanceof MemoryOperand
 }
 
 /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll
@@ -36,7 +36,7 @@ private module SourceVariables {
 
     override string toString() { result = var.toString() }
 
-    override DataFlowType getType() { result = var.getIRType() }
+    override DataFlowType getType() { result = var.getType() }
   }
 
   class BaseCallVariable extends BaseSourceVariable, TBaseCallVariable {
@@ -48,7 +48,7 @@ private module SourceVariables {
 
     override string toString() { result = call.toString() }
 
-    override DataFlowType getType() { result = call.getResultIRType() }
+    override DataFlowType getType() { result = call.getResultType() }
   }
 
   private newtype TSourceVariable =


### PR DESCRIPTION
This PR replaces `IRType` with `Type` in the IR-based use-use dataflow library. This change is needed to remain compatible with the `getType` in the old AST-based dataflow library. And in fact, I think using Type here makes more sense since this is often the type people want to use for dataflow queries.

The main point of this PR is done in [the last commit](e147a6032ef2ff1886bf152ed5c2a7592afae686). The first commit is a refactoring PR that should be behavior-preserving, and the second commit is a slight performance change that reduces the number of dataflow nodes generated from IR operands.