### PR TITLE
Ruby: bugfix in type-tracking singleton class resolution

### DIFF
--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -120,7 +120,7 @@ private MethodBase getAMethod(ModuleBase mod, boolean instance) {
   if result instanceof SingletonMethod then instance = false else instance = true
   or
   exists(SingletonClass cls |
-    cls.getValue().(SelfVariableAccess).getCfgScope() = mod and
+    cls.getValue().(SelfVariableAccess).getVariable().getDeclaringScope() = mod and
     result = cls.getAMethod().(Method) and
     instance = false
   )
@@ -133,7 +133,7 @@ private MethodBase getAMethod(ModuleBase mod, boolean instance) {
 pragma[nomagic]
 private Node fieldPredecessor(ModuleBase mod, boolean instance, string field) {
   exists(InstanceVariableWriteAccess access, AssignExpr assign |
-    access.getReceiver().getCfgScope() = getAMethod(mod, instance) and
+    access.getReceiver().getVariable().getDeclaringScope() = getAMethod(mod, instance) and
     field = access.getVariable().getName() and
     assign.getLeftOperand() = access and
     result.asExpr().getExpr() = assign.getRightOperand()
@@ -147,7 +147,7 @@ private Node fieldPredecessor(ModuleBase mod, boolean instance, string field) {
 pragma[nomagic]
 private Node fieldSuccessor(ModuleBase mod, boolean instance, string field) {
   exists(InstanceVariableReadAccess access |
-    access.getReceiver().getCfgScope() = getAMethod(mod, instance) and
+    access.getReceiver().getVariable().getDeclaringScope() = getAMethod(mod, instance) and
     result.asExpr().getExpr() = access and
     field = access.getVariable().getName()
   )

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -120,6 +120,13 @@ hello.rb:
 #   18| HelloWorld
 #-----| super -> Greeting
 
+instance_fields.rb:
+#   11| A_target
+#-----| super -> Object
+
+#   26| B_target
+#-----| super -> Object
+
 modules.rb:
 #    1| Empty
 

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -219,6 +219,12 @@ getTarget
 | hello.rb:14:16:14:20 | call to hello | hello.rb:2:5:4:7 | hello |
 | hello.rb:20:16:20:20 | call to super | hello.rb:13:5:15:7 | message |
 | hello.rb:20:30:20:34 | call to world | hello.rb:5:5:7:7 | world |
+| instance_fields.rb:4:22:4:35 | call to new | calls.rb:117:5:117:16 | new |
+| instance_fields.rb:7:13:7:25 | call to target | instance_fields.rb:12:5:13:7 | target |
+| instance_fields.rb:7:13:7:25 | call to target | instance_fields.rb:27:5:28:7 | target |
+| instance_fields.rb:19:22:19:35 | call to new | calls.rb:117:5:117:16 | new |
+| instance_fields.rb:22:13:22:25 | call to target | instance_fields.rb:12:5:13:7 | target |
+| instance_fields.rb:22:13:22:25 | call to target | instance_fields.rb:27:5:28:7 | target |
 | modules.rb:12:5:12:26 | call to puts | calls.rb:102:5:102:30 | puts |
 | modules.rb:22:3:22:19 | call to puts | calls.rb:102:5:102:30 | puts |
 | modules.rb:33:3:33:25 | call to puts | calls.rb:102:5:102:30 | puts |
@@ -435,6 +441,12 @@ publicMethod
 | hello.rb:5:5:7:7 | world |
 | hello.rb:13:5:15:7 | message |
 | hello.rb:19:5:21:7 | message |
+| instance_fields.rb:3:9:5:11 | create |
+| instance_fields.rb:6:9:8:11 | use |
+| instance_fields.rb:12:5:13:7 | target |
+| instance_fields.rb:18:9:20:11 | create |
+| instance_fields.rb:21:9:23:11 | use |
+| instance_fields.rb:27:5:28:7 | target |
 | modules.rb:9:5:10:7 | method_in_foo_bar |
 | modules.rb:16:3:17:5 | method_in_foo |
 | modules.rb:27:3:28:5 | method_in_another_definition_of_foo |

--- a/ruby/ql/test/library-tests/modules/callgraph.expected
+++ b/ruby/ql/test/library-tests/modules/callgraph.expected
@@ -221,9 +221,7 @@ getTarget
 | hello.rb:20:30:20:34 | call to world | hello.rb:5:5:7:7 | world |
 | instance_fields.rb:4:22:4:35 | call to new | calls.rb:117:5:117:16 | new |
 | instance_fields.rb:7:13:7:25 | call to target | instance_fields.rb:12:5:13:7 | target |
-| instance_fields.rb:7:13:7:25 | call to target | instance_fields.rb:27:5:28:7 | target |
 | instance_fields.rb:19:22:19:35 | call to new | calls.rb:117:5:117:16 | new |
-| instance_fields.rb:22:13:22:25 | call to target | instance_fields.rb:12:5:13:7 | target |
 | instance_fields.rb:22:13:22:25 | call to target | instance_fields.rb:27:5:28:7 | target |
 | modules.rb:12:5:12:26 | call to puts | calls.rb:102:5:102:30 | puts |
 | modules.rb:22:3:22:19 | call to puts | calls.rb:102:5:102:30 | puts |

--- a/ruby/ql/test/library-tests/modules/instance_fields.rb
+++ b/ruby/ql/test/library-tests/modules/instance_fields.rb
@@ -1,0 +1,29 @@
+class A
+    class << self
+        def create
+            @field = ::A_target.new
+        end
+        def use
+            @field.target
+        end
+    end
+end
+class A_target
+    def target
+    end
+end
+
+class B
+    class << self
+        def create
+            @field = ::B_target.new
+        end
+        def use
+            @field.target
+        end
+    end
+end
+class B_target
+    def target
+    end
+end

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -47,6 +47,8 @@ getMethod
 | hello.rb:1:1:8:3 | EnglishWords | world | hello.rb:5:5:7:7 | world |
 | hello.rb:11:1:16:3 | Greeting | message | hello.rb:13:5:15:7 | message |
 | hello.rb:18:1:22:3 | HelloWorld | message | hello.rb:19:5:21:7 | message |
+| instance_fields.rb:11:1:14:3 | A_target | target | instance_fields.rb:12:5:13:7 | target |
+| instance_fields.rb:26:1:29:3 | B_target | target | instance_fields.rb:27:5:28:7 | target |
 | modules.rb:4:1:24:3 | Foo | method_in_another_definition_of_foo | modules.rb:27:3:28:5 | method_in_another_definition_of_foo |
 | modules.rb:4:1:24:3 | Foo | method_in_foo | modules.rb:16:3:17:5 | method_in_foo |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_another_definition_of_foo_bar | modules.rb:52:3:53:5 | method_in_another_definition_of_foo_bar |
@@ -430,6 +432,14 @@ lookupMethod
 | hello.rb:18:1:22:3 | HelloWorld | puts | calls.rb:102:5:102:30 | puts |
 | hello.rb:18:1:22:3 | HelloWorld | to_s | calls.rb:172:5:173:7 | to_s |
 | hello.rb:18:1:22:3 | HelloWorld | world | hello.rb:5:5:7:7 | world |
+| instance_fields.rb:11:1:14:3 | A_target | new | calls.rb:117:5:117:16 | new |
+| instance_fields.rb:11:1:14:3 | A_target | puts | calls.rb:102:5:102:30 | puts |
+| instance_fields.rb:11:1:14:3 | A_target | target | instance_fields.rb:12:5:13:7 | target |
+| instance_fields.rb:11:1:14:3 | A_target | to_s | calls.rb:172:5:173:7 | to_s |
+| instance_fields.rb:26:1:29:3 | B_target | new | calls.rb:117:5:117:16 | new |
+| instance_fields.rb:26:1:29:3 | B_target | puts | calls.rb:102:5:102:30 | puts |
+| instance_fields.rb:26:1:29:3 | B_target | target | instance_fields.rb:27:5:28:7 | target |
+| instance_fields.rb:26:1:29:3 | B_target | to_s | calls.rb:172:5:173:7 | to_s |
 | modules.rb:4:1:24:3 | Foo | method_in_another_definition_of_foo | modules.rb:27:3:28:5 | method_in_another_definition_of_foo |
 | modules.rb:4:1:24:3 | Foo | method_in_foo | modules.rb:16:3:17:5 | method_in_foo |
 | modules.rb:5:3:14:5 | Foo::Bar | method_in_another_definition_of_foo_bar | modules.rb:52:3:53:5 | method_in_another_definition_of_foo_bar |
@@ -852,6 +862,22 @@ enclosingMethod
 | hello.rb:20:30:20:34 | self | hello.rb:19:5:21:7 | message |
 | hello.rb:20:38:20:40 | "!" | hello.rb:19:5:21:7 | message |
 | hello.rb:20:39:20:39 | ! | hello.rb:19:5:21:7 | message |
+| instance_fields.rb:4:13:4:18 | @field | instance_fields.rb:3:9:5:11 | create |
+| instance_fields.rb:4:13:4:18 | self | instance_fields.rb:3:9:5:11 | create |
+| instance_fields.rb:4:13:4:35 | ... = ... | instance_fields.rb:3:9:5:11 | create |
+| instance_fields.rb:4:22:4:31 | A_target | instance_fields.rb:3:9:5:11 | create |
+| instance_fields.rb:4:22:4:35 | call to new | instance_fields.rb:3:9:5:11 | create |
+| instance_fields.rb:7:13:7:18 | @field | instance_fields.rb:6:9:8:11 | use |
+| instance_fields.rb:7:13:7:18 | self | instance_fields.rb:6:9:8:11 | use |
+| instance_fields.rb:7:13:7:25 | call to target | instance_fields.rb:6:9:8:11 | use |
+| instance_fields.rb:19:13:19:18 | @field | instance_fields.rb:18:9:20:11 | create |
+| instance_fields.rb:19:13:19:18 | self | instance_fields.rb:18:9:20:11 | create |
+| instance_fields.rb:19:13:19:35 | ... = ... | instance_fields.rb:18:9:20:11 | create |
+| instance_fields.rb:19:22:19:31 | B_target | instance_fields.rb:18:9:20:11 | create |
+| instance_fields.rb:19:22:19:35 | call to new | instance_fields.rb:18:9:20:11 | create |
+| instance_fields.rb:22:13:22:18 | @field | instance_fields.rb:21:9:23:11 | use |
+| instance_fields.rb:22:13:22:18 | self | instance_fields.rb:21:9:23:11 | use |
+| instance_fields.rb:22:13:22:25 | call to target | instance_fields.rb:21:9:23:11 | use |
 | private.rb:84:7:84:32 | call to puts | private.rb:83:11:85:5 | m1 |
 | private.rb:84:7:84:32 | self | private.rb:83:11:85:5 | m1 |
 | private.rb:84:12:84:32 | "PrivateOverride1#m1" | private.rb:83:11:85:5 | m1 |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -40,6 +40,8 @@ getModule
 | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld |
+| instance_fields.rb:11:1:14:3 | A_target |
+| instance_fields.rb:26:1:29:3 | B_target |
 | modules.rb:1:1:2:3 | Empty |
 | modules.rb:4:1:24:3 | Foo |
 | modules.rb:5:3:14:5 | Foo::Bar |
@@ -87,6 +89,7 @@ getADeclaration
 | calls.rb:115:1:118:3 | Object | calls.rb:1:1:550:40 | calls.rb |
 | calls.rb:115:1:118:3 | Object | calls.rb:115:1:118:3 | Object |
 | calls.rb:115:1:118:3 | Object | hello.rb:1:1:22:3 | hello.rb |
+| calls.rb:115:1:118:3 | Object | instance_fields.rb:1:1:29:4 | instance_fields.rb |
 | calls.rb:115:1:118:3 | Object | modules.rb:1:1:129:4 | modules.rb |
 | calls.rb:115:1:118:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
 | calls.rb:115:1:118:3 | Object | private.rb:1:1:105:40 | private.rb |
@@ -94,8 +97,10 @@ getADeclaration
 | calls.rb:125:1:138:3 | Array | calls.rb:125:1:138:3 | Array |
 | calls.rb:165:1:169:3 | S | calls.rb:165:1:169:3 | S |
 | calls.rb:171:1:174:3 | A | calls.rb:171:1:174:3 | A |
+| calls.rb:171:1:174:3 | A | instance_fields.rb:1:1:10:3 | A |
 | calls.rb:171:1:174:3 | A | modules_rec.rb:7:1:9:3 | A |
 | calls.rb:176:1:179:3 | B | calls.rb:176:1:179:3 | B |
+| calls.rb:176:1:179:3 | B | instance_fields.rb:16:1:25:3 | B |
 | calls.rb:190:1:226:3 | Singletons | calls.rb:190:1:226:3 | Singletons |
 | calls.rb:310:1:321:3 | SelfNew | calls.rb:310:1:321:3 | SelfNew |
 | calls.rb:325:1:329:3 | C1 | calls.rb:325:1:329:3 | C1 |
@@ -113,6 +118,8 @@ getADeclaration
 | hello.rb:1:1:8:3 | EnglishWords | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:18:1:22:3 | HelloWorld |
+| instance_fields.rb:11:1:14:3 | A_target | instance_fields.rb:11:1:14:3 | A_target |
+| instance_fields.rb:26:1:29:3 | B_target | instance_fields.rb:26:1:29:3 | B_target |
 | modules.rb:1:1:2:3 | Empty | modules.rb:1:1:2:3 | Empty |
 | modules.rb:4:1:24:3 | Foo | modules.rb:4:1:24:3 | Foo |
 | modules.rb:4:1:24:3 | Foo | modules.rb:26:1:35:3 | Foo |
@@ -185,6 +192,8 @@ getSuperClass
 | file://:0:0:0:0 | TrueClass | calls.rb:115:1:118:3 | Object |
 | hello.rb:11:1:16:3 | Greeting | calls.rb:115:1:118:3 | Object |
 | hello.rb:18:1:22:3 | HelloWorld | hello.rb:11:1:16:3 | Greeting |
+| instance_fields.rb:11:1:14:3 | A_target | calls.rb:115:1:118:3 | Object |
+| instance_fields.rb:26:1:29:3 | B_target | calls.rb:115:1:118:3 | Object |
 | modules.rb:6:5:7:7 | Foo::Bar::ClassInFooBar | calls.rb:115:1:118:3 | Object |
 | modules.rb:19:3:20:5 | Foo::ClassInFoo | calls.rb:115:1:118:3 | Object |
 | modules.rb:30:3:31:5 | Foo::ClassInAnotherDefinitionOfFoo | calls.rb:115:1:118:3 | Object |
@@ -299,6 +308,8 @@ resolveConstantReadAccess
 | calls.rb:550:1:550:13 | Array | Array |
 | hello.rb:12:13:12:24 | EnglishWords | EnglishWords |
 | hello.rb:18:20:18:27 | Greeting | Greeting |
+| instance_fields.rb:4:22:4:31 | A_target | A_target |
+| instance_fields.rb:19:22:19:31 | B_target | B_target |
 | modules.rb:48:8:48:10 | Foo | Foo |
 | modules.rb:66:11:66:14 | Foo1 | Test::Foo1 |
 | modules.rb:72:11:72:14 | Foo2 | Test::Foo2::Foo2 |
@@ -364,6 +375,10 @@ resolveConstantWriteAccess
 | hello.rb:1:1:8:3 | EnglishWords | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld | HelloWorld |
+| instance_fields.rb:1:1:10:3 | A | A |
+| instance_fields.rb:11:1:14:3 | A_target | A_target |
+| instance_fields.rb:16:1:25:3 | B | B |
+| instance_fields.rb:26:1:29:3 | B_target | B_target |
 | modules.rb:1:1:2:3 | Empty | Empty |
 | modules.rb:4:1:24:3 | Foo | Foo |
 | modules.rb:5:3:14:5 | Bar | Foo::Bar |
@@ -1366,6 +1381,36 @@ enclosingModule
 | hello.rb:20:30:20:34 | self | hello.rb:18:1:22:3 | HelloWorld |
 | hello.rb:20:38:20:40 | "!" | hello.rb:18:1:22:3 | HelloWorld |
 | hello.rb:20:39:20:39 | ! | hello.rb:18:1:22:3 | HelloWorld |
+| instance_fields.rb:1:1:10:3 | A | instance_fields.rb:1:1:29:4 | instance_fields.rb |
+| instance_fields.rb:2:5:9:7 | class << ... | instance_fields.rb:1:1:10:3 | A |
+| instance_fields.rb:2:14:2:17 | self | instance_fields.rb:1:1:10:3 | A |
+| instance_fields.rb:3:9:5:11 | create | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:4:13:4:18 | @field | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:4:13:4:18 | self | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:4:13:4:35 | ... = ... | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:4:22:4:31 | A_target | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:4:22:4:35 | call to new | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:6:9:8:11 | use | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:7:13:7:18 | @field | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:7:13:7:18 | self | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:7:13:7:25 | call to target | instance_fields.rb:2:5:9:7 | class << ... |
+| instance_fields.rb:11:1:14:3 | A_target | instance_fields.rb:1:1:29:4 | instance_fields.rb |
+| instance_fields.rb:12:5:13:7 | target | instance_fields.rb:11:1:14:3 | A_target |
+| instance_fields.rb:16:1:25:3 | B | instance_fields.rb:1:1:29:4 | instance_fields.rb |
+| instance_fields.rb:17:5:24:7 | class << ... | instance_fields.rb:16:1:25:3 | B |
+| instance_fields.rb:17:14:17:17 | self | instance_fields.rb:16:1:25:3 | B |
+| instance_fields.rb:18:9:20:11 | create | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:19:13:19:18 | @field | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:19:13:19:18 | self | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:19:13:19:35 | ... = ... | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:19:22:19:31 | B_target | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:19:22:19:35 | call to new | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:21:9:23:11 | use | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:22:13:22:18 | @field | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:22:13:22:18 | self | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:22:13:22:25 | call to target | instance_fields.rb:17:5:24:7 | class << ... |
+| instance_fields.rb:26:1:29:3 | B_target | instance_fields.rb:1:1:29:4 | instance_fields.rb |
+| instance_fields.rb:27:5:28:7 | target | instance_fields.rb:26:1:29:3 | B_target |
 | modules.rb:1:1:2:3 | Empty | modules.rb:1:1:129:4 | modules.rb |
 | modules.rb:4:1:24:3 | Foo | modules.rb:1:1:129:4 | modules.rb |
 | modules.rb:5:3:14:5 | Bar | modules.rb:4:1:24:3 | Foo |

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -114,6 +114,13 @@ hello.rb:
 #   18| HelloWorld
 #-----|  -> Greeting
 
+instance_fields.rb:
+#   11| A_target
+#-----|  -> Object
+
+#   26| B_target
+#-----|  -> Object
+
 modules.rb:
 #    1| Empty
 


### PR DESCRIPTION
Fixes a bug in how the type-tracking associates a singleton class with its target module.

[Evaluation](https://github.com/github/codeql-dca-main/issues/7754) looks good, about 4k new call edges, and neutral performance. There are 4 new alerts from `rb/weak-cryptographic-algorithm` which correctly point out that DES is used, although it seems intentional in that codebase.