### PR TITLE
JS: fix that js/file-system-race could have FPs related to loops

### DIFF
--- a/javascript/ql/src/Security/CWE-367/FileSystemRace.ql
+++ b/javascript/ql/src/Security/CWE-367/FileSystemRace.ql
@@ -106,7 +106,7 @@ predicate useAfterCheck(FileCheck check, FileUse use) {
     )
   )
   or
-  check.getBasicBlock().getASuccessor+() = use.getBasicBlock()
+  check.getBasicBlock().(ReachableBasicBlock).strictlyDominates(use.getBasicBlock())
 }
 
 from FileCheck check, FileUse use

--- a/javascript/ql/src/change-notes/2022-10-04-fix-loops-file-system-race.md
+++ b/javascript/ql/src/change-notes/2022-10-04-fix-loops-file-system-race.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Removed some false positives from the `js/file-system-race` query by requiring that the file-check dominates the file-access.

--- a/javascript/ql/test/query-tests/Security/CWE-367/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-367/tst.js
@@ -41,3 +41,8 @@ const filePath3 = createFile();
 if (fs.existsSync(filePath3)) {
   fs.readFileSync(filePath3); // OK - a read after an existence check is OK 
 }
+
+const filePath4 = createFile();
+while(Math.random() > 0.5) {
+    fs.open(filePath4); // OK - it is only ever opened here.
+}


### PR DESCRIPTION
[Evaluation shows that we loose a bunch of results](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-10768-7500a3__nightly-old__CustomSuite/reports), but that was the point.  
In the lost results the file-check doesn't dominate the file-access.  
In most cases that's from the file-check being inside a conditional.  

The point of the PR was originally just to remove FPs from the check/access being inside a loop.   
But I like removing these other results too, so I want to keep this.  