### PR TITLE
Kotlin: extract `protected` modifier from java class files

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -231,7 +231,7 @@ open class KotlinFileExtractor(
                             // default java visibility (top level)
                         }
                         JavaVisibilities.ProtectedAndPackage -> {
-                            // default java visibility (member level)
+                            addModifiers(id, "protected")
                         }
                         else -> logger.errorElement("Unexpected delegated visibility: $v", elementForLocation)
                     }

--- a/java/ql/integration-tests/posix-only/kotlin/java_modifiers/libsrc/extlib/A.java
+++ b/java/ql/integration-tests/posix-only/kotlin/java_modifiers/libsrc/extlib/A.java
@@ -1,0 +1,6 @@
+package extlib;
+
+public class A {
+  protected void m() {}
+}
+

--- a/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.expected
+++ b/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.expected
@@ -1,0 +1,2 @@
+| extlib.jar/extlib/A.class:0:0:0:0 | m |  |
+| test.kt:4:12:4:22 | m | override, protected |

--- a/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.expected
+++ b/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.expected
@@ -1,2 +1,2 @@
-| extlib.jar/extlib/A.class:0:0:0:0 | m |  |
+| extlib.jar/extlib/A.class:0:0:0:0 | m | protected |
 | test.kt:4:12:4:22 | m | override, protected |

--- a/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.kt
+++ b/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.kt
@@ -1,0 +1,6 @@
+import extlib.A;
+
+class B : A() {
+  override fun m() { }
+}
+

--- a/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.py
+++ b/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.py
@@ -1,0 +1,10 @@
+from create_database_utils import *
+import glob
+
+# Compile Java untraced. Note the Java source is hidden under `javasrc` so the Kotlin compiler 
+# will certainly reference the jar, not the source or class file for extlib.Lib
+
+os.mkdir('build')
+runSuccessfully(["javac"] + glob.glob("libsrc/extlib/*.java") + ["-d", "build"])
+runSuccessfully(["jar", "cf", "extlib.jar", "-C", "build", "extlib"])
+run_codeql_database_create(["kotlinc test.kt -cp extlib.jar"], lang="java")

--- a/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.ql
+++ b/java/ql/integration-tests/posix-only/kotlin/java_modifiers/test.ql
@@ -1,0 +1,6 @@
+import java
+
+query predicate mods(Method m, string modifiers) {
+  m.getName() = "m" and
+  modifiers = concat(string s | m.hasModifier(s) | s, ", ")
+}


### PR DESCRIPTION
This change fixes false positives reported by `java/non-overriding-package-private` 