### PR TITLE
Data flow: Improve `fastTC` bound in `PathNodeImpl::getANonHiddenSuccessor`

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForHttpClientLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForHttpClientLibraries.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForPathname.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForPathname.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForRegExp.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForRegExp.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -2927,10 +2927,15 @@ abstract private class PathNodeImpl extends PathNode {
     result = this.getASuccessorImpl()
   }
 
-  final PathNodeImpl getANonHiddenSuccessor() {
-    result = this.getASuccessorImpl().getASuccessorIfHidden*() and
-    not this.isHidden() and
+  pragma[nomagic]
+  private PathNodeImpl getANonHiddenSuccessor0() {
+    result = this.getASuccessorIfHidden*() and
     not result.isHidden()
+  }
+
+  final PathNodeImpl getANonHiddenSuccessor() {
+    result = this.getASuccessorImpl().getANonHiddenSuccessor0() and
+    not this.isHidden()
   }
 
   abstract NodeEx getNodeEx();


### PR DESCRIPTION
Before
```
[2022-10-10 14:34:54] Evaluated non-recursive predicate __DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorImpl#0#dispred#ff_DataFlowImplForRegExp__#higher_order_body@4bb14aoj in 262ms (size: 2418048).
Evaluated relational algebra for predicate __DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorImpl#0#dispred#ff_DataFlowImplForRegExp__#higher_order_body@4bb14aoj with tuple counts:
        4141389  ~75%    {1} r1 = SCAN _DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorImpl#0#dispred#ff_DataFlowImplForRegExp#__#shared OUTPUT In.1
                         return r1

[2022-10-10 14:34:57] Evaluated non-recursive predicate boundedFastTC:DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorIfHidden#0#dispred#ff:__DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorImpl#0#dispred#ff_DataFlowImplForRegExp__#higher_order_body@fb66bb06 in 2754ms (size: 7448123).
[2022-10-10 14:35:09] Evaluated non-recursive predicate DataFlowImplForRegExp#43df744e::PathNodeImpl::getANonHiddenSuccessor#0#dispred#ff@77ff066b in 10892ms (size: 2830055).
Evaluated relational algebra for predicate DataFlowImplForRegExp#43df744e::PathNodeImpl::getANonHiddenSuccessor#0#dispred#ff@77ff066b with tuple counts:
          4141389   ~0%    {3} r1 = SCAN _DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorImpl#0#dispred#ff_DataFlowImplForRegExp#__#shared OUTPUT In.0, In.1, In.1
          2192551   ~4%    {3} r2 = r1 AND NOT DataFlowImplForRegExp#43df744e::PathNodeImpl::isHidden#0#dispred#f(Lhs.2)
          2192551   ~4%    {2} r3 = SCAN r2 OUTPUT In.0, In.2

          4141389   ~0%    {2} r4 = SCAN _DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorImpl#0#dispred#ff_DataFlowImplForRegExp#__#shared OUTPUT In.1, In.0
        147138810   ~0%    {3} r5 = JOIN r4 WITH boundedFastTC:DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorIfHidden#0#dispred#ff:__DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorImpl#0#dispred#ff_DataFlowImplForRegExp__#higher_order_body ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
           637649   ~3%    {3} r6 = r5 AND NOT DataFlowImplForRegExp#43df744e::PathNodeImpl::isHidden#0#dispred#f(Lhs.2)
           637649   ~2%    {2} r7 = SCAN r6 OUTPUT In.0, In.2

          2830200   ~0%    {2} r8 = r3 UNION r7
                           return r8
```

After
```
[2022-10-10 14:59:08] Evaluated non-recursive predicate boundedFastTC:DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorIfHidden#0#dispred#ff_10#higher_order_body:_DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorIfHidden#0#dispred#ff_DataFlowImplForReg__#higher_order_body@98a323ne in 384ms (size: 671076).
[2022-10-10 14:59:09] Evaluated non-recursive predicate DataFlowImplForRegExp#43df744e::PathNodeImpl::getANonHiddenSuccessor0#ff@69f158pf in 222ms (size: 2805795).
Evaluated relational algebra for predicate DataFlowImplForRegExp#43df744e::PathNodeImpl::getANonHiddenSuccessor0#ff@69f158pf with tuple counts:
        2155019   ~0%    {1} r1 = DataFlowImplForRegExp#43df744e::PathNodeImpl#class#f AND NOT DataFlowImplForRegExp#43df744e::PathNodeImpl::isHidden#0#dispred#f(Lhs.0)
        2155019   ~0%    {2} r2 = SCAN r1 OUTPUT In.0, In.0

         650776   ~0%    {2} r3 = boundedFastTC:DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorIfHidden#0#dispred#ff_10#higher_order_body:_DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorIfHidden#0#dispred#ff_DataFlowImplForReg__#higher_order_body AND NOT DataFlowImplForRegExp#43df744e::PathNodeImpl::isHidden#0#dispred#f(Lhs.0)
         650776   ~0%    {2} r4 = SCAN r3 OUTPUT In.1, In.0

        2805795   ~0%    {2} r5 = r2 UNION r4
                         return r5

[2022-10-10 14:59:09] Evaluated non-recursive predicate DataFlowImplForRegExp#43df744e::PathNodeImpl::getANonHiddenSuccessor#0#dispred#ff@5ae9fc5n in 445ms (size: 2830062).
Evaluated relational algebra for predicate DataFlowImplForRegExp#43df744e::PathNodeImpl::getANonHiddenSuccessor#0#dispred#ff@5ae9fc5n with tuple counts:
        4141389  ~5%    {2} r1 = DataFlowImplForRegExp#43df744e::PathNodeImpl::getASuccessorImpl#0#dispred#ff AND NOT DataFlowImplForRegExp#43df744e::PathNodeImpl::isHidden#0#dispred#f(Lhs.0)
        4141389  ~0%    {2} r2 = SCAN r1 OUTPUT In.1, In.0
        2830200  ~0%    {2} r3 = JOIN r2 WITH DataFlowImplForRegExp#43df744e::PathNodeImpl::getANonHiddenSuccessor0#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                        return r3
```