### PR TITLE
C++: Add `UninitializedNode` to experimental IR dataflow

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -232,6 +232,12 @@ class Node extends TIRDataFlowNode {
   Parameter asParameter() { result = asParameter(0) }
 
   /**
+   * Gets the uninitialized local variable corresponding to this node, if
+   * any.
+   */
+  LocalVariable asUninitialized() { result = this.(UninitializedNode).getLocalVariable() }
+
+  /**
    * Gets the positional parameter corresponding to the node that represents
    * the value of the parameter after `index` number of loads, if any. For
    * example, in:
@@ -664,6 +670,25 @@ class IndirectOperand extends Node, TIndirectOperand {
   override string toStringImpl() {
     result = instructionNode(this.getOperand().getDef()).toStringImpl() + " indirection"
   }
+}
+
+/**
+ * The value of an uninitialized local variable, viewed as a node in a data
+ * flow graph.
+ */
+class UninitializedNode extends Node {
+  LocalVariable v;
+
+  UninitializedNode() {
+    exists(Ssa::Def def |
+      def.getDefiningInstruction() instanceof UninitializedInstruction and
+      Ssa::nodeToDefOrUse(this, def) and
+      v = def.getSourceVariable().getBaseVariable().(Ssa::BaseIRVariable).getIRVariable().getAst()
+    )
+  }
+
+  /** Gets the uninitialized local variable corresponding to this node. */
+  LocalVariable getLocalVariable() { result = v }
 }
 
 /**


### PR DESCRIPTION
This is the final piece of syntactic compatibility needed to do the AST to IR dataflow rewrite.

Note that `uninitializedNode` is already present in the non-experimental IR dataflow library, and is implemented as `none()` with a deprecated predicate. However, we have [1 query](https://github.com/github/codeql/blob/af79139c3008e533e6583c91585bccffe02039ae/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql#L46) that currently uses uninitialized nodes, so to ease the transition I've added a proper implementation of this concept in the experimental IR dataflow library.