### PR TITLE
Ruby: Model flow through `initialize` constructors

### DIFF
--- a/ruby/ql/lib/change-notes/2022-12-14-constructor-flow.md
+++ b/ruby/ql/lib/change-notes/2022-12-14-constructor-flow.md
@@ -1,0 +1,14 @@
+---
+ category: majorAnalysis
+---
+ * Flow through `initialize` constructors is now taken into account. For example, in
+ ```rb
+class C
+  def initialize(x)
+    @field = x
+  end
+end
+
+C.new(y)
+```
+there will be flow from `y` to the field `@field` on the constructed `C` object.

--- a/ruby/ql/lib/codeql/ruby/ast/Call.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Call.qll
@@ -53,9 +53,12 @@ class Call extends Expr instanceof CallImpl {
 
   /** Gets a potential target of this call, if any. */
   final Callable getATarget() {
-    exists(DataFlowCall c | this = c.asCall().getExpr() |
-      TCfgScope(result) = [viableCallable(c), viableCallableLambda(c, _)]
+    exists(DataFlowCall c |
+      this = c.asCall().getExpr() and
+      TCfgScope(result) = viableCallableLambda(c, _)
     )
+    or
+    result = getTarget(this.getAControlFlowNode())
   }
 
   override AstNode getAChild(string pred) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -11,7 +11,8 @@ private import codeql.ruby.dataflow.SSA
 
 newtype TReturnKind =
   TNormalReturnKind() or
-  TBreakReturnKind()
+  TBreakReturnKind() or
+  TNewReturnKind()
 
 /**
  * Gets a node that can read the value returned from `call` with return kind
@@ -41,6 +42,15 @@ class NormalReturnKind extends ReturnKind, TNormalReturnKind {
  */
 class BreakReturnKind extends ReturnKind, TBreakReturnKind {
   override string toString() { result = "break" }
+}
+
+/**
+ * A special return kind that is used to represent the value returned
+ * from user-defined `new` methods as well as the effect on `self` in
+ * `initialize` methods.
+ */
+class NewReturnKind extends ReturnKind, TNewReturnKind {
+  override string toString() { result = "new" }
 }
 
 /** A callable defined in library code, identified by a unique string. */
@@ -275,14 +285,33 @@ private predicate hasAdjacentTypeCheckedReads(
   )
 }
 
+/** Holds if `new` is a user-defined `self.new` method. */
+predicate isUserDefinedNew(SingletonMethod new) {
+  exists(Expr object | singletonMethod(new, "new", object) |
+    selfInModule(object.(SelfVariableReadAccess).getVariable(), _)
+    or
+    exists(resolveConstantReadAccess(object))
+  )
+}
+
+private Callable viableSourceCallableNonInit(RelevantCall call) {
+  result = getTarget(call) and
+  not call.getExpr() instanceof YieldCall // handled by `lambdaCreation`/`lambdaCall`
+}
+
+private Callable viableSourceCallableInit(RelevantCall call) {
+  result = getInitializeTarget(call) and
+  not isUserDefinedNew(getTarget(call))
+}
+
 /** Holds if `call` may resolve to the returned source-code method. */
-private DataFlowCallable viableSourceCallable(DataFlowCall call) {
-  result = TCfgScope(getTarget(call.asCall())) and
-  not call.asCall().getExpr() instanceof YieldCall // handled by `lambdaCreation`/`lambdaCall`
+private Callable viableSourceCallable(RelevantCall call) {
+  result = viableSourceCallableNonInit(call) or
+  result = viableSourceCallableInit(call)
 }
 
 /** Holds if `call` may resolve to the returned summarized library method. */
-private DataFlowCallable viableLibraryCallable(DataFlowCall call) {
+DataFlowCallable viableLibraryCallable(DataFlowCall call) {
   exists(LibraryCallable callable |
     result = TLibraryCallable(callable) and
     call.asCall().getExpr() = [callable.getACall(), callable.getACallSimple()]
@@ -340,126 +369,22 @@ private module Cached {
       FlowSummaryImpl::Private::summaryCallbackRange(c, receiver)
     }
 
-  pragma[nomagic]
-  private Method lookupInstanceMethodCall(RelevantCall call, string method, boolean exact) {
-    exists(Module tp, DataFlow::Node receiver |
-      methodCall(call, pragma[only_bind_into](receiver), pragma[only_bind_into](method)) and
-      receiver = trackInstance(tp, exact) and
-      result = lookupMethod(tp, pragma[only_bind_into](method), exact)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate isToplevelMethodInFile(Method m, File f) {
-    m.getEnclosingModule() instanceof Toplevel and
-    f = m.getFile()
-  }
-
-  /** Holds if a `self` access may be the receiver of `call` directly inside module `m`. */
-  pragma[nomagic]
-  private predicate selfInModuleFlowsToMethodCallReceiver(RelevantCall call, Module m, string method) {
-    exists(SsaSelfDefinitionNode self |
-      flowsToMethodCallReceiver(call, self, method) and
-      selfInModule(self.getVariable(), m)
-    )
-  }
-
   /**
-   * Holds if a `self` access may be the receiver of `call` inside some singleton method, where
-   * that method belongs to `m` or one of `m`'s transitive super classes.
+   * Gets the relevant `initialize` method for the `new` call, if any.
    */
-  pragma[nomagic]
-  private predicate selfInSingletonMethodFlowsToMethodCallReceiver(
-    RelevantCall call, Module m, string method
-  ) {
-    exists(SsaSelfDefinitionNode self, MethodBase caller |
-      flowsToMethodCallReceiver(call, self, method) and
-      selfInMethod(self.getVariable(), caller, m) and
-      singletonMethod(caller, _, _)
+  cached
+  Method getInitializeTarget(RelevantCall new) {
+    exists(Module m |
+      moduleFlowsToMethodCallReceiver(new, m, "new") and
+      result = lookupMethod(m, "initialize")
     )
   }
 
   cached
   CfgScope getTarget(RelevantCall call) {
-    exists(string method |
-      exists(boolean exact |
-        result = lookupInstanceMethodCall(call, method, exact) and
-        (
-          if result.(Method).isPrivate()
-          then
-            call.getReceiver().getExpr() instanceof SelfVariableAccess and
-            // For now, we restrict the scope of top-level declarations to their file.
-            // This may remove some plausible targets, but also removes a lot of
-            // implausible targets
-            (
-              isToplevelMethodInFile(result, call.getFile()) or
-              not isToplevelMethodInFile(result, _)
-            )
-          else any()
-        ) and
-        if result.(Method).isProtected()
-        then result = lookupMethod(call.getExpr().getEnclosingModule().getModule(), method, exact)
-        else any()
-      )
-      or
-      // singleton method defined on an instance, e.g.
-      // ```rb
-      // c = C.new
-      // def c.singleton; end # <- result
-      // c.singleton          # <- call
-      // ```
-      // or an `extend`ed instance, e.g.
-      // ```rb
-      // c = C.new
-      // module M
-      //   def instance; end  # <- result
-      // end
-      // c.extend M
-      // c.instance # <- call
-      // ```
-      exists(DataFlow::Node receiver |
-        methodCall(call, receiver, method) and
-        receiver = trackSingletonMethodOnInstance(result, method)
-      )
-      or
-      // singleton method defined on a module
-      // or an `extend`ed module, e.g.
-      // ```rb
-      // module M
-      //   def instance; end  # <- result
-      // end
-      // M.extend(M)
-      // M.instance           # <- call
-      // ```
-      exists(Module m, boolean exact | result = lookupSingletonMethod(m, method, exact) |
-        // ```rb
-        // def C.singleton; end # <- result
-        // C.singleton          # <- call
-        // ```
-        moduleFlowsToMethodCallReceiver(call, m, method) and
-        exact = true
-        or
-        // ```rb
-        // class C
-        //   def self.singleton; end # <- result
-        //   self.singleton          # <- call
-        // end
-        // ```
-        selfInModuleFlowsToMethodCallReceiver(call, m, method) and
-        exact = true
-        or
-        // ```rb
-        // class C
-        //   def self.singleton; end # <- result
-        //   def self.other
-        //     self.singleton        # <- call
-        //   end
-        // end
-        // ```
-        selfInSingletonMethodFlowsToMethodCallReceiver(call, m, method) and
-        exact = false
-      )
-    )
+    result = getTargetInstance(call, _)
+    or
+    result = getTargetSingleton(call, _)
     or
     exists(Module cls, string method |
       superCall(call, cls, method) and
@@ -472,7 +397,7 @@ private module Cached {
   /** Gets a viable run-time target for the call `call`. */
   cached
   DataFlowCallable viableCallable(DataFlowCall call) {
-    result = viableSourceCallable(call)
+    result.asCallable() = viableSourceCallable(call.asCall())
     or
     result = viableLibraryCallable(call)
   }
@@ -547,6 +472,12 @@ private DataFlow::LocalSourceNode trackModuleAccess(Module m) {
   result = trackModuleAccess(m, TypeTracker::end())
 }
 
+pragma[nomagic]
+private predicate hasUserDefinedSelf(Module m) {
+  // cannot use `lookupSingletonMethod` due to negative recursion
+  singletonMethodOnModule(_, "new", m.getSuperClass*()) // not `getAnAncestor` because singleton methods cannot be included
+}
+
 /** Holds if `n` is an instance of type `tp`. */
 private predicate isInstance(DataFlow::Node n, Module tp, boolean exact) {
   n.asExpr().getExpr() instanceof NilLiteral and
@@ -603,7 +534,9 @@ private predicate isInstance(DataFlow::Node n, Module tp, boolean exact) {
   or
   exists(RelevantCall call, DataFlow::LocalSourceNode sourceNode |
     flowsToMethodCallReceiver(call, sourceNode, "new") and
-    n.asExpr() = call
+    n.asExpr() = call and
+    // `tp` should not have a user-defined `self.new` method
+    not hasUserDefinedSelf(tp)
   |
     // `C.new`
     sourceNode = trackModuleAccess(tp) and
@@ -700,6 +633,44 @@ private DataFlow::Node trackInstanceRec(Module tp, TypeTracker t, boolean exact,
 pragma[nomagic]
 private DataFlow::Node trackInstance(Module tp, boolean exact) {
   result = trackInstance(tp, exact, TypeTracker::end())
+}
+
+pragma[nomagic]
+private Method lookupInstanceMethodCall(RelevantCall call, string method, boolean exact) {
+  exists(Module tp, DataFlow::Node receiver |
+    methodCall(call, pragma[only_bind_into](receiver), pragma[only_bind_into](method)) and
+    receiver = trackInstance(tp, exact) and
+    result = lookupMethod(tp, pragma[only_bind_into](method), exact)
+  )
+}
+
+pragma[nomagic]
+private predicate isToplevelMethodInFile(Method m, File f) {
+  m.getEnclosingModule() instanceof Toplevel and
+  f = m.getFile()
+}
+
+pragma[nomagic]
+private CfgScope getTargetInstance(RelevantCall call, string method) {
+  exists(boolean exact |
+    result = lookupInstanceMethodCall(call, method, exact) and
+    (
+      if result.(Method).isPrivate()
+      then
+        call.getReceiver().getExpr() instanceof SelfVariableAccess and
+        // For now, we restrict the scope of top-level declarations to their file.
+        // This may remove some plausible targets, but also removes a lot of
+        // implausible targets
+        (
+          isToplevelMethodInFile(result, call.getFile()) or
+          not isToplevelMethodInFile(result, _)
+        )
+      else any()
+    ) and
+    if result.(Method).isProtected()
+    then result = lookupMethod(call.getExpr().getEnclosingModule().getModule(), method, exact)
+    else any()
+  )
 }
 
 pragma[nomagic]
@@ -813,7 +784,7 @@ private MethodBase lookupSingletonMethod(Module m, string name) {
   // cannot use `lookupSingletonMethodDirect` because it would introduce
   // negative recursion
   not singletonMethodOnModule(_, name, m) and
-  result = lookupSingletonMethod(m.getSuperClass(), name)
+  result = lookupSingletonMethod(m.getSuperClass(), name) // not `getAnImmediateAncestor` because singleton methods cannot be included
 }
 
 pragma[nomagic]
@@ -824,7 +795,9 @@ private MethodBase lookupSingletonMethodInSubClasses(Module m, string name) {
   // being resolved to arbitrary singleton methods.
   // To remedy this, we do not allow following super-classes all the way to Object.
   not m = TResolved("Object") and
-  exists(Module sub | sub.getSuperClass() = m |
+  exists(Module sub |
+    sub.getSuperClass() = m // not `getAnImmediateAncestor` because singleton methods cannot be included
+  |
     result = lookupSingletonMethodDirect(sub, name) or
     result = lookupSingletonMethodInSubClasses(sub, name)
   )
@@ -972,6 +945,91 @@ private DataFlow::Node trackSingletonMethodOnInstance(MethodBase method, string 
   result = trackSingletonMethodOnInstance(method, name, TypeTracker::end())
 }
 
+/** Holds if a `self` access may be the receiver of `call` directly inside module `m`. */
+pragma[nomagic]
+private predicate selfInModuleFlowsToMethodCallReceiver(RelevantCall call, Module m, string method) {
+  exists(SsaSelfDefinitionNode self |
+    flowsToMethodCallReceiver(call, self, method) and
+    selfInModule(self.getVariable(), m)
+  )
+}
+
+/**
+ * Holds if a `self` access may be the receiver of `call` inside some singleton method, where
+ * that method belongs to `m` or one of `m`'s transitive super classes.
+ */
+pragma[nomagic]
+private predicate selfInSingletonMethodFlowsToMethodCallReceiver(
+  RelevantCall call, Module m, string method
+) {
+  exists(SsaSelfDefinitionNode self, MethodBase caller |
+    flowsToMethodCallReceiver(call, self, method) and
+    selfInMethod(self.getVariable(), caller, m) and
+    singletonMethod(caller, _, _)
+  )
+}
+
+pragma[nomagic]
+private CfgScope getTargetSingleton(RelevantCall call, string method) {
+  // singleton method defined on an instance, e.g.
+  // ```rb
+  // c = C.new
+  // def c.singleton; end # <- result
+  // c.singleton          # <- call
+  // ```
+  // or an `extend`ed instance, e.g.
+  // ```rb
+  // c = C.new
+  // module M
+  //   def instance; end  # <- result
+  // end
+  // c.extend M
+  // c.instance # <- call
+  // ```
+  exists(DataFlow::Node receiver |
+    methodCall(call, receiver, method) and
+    receiver = trackSingletonMethodOnInstance(result, method)
+  )
+  or
+  // singleton method defined on a module
+  // or an `extend`ed module, e.g.
+  // ```rb
+  // module M
+  //   def instance; end  # <- result
+  // end
+  // M.extend(M)
+  // M.instance           # <- call
+  // ```
+  exists(Module m, boolean exact | result = lookupSingletonMethod(m, method, exact) |
+    // ```rb
+    // def C.singleton; end # <- result
+    // C.singleton          # <- call
+    // ```
+    moduleFlowsToMethodCallReceiver(call, m, method) and
+    exact = true
+    or
+    // ```rb
+    // class C
+    //   def self.singleton; end # <- result
+    //   self.singleton          # <- call
+    // end
+    // ```
+    selfInModuleFlowsToMethodCallReceiver(call, m, method) and
+    exact = true
+    or
+    // ```rb
+    // class C
+    //   def self.singleton; end # <- result
+    //   def self.other
+    //     self.singleton        # <- call
+    //   end
+    // end
+    // ```
+    selfInSingletonMethodFlowsToMethodCallReceiver(call, m, method) and
+    exact = false
+  )
+}
+
 /**
  * Holds if `ctx` targets `encl`, which is the enclosing callable of `call`, the receiver
  * of `call` is a parameter access, where the corresponding argument of `ctx` is `arg`.
@@ -982,25 +1040,54 @@ private DataFlow::Node trackSingletonMethodOnInstance(MethodBase method, string 
  */
 pragma[nomagic]
 private predicate argMustFlowToReceiver(
-  RelevantCall ctx, DataFlow::LocalSourceNode source, ArgumentNode arg,
+  RelevantCall ctx, DataFlow::LocalSourceNode source, DataFlow::Node arg,
   SsaDefinitionExtNode paramDef, RelevantCall call, Callable encl, string name
 ) {
   exists(ParameterNodeImpl p, ParameterPosition ppos, ArgumentPosition apos |
     // the receiver of `call` references `p`
     exists(DataFlow::Node receiver |
       LocalFlow::localFlowSsaParamInput(p, paramDef) and
-      methodCall(pragma[only_bind_into](call), receiver, pragma[only_bind_into](name)) and
+      methodCall(pragma[only_bind_into](call), pragma[only_bind_into](receiver),
+        pragma[only_bind_into](name)) and
       receiver.asExpr() = paramDef.getDefinitionExt().(Ssa::Definition).getARead()
     ) and
     // `p` is a parameter of `encl`,
     encl = call.getScope() and
     p.isParameterOf(TCfgScope(encl), ppos) and
-    // `ctx` targets `encl`
-    getTarget(ctx) = encl and
     // `arg` is the argument for `p` in the call `ctx`
-    arg.sourceArgumentOf(ctx, apos) and
     parameterMatch(ppos, apos) and
     source.flowsTo(arg)
+  |
+    encl = viableSourceCallableNonInit(ctx) and
+    arg.(ArgumentNode).sourceArgumentOf(ctx, apos)
+    or
+    encl = viableSourceCallableInit(ctx) and
+    if apos.isSelf()
+    then
+      // when we are targeting an initializer, the type of `self` inside the
+      // initializer will be the type of the `new` call itself, not the receiver
+      // of the `new` call
+      arg.asExpr() = ctx
+    else arg.(ArgumentNode).sourceArgumentOf(ctx, apos)
+  )
+}
+
+/**
+ * Holds if `ctx` targets `encl`, which is the enclosing callable of `new`, and
+ * the receiver of `new` is a parameter access, where the corresponding argument
+ * `arg` of `ctx` has type `tp`.
+ *
+ * `new` calls the object creation `new` method.
+ */
+pragma[nomagic]
+private predicate mayBenefitFromCallContextInitialize(
+  RelevantCall ctx, RelevantCall new, DataFlow::Node arg, Callable encl, Module tp, string name
+) {
+  exists(DataFlow::LocalSourceNode source |
+    argMustFlowToReceiver(ctx, pragma[only_bind_into](source), arg, _, new, encl, "new") and
+    source = trackModuleAccess(tp) and
+    name = "initialize" and
+    exists(lookupMethod(tp, name))
   )
 }
 
@@ -1014,7 +1101,7 @@ private predicate argMustFlowToReceiver(
  */
 pragma[nomagic]
 private predicate mayBenefitFromCallContextInstance(
-  RelevantCall ctx, RelevantCall call, ArgumentNode arg, Callable encl, Module tp, boolean exact,
+  RelevantCall ctx, RelevantCall call, DataFlow::Node arg, Callable encl, Module tp, boolean exact,
   string name
 ) {
   exists(DataFlow::LocalSourceNode source |
@@ -1035,7 +1122,7 @@ private predicate mayBenefitFromCallContextInstance(
  */
 pragma[nomagic]
 private predicate mayBenefitFromCallContextSingleton(
-  RelevantCall ctx, RelevantCall call, ArgumentNode arg, Callable encl, Module tp, boolean exact,
+  RelevantCall ctx, RelevantCall call, DataFlow::Node arg, Callable encl, Module tp, boolean exact,
   string name
 ) {
   exists(DataFlow::LocalSourceNode source |
@@ -1066,6 +1153,8 @@ private predicate mayBenefitFromCallContextSingleton(
  * the implicit `self` parameter).
  */
 predicate mayBenefitFromCallContext(DataFlowCall call, DataFlowCallable c) {
+  mayBenefitFromCallContextInitialize(_, call.asCall(), _, c.asCallable(), _, _)
+  or
   mayBenefitFromCallContextInstance(_, call.asCall(), _, c.asCallable(), _, _, _)
   or
   mayBenefitFromCallContextSingleton(_, call.asCall(), _, c.asCallable(), _, _, _)
@@ -1083,30 +1172,39 @@ DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
     exists(RelevantCall call0, Callable res |
       call0 = call.asCall() and
       res = result.asCallable() and
-      result = viableSourceCallable(call) and // make sure to not include e.g. private methods
-      exists(Module m, boolean exact, string name |
-        mayBenefitFromCallContextInstance(ctx.asCall(), pragma[only_bind_into](call0), _, _,
-          pragma[only_bind_into](m), exact, pragma[only_bind_into](name)) and
-        res = lookupMethod(m, name, exact)
+      exists(Module m, string name |
+        mayBenefitFromCallContextInitialize(ctx.asCall(), pragma[only_bind_into](call0), _, _,
+          pragma[only_bind_into](m), pragma[only_bind_into](name)) and
+        res = getTargetInstance(call0, name) and
+        res = lookupMethod(m, name)
         or
-        mayBenefitFromCallContextSingleton(ctx.asCall(), pragma[only_bind_into](call0), _, _,
-          pragma[only_bind_into](m), exact, pragma[only_bind_into](name)) and
-        res = lookupSingletonMethod(m, name, exact)
+        exists(boolean exact |
+          mayBenefitFromCallContextInstance(ctx.asCall(), pragma[only_bind_into](call0), _, _,
+            pragma[only_bind_into](m), pragma[only_bind_into](exact), pragma[only_bind_into](name)) and
+          res = getTargetInstance(call0, name) and
+          res = lookupMethod(m, name, exact)
+          or
+          mayBenefitFromCallContextSingleton(ctx.asCall(), pragma[only_bind_into](call0), _, _,
+            pragma[only_bind_into](m), pragma[only_bind_into](exact), pragma[only_bind_into](name)) and
+          res = getTargetSingleton(call0, name) and
+          res = lookupSingletonMethod(m, name, exact)
+        )
       )
     )
     or
     // `ctx` cannot provide a type bound, and the receiver of the call is `self`;
     // in this case, still apply an open-world assumption
     exists(
-      RelevantCall call0, RelevantCall ctx0, ArgumentNode arg, SsaSelfDefinitionNode self,
+      RelevantCall call0, RelevantCall ctx0, DataFlow::Node arg, SsaSelfDefinitionNode self,
       string name
     |
       call0 = call.asCall() and
       ctx0 = ctx.asCall() and
       argMustFlowToReceiver(ctx0, _, arg, self, call0, _, name) and
+      not mayBenefitFromCallContextInitialize(ctx0, call0, arg, _, _, _) and
       not mayBenefitFromCallContextInstance(ctx0, call0, arg, _, _, _, name) and
       not mayBenefitFromCallContextSingleton(ctx0, call0, arg, _, _, _, name) and
-      result = viableSourceCallable(call)
+      result.asCallable() = viableSourceCallable(call0)
     )
     or
     // library calls should always be able to resolve

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -233,8 +233,8 @@ predicate returnStep(Node nodeFrom, Node nodeTo) {
   exists(ExprNodes::CallCfgNode call |
     nodeFrom instanceof DataFlowPrivate::ReturnNode and
     nodeFrom.(DataFlowPrivate::NodeImpl).getCfgScope() = DataFlowDispatch::getTarget(call) and
-    // deliberately do not include `getInitializeTarget`, since there is no direct
-    // flow out (only side-effects on `self`). Any fields being set in the initializer
+    // deliberately do not include `getInitializeTarget`, since calls to `new` should not
+    // get the return value from `initialize`. Any fields being set in the initializer
     // will reach all reads via `callStep` and `localFieldStep`.
     nodeTo.asExpr().getNode() = call.getNode()
   )

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -79,10 +79,15 @@ predicate jumpStep = DataFlowPrivate::jumpStep/2;
 /** Holds if there is direct flow from `param` to a return. */
 pragma[nomagic]
 private predicate flowThrough(DataFlowPublic::ParameterNode param) {
-  exists(DataFlowPrivate::ReturningNode returnNode |
+  exists(DataFlowPrivate::ReturningNode returnNode, DataFlowDispatch::ReturnKind rk |
     DataFlowPrivate::LocalFlow::getParameterDefNode(param.getParameter())
         .(TypeTrackingNode)
-        .flowsTo(returnNode)
+        .flowsTo(returnNode) and
+    rk = returnNode.getKind()
+  |
+    rk instanceof DataFlowDispatch::NormalReturnKind
+    or
+    rk instanceof DataFlowDispatch::BreakReturnKind
   )
 }
 
@@ -184,7 +189,9 @@ private predicate viableParam(
   DataFlowDispatch::ParameterPosition ppos
 ) {
   exists(Cfg::CfgScope callable |
-    DataFlowDispatch::getTarget(call) = callable and
+    DataFlowDispatch::getTarget(call) = callable or
+    DataFlowDispatch::getInitializeTarget(call) = callable
+  |
     p.isSourceParameterOf(callable, ppos)
   )
 }
@@ -226,6 +233,9 @@ predicate returnStep(Node nodeFrom, Node nodeTo) {
   exists(ExprNodes::CallCfgNode call |
     nodeFrom instanceof DataFlowPrivate::ReturnNode and
     nodeFrom.(DataFlowPrivate::NodeImpl).getCfgScope() = DataFlowDispatch::getTarget(call) and
+    // deliberately do not include `getInitializeTarget`, since there is no direct
+    // flow out (only side-effects on `self`). Any fields being set in the initializer
+    // will reach all reads via `callStep` and `localFieldStep`.
     nodeTo.asExpr().getNode() = call.getNode()
   )
   or
@@ -233,7 +243,8 @@ predicate returnStep(Node nodeFrom, Node nodeTo) {
   // we model it as a returning flow step, in order to avoid computing a potential
   // self-cross product of all calls to a function that returns one of its parameters
   // (only to later filter that flow out using `TypeTracker::append`).
-  nodeTo.(DataFlowPrivate::SynthReturnNode).getAnInput() = nodeFrom
+  nodeTo.(DataFlowPrivate::SynthReturnNode).getAnInput() = nodeFrom and
+  not nodeFrom instanceof DataFlowPrivate::InitializeReturnNode
 }
 
 /**

--- a/ruby/ql/src/queries/analysis/Definitions.ql
+++ b/ruby/ql/src/queries/analysis/Definitions.ql
@@ -12,6 +12,7 @@
 
 import codeql.ruby.AST
 import codeql.ruby.dataflow.SSA
+import codeql.ruby.dataflow.internal.DataFlowDispatch
 
 from DefLoc loc, Expr src, Expr target, string kind
 where
@@ -38,7 +39,12 @@ newtype DefLoc =
     write = definitionOf(read.getAQualifiedName())
   } or
   /** A method call. */
-  MethodLoc(MethodCall call, Method meth) { meth = call.getATarget() } or
+  MethodLoc(MethodCall call, Method meth) {
+    meth = call.getATarget()
+    or
+    // include implicit `initialize` calls
+    meth = getInitializeTarget(call.getAControlFlowNode())
+  } or
   /** A local variable. */
   LocalVariableLoc(VariableReadAccess read, VariableWriteAccess write) {
     exists(Ssa::WriteDefinition w |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,8 +1,5 @@
 failures
-| call_sensitivity.rb:51:12:51:148 | # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ hasValueFlow=30 $ SPURIOUS: hasValueFlow=27 | Missing result:hasValueFlow=30 |
 | call_sensitivity.rb:97:12:97:66 | # $ hasValueFlow=26 $ hasValueFlow=30 $ hasValueFlow=32 | Missing result:hasValueFlow=26 |
-| call_sensitivity.rb:97:12:97:66 | # $ hasValueFlow=26 $ hasValueFlow=30 $ hasValueFlow=32 | Missing result:hasValueFlow=30 |
-| call_sensitivity.rb:97:12:97:66 | # $ hasValueFlow=26 $ hasValueFlow=30 $ hasValueFlow=32 | Missing result:hasValueFlow=32 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
@@ -96,6 +93,18 @@ edges
 | call_sensitivity.rb:92:35:92:35 | x :  | call_sensitivity.rb:93:34:93:34 | x :  |
 | call_sensitivity.rb:93:34:93:34 | x :  | call_sensitivity.rb:88:33:88:33 | y :  |
 | call_sensitivity.rb:93:34:93:34 | x :  | call_sensitivity.rb:88:33:88:33 | y :  |
+| call_sensitivity.rb:96:18:96:18 | x :  | call_sensitivity.rb:97:10:97:10 | x |
+| call_sensitivity.rb:96:18:96:18 | x :  | call_sensitivity.rb:97:10:97:10 | x |
+| call_sensitivity.rb:96:18:96:18 | x :  | call_sensitivity.rb:97:10:97:10 | x |
+| call_sensitivity.rb:96:18:96:18 | x :  | call_sensitivity.rb:97:10:97:10 | x |
+| call_sensitivity.rb:96:18:96:18 | x :  | call_sensitivity.rb:98:13:98:13 | x :  |
+| call_sensitivity.rb:96:18:96:18 | x :  | call_sensitivity.rb:98:13:98:13 | x :  |
+| call_sensitivity.rb:98:13:98:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:98:13:98:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:102:11:102:20 | ( ... ) :  | call_sensitivity.rb:96:18:96:18 | x :  |
+| call_sensitivity.rb:102:11:102:20 | ( ... ) :  | call_sensitivity.rb:96:18:96:18 | x :  |
+| call_sensitivity.rb:102:12:102:19 | call to taint :  | call_sensitivity.rb:102:11:102:20 | ( ... ) :  |
+| call_sensitivity.rb:102:12:102:19 | call to taint :  | call_sensitivity.rb:102:11:102:20 | ( ... ) :  |
 | call_sensitivity.rb:103:11:103:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
 | call_sensitivity.rb:103:11:103:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
 | call_sensitivity.rb:104:16:104:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
@@ -116,6 +125,10 @@ edges
 | call_sensitivity.rb:112:26:112:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
 | call_sensitivity.rb:149:14:149:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
 | call_sensitivity.rb:149:14:149:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:169:11:169:20 | ( ... ) :  | call_sensitivity.rb:96:18:96:18 | x :  |
+| call_sensitivity.rb:169:11:169:20 | ( ... ) :  | call_sensitivity.rb:96:18:96:18 | x :  |
+| call_sensitivity.rb:169:12:169:19 | call to taint :  | call_sensitivity.rb:169:11:169:20 | ( ... ) :  |
+| call_sensitivity.rb:169:12:169:19 | call to taint :  | call_sensitivity.rb:169:11:169:20 | ( ... ) :  |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
@@ -223,6 +236,18 @@ nodes
 | call_sensitivity.rb:92:35:92:35 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:93:34:93:34 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:93:34:93:34 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:96:18:96:18 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:96:18:96:18 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:96:18:96:18 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:96:18:96:18 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:97:10:97:10 | x | semmle.label | x |
+| call_sensitivity.rb:97:10:97:10 | x | semmle.label | x |
+| call_sensitivity.rb:98:13:98:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:98:13:98:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:102:11:102:20 | ( ... ) :  | semmle.label | ( ... ) :  |
+| call_sensitivity.rb:102:11:102:20 | ( ... ) :  | semmle.label | ( ... ) :  |
+| call_sensitivity.rb:102:12:102:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:102:12:102:19 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:103:11:103:18 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:103:11:103:18 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:104:16:104:23 | call to taint :  | semmle.label | call to taint :  |
@@ -243,6 +268,10 @@ nodes
 | call_sensitivity.rb:112:26:112:33 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:149:14:149:22 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:149:14:149:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:169:11:169:20 | ( ... ) :  | semmle.label | ( ... ) :  |
+| call_sensitivity.rb:169:11:169:20 | ( ... ) :  | semmle.label | ( ... ) :  |
+| call_sensitivity.rb:169:12:169:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:169:12:169:19 | call to taint :  | semmle.label | call to taint :  |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint :  | call to taint :  |
@@ -250,6 +279,7 @@ subpaths
 | call_sensitivity.rb:31:27:31:27 | x | call_sensitivity.rb:32:25:32:32 | call to taint :  | call_sensitivity.rb:31:27:31:27 | x | $@ | call_sensitivity.rb:32:25:32:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:40:31:40:31 | x | call_sensitivity.rb:41:25:41:32 | call to taint :  | call_sensitivity.rb:40:31:40:31 | x | $@ | call_sensitivity.rb:41:25:41:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:43:32:43:32 | x | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:43:32:43:32 | x | $@ | call_sensitivity.rb:44:26:44:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:102:12:102:19 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:102:12:102:19 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:103:11:103:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:103:11:103:18 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:104:16:104:23 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:104:16:104:23 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:105:14:105:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:105:14:105:22 | call to taint :  | call to taint :  |
@@ -260,6 +290,8 @@ subpaths
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:110:26:110:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:110:26:110:33 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:111:24:111:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:111:24:111:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:112:26:112:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:112:26:112:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:97:10:97:10 | x | call_sensitivity.rb:102:12:102:19 | call to taint :  | call_sensitivity.rb:97:10:97:10 | x | $@ | call_sensitivity.rb:102:12:102:19 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:97:10:97:10 | x | call_sensitivity.rb:169:12:169:19 | call to taint :  | call_sensitivity.rb:97:10:97:10 | x | $@ | call_sensitivity.rb:169:12:169:19 | call to taint :  | call to taint :  |
 mayBenefitFromCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:50:3:52:5 | method1 |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:54:3:56:5 | method2 |
@@ -270,10 +302,13 @@ mayBenefitFromCallContext
 | call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:84:3:86:5 | call_singleton_method2 |
 | call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |
 | call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:92:3:94:5 | call_singleton_method3 |
+| call_sensitivity.rb:97:5:97:10 | call to sink | call_sensitivity.rb:96:3:99:5 | initialize |
+| call_sensitivity.rb:98:5:98:13 | call to method1 | call_sensitivity.rb:96:3:99:5 | initialize |
 | call_sensitivity.rb:124:5:124:18 | call to method2 | call_sensitivity.rb:123:3:125:5 | call_method2 |
 | call_sensitivity.rb:128:5:128:25 | call to method3 | call_sensitivity.rb:127:3:129:5 | call_method3 |
 | call_sensitivity.rb:132:5:132:28 | call to singleton_method2 | call_sensitivity.rb:131:3:133:5 | call_singleton_method2 |
 | call_sensitivity.rb:136:5:136:35 | call to singleton_method3 | call_sensitivity.rb:135:3:137:5 | call_singleton_method3 |
+| call_sensitivity.rb:157:3:157:12 | call to new | call_sensitivity.rb:156:1:158:3 | create |
 viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
@@ -305,6 +340,13 @@ viableImplInCallContext
 | call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:136:5:136:35 | call to singleton_method3 | call_sensitivity.rb:119:3:121:5 | singleton_method1 |
 | call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:153:1:153:33 | call to singleton_method3 | call_sensitivity.rb:119:3:121:5 | singleton_method1 |
 | call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:112:1:112:34 | call to call_singleton_method3 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |
+| call_sensitivity.rb:97:5:97:10 | call to sink | call_sensitivity.rb:102:5:102:20 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:97:5:97:10 | call to sink | call_sensitivity.rb:157:3:157:12 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:97:5:97:10 | call to sink | call_sensitivity.rb:169:5:169:20 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:98:5:98:13 | call to method1 | call_sensitivity.rb:102:5:102:20 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:98:5:98:13 | call to method1 | call_sensitivity.rb:157:3:157:12 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:98:5:98:13 | call to method1 | call_sensitivity.rb:157:3:157:12 | call to new | call_sensitivity.rb:115:3:117:5 | method1 |
+| call_sensitivity.rb:98:5:98:13 | call to method1 | call_sensitivity.rb:169:5:169:20 | call to new | call_sensitivity.rb:164:3:166:5 | method1 |
 | call_sensitivity.rb:124:5:124:18 | call to method2 | call_sensitivity.rb:146:1:146:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
 | call_sensitivity.rb:128:5:128:25 | call to method3 | call_sensitivity.rb:148:1:148:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
 | call_sensitivity.rb:132:5:132:28 | call to singleton_method2 | call_sensitivity.rb:152:1:152:34 | call to call_singleton_method2 | call_sensitivity.rb:80:3:82:5 | singleton_method2 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,4 +1,8 @@
 failures
+| call_sensitivity.rb:51:12:51:148 | # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ hasValueFlow=30 $ SPURIOUS: hasValueFlow=27 | Missing result:hasValueFlow=30 |
+| call_sensitivity.rb:97:12:97:66 | # $ hasValueFlow=26 $ hasValueFlow=30 $ hasValueFlow=32 | Missing result:hasValueFlow=26 |
+| call_sensitivity.rb:97:12:97:66 | # $ hasValueFlow=26 $ hasValueFlow=30 $ hasValueFlow=32 | Missing result:hasValueFlow=30 |
+| call_sensitivity.rb:97:12:97:66 | # $ hasValueFlow=26 $ hasValueFlow=30 $ hasValueFlow=32 | Missing result:hasValueFlow=32 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
@@ -92,26 +96,26 @@ edges
 | call_sensitivity.rb:92:35:92:35 | x :  | call_sensitivity.rb:93:34:93:34 | x :  |
 | call_sensitivity.rb:93:34:93:34 | x :  | call_sensitivity.rb:88:33:88:33 | y :  |
 | call_sensitivity.rb:93:34:93:34 | x :  | call_sensitivity.rb:88:33:88:33 | y :  |
-| call_sensitivity.rb:98:11:98:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:98:11:98:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:99:16:99:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
-| call_sensitivity.rb:99:16:99:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
-| call_sensitivity.rb:100:14:100:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
-| call_sensitivity.rb:100:14:100:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
-| call_sensitivity.rb:101:16:101:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
-| call_sensitivity.rb:101:16:101:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
-| call_sensitivity.rb:102:14:102:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
-| call_sensitivity.rb:102:14:102:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
-| call_sensitivity.rb:104:21:104:28 | call to taint :  | call_sensitivity.rb:80:30:80:30 | x :  |
-| call_sensitivity.rb:104:21:104:28 | call to taint :  | call_sensitivity.rb:80:30:80:30 | x :  |
-| call_sensitivity.rb:105:26:105:33 | call to taint :  | call_sensitivity.rb:84:35:84:35 | x :  |
-| call_sensitivity.rb:105:26:105:33 | call to taint :  | call_sensitivity.rb:84:35:84:35 | x :  |
-| call_sensitivity.rb:106:24:106:32 | call to taint :  | call_sensitivity.rb:88:33:88:33 | y :  |
-| call_sensitivity.rb:106:24:106:32 | call to taint :  | call_sensitivity.rb:88:33:88:33 | y :  |
-| call_sensitivity.rb:107:26:107:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
-| call_sensitivity.rb:107:26:107:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
-| call_sensitivity.rb:140:14:140:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
-| call_sensitivity.rb:140:14:140:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:103:11:103:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:103:11:103:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:104:16:104:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
+| call_sensitivity.rb:104:16:104:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
+| call_sensitivity.rb:105:14:105:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:105:14:105:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:106:16:106:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
+| call_sensitivity.rb:106:16:106:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
+| call_sensitivity.rb:107:14:107:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:107:14:107:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:109:21:109:28 | call to taint :  | call_sensitivity.rb:80:30:80:30 | x :  |
+| call_sensitivity.rb:109:21:109:28 | call to taint :  | call_sensitivity.rb:80:30:80:30 | x :  |
+| call_sensitivity.rb:110:26:110:33 | call to taint :  | call_sensitivity.rb:84:35:84:35 | x :  |
+| call_sensitivity.rb:110:26:110:33 | call to taint :  | call_sensitivity.rb:84:35:84:35 | x :  |
+| call_sensitivity.rb:111:24:111:32 | call to taint :  | call_sensitivity.rb:88:33:88:33 | y :  |
+| call_sensitivity.rb:111:24:111:32 | call to taint :  | call_sensitivity.rb:88:33:88:33 | y :  |
+| call_sensitivity.rb:112:26:112:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
+| call_sensitivity.rb:112:26:112:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
+| call_sensitivity.rb:149:14:149:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:149:14:149:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
@@ -219,26 +223,26 @@ nodes
 | call_sensitivity.rb:92:35:92:35 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:93:34:93:34 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:93:34:93:34 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:98:11:98:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:98:11:98:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:99:16:99:23 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:99:16:99:23 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:100:14:100:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:100:14:100:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:101:16:101:24 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:101:16:101:24 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:102:14:102:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:102:14:102:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:104:21:104:28 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:104:21:104:28 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:105:26:105:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:105:26:105:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:106:24:106:32 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:106:24:106:32 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:107:26:107:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:107:26:107:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:140:14:140:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:140:14:140:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:103:11:103:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:103:11:103:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:104:16:104:23 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:104:16:104:23 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:105:14:105:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:105:14:105:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:106:16:106:24 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:106:16:106:24 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:107:14:107:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:107:14:107:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:109:21:109:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:109:21:109:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:110:26:110:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:110:26:110:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:111:24:111:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:111:24:111:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:112:26:112:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:112:26:112:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:149:14:149:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:149:14:149:22 | call to taint :  | semmle.label | call to taint :  |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint :  | call to taint :  |
@@ -246,16 +250,16 @@ subpaths
 | call_sensitivity.rb:31:27:31:27 | x | call_sensitivity.rb:32:25:32:32 | call to taint :  | call_sensitivity.rb:31:27:31:27 | x | $@ | call_sensitivity.rb:32:25:32:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:40:31:40:31 | x | call_sensitivity.rb:41:25:41:32 | call to taint :  | call_sensitivity.rb:40:31:40:31 | x | $@ | call_sensitivity.rb:41:25:41:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:43:32:43:32 | x | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:43:32:43:32 | x | $@ | call_sensitivity.rb:44:26:44:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:98:11:98:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:98:11:98:18 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:99:16:99:23 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:99:16:99:23 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:100:14:100:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:100:14:100:22 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:101:16:101:24 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:101:16:101:24 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:102:14:102:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:102:14:102:22 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:140:14:140:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:140:14:140:22 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:104:21:104:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:104:21:104:28 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:105:26:105:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:105:26:105:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:106:24:106:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:106:24:106:32 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:107:26:107:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:107:26:107:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:103:11:103:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:103:11:103:18 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:104:16:104:23 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:104:16:104:23 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:105:14:105:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:105:14:105:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:106:16:106:24 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:106:16:106:24 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:107:14:107:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:107:14:107:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:149:14:149:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:149:14:149:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:109:21:109:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:109:21:109:28 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:110:26:110:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:110:26:110:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:111:24:111:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:111:24:111:32 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:112:26:112:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:112:26:112:33 | call to taint :  | call to taint :  |
 mayBenefitFromCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:50:3:52:5 | method1 |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:54:3:56:5 | method2 |
@@ -266,39 +270,42 @@ mayBenefitFromCallContext
 | call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:84:3:86:5 | call_singleton_method2 |
 | call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |
 | call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:92:3:94:5 | call_singleton_method3 |
-| call_sensitivity.rb:119:5:119:18 | call to method2 | call_sensitivity.rb:118:3:120:5 | call_method2 |
-| call_sensitivity.rb:123:5:123:25 | call to method3 | call_sensitivity.rb:122:3:124:5 | call_method3 |
-| call_sensitivity.rb:127:5:127:28 | call to singleton_method2 | call_sensitivity.rb:126:3:128:5 | call_singleton_method2 |
-| call_sensitivity.rb:131:5:131:35 | call to singleton_method3 | call_sensitivity.rb:130:3:132:5 | call_singleton_method3 |
+| call_sensitivity.rb:124:5:124:18 | call to method2 | call_sensitivity.rb:123:3:125:5 | call_method2 |
+| call_sensitivity.rb:128:5:128:25 | call to method3 | call_sensitivity.rb:127:3:129:5 | call_method3 |
+| call_sensitivity.rb:132:5:132:28 | call to singleton_method2 | call_sensitivity.rb:131:3:133:5 | call_singleton_method2 |
+| call_sensitivity.rb:136:5:136:35 | call to singleton_method3 | call_sensitivity.rb:135:3:137:5 | call_singleton_method3 |
 viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:76:7:76:18 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:98:5:98:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:110:3:112:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:98:1:98:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:119:5:119:18 | call to method2 | call_sensitivity.rb:110:3:112:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:136:1:136:19 | call to method2 | call_sensitivity.rb:110:3:112:5 | method1 |
-| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:99:1:99:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:115:3:117:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:164:3:166:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:103:1:103:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:124:5:124:18 | call to method2 | call_sensitivity.rb:115:3:117:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:145:1:145:19 | call to method2 | call_sensitivity.rb:115:3:117:5 | method1 |
+| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:104:1:104:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
 | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:110:3:112:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:100:1:100:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:123:5:123:25 | call to method3 | call_sensitivity.rb:110:3:112:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:138:1:138:23 | call to method3 | call_sensitivity.rb:110:3:112:5 | method1 |
-| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:101:1:101:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:115:3:117:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:164:3:166:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:105:1:105:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:128:5:128:25 | call to method3 | call_sensitivity.rb:115:3:117:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:147:1:147:23 | call to method3 | call_sensitivity.rb:115:3:117:5 | method1 |
+| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:106:1:106:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
 | call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
-| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:104:1:104:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:127:5:127:28 | call to singleton_method2 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
-| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:142:1:142:29 | call to singleton_method2 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
-| call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:105:1:105:34 | call to call_singleton_method2 | call_sensitivity.rb:80:3:82:5 | singleton_method2 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:119:3:121:5 | singleton_method1 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:109:1:109:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:132:5:132:28 | call to singleton_method2 | call_sensitivity.rb:119:3:121:5 | singleton_method1 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:151:1:151:29 | call to singleton_method2 | call_sensitivity.rb:119:3:121:5 | singleton_method1 |
+| call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:110:1:110:34 | call to call_singleton_method2 | call_sensitivity.rb:80:3:82:5 | singleton_method2 |
 | call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
-| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:106:1:106:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:131:5:131:35 | call to singleton_method3 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
-| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:144:1:144:33 | call to singleton_method3 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
-| call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:107:1:107:34 | call to call_singleton_method3 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |
-| call_sensitivity.rb:119:5:119:18 | call to method2 | call_sensitivity.rb:137:1:137:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
-| call_sensitivity.rb:123:5:123:25 | call to method3 | call_sensitivity.rb:139:1:139:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
-| call_sensitivity.rb:127:5:127:28 | call to singleton_method2 | call_sensitivity.rb:143:1:143:34 | call to call_singleton_method2 | call_sensitivity.rb:80:3:82:5 | singleton_method2 |
-| call_sensitivity.rb:131:5:131:35 | call to singleton_method3 | call_sensitivity.rb:145:1:145:34 | call to call_singleton_method3 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:119:3:121:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:111:1:111:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:136:5:136:35 | call to singleton_method3 | call_sensitivity.rb:119:3:121:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:153:1:153:33 | call to singleton_method3 | call_sensitivity.rb:119:3:121:5 | singleton_method1 |
+| call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:112:1:112:34 | call to call_singleton_method3 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |
+| call_sensitivity.rb:124:5:124:18 | call to method2 | call_sensitivity.rb:146:1:146:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:128:5:128:25 | call to method3 | call_sensitivity.rb:148:1:148:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:132:5:132:28 | call to singleton_method2 | call_sensitivity.rb:152:1:152:34 | call to call_singleton_method2 | call_sensitivity.rb:80:3:82:5 | singleton_method2 |
+| call_sensitivity.rb:136:5:136:35 | call to singleton_method3 | call_sensitivity.rb:154:1:154:34 | call to call_singleton_method3 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
@@ -48,7 +48,7 @@ apply_lambda(MY_LAMBDA2, taint(9))
 
 class A
   def method1 x
-    sink x # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ SPURIOUS: hasValueFlow=27
+    sink x # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ hasValueFlow=30 $ SPURIOUS: hasValueFlow=27
   end
 
   def method2 x
@@ -92,9 +92,14 @@ class A
   def self.call_singleton_method3 x
     self.singleton_method3(self, x)
   end
+
+  def initialize(x)
+    sink x # $ hasValueFlow=26 $ hasValueFlow=30 $ hasValueFlow=32
+    method1 x
+  end
 end
 
-a = A.new
+a = A.new (taint 30)
 a.method2(taint 10)
 a.call_method2(taint 11)
 a.method3(a, taint(12))
@@ -130,9 +135,13 @@ class B < A
   def self.call_singleton_method3 x
     self.singleton_method3(self, x)
   end
+
+  def initialize(x)
+    puts "NON SINK: #{x}"
+  end
 end
 
-b = B.new
+b = B.new (taint 31)
 b.method2(taint 18)
 b.call_method2(taint 19)
 b.method3(b, taint(20))
@@ -143,3 +152,18 @@ B.singleton_method2(taint 22)
 B.call_singleton_method2(taint 23)
 B.singleton_method3(B, taint(24))
 B.call_singleton_method3(taint 25)
+
+def create (type, x)
+  type.new x
+end
+
+create(A, taint(26))
+create(B, taint(27))
+
+class C < A
+  def method1 x
+    puts "NON SINK: #{x}"
+  end
+end
+
+c = C.new (taint 32)

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -1,5 +1,4 @@
 failures
-| instance_variables.rb:102:23:102:41 | # $ hasValueFlow=29 | Missing result:hasValueFlow=29 |
 edges
 | captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
 | captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
@@ -180,6 +179,16 @@ edges
 | instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
 | instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:99:6:99:20 | call to get_field |
 | instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:99:6:99:20 | call to get_field |
+| instance_variables.rb:101:9:101:26 | call to new [@field] :  | instance_variables.rb:102:6:102:10 | foo15 [@field] :  |
+| instance_variables.rb:101:9:101:26 | call to new [@field] :  | instance_variables.rb:102:6:102:10 | foo15 [@field] :  |
+| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:101:9:101:26 | call to new [@field] :  |
+| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:101:9:101:26 | call to new [@field] :  |
+| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:102:6:102:20 | call to get_field |
+| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:102:6:102:20 | call to get_field |
 | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | instance_variables.rb:105:6:105:10 | foo16 [@field] :  |
 | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | instance_variables.rb:105:6:105:10 | foo16 [@field] :  |
 | instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  |
@@ -363,6 +372,14 @@ nodes
 | instance_variables.rb:99:6:99:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
 | instance_variables.rb:99:6:99:20 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:99:6:99:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:101:9:101:26 | call to new [@field] :  | semmle.label | call to new [@field] :  |
+| instance_variables.rb:101:9:101:26 | call to new [@field] :  | semmle.label | call to new [@field] :  |
+| instance_variables.rb:101:17:101:25 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:101:17:101:25 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | semmle.label | foo15 [@field] :  |
+| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | semmle.label | foo15 [@field] :  |
+| instance_variables.rb:102:6:102:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:102:6:102:20 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | semmle.label | [post] foo16 [@field] :  |
 | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | semmle.label | [post] foo16 [@field] :  |
 | instance_variables.rb:104:6:104:37 | call to call_initialize | semmle.label | call to call_initialize |
@@ -427,6 +444,10 @@ subpaths
 | instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:94:6:94:20 | call to get_field |
 | instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:99:6:99:20 | call to get_field |
 | instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:99:6:99:20 | call to get_field |
+| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:101:9:101:26 | call to new [@field] :  |
+| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:101:9:101:26 | call to new [@field] :  |
+| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:102:6:102:20 | call to get_field |
+| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:102:6:102:20 | call to get_field |
 | instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
 | instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
 | instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:105:6:105:20 | call to get_field |
@@ -452,6 +473,7 @@ subpaths
 | instance_variables.rb:90:6:90:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:90:6:90:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
 | instance_variables.rb:94:6:94:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:94:6:94:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
 | instance_variables.rb:99:6:99:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:99:6:99:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:102:6:102:20 | call to get_field | instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:102:6:102:20 | call to get_field | $@ | instance_variables.rb:101:17:101:25 | call to taint :  | call to taint :  |
 | instance_variables.rb:104:6:104:37 | call to call_initialize | instance_variables.rb:24:9:24:17 | call to taint :  | instance_variables.rb:104:6:104:37 | call to call_initialize | $@ | instance_variables.rb:24:9:24:17 | call to taint :  | call to taint :  |
 | instance_variables.rb:105:6:105:20 | call to get_field | instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:105:6:105:20 | call to get_field | $@ | instance_variables.rb:104:28:104:36 | call to taint :  | call to taint :  |
 | instance_variables.rb:107:6:107:8 | bar | instance_variables.rb:34:9:34:17 | call to taint :  | instance_variables.rb:107:6:107:8 | bar | $@ | instance_variables.rb:34:9:34:17 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -1,4 +1,5 @@
 failures
+| instance_variables.rb:102:23:102:41 | # $ hasValueFlow=29 | Missing result:hasValueFlow=29 |
 edges
 | captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
 | captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
@@ -30,139 +31,167 @@ edges
 | instance_variables.rb:19:12:19:21 | call to taint :  | instance_variables.rb:19:5:19:8 | [post] self [@foo] :  |
 | instance_variables.rb:20:10:20:13 | self [@foo] :  | instance_variables.rb:20:10:20:13 | @foo |
 | instance_variables.rb:20:10:20:13 | self [@foo] :  | instance_variables.rb:20:10:20:13 | @foo |
-| instance_variables.rb:24:1:24:3 | [post] foo [@field] :  | instance_variables.rb:25:6:25:8 | foo [@field] :  |
-| instance_variables.rb:24:1:24:3 | [post] foo [@field] :  | instance_variables.rb:25:6:25:8 | foo [@field] :  |
-| instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:24:1:24:3 | [post] foo [@field] :  |
-| instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:24:1:24:3 | [post] foo [@field] :  |
-| instance_variables.rb:25:6:25:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:25:6:25:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:25:6:25:8 | foo [@field] :  | instance_variables.rb:25:6:25:18 | call to get_field |
-| instance_variables.rb:25:6:25:8 | foo [@field] :  | instance_variables.rb:25:6:25:18 | call to get_field |
-| instance_variables.rb:28:1:28:3 | [post] bar [@field] :  | instance_variables.rb:29:6:29:8 | bar [@field] :  |
-| instance_variables.rb:28:15:28:22 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:28:15:28:22 | call to taint :  | instance_variables.rb:28:1:28:3 | [post] bar [@field] :  |
-| instance_variables.rb:29:6:29:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  |
-| instance_variables.rb:29:6:29:8 | bar [@field] :  | instance_variables.rb:29:6:29:18 | call to inc_field |
-| instance_variables.rb:32:1:32:4 | [post] foo1 [@field] :  | instance_variables.rb:33:6:33:9 | foo1 [@field] :  |
-| instance_variables.rb:32:1:32:4 | [post] foo1 [@field] :  | instance_variables.rb:33:6:33:9 | foo1 [@field] :  |
-| instance_variables.rb:32:14:32:22 | call to taint :  | instance_variables.rb:32:1:32:4 | [post] foo1 [@field] :  |
-| instance_variables.rb:32:14:32:22 | call to taint :  | instance_variables.rb:32:1:32:4 | [post] foo1 [@field] :  |
-| instance_variables.rb:33:6:33:9 | foo1 [@field] :  | instance_variables.rb:33:6:33:15 | call to field |
-| instance_variables.rb:33:6:33:9 | foo1 [@field] :  | instance_variables.rb:33:6:33:15 | call to field |
-| instance_variables.rb:36:1:36:4 | [post] foo2 [@field] :  | instance_variables.rb:37:6:37:9 | foo2 [@field] :  |
-| instance_variables.rb:36:1:36:4 | [post] foo2 [@field] :  | instance_variables.rb:37:6:37:9 | foo2 [@field] :  |
-| instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:36:1:36:4 | [post] foo2 [@field] :  |
-| instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:36:1:36:4 | [post] foo2 [@field] :  |
-| instance_variables.rb:37:6:37:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:37:6:37:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:37:6:37:9 | foo2 [@field] :  | instance_variables.rb:37:6:37:19 | call to get_field |
-| instance_variables.rb:37:6:37:9 | foo2 [@field] :  | instance_variables.rb:37:6:37:19 | call to get_field |
-| instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  | instance_variables.rb:41:6:41:9 | foo3 [@field] :  |
-| instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  | instance_variables.rb:41:6:41:9 | foo3 [@field] :  |
-| instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  | instance_variables.rb:53:6:53:9 | foo3 [@field] :  |
-| instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  | instance_variables.rb:53:6:53:9 | foo3 [@field] :  |
-| instance_variables.rb:40:16:40:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:40:16:40:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:40:16:40:24 | call to taint :  | instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  |
-| instance_variables.rb:40:16:40:24 | call to taint :  | instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  |
-| instance_variables.rb:41:6:41:9 | foo3 [@field] :  | instance_variables.rb:41:6:41:15 | call to field |
-| instance_variables.rb:41:6:41:9 | foo3 [@field] :  | instance_variables.rb:41:6:41:15 | call to field |
-| instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  | instance_variables.rb:49:6:49:9 | foo5 [@field] :  |
-| instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  | instance_variables.rb:49:6:49:9 | foo5 [@field] :  |
-| instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  | instance_variables.rb:54:6:54:9 | foo5 [@field] :  |
-| instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  | instance_variables.rb:54:6:54:9 | foo5 [@field] :  |
-| instance_variables.rb:48:18:48:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:48:18:48:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:48:18:48:26 | call to taint :  | instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  |
-| instance_variables.rb:48:18:48:26 | call to taint :  | instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  |
-| instance_variables.rb:49:6:49:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:49:6:49:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:49:6:49:9 | foo5 [@field] :  | instance_variables.rb:49:6:49:19 | call to get_field |
-| instance_variables.rb:49:6:49:9 | foo5 [@field] :  | instance_variables.rb:49:6:49:19 | call to get_field |
-| instance_variables.rb:52:15:52:18 | [post] foo6 [@field] :  | instance_variables.rb:55:6:55:9 | foo6 [@field] :  |
-| instance_variables.rb:52:15:52:18 | [post] foo6 [@field] :  | instance_variables.rb:55:6:55:9 | foo6 [@field] :  |
-| instance_variables.rb:52:32:52:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:52:32:52:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:52:32:52:40 | call to taint :  | instance_variables.rb:52:15:52:18 | [post] foo6 [@field] :  |
-| instance_variables.rb:52:32:52:40 | call to taint :  | instance_variables.rb:52:15:52:18 | [post] foo6 [@field] :  |
-| instance_variables.rb:53:6:53:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:53:6:53:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:53:6:53:9 | foo3 [@field] :  | instance_variables.rb:53:6:53:19 | call to get_field |
-| instance_variables.rb:53:6:53:9 | foo3 [@field] :  | instance_variables.rb:53:6:53:19 | call to get_field |
-| instance_variables.rb:54:6:54:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:54:6:54:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:54:6:54:9 | foo5 [@field] :  | instance_variables.rb:54:6:54:19 | call to get_field |
-| instance_variables.rb:54:6:54:9 | foo5 [@field] :  | instance_variables.rb:54:6:54:19 | call to get_field |
-| instance_variables.rb:55:6:55:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:55:6:55:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:55:6:55:9 | foo6 [@field] :  | instance_variables.rb:55:6:55:19 | call to get_field |
-| instance_variables.rb:55:6:55:9 | foo6 [@field] :  | instance_variables.rb:55:6:55:19 | call to get_field |
-| instance_variables.rb:59:15:59:18 | [post] foo7 [@field] :  | instance_variables.rb:60:6:60:9 | foo7 [@field] :  |
-| instance_variables.rb:59:15:59:18 | [post] foo7 [@field] :  | instance_variables.rb:60:6:60:9 | foo7 [@field] :  |
-| instance_variables.rb:59:25:59:28 | [post] foo8 [@field] :  | instance_variables.rb:61:6:61:9 | foo8 [@field] :  |
-| instance_variables.rb:59:25:59:28 | [post] foo8 [@field] :  | instance_variables.rb:61:6:61:9 | foo8 [@field] :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:59:15:59:18 | [post] foo7 [@field] :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:59:15:59:18 | [post] foo7 [@field] :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:59:25:59:28 | [post] foo8 [@field] :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:59:25:59:28 | [post] foo8 [@field] :  |
-| instance_variables.rb:60:6:60:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:60:6:60:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:60:6:60:9 | foo7 [@field] :  | instance_variables.rb:60:6:60:19 | call to get_field |
-| instance_variables.rb:60:6:60:9 | foo7 [@field] :  | instance_variables.rb:60:6:60:19 | call to get_field |
-| instance_variables.rb:61:6:61:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:61:6:61:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:61:6:61:9 | foo8 [@field] :  | instance_variables.rb:61:6:61:19 | call to get_field |
-| instance_variables.rb:61:6:61:9 | foo8 [@field] :  | instance_variables.rb:61:6:61:19 | call to get_field |
-| instance_variables.rb:65:22:65:25 | [post] foo9 [@field] :  | instance_variables.rb:66:6:66:9 | foo9 [@field] :  |
-| instance_variables.rb:65:22:65:25 | [post] foo9 [@field] :  | instance_variables.rb:66:6:66:9 | foo9 [@field] :  |
-| instance_variables.rb:65:32:65:36 | [post] foo10 [@field] :  | instance_variables.rb:67:6:67:10 | foo10 [@field] :  |
-| instance_variables.rb:65:32:65:36 | [post] foo10 [@field] :  | instance_variables.rb:67:6:67:10 | foo10 [@field] :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:65:22:65:25 | [post] foo9 [@field] :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:65:22:65:25 | [post] foo9 [@field] :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:65:32:65:36 | [post] foo10 [@field] :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:65:32:65:36 | [post] foo10 [@field] :  |
-| instance_variables.rb:66:6:66:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:66:6:66:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:66:6:66:9 | foo9 [@field] :  | instance_variables.rb:66:6:66:19 | call to get_field |
-| instance_variables.rb:66:6:66:9 | foo9 [@field] :  | instance_variables.rb:66:6:66:19 | call to get_field |
-| instance_variables.rb:67:6:67:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:67:6:67:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:67:6:67:10 | foo10 [@field] :  | instance_variables.rb:67:6:67:20 | call to get_field |
-| instance_variables.rb:67:6:67:10 | foo10 [@field] :  | instance_variables.rb:67:6:67:20 | call to get_field |
-| instance_variables.rb:70:5:70:5 | [post] x [@field] :  | instance_variables.rb:74:14:74:18 | [post] foo11 [@field] :  |
-| instance_variables.rb:70:5:70:5 | [post] x [@field] :  | instance_variables.rb:74:14:74:18 | [post] foo11 [@field] :  |
-| instance_variables.rb:70:5:70:5 | [post] x [@field] :  | instance_variables.rb:78:15:78:19 | [post] foo12 [@field] :  |
-| instance_variables.rb:70:5:70:5 | [post] x [@field] :  | instance_variables.rb:78:15:78:19 | [post] foo12 [@field] :  |
-| instance_variables.rb:70:5:70:5 | [post] x [@field] :  | instance_variables.rb:83:22:83:26 | [post] foo13 [@field] :  |
-| instance_variables.rb:70:5:70:5 | [post] x [@field] :  | instance_variables.rb:83:22:83:26 | [post] foo13 [@field] :  |
-| instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:70:5:70:5 | [post] x [@field] :  |
-| instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:70:5:70:5 | [post] x [@field] :  |
-| instance_variables.rb:74:14:74:18 | [post] foo11 [@field] :  | instance_variables.rb:75:6:75:10 | foo11 [@field] :  |
-| instance_variables.rb:74:14:74:18 | [post] foo11 [@field] :  | instance_variables.rb:75:6:75:10 | foo11 [@field] :  |
-| instance_variables.rb:75:6:75:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:75:6:75:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:75:6:75:10 | foo11 [@field] :  | instance_variables.rb:75:6:75:20 | call to get_field |
-| instance_variables.rb:75:6:75:10 | foo11 [@field] :  | instance_variables.rb:75:6:75:20 | call to get_field |
-| instance_variables.rb:78:15:78:19 | [post] foo12 [@field] :  | instance_variables.rb:79:6:79:10 | foo12 [@field] :  |
-| instance_variables.rb:78:15:78:19 | [post] foo12 [@field] :  | instance_variables.rb:79:6:79:10 | foo12 [@field] :  |
-| instance_variables.rb:79:6:79:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:79:6:79:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:79:6:79:10 | foo12 [@field] :  | instance_variables.rb:79:6:79:20 | call to get_field |
-| instance_variables.rb:79:6:79:10 | foo12 [@field] :  | instance_variables.rb:79:6:79:20 | call to get_field |
-| instance_variables.rb:83:22:83:26 | [post] foo13 [@field] :  | instance_variables.rb:84:6:84:10 | foo13 [@field] :  |
-| instance_variables.rb:83:22:83:26 | [post] foo13 [@field] :  | instance_variables.rb:84:6:84:10 | foo13 [@field] :  |
-| instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:84:6:84:20 | call to get_field |
-| instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:84:6:84:20 | call to get_field |
+| instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:18:23:22 | field :  |
+| instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:18:23:22 | field :  |
+| instance_variables.rb:23:18:23:22 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  |
+| instance_variables.rb:23:18:23:22 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  |
+| instance_variables.rb:24:9:24:17 | call to taint :  | instance_variables.rb:28:9:28:25 | call to initialize :  |
+| instance_variables.rb:24:9:24:17 | call to taint :  | instance_variables.rb:28:9:28:25 | call to initialize :  |
+| instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:20:28:24 | field :  |
+| instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:20:28:24 | field :  |
+| instance_variables.rb:28:9:28:25 | call to initialize :  | instance_variables.rb:104:6:104:37 | call to call_initialize |
+| instance_variables.rb:28:9:28:25 | call to initialize :  | instance_variables.rb:104:6:104:37 | call to call_initialize |
+| instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
+| instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
+| instance_variables.rb:34:9:34:17 | call to taint :  | instance_variables.rb:106:7:106:24 | call to new :  |
+| instance_variables.rb:34:9:34:17 | call to taint :  | instance_variables.rb:106:7:106:24 | call to new :  |
+| instance_variables.rb:39:1:39:3 | [post] foo [@field] :  | instance_variables.rb:40:6:40:8 | foo [@field] :  |
+| instance_variables.rb:39:1:39:3 | [post] foo [@field] :  | instance_variables.rb:40:6:40:8 | foo [@field] :  |
+| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:39:1:39:3 | [post] foo [@field] :  |
+| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:39:1:39:3 | [post] foo [@field] :  |
+| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:40:6:40:18 | call to get_field |
+| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:40:6:40:18 | call to get_field |
+| instance_variables.rb:43:1:43:3 | [post] bar [@field] :  | instance_variables.rb:44:6:44:8 | bar [@field] :  |
+| instance_variables.rb:43:15:43:22 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:43:15:43:22 | call to taint :  | instance_variables.rb:43:1:43:3 | [post] bar [@field] :  |
+| instance_variables.rb:44:6:44:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  |
+| instance_variables.rb:44:6:44:8 | bar [@field] :  | instance_variables.rb:44:6:44:18 | call to inc_field |
+| instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  | instance_variables.rb:48:6:48:9 | foo1 [@field] :  |
+| instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  | instance_variables.rb:48:6:48:9 | foo1 [@field] :  |
+| instance_variables.rb:47:14:47:22 | call to taint :  | instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  |
+| instance_variables.rb:47:14:47:22 | call to taint :  | instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  |
+| instance_variables.rb:48:6:48:9 | foo1 [@field] :  | instance_variables.rb:48:6:48:15 | call to field |
+| instance_variables.rb:48:6:48:9 | foo1 [@field] :  | instance_variables.rb:48:6:48:15 | call to field |
+| instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  | instance_variables.rb:52:6:52:9 | foo2 [@field] :  |
+| instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  | instance_variables.rb:52:6:52:9 | foo2 [@field] :  |
+| instance_variables.rb:51:14:51:22 | call to taint :  | instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  |
+| instance_variables.rb:51:14:51:22 | call to taint :  | instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  |
+| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:52:6:52:19 | call to get_field |
+| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:52:6:52:19 | call to get_field |
+| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | instance_variables.rb:56:6:56:9 | foo3 [@field] :  |
+| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | instance_variables.rb:56:6:56:9 | foo3 [@field] :  |
+| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | instance_variables.rb:68:6:68:9 | foo3 [@field] :  |
+| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | instance_variables.rb:68:6:68:9 | foo3 [@field] :  |
+| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  |
+| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  |
+| instance_variables.rb:56:6:56:9 | foo3 [@field] :  | instance_variables.rb:56:6:56:15 | call to field |
+| instance_variables.rb:56:6:56:9 | foo3 [@field] :  | instance_variables.rb:56:6:56:15 | call to field |
+| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | instance_variables.rb:64:6:64:9 | foo5 [@field] :  |
+| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | instance_variables.rb:64:6:64:9 | foo5 [@field] :  |
+| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | instance_variables.rb:69:6:69:9 | foo5 [@field] :  |
+| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | instance_variables.rb:69:6:69:9 | foo5 [@field] :  |
+| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  |
+| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  |
+| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:64:6:64:19 | call to get_field |
+| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:64:6:64:19 | call to get_field |
+| instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  | instance_variables.rb:70:6:70:9 | foo6 [@field] :  |
+| instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  | instance_variables.rb:70:6:70:9 | foo6 [@field] :  |
+| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  |
+| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  |
+| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:68:6:68:19 | call to get_field |
+| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:68:6:68:19 | call to get_field |
+| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:69:6:69:19 | call to get_field |
+| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:69:6:69:19 | call to get_field |
+| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:70:6:70:19 | call to get_field |
+| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:70:6:70:19 | call to get_field |
+| instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  | instance_variables.rb:75:6:75:9 | foo7 [@field] :  |
+| instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  | instance_variables.rb:75:6:75:9 | foo7 [@field] :  |
+| instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  | instance_variables.rb:76:6:76:9 | foo8 [@field] :  |
+| instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  | instance_variables.rb:76:6:76:9 | foo8 [@field] :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  |
+| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:75:6:75:19 | call to get_field |
+| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:75:6:75:19 | call to get_field |
+| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:76:6:76:19 | call to get_field |
+| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:76:6:76:19 | call to get_field |
+| instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  | instance_variables.rb:81:6:81:9 | foo9 [@field] :  |
+| instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  | instance_variables.rb:81:6:81:9 | foo9 [@field] :  |
+| instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  | instance_variables.rb:82:6:82:10 | foo10 [@field] :  |
+| instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  | instance_variables.rb:82:6:82:10 | foo10 [@field] :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  |
+| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:81:6:81:19 | call to get_field |
+| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:81:6:81:19 | call to get_field |
+| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:82:6:82:20 | call to get_field |
+| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:82:6:82:20 | call to get_field |
+| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  |
+| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  |
+| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  |
+| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  |
+| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  |
+| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  |
+| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:85:5:85:5 | [post] x [@field] :  |
+| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:85:5:85:5 | [post] x [@field] :  |
+| instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  | instance_variables.rb:90:6:90:10 | foo11 [@field] :  |
+| instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  | instance_variables.rb:90:6:90:10 | foo11 [@field] :  |
+| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:90:6:90:20 | call to get_field |
+| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:90:6:90:20 | call to get_field |
+| instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  | instance_variables.rb:94:6:94:10 | foo12 [@field] :  |
+| instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  | instance_variables.rb:94:6:94:10 | foo12 [@field] :  |
+| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:94:6:94:20 | call to get_field |
+| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:94:6:94:20 | call to get_field |
+| instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  | instance_variables.rb:99:6:99:10 | foo13 [@field] :  |
+| instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  | instance_variables.rb:99:6:99:10 | foo13 [@field] :  |
+| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:99:6:99:20 | call to get_field |
+| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:99:6:99:20 | call to get_field |
+| instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | instance_variables.rb:105:6:105:10 | foo16 [@field] :  |
+| instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | instance_variables.rb:105:6:105:10 | foo16 [@field] :  |
+| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  |
+| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  |
+| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
+| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:106:7:106:24 | call to new :  | instance_variables.rb:107:6:107:8 | bar |
+| instance_variables.rb:106:7:106:24 | call to new :  | instance_variables.rb:107:6:107:8 | bar |
 nodes
 | captured_variables.rb:1:24:1:24 | x :  | semmle.label | x :  |
 | captured_variables.rb:1:24:1:24 | x :  | semmle.label | x :  |
@@ -206,182 +235,223 @@ nodes
 | instance_variables.rb:20:10:20:13 | @foo | semmle.label | @foo |
 | instance_variables.rb:20:10:20:13 | self [@foo] :  | semmle.label | self [@foo] :  |
 | instance_variables.rb:20:10:20:13 | self [@foo] :  | semmle.label | self [@foo] :  |
-| instance_variables.rb:24:1:24:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
-| instance_variables.rb:24:1:24:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
-| instance_variables.rb:24:15:24:23 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:24:15:24:23 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:25:6:25:8 | foo [@field] :  | semmle.label | foo [@field] :  |
-| instance_variables.rb:25:6:25:8 | foo [@field] :  | semmle.label | foo [@field] :  |
-| instance_variables.rb:25:6:25:18 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:25:6:25:18 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:28:1:28:3 | [post] bar [@field] :  | semmle.label | [post] bar [@field] :  |
-| instance_variables.rb:28:15:28:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:29:6:29:8 | bar [@field] :  | semmle.label | bar [@field] :  |
-| instance_variables.rb:29:6:29:18 | call to inc_field | semmle.label | call to inc_field |
-| instance_variables.rb:32:1:32:4 | [post] foo1 [@field] :  | semmle.label | [post] foo1 [@field] :  |
-| instance_variables.rb:32:1:32:4 | [post] foo1 [@field] :  | semmle.label | [post] foo1 [@field] :  |
-| instance_variables.rb:32:14:32:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:32:14:32:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:33:6:33:9 | foo1 [@field] :  | semmle.label | foo1 [@field] :  |
-| instance_variables.rb:33:6:33:9 | foo1 [@field] :  | semmle.label | foo1 [@field] :  |
-| instance_variables.rb:33:6:33:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:33:6:33:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:36:1:36:4 | [post] foo2 [@field] :  | semmle.label | [post] foo2 [@field] :  |
-| instance_variables.rb:36:1:36:4 | [post] foo2 [@field] :  | semmle.label | [post] foo2 [@field] :  |
-| instance_variables.rb:36:14:36:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:36:14:36:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:37:6:37:9 | foo2 [@field] :  | semmle.label | foo2 [@field] :  |
-| instance_variables.rb:37:6:37:9 | foo2 [@field] :  | semmle.label | foo2 [@field] :  |
-| instance_variables.rb:37:6:37:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:37:6:37:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  | semmle.label | [post] foo3 [@field] :  |
-| instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  | semmle.label | [post] foo3 [@field] :  |
-| instance_variables.rb:40:16:40:24 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:40:16:40:24 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:41:6:41:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
-| instance_variables.rb:41:6:41:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
-| instance_variables.rb:41:6:41:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:41:6:41:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  | semmle.label | [post] foo5 [@field] :  |
-| instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  | semmle.label | [post] foo5 [@field] :  |
-| instance_variables.rb:48:18:48:26 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:48:18:48:26 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:49:6:49:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
-| instance_variables.rb:49:6:49:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
-| instance_variables.rb:49:6:49:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:49:6:49:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:52:15:52:18 | [post] foo6 [@field] :  | semmle.label | [post] foo6 [@field] :  |
-| instance_variables.rb:52:15:52:18 | [post] foo6 [@field] :  | semmle.label | [post] foo6 [@field] :  |
-| instance_variables.rb:52:32:52:40 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:52:32:52:40 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:53:6:53:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
-| instance_variables.rb:53:6:53:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
-| instance_variables.rb:53:6:53:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:53:6:53:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:54:6:54:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
-| instance_variables.rb:54:6:54:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
-| instance_variables.rb:54:6:54:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:54:6:54:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:55:6:55:9 | foo6 [@field] :  | semmle.label | foo6 [@field] :  |
-| instance_variables.rb:55:6:55:9 | foo6 [@field] :  | semmle.label | foo6 [@field] :  |
-| instance_variables.rb:55:6:55:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:55:6:55:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:59:15:59:18 | [post] foo7 [@field] :  | semmle.label | [post] foo7 [@field] :  |
-| instance_variables.rb:59:15:59:18 | [post] foo7 [@field] :  | semmle.label | [post] foo7 [@field] :  |
-| instance_variables.rb:59:25:59:28 | [post] foo8 [@field] :  | semmle.label | [post] foo8 [@field] :  |
-| instance_variables.rb:59:25:59:28 | [post] foo8 [@field] :  | semmle.label | [post] foo8 [@field] :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:60:6:60:9 | foo7 [@field] :  | semmle.label | foo7 [@field] :  |
-| instance_variables.rb:60:6:60:9 | foo7 [@field] :  | semmle.label | foo7 [@field] :  |
-| instance_variables.rb:60:6:60:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:60:6:60:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:61:6:61:9 | foo8 [@field] :  | semmle.label | foo8 [@field] :  |
-| instance_variables.rb:61:6:61:9 | foo8 [@field] :  | semmle.label | foo8 [@field] :  |
-| instance_variables.rb:61:6:61:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:61:6:61:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:65:22:65:25 | [post] foo9 [@field] :  | semmle.label | [post] foo9 [@field] :  |
-| instance_variables.rb:65:22:65:25 | [post] foo9 [@field] :  | semmle.label | [post] foo9 [@field] :  |
-| instance_variables.rb:65:32:65:36 | [post] foo10 [@field] :  | semmle.label | [post] foo10 [@field] :  |
-| instance_variables.rb:65:32:65:36 | [post] foo10 [@field] :  | semmle.label | [post] foo10 [@field] :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:66:6:66:9 | foo9 [@field] :  | semmle.label | foo9 [@field] :  |
-| instance_variables.rb:66:6:66:9 | foo9 [@field] :  | semmle.label | foo9 [@field] :  |
-| instance_variables.rb:66:6:66:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:66:6:66:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:67:6:67:10 | foo10 [@field] :  | semmle.label | foo10 [@field] :  |
-| instance_variables.rb:67:6:67:10 | foo10 [@field] :  | semmle.label | foo10 [@field] :  |
-| instance_variables.rb:67:6:67:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:67:6:67:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:70:5:70:5 | [post] x [@field] :  | semmle.label | [post] x [@field] :  |
-| instance_variables.rb:70:5:70:5 | [post] x [@field] :  | semmle.label | [post] x [@field] :  |
-| instance_variables.rb:70:17:70:25 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:70:17:70:25 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:74:14:74:18 | [post] foo11 [@field] :  | semmle.label | [post] foo11 [@field] :  |
-| instance_variables.rb:74:14:74:18 | [post] foo11 [@field] :  | semmle.label | [post] foo11 [@field] :  |
-| instance_variables.rb:75:6:75:10 | foo11 [@field] :  | semmle.label | foo11 [@field] :  |
-| instance_variables.rb:75:6:75:10 | foo11 [@field] :  | semmle.label | foo11 [@field] :  |
-| instance_variables.rb:75:6:75:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:75:6:75:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:78:15:78:19 | [post] foo12 [@field] :  | semmle.label | [post] foo12 [@field] :  |
-| instance_variables.rb:78:15:78:19 | [post] foo12 [@field] :  | semmle.label | [post] foo12 [@field] :  |
-| instance_variables.rb:79:6:79:10 | foo12 [@field] :  | semmle.label | foo12 [@field] :  |
-| instance_variables.rb:79:6:79:10 | foo12 [@field] :  | semmle.label | foo12 [@field] :  |
-| instance_variables.rb:79:6:79:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:79:6:79:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:83:22:83:26 | [post] foo13 [@field] :  | semmle.label | [post] foo13 [@field] :  |
-| instance_variables.rb:83:22:83:26 | [post] foo13 [@field] :  | semmle.label | [post] foo13 [@field] :  |
-| instance_variables.rb:84:6:84:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
-| instance_variables.rb:84:6:84:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
-| instance_variables.rb:84:6:84:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:84:6:84:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:22:20:22:24 | field :  | semmle.label | field :  |
+| instance_variables.rb:22:20:22:24 | field :  | semmle.label | field :  |
+| instance_variables.rb:23:9:23:14 | [post] self [@field] :  | semmle.label | [post] self [@field] :  |
+| instance_variables.rb:23:9:23:14 | [post] self [@field] :  | semmle.label | [post] self [@field] :  |
+| instance_variables.rb:23:18:23:22 | field :  | semmle.label | field :  |
+| instance_variables.rb:23:18:23:22 | field :  | semmle.label | field :  |
+| instance_variables.rb:24:9:24:17 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:24:9:24:17 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:27:25:27:29 | field :  | semmle.label | field :  |
+| instance_variables.rb:27:25:27:29 | field :  | semmle.label | field :  |
+| instance_variables.rb:28:9:28:25 | [post] self [@field] :  | semmle.label | [post] self [@field] :  |
+| instance_variables.rb:28:9:28:25 | [post] self [@field] :  | semmle.label | [post] self [@field] :  |
+| instance_variables.rb:28:9:28:25 | call to initialize :  | semmle.label | call to initialize :  |
+| instance_variables.rb:28:9:28:25 | call to initialize :  | semmle.label | call to initialize :  |
+| instance_variables.rb:28:20:28:24 | field :  | semmle.label | field :  |
+| instance_variables.rb:28:20:28:24 | field :  | semmle.label | field :  |
+| instance_variables.rb:34:9:34:17 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:34:9:34:17 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:39:1:39:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| instance_variables.rb:39:1:39:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| instance_variables.rb:39:15:39:23 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:39:15:39:23 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:40:6:40:8 | foo [@field] :  | semmle.label | foo [@field] :  |
+| instance_variables.rb:40:6:40:8 | foo [@field] :  | semmle.label | foo [@field] :  |
+| instance_variables.rb:40:6:40:18 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:40:6:40:18 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:43:1:43:3 | [post] bar [@field] :  | semmle.label | [post] bar [@field] :  |
+| instance_variables.rb:43:15:43:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:44:6:44:8 | bar [@field] :  | semmle.label | bar [@field] :  |
+| instance_variables.rb:44:6:44:18 | call to inc_field | semmle.label | call to inc_field |
+| instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  | semmle.label | [post] foo1 [@field] :  |
+| instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  | semmle.label | [post] foo1 [@field] :  |
+| instance_variables.rb:47:14:47:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:47:14:47:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:48:6:48:9 | foo1 [@field] :  | semmle.label | foo1 [@field] :  |
+| instance_variables.rb:48:6:48:9 | foo1 [@field] :  | semmle.label | foo1 [@field] :  |
+| instance_variables.rb:48:6:48:15 | call to field | semmle.label | call to field |
+| instance_variables.rb:48:6:48:15 | call to field | semmle.label | call to field |
+| instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  | semmle.label | [post] foo2 [@field] :  |
+| instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  | semmle.label | [post] foo2 [@field] :  |
+| instance_variables.rb:51:14:51:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:51:14:51:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | semmle.label | foo2 [@field] :  |
+| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | semmle.label | foo2 [@field] :  |
+| instance_variables.rb:52:6:52:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:52:6:52:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | semmle.label | [post] foo3 [@field] :  |
+| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | semmle.label | [post] foo3 [@field] :  |
+| instance_variables.rb:55:16:55:24 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:55:16:55:24 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:56:6:56:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
+| instance_variables.rb:56:6:56:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
+| instance_variables.rb:56:6:56:15 | call to field | semmle.label | call to field |
+| instance_variables.rb:56:6:56:15 | call to field | semmle.label | call to field |
+| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | semmle.label | [post] foo5 [@field] :  |
+| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | semmle.label | [post] foo5 [@field] :  |
+| instance_variables.rb:63:18:63:26 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:63:18:63:26 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
+| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
+| instance_variables.rb:64:6:64:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:64:6:64:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  | semmle.label | [post] foo6 [@field] :  |
+| instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  | semmle.label | [post] foo6 [@field] :  |
+| instance_variables.rb:67:32:67:40 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:67:32:67:40 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
+| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
+| instance_variables.rb:68:6:68:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:68:6:68:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
+| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
+| instance_variables.rb:69:6:69:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:69:6:69:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | semmle.label | foo6 [@field] :  |
+| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | semmle.label | foo6 [@field] :  |
+| instance_variables.rb:70:6:70:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:70:6:70:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  | semmle.label | [post] foo7 [@field] :  |
+| instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  | semmle.label | [post] foo7 [@field] :  |
+| instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  | semmle.label | [post] foo8 [@field] :  |
+| instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  | semmle.label | [post] foo8 [@field] :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | semmle.label | foo7 [@field] :  |
+| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | semmle.label | foo7 [@field] :  |
+| instance_variables.rb:75:6:75:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:75:6:75:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | semmle.label | foo8 [@field] :  |
+| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | semmle.label | foo8 [@field] :  |
+| instance_variables.rb:76:6:76:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:76:6:76:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  | semmle.label | [post] foo9 [@field] :  |
+| instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  | semmle.label | [post] foo9 [@field] :  |
+| instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  | semmle.label | [post] foo10 [@field] :  |
+| instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  | semmle.label | [post] foo10 [@field] :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | semmle.label | foo9 [@field] :  |
+| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | semmle.label | foo9 [@field] :  |
+| instance_variables.rb:81:6:81:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:81:6:81:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | semmle.label | foo10 [@field] :  |
+| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | semmle.label | foo10 [@field] :  |
+| instance_variables.rb:82:6:82:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:82:6:82:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | semmle.label | [post] x [@field] :  |
+| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | semmle.label | [post] x [@field] :  |
+| instance_variables.rb:85:17:85:25 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:85:17:85:25 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  | semmle.label | [post] foo11 [@field] :  |
+| instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  | semmle.label | [post] foo11 [@field] :  |
+| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | semmle.label | foo11 [@field] :  |
+| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | semmle.label | foo11 [@field] :  |
+| instance_variables.rb:90:6:90:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:90:6:90:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  | semmle.label | [post] foo12 [@field] :  |
+| instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  | semmle.label | [post] foo12 [@field] :  |
+| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | semmle.label | foo12 [@field] :  |
+| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | semmle.label | foo12 [@field] :  |
+| instance_variables.rb:94:6:94:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:94:6:94:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  | semmle.label | [post] foo13 [@field] :  |
+| instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  | semmle.label | [post] foo13 [@field] :  |
+| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
+| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
+| instance_variables.rb:99:6:99:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:99:6:99:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | semmle.label | [post] foo16 [@field] :  |
+| instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | semmle.label | [post] foo16 [@field] :  |
+| instance_variables.rb:104:6:104:37 | call to call_initialize | semmle.label | call to call_initialize |
+| instance_variables.rb:104:6:104:37 | call to call_initialize | semmle.label | call to call_initialize |
+| instance_variables.rb:104:28:104:36 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:104:28:104:36 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | semmle.label | foo16 [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | semmle.label | foo16 [@field] :  |
+| instance_variables.rb:105:6:105:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:105:6:105:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:106:7:106:24 | call to new :  | semmle.label | call to new :  |
+| instance_variables.rb:106:7:106:24 | call to new :  | semmle.label | call to new :  |
+| instance_variables.rb:107:6:107:8 | bar | semmle.label | bar |
+| instance_variables.rb:107:6:107:8 | bar | semmle.label | bar |
 subpaths
-| instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:24:1:24:3 | [post] foo [@field] :  |
-| instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:24:1:24:3 | [post] foo [@field] :  |
-| instance_variables.rb:25:6:25:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:25:6:25:18 | call to get_field |
-| instance_variables.rb:25:6:25:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:25:6:25:18 | call to get_field |
-| instance_variables.rb:28:15:28:22 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:28:1:28:3 | [post] bar [@field] :  |
-| instance_variables.rb:29:6:29:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:29:6:29:18 | call to inc_field |
-| instance_variables.rb:29:6:29:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:17:9:17:14 | [post] self [@field] :  | instance_variables.rb:29:6:29:18 | call to inc_field |
-| instance_variables.rb:37:6:37:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:37:6:37:19 | call to get_field |
-| instance_variables.rb:37:6:37:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:37:6:37:19 | call to get_field |
-| instance_variables.rb:40:16:40:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  |
-| instance_variables.rb:40:16:40:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:40:1:40:4 | [post] foo3 [@field] :  |
-| instance_variables.rb:48:18:48:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  |
-| instance_variables.rb:48:18:48:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:48:2:48:5 | [post] foo5 [@field] :  |
-| instance_variables.rb:49:6:49:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:49:6:49:19 | call to get_field |
-| instance_variables.rb:49:6:49:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:49:6:49:19 | call to get_field |
-| instance_variables.rb:52:32:52:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:52:15:52:18 | [post] foo6 [@field] :  |
-| instance_variables.rb:52:32:52:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:52:15:52:18 | [post] foo6 [@field] :  |
-| instance_variables.rb:53:6:53:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:53:6:53:19 | call to get_field |
-| instance_variables.rb:53:6:53:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:53:6:53:19 | call to get_field |
-| instance_variables.rb:54:6:54:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:54:6:54:19 | call to get_field |
-| instance_variables.rb:54:6:54:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:54:6:54:19 | call to get_field |
-| instance_variables.rb:55:6:55:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:55:6:55:19 | call to get_field |
-| instance_variables.rb:55:6:55:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:55:6:55:19 | call to get_field |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:59:15:59:18 | [post] foo7 [@field] :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:59:15:59:18 | [post] foo7 [@field] :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:59:25:59:28 | [post] foo8 [@field] :  |
-| instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:59:25:59:28 | [post] foo8 [@field] :  |
-| instance_variables.rb:60:6:60:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:60:6:60:19 | call to get_field |
-| instance_variables.rb:60:6:60:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:60:6:60:19 | call to get_field |
-| instance_variables.rb:61:6:61:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:61:6:61:19 | call to get_field |
-| instance_variables.rb:61:6:61:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:61:6:61:19 | call to get_field |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:65:22:65:25 | [post] foo9 [@field] :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:65:22:65:25 | [post] foo9 [@field] :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:65:32:65:36 | [post] foo10 [@field] :  |
-| instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:65:32:65:36 | [post] foo10 [@field] :  |
-| instance_variables.rb:66:6:66:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:66:6:66:19 | call to get_field |
-| instance_variables.rb:66:6:66:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:66:6:66:19 | call to get_field |
-| instance_variables.rb:67:6:67:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:67:6:67:20 | call to get_field |
-| instance_variables.rb:67:6:67:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:67:6:67:20 | call to get_field |
-| instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:70:5:70:5 | [post] x [@field] :  |
-| instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:70:5:70:5 | [post] x [@field] :  |
-| instance_variables.rb:75:6:75:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:75:6:75:20 | call to get_field |
-| instance_variables.rb:75:6:75:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:75:6:75:20 | call to get_field |
-| instance_variables.rb:79:6:79:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:79:6:79:20 | call to get_field |
-| instance_variables.rb:79:6:79:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:79:6:79:20 | call to get_field |
-| instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:84:6:84:20 | call to get_field |
-| instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:84:6:84:20 | call to get_field |
+| instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
+| instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
+| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:39:1:39:3 | [post] foo [@field] :  |
+| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:39:1:39:3 | [post] foo [@field] :  |
+| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:40:6:40:18 | call to get_field |
+| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:40:6:40:18 | call to get_field |
+| instance_variables.rb:43:15:43:22 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:43:1:43:3 | [post] bar [@field] :  |
+| instance_variables.rb:44:6:44:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:44:6:44:18 | call to inc_field |
+| instance_variables.rb:44:6:44:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:17:9:17:14 | [post] self [@field] :  | instance_variables.rb:44:6:44:18 | call to inc_field |
+| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:52:6:52:19 | call to get_field |
+| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:52:6:52:19 | call to get_field |
+| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  |
+| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  |
+| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  |
+| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  |
+| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:64:6:64:19 | call to get_field |
+| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:64:6:64:19 | call to get_field |
+| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  |
+| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  |
+| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:68:6:68:19 | call to get_field |
+| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:68:6:68:19 | call to get_field |
+| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:69:6:69:19 | call to get_field |
+| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:69:6:69:19 | call to get_field |
+| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:70:6:70:19 | call to get_field |
+| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:70:6:70:19 | call to get_field |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  |
+| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  |
+| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:75:6:75:19 | call to get_field |
+| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:75:6:75:19 | call to get_field |
+| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:76:6:76:19 | call to get_field |
+| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:76:6:76:19 | call to get_field |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  |
+| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  |
+| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:81:6:81:19 | call to get_field |
+| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:81:6:81:19 | call to get_field |
+| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:82:6:82:20 | call to get_field |
+| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:82:6:82:20 | call to get_field |
+| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:85:5:85:5 | [post] x [@field] :  |
+| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:85:5:85:5 | [post] x [@field] :  |
+| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:90:6:90:20 | call to get_field |
+| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:90:6:90:20 | call to get_field |
+| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:94:6:94:20 | call to get_field |
+| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:94:6:94:20 | call to get_field |
+| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:99:6:99:20 | call to get_field |
+| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:99:6:99:20 | call to get_field |
+| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
+| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:105:6:105:20 | call to get_field |
 #select
 | captured_variables.rb:2:20:2:20 | x | captured_variables.rb:5:20:5:30 | call to source :  | captured_variables.rb:2:20:2:20 | x | $@ | captured_variables.rb:5:20:5:30 | call to source :  | call to source :  |
 | captured_variables.rb:23:14:23:14 | x | captured_variables.rb:27:29:27:39 | call to source :  | captured_variables.rb:23:14:23:14 | x | $@ | captured_variables.rb:27:29:27:39 | call to source :  | call to source :  |
 | captured_variables.rb:34:14:34:14 | x | captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:34:14:34:14 | x | $@ | captured_variables.rb:38:27:38:37 | call to source :  | call to source :  |
 | instance_variables.rb:20:10:20:13 | @foo | instance_variables.rb:19:12:19:21 | call to taint :  | instance_variables.rb:20:10:20:13 | @foo | $@ | instance_variables.rb:19:12:19:21 | call to taint :  | call to taint :  |
-| instance_variables.rb:25:6:25:18 | call to get_field | instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:25:6:25:18 | call to get_field | $@ | instance_variables.rb:24:15:24:23 | call to taint :  | call to taint :  |
-| instance_variables.rb:29:6:29:18 | call to inc_field | instance_variables.rb:28:15:28:22 | call to taint :  | instance_variables.rb:29:6:29:18 | call to inc_field | $@ | instance_variables.rb:28:15:28:22 | call to taint :  | call to taint :  |
-| instance_variables.rb:33:6:33:15 | call to field | instance_variables.rb:32:14:32:22 | call to taint :  | instance_variables.rb:33:6:33:15 | call to field | $@ | instance_variables.rb:32:14:32:22 | call to taint :  | call to taint :  |
-| instance_variables.rb:37:6:37:19 | call to get_field | instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:37:6:37:19 | call to get_field | $@ | instance_variables.rb:36:14:36:22 | call to taint :  | call to taint :  |
-| instance_variables.rb:41:6:41:15 | call to field | instance_variables.rb:40:16:40:24 | call to taint :  | instance_variables.rb:41:6:41:15 | call to field | $@ | instance_variables.rb:40:16:40:24 | call to taint :  | call to taint :  |
-| instance_variables.rb:49:6:49:19 | call to get_field | instance_variables.rb:48:18:48:26 | call to taint :  | instance_variables.rb:49:6:49:19 | call to get_field | $@ | instance_variables.rb:48:18:48:26 | call to taint :  | call to taint :  |
-| instance_variables.rb:53:6:53:19 | call to get_field | instance_variables.rb:40:16:40:24 | call to taint :  | instance_variables.rb:53:6:53:19 | call to get_field | $@ | instance_variables.rb:40:16:40:24 | call to taint :  | call to taint :  |
-| instance_variables.rb:54:6:54:19 | call to get_field | instance_variables.rb:48:18:48:26 | call to taint :  | instance_variables.rb:54:6:54:19 | call to get_field | $@ | instance_variables.rb:48:18:48:26 | call to taint :  | call to taint :  |
-| instance_variables.rb:55:6:55:19 | call to get_field | instance_variables.rb:52:32:52:40 | call to taint :  | instance_variables.rb:55:6:55:19 | call to get_field | $@ | instance_variables.rb:52:32:52:40 | call to taint :  | call to taint :  |
-| instance_variables.rb:60:6:60:19 | call to get_field | instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:60:6:60:19 | call to get_field | $@ | instance_variables.rb:59:45:59:53 | call to taint :  | call to taint :  |
-| instance_variables.rb:61:6:61:19 | call to get_field | instance_variables.rb:59:45:59:53 | call to taint :  | instance_variables.rb:61:6:61:19 | call to get_field | $@ | instance_variables.rb:59:45:59:53 | call to taint :  | call to taint :  |
-| instance_variables.rb:66:6:66:19 | call to get_field | instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:66:6:66:19 | call to get_field | $@ | instance_variables.rb:65:53:65:61 | call to taint :  | call to taint :  |
-| instance_variables.rb:67:6:67:20 | call to get_field | instance_variables.rb:65:53:65:61 | call to taint :  | instance_variables.rb:67:6:67:20 | call to get_field | $@ | instance_variables.rb:65:53:65:61 | call to taint :  | call to taint :  |
-| instance_variables.rb:75:6:75:20 | call to get_field | instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:75:6:75:20 | call to get_field | $@ | instance_variables.rb:70:17:70:25 | call to taint :  | call to taint :  |
-| instance_variables.rb:79:6:79:20 | call to get_field | instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:79:6:79:20 | call to get_field | $@ | instance_variables.rb:70:17:70:25 | call to taint :  | call to taint :  |
-| instance_variables.rb:84:6:84:20 | call to get_field | instance_variables.rb:70:17:70:25 | call to taint :  | instance_variables.rb:84:6:84:20 | call to get_field | $@ | instance_variables.rb:70:17:70:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:40:6:40:18 | call to get_field | instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:40:6:40:18 | call to get_field | $@ | instance_variables.rb:39:15:39:23 | call to taint :  | call to taint :  |
+| instance_variables.rb:44:6:44:18 | call to inc_field | instance_variables.rb:43:15:43:22 | call to taint :  | instance_variables.rb:44:6:44:18 | call to inc_field | $@ | instance_variables.rb:43:15:43:22 | call to taint :  | call to taint :  |
+| instance_variables.rb:48:6:48:15 | call to field | instance_variables.rb:47:14:47:22 | call to taint :  | instance_variables.rb:48:6:48:15 | call to field | $@ | instance_variables.rb:47:14:47:22 | call to taint :  | call to taint :  |
+| instance_variables.rb:52:6:52:19 | call to get_field | instance_variables.rb:51:14:51:22 | call to taint :  | instance_variables.rb:52:6:52:19 | call to get_field | $@ | instance_variables.rb:51:14:51:22 | call to taint :  | call to taint :  |
+| instance_variables.rb:56:6:56:15 | call to field | instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:56:6:56:15 | call to field | $@ | instance_variables.rb:55:16:55:24 | call to taint :  | call to taint :  |
+| instance_variables.rb:64:6:64:19 | call to get_field | instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:64:6:64:19 | call to get_field | $@ | instance_variables.rb:63:18:63:26 | call to taint :  | call to taint :  |
+| instance_variables.rb:68:6:68:19 | call to get_field | instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:68:6:68:19 | call to get_field | $@ | instance_variables.rb:55:16:55:24 | call to taint :  | call to taint :  |
+| instance_variables.rb:69:6:69:19 | call to get_field | instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:69:6:69:19 | call to get_field | $@ | instance_variables.rb:63:18:63:26 | call to taint :  | call to taint :  |
+| instance_variables.rb:70:6:70:19 | call to get_field | instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:70:6:70:19 | call to get_field | $@ | instance_variables.rb:67:32:67:40 | call to taint :  | call to taint :  |
+| instance_variables.rb:75:6:75:19 | call to get_field | instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:75:6:75:19 | call to get_field | $@ | instance_variables.rb:74:45:74:53 | call to taint :  | call to taint :  |
+| instance_variables.rb:76:6:76:19 | call to get_field | instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:76:6:76:19 | call to get_field | $@ | instance_variables.rb:74:45:74:53 | call to taint :  | call to taint :  |
+| instance_variables.rb:81:6:81:19 | call to get_field | instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:81:6:81:19 | call to get_field | $@ | instance_variables.rb:80:53:80:61 | call to taint :  | call to taint :  |
+| instance_variables.rb:82:6:82:20 | call to get_field | instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:82:6:82:20 | call to get_field | $@ | instance_variables.rb:80:53:80:61 | call to taint :  | call to taint :  |
+| instance_variables.rb:90:6:90:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:90:6:90:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:94:6:94:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:94:6:94:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:99:6:99:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:99:6:99:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:104:6:104:37 | call to call_initialize | instance_variables.rb:24:9:24:17 | call to taint :  | instance_variables.rb:104:6:104:37 | call to call_initialize | $@ | instance_variables.rb:24:9:24:17 | call to taint :  | call to taint :  |
+| instance_variables.rb:105:6:105:20 | call to get_field | instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:105:6:105:20 | call to get_field | $@ | instance_variables.rb:104:28:104:36 | call to taint :  | call to taint :  |
+| instance_variables.rb:107:6:107:8 | bar | instance_variables.rb:34:9:34:17 | call to taint :  | instance_variables.rb:107:6:107:8 | bar | $@ | instance_variables.rb:34:9:34:17 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,17 +1,19 @@
 | captured_variables.rb:9:14:9:14 | x | Fixed missing result:hasValueFlow=1.2 |
 | captured_variables.rb:16:14:16:14 | x | Fixed missing result:hasValueFlow=1.3 |
 | instance_variables.rb:20:16:20:33 | # $ hasValueFlow=7 | Missing result:hasValueFlow=7 |
-| instance_variables.rb:25:21:25:39 | # $ hasValueFlow=42 | Missing result:hasValueFlow=42 |
-| instance_variables.rb:37:22:37:40 | # $ hasValueFlow=21 | Missing result:hasValueFlow=21 |
-| instance_variables.rb:41:18:41:36 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
-| instance_variables.rb:49:22:49:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
-| instance_variables.rb:53:22:53:40 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
-| instance_variables.rb:54:22:54:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
-| instance_variables.rb:55:22:55:40 | # $ hasValueFlow=25 | Missing result:hasValueFlow=25 |
-| instance_variables.rb:60:22:60:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
-| instance_variables.rb:61:22:61:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
-| instance_variables.rb:66:22:66:40 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
-| instance_variables.rb:67:23:67:41 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
-| instance_variables.rb:75:23:75:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
-| instance_variables.rb:79:23:79:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
-| instance_variables.rb:84:23:84:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:40:21:40:39 | # $ hasValueFlow=42 | Missing result:hasValueFlow=42 |
+| instance_variables.rb:52:22:52:40 | # $ hasValueFlow=21 | Missing result:hasValueFlow=21 |
+| instance_variables.rb:56:18:56:36 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
+| instance_variables.rb:64:22:64:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
+| instance_variables.rb:68:22:68:40 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
+| instance_variables.rb:69:22:69:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
+| instance_variables.rb:70:22:70:40 | # $ hasValueFlow=25 | Missing result:hasValueFlow=25 |
+| instance_variables.rb:75:22:75:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
+| instance_variables.rb:76:22:76:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
+| instance_variables.rb:81:22:81:40 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
+| instance_variables.rb:82:23:82:41 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
+| instance_variables.rb:90:23:90:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:94:23:94:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:99:23:99:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:102:23:102:41 | # $ hasValueFlow=29 | Missing result:hasValueFlow=29 |
+| instance_variables.rb:105:23:105:41 | # $ hasValueFlow=30 | Missing result:hasValueFlow=30 |

--- a/ruby/ql/test/library-tests/dataflow/global/instance_variables.rb
+++ b/ruby/ql/test/library-tests/dataflow/global/instance_variables.rb
@@ -19,7 +19,22 @@ class Foo
     @foo = taint("7")
     sink(@foo) # $ hasValueFlow=7
 
+    def initialize(field = nil)
+        @field = field
+        taint(31)
+    end
+
+    def call_initialize(field)
+        initialize(field)
+    end
 end
+
+class Bar < Foo
+    def self.new arg
+        taint(32)
+    end
+end
+
 foo = Foo.new
 foo.set_field(taint(42))
 sink(foo.get_field) # $ hasValueFlow=42
@@ -82,3 +97,12 @@ foo13 = Foo.new
 foo14 = Foo.new
 set_field_on(foo14 = foo13)
 sink(foo13.get_field) # $ hasValueFlow=28
+
+foo15 = Foo.new(taint(29))
+sink(foo15.get_field) # $ hasValueFlow=29
+foo16 = Foo.new
+sink(foo16.call_initialize(taint(30))) # $ hasValueFlow=31
+sink(foo16.get_field) # $ hasValueFlow=30
+bar = Bar.new(taint(33))
+sink(bar) # $ hasValueFlow=32
+sink(bar.get_field)

--- a/ruby/ql/test/query-tests/analysis/Definitions.expected
+++ b/ruby/ql/test/query-tests/analysis/Definitions.expected
@@ -12,3 +12,4 @@
 | Definitions.rb:41:7:41:9 | @@b | Definitions.rb:27:5:27:7 | @@b | class variable |
 | Definitions.rb:46:1:46:1 | C | Definitions.rb:19:1:44:3 | C | constant |
 | Definitions.rb:46:1:46:4 | D | Definitions.rb:26:3:43:5 | D | constant |
+| Definitions.rb:46:1:46:8 | call to new | Definitions.rb:29:5:33:7 | initialize | method |


### PR DESCRIPTION
As discussed with @asgerf offline, we have decided to model flow through `initialize` constructors in the following way:

- When we see a call to `C.new(x1, ..., xn)`, pretend that it is actually a call to `C#initialize(x1, ..., xn)`, but only if `C` does not define it's own `self.new` method (in which case we dispatch to that instead).
- Introduce a new return kind, `NewReturnKind`, and
  - let all calls to `new` accept only `NewReturnKind` (and not `NormalReturnKind`),
  - let user-defined `self.new` methods have return kind `NewReturnKind` instead of `NormalReturnKind`, and
  - let `initialize` methods have `NewReturnKind` for all post-update accesses to `self` (and still have `NormalReturnKind` for normal returns, in case someone were to invoke `initialize` directly).

This means that if we have
```rb
class C
  def initialize(x)
    @field = x
  end
end

C.new(y)
```

then `y` will flow into the parameter `x` of `initalize`, and from there to `(post-update) self [field]`. And since `(post-update) self` has `NewReturnKind`, we will get flow back out to `C.new(y) [field]`.