### PR TITLE
CI: fix qhelp preview

### DIFF
--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -52,7 +52,7 @@ jobs:
         id: changes
         run: |
           (git diff -z --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep -z '.qhelp$' | grep -z -v '.inc.qhelp';
-           git diff -z --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep -z '.inc.qhelp$' | xargs --null -rn1 basename | xargs --null -rn1 git grep -z -l) |
+           git diff -z --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep -z '.inc.qhelp$' | xargs --null -rn1 basename -z | xargs --null -rn1 git grep -z -l) |
            grep -z '.qhelp$' | grep -z -v '^-' | sort -z -u > "${RUNNER_TEMP}/paths.txt"
 
       - name: QHelp preview


### PR DESCRIPTION
The command to gather the changed files uses NULL character terminated "lines", therefore we should supply the `-z` flag to `basename` as well. Otherwise we end up calling `git grep -l "\n"` which would list all files containing a newline.

This should fix errors on `qhelp.inc` files like in https://github.com/github/codeql/actions/runs/3214105642/jobs/5261655998 .