### PR TITLE
Swift: Add taint sources for custom URL scheme URLs

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -78,6 +78,7 @@ private import internal.FlowSummaryImplSpecific
  * ensuring that they are visible to the taint tracking / data flow library.
  */
 private module Frameworks {
+  private import codeql.swift.frameworks.StandardLibrary.CustomUrlSchemes
   private import codeql.swift.frameworks.StandardLibrary.String
   private import codeql.swift.frameworks.StandardLibrary.Url
   private import codeql.swift.frameworks.StandardLibrary.UrlSession

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -1,0 +1,13 @@
+import swift
+private import codeql.swift.dataflow.ExternalFlow
+
+private class UrlRemoteFlowSource extends SourceModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";UIApplicationDelegate;true;application(_:open:options:);;;Parameter[1];remote",
+        ";UIApplicationDelegate;true;application(_:handleOpen:);;;Parameter[1];remote",
+        ";UIApplicationDelegate;true;application(_:open:sourceApplication:annotation:);;;Parameter[1];remote"
+      ]
+  }
+}

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -1,3 +1,6 @@
+| customurlschemes.swift:17:44:17:54 | url | external |
+| customurlschemes.swift:20:52:20:68 | url | external |
+| customurlschemes.swift:23:52:23:62 | url | external |
 | string.swift:27:21:27:21 | call to init(contentsOf:) | external |
 | string.swift:27:21:27:44 | call to init(contentsOf:) | external |
 | url.swift:53:15:53:19 | .resourceBytes | external |

--- a/swift/ql/test/library-tests/dataflow/flowsources/customurlschemes.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/customurlschemes.swift
@@ -1,0 +1,26 @@
+// --- stubs ---
+class UIApplication {
+    struct OpenURLOptionsKey {}
+}
+
+struct URL {}
+
+protocol UIApplicationDelegate {
+    optional func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool
+    optional func application(_ application: UIApplication, handleOpen url: URL) -> Bool
+    optional func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool
+}
+
+// --- tests ---
+
+class AppDelegate: UIApplicationDelegate {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool { // SOURCE
+    }
+
+    func application(_ application: UIApplication, handleOpen url: URL) -> Bool { // SOURCE
+    }
+
+    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool { // SOURCE
+    }
+
+}


### PR DESCRIPTION
As explained [here](https://github.com/OWASP/owasp-mastg/blob/b7a93a2e5e0557cc9a12e55fc3f6675f6986bb86/Document/0x06h-Testing-Platform-Interaction.md#testing-custom-url-schemes-mstg-platform-3), iOS apps can receive arbitrary URLs from other apps in the following functions if they register a custom URL scheme:

* [`application(_:open:options:`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application?language=swift)
* [`application(_:handleOpen:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622964-application?language=swift)
* [`application(_:open:sourceApplication:annotation:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623073-application?language=swift)

Note that the last two are deprecated, but still should be supported IMHO.