### PR TITLE
Kotlin: Extract `override` modifier on SAM methods

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -4731,7 +4731,7 @@ open class KotlinFileExtractor(
                        class <Anon> extends Object implements IntPredicate {
                            Function1<Integer, Boolean> <fn>;
                            public <Anon>(Function1<Integer, Boolean> <fn>) { this.<fn> = <fn>; }
-                           public Boolean accept(Integer i) { return <fn>.invoke(i); }
+                           public override Boolean accept(Integer i) { return <fn>.invoke(i); }
                        }
 
                        IntPredicate x = (IntPredicate)new <Anon>(...);
@@ -4811,6 +4811,7 @@ open class KotlinFileExtractor(
                     // the real underlying R Function<T, R>.apply(T t).
                     forceExtractFunction(samMember, classId, extractBody = false, extractMethodAndParameterTypeAccesses = true, typeSub, classTypeArgs, overriddenAttributes = OverriddenFunctionAttributes(id = ids.function, sourceLoc = tw.getLocation(e)))
 
+                    addModifiers(ids.function, "override")
                     if (st.isSuspendFunctionOrKFunction()) {
                         addModifiers(ids.function, "suspend")
                     }

--- a/java/ql/test/kotlin/library-tests/exprs/funcExprs.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/funcExprs.expected
@@ -221,25 +221,25 @@ anon_class_member_modifiers
 | funcExprs.kt:90:15:90:69 | new FunctionN<String>(...) { ... } | funcExprs.kt:90:15:90:69 | invoke | public |
 | funcExprs.kt:94:15:94:67 | new Function22<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,String>(...) { ... } | funcExprs.kt:94:15:94:67 | invoke | override, public, suspend |
 | kFunctionInvoke.kt:8:44:8:47 | new Function1<String,Unit>(...) { ... } | kFunctionInvoke.kt:8:44:8:47 | invoke | override, public |
-| samConversion.kt:2:18:2:45 | new IntPredicate(...) { ... } | samConversion.kt:2:18:2:45 | accept | public |
+| samConversion.kt:2:18:2:45 | new IntPredicate(...) { ... } | samConversion.kt:2:18:2:45 | accept | override, public |
 | samConversion.kt:2:31:2:45 | new Function1<Integer,Boolean>(...) { ... } | samConversion.kt:2:31:2:45 | invoke | override, public |
-| samConversion.kt:4:14:4:42 | new InterfaceFn1(...) { ... } | samConversion.kt:4:14:4:42 | fn1 | public |
+| samConversion.kt:4:14:4:42 | new InterfaceFn1(...) { ... } | samConversion.kt:4:14:4:42 | fn1 | override, public |
 | samConversion.kt:4:27:4:42 | new Function2<Integer,Integer,Unit>(...) { ... } | samConversion.kt:4:27:4:42 | invoke | override, public |
-| samConversion.kt:5:14:5:32 | new InterfaceFn1(...) { ... } | samConversion.kt:5:14:5:32 | fn1 | public |
+| samConversion.kt:5:14:5:32 | new InterfaceFn1(...) { ... } | samConversion.kt:5:14:5:32 | fn1 | override, public |
 | samConversion.kt:5:27:5:31 | new Function2<Integer,Integer,Unit>(...) { ... } | samConversion.kt:5:27:5:31 | invoke | override, public |
-| samConversion.kt:7:13:7:46 | new InterfaceFnExt1(...) { ... } | samConversion.kt:7:13:7:46 | ext | public |
+| samConversion.kt:7:13:7:46 | new InterfaceFnExt1(...) { ... } | samConversion.kt:7:13:7:46 | ext | override, public |
 | samConversion.kt:7:29:7:46 | new Function2<String,Integer,Boolean>(...) { ... } | samConversion.kt:7:29:7:46 | invoke | override, public |
-| samConversion.kt:9:13:13:6 | new IntPredicate(...) { ... } | samConversion.kt:9:13:13:6 | accept | public |
+| samConversion.kt:9:13:13:6 | new IntPredicate(...) { ... } | samConversion.kt:9:13:13:6 | accept | override, public |
 | samConversion.kt:9:33:11:5 | new Function1<Integer,Boolean>(...) { ... } | samConversion.kt:9:33:11:5 | invoke | override, public |
 | samConversion.kt:11:12:13:5 | new Function1<Integer,Boolean>(...) { ... } | samConversion.kt:11:12:13:5 | invoke | override, public |
 | samConversion.kt:41:13:41:16 | new FunctionN<Boolean>(...) { ... } | samConversion.kt:41:13:41:16 | invoke | override, public |
-| samConversion.kt:42:13:42:32 | new BigArityPredicate(...) { ... } | samConversion.kt:42:13:42:32 | accept | public |
-| samConversion.kt:43:13:45:68 | new BigArityPredicate(...) { ... } | samConversion.kt:43:13:45:68 | accept | public |
+| samConversion.kt:42:13:42:32 | new BigArityPredicate(...) { ... } | samConversion.kt:42:13:42:32 | accept | override, public |
+| samConversion.kt:43:13:45:68 | new BigArityPredicate(...) { ... } | samConversion.kt:43:13:45:68 | accept | override, public |
 | samConversion.kt:43:31:45:68 | new FunctionN<Boolean>(...) { ... } | samConversion.kt:43:31:45:68 | invoke | override, public |
 | samConversion.kt:43:31:45:68 | new FunctionN<Boolean>(...) { ... } | samConversion.kt:43:31:45:68 | invoke | public |
-| samConversion.kt:46:13:46:44 | new SomePredicate<Integer>(...) { ... } | samConversion.kt:46:13:46:44 | fn | public |
+| samConversion.kt:46:13:46:44 | new SomePredicate<Integer>(...) { ... } | samConversion.kt:46:13:46:44 | fn | override, public |
 | samConversion.kt:46:32:46:44 | new Function1<Integer,Boolean>(...) { ... } | samConversion.kt:46:32:46:44 | invoke | override, public |
-| samConversion.kt:58:14:58:45 | new InterfaceFn1Sus(...) { ... } | samConversion.kt:58:14:58:45 | fn1 | public, suspend |
+| samConversion.kt:58:14:58:45 | new InterfaceFn1Sus(...) { ... } | samConversion.kt:58:14:58:45 | fn1 | override, public, suspend |
 | samConversion.kt:58:30:58:45 | new Function2<Integer,Integer,Unit>(...) { ... } | samConversion.kt:58:30:58:45 | invoke | override, public, suspend |
 nonOverrideInvoke
 | funcExprs.kt:36:29:36:117 | ...->... | funcExprs.kt:36:29:36:117 | invoke | 23 |

--- a/java/ql/test/kotlin/library-tests/exprs/funcExprs.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/funcExprs.expected
@@ -42,7 +42,7 @@ memberRefExprs
 | kFunctionInvoke.kt:8:44:8:47 | ...::... | kFunctionInvoke.kt:8:44:8:47 | invoke | invoke(java.lang.String) | kFunctionInvoke.kt:8:44:8:47 | new Function1<String,Unit>(...) { ... } |
 | samConversion.kt:5:27:5:31 | ...::... | samConversion.kt:5:27:5:31 | invoke | invoke(int,int) | samConversion.kt:5:27:5:31 | new Function2<Integer,Integer,Unit>(...) { ... } |
 | samConversion.kt:41:13:41:16 | ...::... | samConversion.kt:41:13:41:16 | invoke | invoke(java.lang.Object[]) | samConversion.kt:41:13:41:16 | new FunctionN<Boolean>(...) { ... } |
-modifiers
+lambda_modifiers
 | delegatedProperties.kt:6:32:9:9 | ...->... | delegatedProperties.kt:6:32:9:9 | invoke | override, public |
 | funcExprs.kt:22:26:22:33 | ...->... | funcExprs.kt:22:26:22:33 | invoke | override, public |
 | funcExprs.kt:23:26:23:33 | ...->... | funcExprs.kt:23:26:23:33 | invoke | override, public |
@@ -74,6 +74,173 @@ modifiers
 | samConversion.kt:43:31:45:68 | ...->... | samConversion.kt:43:31:45:68 | invoke | public |
 | samConversion.kt:46:32:46:44 | ...->... | samConversion.kt:46:32:46:44 | invoke | override, public |
 | samConversion.kt:58:30:58:45 | ...->... | samConversion.kt:58:30:58:45 | invoke | override, public, suspend |
+anon_class_member_modifiers
+| delegatedProperties.kt:6:24:9:9 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:6:24:9:9 | get | override, public |
+| delegatedProperties.kt:6:24:9:9 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:6:24:9:9 | invoke | override, public |
+| delegatedProperties.kt:6:32:9:9 | new Function0<Integer>(...) { ... } | delegatedProperties.kt:6:32:9:9 | invoke | override, public |
+| delegatedProperties.kt:19:31:19:51 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:19:31:19:51 | get | override, public |
+| delegatedProperties.kt:19:31:19:51 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:19:31:19:51 | get | override, public |
+| delegatedProperties.kt:19:31:19:51 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:19:31:19:51 | invoke | override, public |
+| delegatedProperties.kt:19:31:19:51 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:19:31:19:51 | invoke | override, public |
+| delegatedProperties.kt:19:31:19:51 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:19:31:19:51 | set | override, public |
+| delegatedProperties.kt:19:31:19:51 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:19:31:19:51 | set | override, public |
+| delegatedProperties.kt:23:26:23:31 | new KProperty0<String>(...) { ... } | delegatedProperties.kt:23:26:23:31 | get | override, public |
+| delegatedProperties.kt:23:26:23:31 | new KProperty0<String>(...) { ... } | delegatedProperties.kt:23:26:23:31 | invoke | override, public |
+| delegatedProperties.kt:25:64:31:9 | new ReadWriteProperty<Object,Integer>(...) { ... } | delegatedProperties.kt:26:13:26:28 | getCurValue | public |
+| delegatedProperties.kt:25:64:31:9 | new ReadWriteProperty<Object,Integer>(...) { ... } | delegatedProperties.kt:26:13:26:28 | setCurValue | public |
+| delegatedProperties.kt:25:64:31:9 | new ReadWriteProperty<Object,Integer>(...) { ... } | delegatedProperties.kt:27:22:27:88 | getValue | override, public |
+| delegatedProperties.kt:25:64:31:9 | new ReadWriteProperty<Object,Integer>(...) { ... } | delegatedProperties.kt:28:22:30:13 | setValue | override, public |
+| delegatedProperties.kt:33:27:33:47 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:33:27:33:47 | get | override, public |
+| delegatedProperties.kt:33:27:33:47 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:33:27:33:47 | invoke | override, public |
+| delegatedProperties.kt:34:28:34:48 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:34:28:34:48 | get | override, public |
+| delegatedProperties.kt:34:28:34:48 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:34:28:34:48 | get | override, public |
+| delegatedProperties.kt:34:28:34:48 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:34:28:34:48 | invoke | override, public |
+| delegatedProperties.kt:34:28:34:48 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:34:28:34:48 | invoke | override, public |
+| delegatedProperties.kt:34:28:34:48 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:34:28:34:48 | set | override, public |
+| delegatedProperties.kt:34:28:34:48 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:34:28:34:48 | set | override, public |
+| delegatedProperties.kt:39:31:39:51 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:39:31:39:51 | get | override, public |
+| delegatedProperties.kt:39:31:39:51 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:39:31:39:51 | get | override, public |
+| delegatedProperties.kt:39:31:39:51 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:39:31:39:51 | invoke | override, public |
+| delegatedProperties.kt:39:31:39:51 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:39:31:39:51 | invoke | override, public |
+| delegatedProperties.kt:42:27:42:47 | new KMutableProperty1<Owner,Integer>(...) { ... } | delegatedProperties.kt:42:27:42:47 | get | override, public |
+| delegatedProperties.kt:42:27:42:47 | new KMutableProperty1<Owner,Integer>(...) { ... } | delegatedProperties.kt:42:27:42:47 | get | override, public |
+| delegatedProperties.kt:42:27:42:47 | new KMutableProperty1<Owner,Integer>(...) { ... } | delegatedProperties.kt:42:27:42:47 | invoke | override, public |
+| delegatedProperties.kt:42:27:42:47 | new KMutableProperty1<Owner,Integer>(...) { ... } | delegatedProperties.kt:42:27:42:47 | invoke | override, public |
+| delegatedProperties.kt:42:27:42:47 | new KMutableProperty1<Owner,Integer>(...) { ... } | delegatedProperties.kt:42:27:42:47 | set | override, public |
+| delegatedProperties.kt:42:27:42:47 | new KMutableProperty1<Owner,Integer>(...) { ... } | delegatedProperties.kt:42:27:42:47 | set | override, public |
+| delegatedProperties.kt:66:33:66:50 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:66:33:66:50 | get | override, public |
+| delegatedProperties.kt:66:33:66:50 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:66:33:66:50 | get | override, public |
+| delegatedProperties.kt:66:33:66:50 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:66:33:66:50 | invoke | override, public |
+| delegatedProperties.kt:66:33:66:50 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:66:33:66:50 | invoke | override, public |
+| delegatedProperties.kt:66:33:66:50 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:66:33:66:50 | set | override, public |
+| delegatedProperties.kt:66:33:66:50 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:66:33:66:50 | set | override, public |
+| delegatedProperties.kt:66:36:66:50 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:66:36:66:50 | get | override, public |
+| delegatedProperties.kt:66:36:66:50 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:66:36:66:50 | invoke | override, public |
+| delegatedProperties.kt:66:36:66:50 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:66:36:66:50 | set | override, public |
+| delegatedProperties.kt:67:33:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:33:67:53 | get | override, public |
+| delegatedProperties.kt:67:33:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:33:67:53 | get | override, public |
+| delegatedProperties.kt:67:33:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:33:67:53 | invoke | override, public |
+| delegatedProperties.kt:67:33:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:33:67:53 | invoke | override, public |
+| delegatedProperties.kt:67:33:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:33:67:53 | set | override, public |
+| delegatedProperties.kt:67:33:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:33:67:53 | set | override, public |
+| delegatedProperties.kt:67:36:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:36:67:53 | get | override, public |
+| delegatedProperties.kt:67:36:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:36:67:53 | invoke | override, public |
+| delegatedProperties.kt:67:36:67:53 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:67:36:67:53 | set | override, public |
+| delegatedProperties.kt:69:36:69:56 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:69:36:69:56 | get | override, public |
+| delegatedProperties.kt:69:36:69:56 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:69:36:69:56 | get | override, public |
+| delegatedProperties.kt:69:36:69:56 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:69:36:69:56 | invoke | override, public |
+| delegatedProperties.kt:69:36:69:56 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:69:36:69:56 | invoke | override, public |
+| delegatedProperties.kt:69:36:69:56 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:69:36:69:56 | set | override, public |
+| delegatedProperties.kt:69:36:69:56 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:69:36:69:56 | set | override, public |
+| delegatedProperties.kt:69:39:69:56 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:69:39:69:56 | get | override, public |
+| delegatedProperties.kt:69:39:69:56 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:69:39:69:56 | invoke | override, public |
+| delegatedProperties.kt:69:39:69:56 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:69:39:69:56 | set | override, public |
+| delegatedProperties.kt:70:36:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:36:70:59 | get | override, public |
+| delegatedProperties.kt:70:36:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:36:70:59 | get | override, public |
+| delegatedProperties.kt:70:36:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:36:70:59 | invoke | override, public |
+| delegatedProperties.kt:70:36:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:36:70:59 | invoke | override, public |
+| delegatedProperties.kt:70:36:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:36:70:59 | set | override, public |
+| delegatedProperties.kt:70:36:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:36:70:59 | set | override, public |
+| delegatedProperties.kt:70:39:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:39:70:59 | get | override, public |
+| delegatedProperties.kt:70:39:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:39:70:59 | invoke | override, public |
+| delegatedProperties.kt:70:39:70:59 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:70:39:70:59 | set | override, public |
+| delegatedProperties.kt:72:36:72:56 | new KProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:72:36:72:56 | get | override, public |
+| delegatedProperties.kt:72:36:72:56 | new KProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:72:36:72:56 | invoke | override, public |
+| delegatedProperties.kt:72:39:72:56 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:72:39:72:56 | get | override, public |
+| delegatedProperties.kt:72:39:72:56 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:72:39:72:56 | invoke | override, public |
+| delegatedProperties.kt:73:36:73:56 | new KProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:73:36:73:56 | get | override, public |
+| delegatedProperties.kt:73:36:73:56 | new KProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:73:36:73:56 | invoke | override, public |
+| delegatedProperties.kt:73:39:73:56 | new KProperty1<Base,Integer>(...) { ... } | delegatedProperties.kt:73:39:73:56 | get | override, public |
+| delegatedProperties.kt:73:39:73:56 | new KProperty1<Base,Integer>(...) { ... } | delegatedProperties.kt:73:39:73:56 | invoke | override, public |
+| delegatedProperties.kt:75:39:75:78 | new KProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:75:39:75:78 | get | override, public |
+| delegatedProperties.kt:75:39:75:78 | new KProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:75:39:75:78 | invoke | override, public |
+| delegatedProperties.kt:75:42:75:78 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:75:42:75:78 | get | override, public |
+| delegatedProperties.kt:75:42:75:78 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:75:42:75:78 | invoke | override, public |
+| delegatedProperties.kt:77:34:77:49 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:77:34:77:49 | get | override, public |
+| delegatedProperties.kt:77:34:77:49 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:77:34:77:49 | get | override, public |
+| delegatedProperties.kt:77:34:77:49 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:77:34:77:49 | invoke | override, public |
+| delegatedProperties.kt:77:34:77:49 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:77:34:77:49 | invoke | override, public |
+| delegatedProperties.kt:77:34:77:49 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:77:34:77:49 | set | override, public |
+| delegatedProperties.kt:77:34:77:49 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:77:34:77:49 | set | override, public |
+| delegatedProperties.kt:77:37:77:49 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:77:37:77:49 | get | override, public |
+| delegatedProperties.kt:77:37:77:49 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:77:37:77:49 | invoke | override, public |
+| delegatedProperties.kt:77:37:77:49 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:77:37:77:49 | set | override, public |
+| delegatedProperties.kt:79:18:79:38 | new KProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:79:18:79:38 | get | override, public |
+| delegatedProperties.kt:79:18:79:38 | new KProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:79:18:79:38 | invoke | override, public |
+| delegatedProperties.kt:79:21:79:38 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:79:21:79:38 | get | override, public |
+| delegatedProperties.kt:79:21:79:38 | new KProperty0<Integer>(...) { ... } | delegatedProperties.kt:79:21:79:38 | invoke | override, public |
+| delegatedProperties.kt:82:37:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:37:82:54 | get | override, public |
+| delegatedProperties.kt:82:37:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:37:82:54 | get | override, public |
+| delegatedProperties.kt:82:37:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:37:82:54 | invoke | override, public |
+| delegatedProperties.kt:82:37:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:37:82:54 | invoke | override, public |
+| delegatedProperties.kt:82:37:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:37:82:54 | set | override, public |
+| delegatedProperties.kt:82:37:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:37:82:54 | set | override, public |
+| delegatedProperties.kt:82:40:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:40:82:54 | get | override, public |
+| delegatedProperties.kt:82:40:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:40:82:54 | invoke | override, public |
+| delegatedProperties.kt:82:40:82:54 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:82:40:82:54 | set | override, public |
+| delegatedProperties.kt:87:31:87:46 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:87:31:87:46 | get | override, public |
+| delegatedProperties.kt:87:31:87:46 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:87:31:87:46 | get | override, public |
+| delegatedProperties.kt:87:31:87:46 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:87:31:87:46 | invoke | override, public |
+| delegatedProperties.kt:87:31:87:46 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:87:31:87:46 | invoke | override, public |
+| delegatedProperties.kt:87:31:87:46 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:87:31:87:46 | set | override, public |
+| delegatedProperties.kt:87:31:87:46 | new KMutableProperty1<MyClass,Integer>(...) { ... } | delegatedProperties.kt:87:31:87:46 | set | override, public |
+| delegatedProperties.kt:87:34:87:46 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:87:34:87:46 | get | override, public |
+| delegatedProperties.kt:87:34:87:46 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:87:34:87:46 | invoke | override, public |
+| delegatedProperties.kt:87:34:87:46 | new KMutableProperty0<Integer>(...) { ... } | delegatedProperties.kt:87:34:87:46 | set | override, public |
+| exprs.kt:189:16:191:9 | new Interface1(...) { ... } | exprs.kt:190:13:190:49 | getA3 | public |
+| funcExprs.kt:22:26:22:33 | new Function0<Integer>(...) { ... } | funcExprs.kt:22:26:22:33 | invoke | override, public |
+| funcExprs.kt:23:26:23:33 | new Function0<Object>(...) { ... } | funcExprs.kt:23:26:23:33 | invoke | override, public |
+| funcExprs.kt:24:26:24:33 | new Function0<Object>(...) { ... } | funcExprs.kt:24:26:24:33 | invoke | override, public |
+| funcExprs.kt:25:29:25:38 | new Function1<Integer,Integer>(...) { ... } | funcExprs.kt:25:29:25:38 | invoke | override, public |
+| funcExprs.kt:26:29:26:34 | new Function1<Integer,Integer>(...) { ... } | funcExprs.kt:26:29:26:34 | invoke | override, public |
+| funcExprs.kt:27:29:27:42 | new Function1<Integer,Integer>(...) { ... } | funcExprs.kt:27:29:27:42 | invoke | override, public |
+| funcExprs.kt:29:29:29:37 | new Function1<Object,Object>(...) { ... } | funcExprs.kt:29:29:29:37 | invoke | override, public |
+| funcExprs.kt:30:28:30:50 | new Function2<Integer,Integer,Integer>(...) { ... } | funcExprs.kt:30:28:30:50 | invoke | override, public |
+| funcExprs.kt:31:28:31:40 | new Function2<Integer,Integer,Integer>(...) { ... } | funcExprs.kt:31:28:31:40 | invoke | override, public |
+| funcExprs.kt:32:28:32:44 | new Function2<Integer,Integer,Integer>(...) { ... } | funcExprs.kt:32:28:32:44 | invoke | override, public |
+| funcExprs.kt:33:28:33:51 | new Function1<Integer,Function1<Integer,Double>>(...) { ... } | funcExprs.kt:33:28:33:51 | invoke | override, public |
+| funcExprs.kt:33:37:33:47 | new Function1<Integer,Double>(...) { ... } | funcExprs.kt:33:37:33:47 | invoke | override, public |
+| funcExprs.kt:35:29:35:112 | new Function22<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Unit>(...) { ... } | funcExprs.kt:35:29:35:112 | invoke | override, public |
+| funcExprs.kt:36:29:36:117 | new FunctionN<String>(...) { ... } | funcExprs.kt:36:29:36:117 | invoke | override, public |
+| funcExprs.kt:36:29:36:117 | new FunctionN<String>(...) { ... } | funcExprs.kt:36:29:36:117 | invoke | public |
+| funcExprs.kt:38:26:38:38 | new Function0<Integer>(...) { ... } | funcExprs.kt:38:26:38:38 | invoke | override, public |
+| funcExprs.kt:39:26:39:36 | new Function0<Integer>(...) { ... } | funcExprs.kt:39:26:39:36 | invoke | override, public |
+| funcExprs.kt:40:29:40:41 | new Function1<Integer,Integer>(...) { ... } | funcExprs.kt:40:29:40:41 | invoke | override, public |
+| funcExprs.kt:41:29:41:39 | new Function2<FuncRef,Integer,Integer>(...) { ... } | funcExprs.kt:41:29:41:39 | invoke | override, public |
+| funcExprs.kt:42:29:42:33 | new Function1<Integer,Integer>(...) { ... } | funcExprs.kt:42:29:42:33 | invoke | override, public |
+| funcExprs.kt:43:28:43:34 | new Function2<Integer,Integer,Integer>(...) { ... } | funcExprs.kt:43:28:43:34 | invoke | override, public |
+| funcExprs.kt:44:29:44:42 | new Function22<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Unit>(...) { ... } | funcExprs.kt:44:29:44:42 | invoke | override, public |
+| funcExprs.kt:45:29:45:42 | new FunctionN<String>(...) { ... } | funcExprs.kt:45:29:45:42 | invoke | override, public |
+| funcExprs.kt:46:30:46:41 | new FunctionN<String>(...) { ... } | funcExprs.kt:46:30:46:41 | invoke | override, public |
+| funcExprs.kt:49:26:49:32 | new Function0<Integer>(...) { ... } | funcExprs.kt:49:26:49:32 | invoke | override, public |
+| funcExprs.kt:51:8:51:16 | new Function0<FuncRef>(...) { ... } | funcExprs.kt:51:8:51:16 | invoke | override, public |
+| funcExprs.kt:75:12:75:22 | new Function1<Generic<Generic<Integer>>,String>(...) { ... } | funcExprs.kt:75:12:75:22 | invoke | override, public |
+| funcExprs.kt:83:31:83:51 | new Function1<Integer,String>(...) { ... } | funcExprs.kt:83:31:83:51 | invoke | override, public |
+| funcExprs.kt:86:39:86:59 | new Function1<Integer,String>(...) { ... } | funcExprs.kt:86:39:86:59 | invoke | override, public, suspend |
+| funcExprs.kt:90:15:90:69 | new FunctionN<String>(...) { ... } | funcExprs.kt:90:15:90:69 | invoke | override, public |
+| funcExprs.kt:90:15:90:69 | new FunctionN<String>(...) { ... } | funcExprs.kt:90:15:90:69 | invoke | public |
+| funcExprs.kt:94:15:94:67 | new Function22<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer,String>(...) { ... } | funcExprs.kt:94:15:94:67 | invoke | override, public, suspend |
+| kFunctionInvoke.kt:8:44:8:47 | new Function1<String,Unit>(...) { ... } | kFunctionInvoke.kt:8:44:8:47 | invoke | override, public |
+| samConversion.kt:2:18:2:45 | new IntPredicate(...) { ... } | samConversion.kt:2:18:2:45 | accept | public |
+| samConversion.kt:2:31:2:45 | new Function1<Integer,Boolean>(...) { ... } | samConversion.kt:2:31:2:45 | invoke | override, public |
+| samConversion.kt:4:14:4:42 | new InterfaceFn1(...) { ... } | samConversion.kt:4:14:4:42 | fn1 | public |
+| samConversion.kt:4:27:4:42 | new Function2<Integer,Integer,Unit>(...) { ... } | samConversion.kt:4:27:4:42 | invoke | override, public |
+| samConversion.kt:5:14:5:32 | new InterfaceFn1(...) { ... } | samConversion.kt:5:14:5:32 | fn1 | public |
+| samConversion.kt:5:27:5:31 | new Function2<Integer,Integer,Unit>(...) { ... } | samConversion.kt:5:27:5:31 | invoke | override, public |
+| samConversion.kt:7:13:7:46 | new InterfaceFnExt1(...) { ... } | samConversion.kt:7:13:7:46 | ext | public |
+| samConversion.kt:7:29:7:46 | new Function2<String,Integer,Boolean>(...) { ... } | samConversion.kt:7:29:7:46 | invoke | override, public |
+| samConversion.kt:9:13:13:6 | new IntPredicate(...) { ... } | samConversion.kt:9:13:13:6 | accept | public |
+| samConversion.kt:9:33:11:5 | new Function1<Integer,Boolean>(...) { ... } | samConversion.kt:9:33:11:5 | invoke | override, public |
+| samConversion.kt:11:12:13:5 | new Function1<Integer,Boolean>(...) { ... } | samConversion.kt:11:12:13:5 | invoke | override, public |
+| samConversion.kt:41:13:41:16 | new FunctionN<Boolean>(...) { ... } | samConversion.kt:41:13:41:16 | invoke | override, public |
+| samConversion.kt:42:13:42:32 | new BigArityPredicate(...) { ... } | samConversion.kt:42:13:42:32 | accept | public |
+| samConversion.kt:43:13:45:68 | new BigArityPredicate(...) { ... } | samConversion.kt:43:13:45:68 | accept | public |
+| samConversion.kt:43:31:45:68 | new FunctionN<Boolean>(...) { ... } | samConversion.kt:43:31:45:68 | invoke | override, public |
+| samConversion.kt:43:31:45:68 | new FunctionN<Boolean>(...) { ... } | samConversion.kt:43:31:45:68 | invoke | public |
+| samConversion.kt:46:13:46:44 | new SomePredicate<Integer>(...) { ... } | samConversion.kt:46:13:46:44 | fn | public |
+| samConversion.kt:46:32:46:44 | new Function1<Integer,Boolean>(...) { ... } | samConversion.kt:46:32:46:44 | invoke | override, public |
+| samConversion.kt:58:14:58:45 | new InterfaceFn1Sus(...) { ... } | samConversion.kt:58:14:58:45 | fn1 | public, suspend |
+| samConversion.kt:58:30:58:45 | new Function2<Integer,Integer,Unit>(...) { ... } | samConversion.kt:58:30:58:45 | invoke | override, public, suspend |
 nonOverrideInvoke
 | funcExprs.kt:36:29:36:117 | ...->... | funcExprs.kt:36:29:36:117 | invoke | 23 |
 | funcExprs.kt:90:15:90:69 | ...->... | funcExprs.kt:90:15:90:69 | invoke | 23 |

--- a/java/ql/test/kotlin/library-tests/exprs/funcExprs.ql
+++ b/java/ql/test/kotlin/library-tests/exprs/funcExprs.ql
@@ -19,8 +19,13 @@ query predicate memberRefExprs(MemberRefExpr e, Method m, string signature, Anon
   e.getAnonymousClass() = an
 }
 
-query predicate modifiers(LambdaExpr le, Method m, string modifiers) {
+query predicate lambda_modifiers(LambdaExpr le, Method m, string modifiers) {
   le.getAnonymousClass().getAMethod() = m and
+  modifiers = concat(string s | m.hasModifier(s) | s, ", ")
+}
+
+query predicate anon_class_member_modifiers(AnonymousClass ac, Method m, string modifiers) {
+  ac.getAMethod() = m and
   modifiers = concat(string s | m.hasModifier(s) | s, ", ")
 }
 


### PR DESCRIPTION
This PR fixes false positives with the "Missing Override annotation" check.