### PR TITLE
Ruby: fix use of deprecated class

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -392,7 +392,7 @@ private module ParamsSummaries {
    */
   private class ParamsInstance extends DataFlow::Node {
     ParamsInstance() {
-      this.asExpr().getExpr() instanceof ParamsCall
+      this.asExpr().getExpr() instanceof Rails::ParamsCall
       or
       this =
         any(DataFlow::CallNode call |

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.ql
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.ql
@@ -5,10 +5,12 @@
 import ruby
 import TestUtilities.InlineFlowTest
 import PathGraph
-import codeql.ruby.frameworks.ActionController
+import codeql.ruby.frameworks.Rails
 
 class ParamsTaintFlowConf extends DefaultTaintFlowConf {
-  override predicate isSource(DataFlow::Node n) { n.asExpr().getExpr() instanceof ParamsCall }
+  override predicate isSource(DataFlow::Node n) {
+    n.asExpr().getExpr() instanceof Rails::ParamsCall
+  }
 }
 
 from DataFlow::PathNode source, DataFlow::PathNode sink, ParamsTaintFlowConf conf


### PR DESCRIPTION
Semantic merge conflict between https://github.com/github/codeql/pull/10538 and https://github.com/github/codeql/pull/10673