### PR TITLE
Swift: detect hardcoded encryption keys

### DIFF
--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.qhelp
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.qhelp
@@ -1,0 +1,17 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+  <overview>
+    <p>Hardcoded keys should not be used for creating encryption ciphers. Data encrypted using hardcoded keys are more vulnerable to the possiblity of recovering them.</p>
+  </overview>
+
+  <recommendation>
+    <p>Use a randomly generated key material to initialize the encryption cipher.</p>
+  </recommendation>
+
+  <example>
+    <p>The following example shows a few cases of instantiating a cipher with various encryption keys. In the 'BAD' cases, the key material is hardcoded, making the encrypted data vulnerable to recovery.  In the 'GOOD' cases, the key material is randomly generated and not hardcoded, which protects the encrypted data against recovery.</p>
+    <sample src="HardcodedEncryptionKey.swift" />
+  </example>
+</qhelp>

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.qhelp
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.qhelp
@@ -3,7 +3,7 @@
   "qhelp.dtd">
 <qhelp>
   <overview>
-    <p>Hardcoded keys should not be used for creating encryption ciphers. Data encrypted using hardcoded keys are more vulnerable to the possiblity of recovering them.</p>
+    <p>Hardcoded keys should not be used for creating encryption ciphers. Data encrypted using hardcoded keys are more vulnerable to the possibility of recovering them.</p>
   </overview>
 
   <recommendation>

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.qhelp
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.qhelp
@@ -7,7 +7,7 @@
   </overview>
 
   <recommendation>
-    <p>Use a randomly generated key material to initialize the encryption cipher.</p>
+    <p>Use randomly generated key material to initialize the encryption cipher.</p>
   </recommendation>
 
   <example>

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -1,6 +1,6 @@
 /**
  * @name Hard-coded encryption key
- * @description Using hardcoded keys for encryption is not secure, because potential attacker can easiy guess them.
+ * @description Using hardcoded keys for encryption is not secure, because potential attackers can easily guess them.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 8.1
@@ -29,9 +29,7 @@ class ByteArrayLiteralSource extends KeySource {
 /**
  * A string literal is a key source.
  */
-class StringLiteralSource extends KeySource {
-  StringLiteralSource() { this instanceof StringLiteralExpr }
-}
+class StringLiteralSource extends KeySource instanceof StringLiteralExpr { }
 
 /**
  * A class for all ways to set a key.

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -23,7 +23,7 @@ abstract class KeySource extends Expr { }
  * A literal byte array is a key source.
  */
 class ByteArrayLiteralSource extends KeySource {
-  ByteArrayLiteralSource() { this = any(ArrayExpr arr | arr.getType().toString() = "Array<UInt8>") }
+  ByteArrayLiteralSource() { this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") }
 }
 
 /**

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -1,0 +1,70 @@
+/**
+ * @name Hard-coded encryption key
+ * @description Using hardcoded keys for encryption is not secure, because potential attacker can easiy guess them.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 8.1
+ * @precision high
+ * @id swift/hardcoded-key
+ * @tags security
+ *       external/cwe/cwe-321
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import DataFlow::PathGraph
+
+/**
+ * An `Expr` that is used to initialize a key.
+ */
+abstract class KeySource extends Expr { }
+
+/**
+ * The creation of a literal byte array.
+ */
+class ByteArrayLiteralSource extends KeySource {
+  ByteArrayLiteralSource() { this = any(ArrayExpr arr | arr.getType().toString() = "Array<UInt8>") }
+}
+
+/**
+ * Any string literal as a key source.
+ */
+class StringLiteralSource extends KeySource {
+  StringLiteralSource() { this instanceof StringLiteralExpr }
+}
+
+/**
+ * A class for all ways to set a key.
+ */
+class EncryptionKeySink extends Expr {
+  EncryptionKeySink() {
+    // `key` arg in `init` is a sink
+    exists(ClassDecl c, AbstractFunctionDecl f, CallExpr call |
+      c.getName() = ["AES", "HMAC", "ChaCha20", "CBCMAC", "CMAC", "Poly1305", "Blowfish", "Rabbit"] and
+      c.getAMember() = f and
+      f.getName().matches("init(key:%") and
+      call.getStaticTarget() = f and
+      call.getArgument(0).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A dataflow configuration from the key source to expressions that use
+ * it to initialize a cipher.
+ */
+class HardcodedKeyConfig extends DataFlow::Configuration {
+  HardcodedKeyConfig() { this = "HardcodedKeyConfig" }
+
+  override predicate isSource(DataFlow::Node node) { node.asExpr() instanceof KeySource }
+
+  override predicate isSink(DataFlow::Node node) { node.asExpr() instanceof EncryptionKeySink }
+}
+
+// The query itself
+from HardcodedKeyConfig config, DataFlow::PathNode sourceNode, DataFlow::PathNode sinkNode
+where config.hasFlowPath(sourceNode, sinkNode)
+select sinkNode.getNode(), sourceNode, sinkNode,
+  "The key '" + sinkNode.getNode().toString() +
+    "' has been initialized with hard-coded values from $@.", sourceNode,
+  sourceNode.getNode().toString()

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -20,14 +20,14 @@ import DataFlow::PathGraph
 abstract class KeySource extends Expr { }
 
 /**
- * The creation of a literal byte array.
+ * A literal byte array is a key source.
  */
 class ByteArrayLiteralSource extends KeySource {
   ByteArrayLiteralSource() { this = any(ArrayExpr arr | arr.getType().toString() = "Array<UInt8>") }
 }
 
 /**
- * Any string literal as a key source.
+ * A string literal is a key source.
  */
 class StringLiteralSource extends KeySource {
   StringLiteralSource() { this instanceof StringLiteralExpr }

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.swift
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.swift
@@ -1,0 +1,22 @@
+
+func encrypt(padding : Padding) {
+	// ...
+
+	// BAD: Using hardcoded keys for encryption
+	let key: Array<UInt8> = [0x2a, 0x3a, 0x80, 0x05]
+	let keyString = "this is a constant string"
+	let ivString = getRandomIV()
+	_ = try AES(key: key, blockMode: CBC(), padding: padding)
+	_ = try AES(key: keyString, iv: ivString)
+
+
+
+	// GOOD: Using randomly generated keys for encryption
+	let key = (0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+	let keyString = String(cString: key)
+	let ivString = getRandomIV()
+	_ = try Blowfish(key: key, blockMode: CBC(), padding: padding)
+	_ = try Blowfish(key: keyString, iv: ivString)
+
+	// ...
+}

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.swift
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.swift
@@ -8,13 +8,16 @@ func encrypt(padding : Padding) {
 	let ivString = getRandomIV()
 	_ = try AES(key: key, blockMode: CBC(), padding: padding)
 	_ = try AES(key: keyString, iv: ivString)
-
+	_ = try Blowfish(key: key, blockMode: CBC(), padding: padding)
+	_ = try Blowfish(key: keyString, iv: ivString)
 
 
 	// GOOD: Using randomly generated keys for encryption
 	let key = (0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
 	let keyString = String(cString: key)
 	let ivString = getRandomIV()
+	_ = try AES(key: key, blockMode: CBC(), padding: padding)
+	_ = try AES(key: keyString, iv: ivString)
 	_ = try Blowfish(key: key, blockMode: CBC(), padding: padding)
 	_ = try Blowfish(key: keyString, iv: ivString)
 

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -1,0 +1,71 @@
+edges
+| test.swift:76:3:76:3 | this string is constant :  | test.swift:91:18:91:36 | call to getConstantString() :  |
+| test.swift:90:26:90:121 | [...] :  | test.swift:105:21:105:21 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:106:21:106:21 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:116:22:116:22 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:117:22:117:22 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:127:26:127:26 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:134:25:134:25 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:139:25:139:25 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:144:26:144:26 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:149:26:149:26 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:150:26:150:26 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:160:24:160:24 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:162:24:162:24 | key |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:107:21:107:21 | keyString |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:108:21:108:21 | keyString |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:118:22:118:22 | keyString |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:119:22:119:22 | keyString |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:128:26:128:26 | keyString |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:151:26:151:26 | keyString |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:152:26:152:26 | keyString |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:161:24:161:24 | keyString |
+| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:163:24:163:24 | keyString |
+nodes
+| test.swift:76:3:76:3 | this string is constant :  | semmle.label | this string is constant :  |
+| test.swift:90:26:90:121 | [...] :  | semmle.label | [...] :  |
+| test.swift:91:18:91:36 | call to getConstantString() :  | semmle.label | call to getConstantString() :  |
+| test.swift:105:21:105:21 | key | semmle.label | key |
+| test.swift:106:21:106:21 | key | semmle.label | key |
+| test.swift:107:21:107:21 | keyString | semmle.label | keyString |
+| test.swift:108:21:108:21 | keyString | semmle.label | keyString |
+| test.swift:116:22:116:22 | key | semmle.label | key |
+| test.swift:117:22:117:22 | key | semmle.label | key |
+| test.swift:118:22:118:22 | keyString | semmle.label | keyString |
+| test.swift:119:22:119:22 | keyString | semmle.label | keyString |
+| test.swift:127:26:127:26 | key | semmle.label | key |
+| test.swift:128:26:128:26 | keyString | semmle.label | keyString |
+| test.swift:134:25:134:25 | key | semmle.label | key |
+| test.swift:139:25:139:25 | key | semmle.label | key |
+| test.swift:144:26:144:26 | key | semmle.label | key |
+| test.swift:149:26:149:26 | key | semmle.label | key |
+| test.swift:150:26:150:26 | key | semmle.label | key |
+| test.swift:151:26:151:26 | keyString | semmle.label | keyString |
+| test.swift:152:26:152:26 | keyString | semmle.label | keyString |
+| test.swift:160:24:160:24 | key | semmle.label | key |
+| test.swift:161:24:161:24 | keyString | semmle.label | keyString |
+| test.swift:162:24:162:24 | key | semmle.label | key |
+| test.swift:163:24:163:24 | keyString | semmle.label | keyString |
+subpaths
+#select
+| test.swift:105:21:105:21 | key | test.swift:90:26:90:121 | [...] :  | test.swift:105:21:105:21 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:106:21:106:21 | key | test.swift:90:26:90:121 | [...] :  | test.swift:106:21:106:21 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:107:21:107:21 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:107:21:107:21 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:108:21:108:21 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:108:21:108:21 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:116:22:116:22 | key | test.swift:90:26:90:121 | [...] :  | test.swift:116:22:116:22 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:117:22:117:22 | key | test.swift:90:26:90:121 | [...] :  | test.swift:117:22:117:22 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:118:22:118:22 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:118:22:118:22 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:119:22:119:22 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:119:22:119:22 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:127:26:127:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:127:26:127:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:128:26:128:26 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:128:26:128:26 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:134:25:134:25 | key | test.swift:90:26:90:121 | [...] :  | test.swift:134:25:134:25 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:139:25:139:25 | key | test.swift:90:26:90:121 | [...] :  | test.swift:139:25:139:25 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:144:26:144:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:144:26:144:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:149:26:149:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:149:26:149:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:150:26:150:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:150:26:150:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:151:26:151:26 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:151:26:151:26 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:152:26:152:26 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:152:26:152:26 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:160:24:160:24 | key | test.swift:90:26:90:121 | [...] :  | test.swift:160:24:160:24 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:161:24:161:24 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:161:24:161:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:162:24:162:24 | key | test.swift:90:26:90:121 | [...] :  | test.swift:162:24:162:24 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:163:24:163:24 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:163:24:163:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -1,71 +1,65 @@
 edges
-| test.swift:76:3:76:3 | this string is constant :  | test.swift:91:18:91:36 | call to getConstantString() :  |
-| test.swift:90:26:90:121 | [...] :  | test.swift:105:21:105:21 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:106:21:106:21 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:116:22:116:22 | key |
+| test.swift:76:3:76:3 | this string is constant :  | test.swift:92:18:92:36 | call to getConstantString() :  |
 | test.swift:90:26:90:121 | [...] :  | test.swift:117:22:117:22 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:127:26:127:26 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:134:25:134:25 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:139:25:139:25 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:144:26:144:26 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:149:26:149:26 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:118:22:118:22 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:128:26:128:26 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:135:25:135:25 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:140:25:140:25 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:145:26:145:26 | key |
 | test.swift:90:26:90:121 | [...] :  | test.swift:150:26:150:26 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:160:24:160:24 | key |
-| test.swift:90:26:90:121 | [...] :  | test.swift:162:24:162:24 | key |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:107:21:107:21 | keyString |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:108:21:108:21 | keyString |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:118:22:118:22 | keyString |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:119:22:119:22 | keyString |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:128:26:128:26 | keyString |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:151:26:151:26 | keyString |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:152:26:152:26 | keyString |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:161:24:161:24 | keyString |
-| test.swift:91:18:91:36 | call to getConstantString() :  | test.swift:163:24:163:24 | keyString |
+| test.swift:90:26:90:121 | [...] :  | test.swift:151:26:151:26 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:161:24:161:24 | key |
+| test.swift:90:26:90:121 | [...] :  | test.swift:163:24:163:24 | key |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:108:21:108:21 | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:109:21:109:21 | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:119:22:119:22 | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:120:22:120:22 | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:129:26:129:26 | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:152:26:152:26 | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:153:26:153:26 | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:162:24:162:24 | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:164:24:164:24 | keyString |
 nodes
 | test.swift:76:3:76:3 | this string is constant :  | semmle.label | this string is constant :  |
 | test.swift:90:26:90:121 | [...] :  | semmle.label | [...] :  |
-| test.swift:91:18:91:36 | call to getConstantString() :  | semmle.label | call to getConstantString() :  |
-| test.swift:105:21:105:21 | key | semmle.label | key |
-| test.swift:106:21:106:21 | key | semmle.label | key |
-| test.swift:107:21:107:21 | keyString | semmle.label | keyString |
+| test.swift:92:18:92:36 | call to getConstantString() :  | semmle.label | call to getConstantString() :  |
 | test.swift:108:21:108:21 | keyString | semmle.label | keyString |
-| test.swift:116:22:116:22 | key | semmle.label | key |
+| test.swift:109:21:109:21 | keyString | semmle.label | keyString |
 | test.swift:117:22:117:22 | key | semmle.label | key |
-| test.swift:118:22:118:22 | keyString | semmle.label | keyString |
+| test.swift:118:22:118:22 | key | semmle.label | key |
 | test.swift:119:22:119:22 | keyString | semmle.label | keyString |
-| test.swift:127:26:127:26 | key | semmle.label | key |
-| test.swift:128:26:128:26 | keyString | semmle.label | keyString |
-| test.swift:134:25:134:25 | key | semmle.label | key |
-| test.swift:139:25:139:25 | key | semmle.label | key |
-| test.swift:144:26:144:26 | key | semmle.label | key |
-| test.swift:149:26:149:26 | key | semmle.label | key |
+| test.swift:120:22:120:22 | keyString | semmle.label | keyString |
+| test.swift:128:26:128:26 | key | semmle.label | key |
+| test.swift:129:26:129:26 | keyString | semmle.label | keyString |
+| test.swift:135:25:135:25 | key | semmle.label | key |
+| test.swift:140:25:140:25 | key | semmle.label | key |
+| test.swift:145:26:145:26 | key | semmle.label | key |
 | test.swift:150:26:150:26 | key | semmle.label | key |
-| test.swift:151:26:151:26 | keyString | semmle.label | keyString |
+| test.swift:151:26:151:26 | key | semmle.label | key |
 | test.swift:152:26:152:26 | keyString | semmle.label | keyString |
-| test.swift:160:24:160:24 | key | semmle.label | key |
-| test.swift:161:24:161:24 | keyString | semmle.label | keyString |
-| test.swift:162:24:162:24 | key | semmle.label | key |
-| test.swift:163:24:163:24 | keyString | semmle.label | keyString |
+| test.swift:153:26:153:26 | keyString | semmle.label | keyString |
+| test.swift:161:24:161:24 | key | semmle.label | key |
+| test.swift:162:24:162:24 | keyString | semmle.label | keyString |
+| test.swift:163:24:163:24 | key | semmle.label | key |
+| test.swift:164:24:164:24 | keyString | semmle.label | keyString |
 subpaths
 #select
-| test.swift:105:21:105:21 | key | test.swift:90:26:90:121 | [...] :  | test.swift:105:21:105:21 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:106:21:106:21 | key | test.swift:90:26:90:121 | [...] :  | test.swift:106:21:106:21 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:107:21:107:21 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:107:21:107:21 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
 | test.swift:108:21:108:21 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:108:21:108:21 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
-| test.swift:116:22:116:22 | key | test.swift:90:26:90:121 | [...] :  | test.swift:116:22:116:22 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:109:21:109:21 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:109:21:109:21 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
 | test.swift:117:22:117:22 | key | test.swift:90:26:90:121 | [...] :  | test.swift:117:22:117:22 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:118:22:118:22 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:118:22:118:22 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:118:22:118:22 | key | test.swift:90:26:90:121 | [...] :  | test.swift:118:22:118:22 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
 | test.swift:119:22:119:22 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:119:22:119:22 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
-| test.swift:127:26:127:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:127:26:127:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:128:26:128:26 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:128:26:128:26 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
-| test.swift:134:25:134:25 | key | test.swift:90:26:90:121 | [...] :  | test.swift:134:25:134:25 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:139:25:139:25 | key | test.swift:90:26:90:121 | [...] :  | test.swift:139:25:139:25 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:144:26:144:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:144:26:144:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:149:26:149:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:149:26:149:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:120:22:120:22 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:120:22:120:22 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:128:26:128:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:128:26:128:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:129:26:129:26 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:129:26:129:26 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:135:25:135:25 | key | test.swift:90:26:90:121 | [...] :  | test.swift:135:25:135:25 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:140:25:140:25 | key | test.swift:90:26:90:121 | [...] :  | test.swift:140:25:140:25 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:145:26:145:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:145:26:145:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
 | test.swift:150:26:150:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:150:26:150:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:151:26:151:26 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:151:26:151:26 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:151:26:151:26 | key | test.swift:90:26:90:121 | [...] :  | test.swift:151:26:151:26 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
 | test.swift:152:26:152:26 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:152:26:152:26 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
-| test.swift:160:24:160:24 | key | test.swift:90:26:90:121 | [...] :  | test.swift:160:24:160:24 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:161:24:161:24 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:161:24:161:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
-| test.swift:162:24:162:24 | key | test.swift:90:26:90:121 | [...] :  | test.swift:162:24:162:24 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
-| test.swift:163:24:163:24 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:163:24:163:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:153:26:153:26 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:153:26:153:26 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:161:24:161:24 | key | test.swift:90:26:90:121 | [...] :  | test.swift:161:24:161:24 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:162:24:162:24 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:162:24:162:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
+| test.swift:163:24:163:24 | key | test.swift:90:26:90:121 | [...] :  | test.swift:163:24:163:24 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |
+| test.swift:164:24:164:24 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:164:24:164:24 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.qlref
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.qlref
@@ -1,0 +1,1 @@
+queries/Security/CWE-321/HardcodedEncryptionKey.ql

--- a/swift/ql/test/query-tests/Security/CWE-321/test.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/test.swift
@@ -1,0 +1,169 @@
+
+// --- stubs ---
+
+// These stubs roughly follows the same structure as classes from CryptoSwift
+class AES
+{
+	init(key: Array<UInt8>, blockMode: BlockMode, padding: Padding) { }
+	init(key: Array<UInt8>, blockMode: BlockMode) { }
+	init(key: String, iv: String) { }
+	init(key: String, iv: String, padding: Padding) { }
+}
+
+class Blowfish
+{
+	init(key: Array<UInt8>, blockMode: BlockMode, padding: Padding) { }
+	init(key: Array<UInt8>, blockMode: BlockMode) { }
+	init(key: String, iv: String) { }
+	init(key: String, iv: String, padding: Padding) { }
+}
+
+class HMAC
+{
+	init(key: Array<UInt8>) { }
+	init(key: Array<UInt8>, variant: Variant) { }
+	init(key: String) { }
+	init(key: String, variant: Variant) { }
+}
+
+class ChaCha20
+{
+	init(key: Array<UInt8>, iv: Array<UInt8>) { }
+	init(key: String, iv: String) { }
+}
+
+class CBCMAC
+{
+	init(key: Array<UInt8>) { }
+}
+
+class CMAC
+{
+	init(key: Array<UInt8>) { }
+}
+
+class Poly1305
+{
+	init(key: Array<UInt8>) { }
+}
+
+class Rabbit
+{
+	init(key: Array<UInt8>) { }
+	init(key: String) { }
+	init(key: Array<UInt8>, iv: Array<UInt8>) { }
+	init(key: String, iv: String) { }
+}
+
+enum Variant {
+	case md5, sha1, sha2, sha3
+}
+
+protocol BlockMode { }
+
+struct CBC: BlockMode { 
+	init() { }
+}
+
+protocol PaddingProtocol { }
+
+enum Padding: PaddingProtocol {
+  case noPadding, zeroPadding, pkcs7, pkcs5, eme_pkcs1v15, emsa_pkcs1v15, iso78164, iso10126
+}
+
+// Helper functions
+func getConstantString() -> String {
+  "this string is constant"
+}
+
+func getConstantArray() -> Array<UInt8> {
+	[UInt8](getConstantString().utf8)
+}
+
+func getRandomArray() -> Array<UInt8> {
+	(0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+}
+
+// --- tests ---
+
+func test() {
+	let key: Array<UInt8> = [0x2a, 0x3a, 0x80, 0x05, 0xaf, 0x46, 0x58, 0x2d, 0x66, 0x52, 0x10, 0xae, 0x86, 0xd3, 0x8e, 0x8f]
+	let keyString = getConstantString()
+
+	let randomArray = getRandomArray()
+	let randomKey = getRandomArray()
+	let randomKeyString = String(cString: getRandomArray())
+
+	let blockMode = CBC()
+	let padding = Padding.noPadding
+	let variant = Variant.sha2
+	
+	let iv = getRandomArray()
+	let ivString = String(cString: iv)
+
+	// AES test cases
+	let ab1 = AES(key: key, blockMode: blockMode, padding: padding) // BAD
+	let ab2 = AES(key: key, blockMode: blockMode) // BAD
+	let ab3 = AES(key: keyString, iv: ivString) // BAD
+	let ab4 = AES(key: keyString, iv: ivString, padding: padding) // BAD
+
+	let ag1 = AES(key: randomKey, blockMode: blockMode, padding: padding) // GOOD
+	let ag2 = AES(key: randomKey, blockMode: blockMode) // GOOD
+	let ag3 = AES(key: randomKeyString, iv: ivString) // GOOD
+	let ag4 = AES(key: randomKeyString, iv: ivString, padding: padding) // GOOD
+
+	// HMAC test cases
+	let hb1 = HMAC(key: key) // BAD
+	let hb2 = HMAC(key: key, variant: variant) // BAD
+	let hb3 = HMAC(key: keyString) // BAD
+	let hb4 = HMAC(key: keyString, variant: variant) // BAD
+
+	let hg1 = HMAC(key: randomKey) // GOOD
+	let hg2 = HMAC(key: randomKey, variant: variant) // GOOD
+	let hg3 = HMAC(key: randomKeyString) // GOOD
+	let hg4 = HMAC(key: randomKeyString, variant: variant) // GOOD
+
+	// ChaCha20 test cases
+	let cb1 = ChaCha20(key: key, iv: iv) // BAD
+	let cb2 = ChaCha20(key: keyString, iv: ivString) // BAD
+
+	let cg1 = ChaCha20(key: randomKey, iv: iv) // GOOD
+	let cg2 = ChaCha20(key: randomKeyString, iv: ivString) // GOOD
+
+	// CBCMAC test cases
+	let cmb1 = CBCMAC(key: key) // BAD
+
+	let cmg1 = CBCMAC(key: randomKey) // GOOD
+
+	// CMAC test cases
+	let cmacb1 = CMAC(key: key) // BAD
+
+	let cmacg1 = CMAC(key: randomKey) // GOOD
+
+	// Poly1305 test cases
+	let pb1 = Poly1305(key: key) // BAD
+
+	let pg1 = Poly1305(key: randomKey) // GOOD
+
+	// Blowfish test cases
+	let bb1 = Blowfish(key: key, blockMode: blockMode, padding: padding) // BAD
+	let bb2 = Blowfish(key: key, blockMode: blockMode) // BAD
+	let bb3 = Blowfish(key: keyString, iv: ivString) // BAD
+	let bb4 = Blowfish(key: keyString, iv: ivString, padding: padding) // BAD
+
+	let bg1 = Blowfish(key: randomKey, blockMode: blockMode, padding: padding) // GOOD
+	let bg2 = Blowfish(key: randomKey, blockMode: blockMode) // GOOD
+	let bg3 = Blowfish(key: randomKeyString, iv: ivString) // GOOD
+	let bg4 = Blowfish(key: randomKeyString, iv: ivString, padding: padding) // GOOD
+
+	// Rabbit
+	let rb1 = Rabbit(key: key) // BAD
+	let rb2 = Rabbit(key: keyString) // BAD
+	let rb3 = Rabbit(key: key, iv: iv) // BAD
+	let rb4 = Rabbit(key: keyString, iv: ivString) // BAD
+
+	let rg1 = Rabbit(key: randomKey) // GOOD
+	let rg2 = Rabbit(key: randomKeyString) // GOOD
+	let rg3 = Rabbit(key: randomKey, iv: iv) // GOOD
+	let rg4 = Rabbit(key: randomKeyString, iv: ivString) // GOOD
+}

--- a/swift/ql/test/query-tests/Security/CWE-321/test.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/test.swift
@@ -88,6 +88,7 @@ func getRandomArray() -> Array<UInt8> {
 
 func test() {
 	let key: Array<UInt8> = [0x2a, 0x3a, 0x80, 0x05, 0xaf, 0x46, 0x58, 0x2d, 0x66, 0x52, 0x10, 0xae, 0x86, 0xd3, 0x8e, 0x8f]
+	let key2 = getConstantArray()
 	let keyString = getConstantString()
 
 	let randomArray = getRandomArray()
@@ -102,8 +103,8 @@ func test() {
 	let ivString = String(cString: iv)
 
 	// AES test cases
-	let ab1 = AES(key: key, blockMode: blockMode, padding: padding) // BAD
-	let ab2 = AES(key: key, blockMode: blockMode) // BAD
+	let ab1 = AES(key: key2, blockMode: blockMode, padding: padding) // BAD [NOT DETECTED]
+	let ab2 = AES(key: key2, blockMode: blockMode) // BAD [NOT DETECTED]
 	let ab3 = AES(key: keyString, iv: ivString) // BAD
 	let ab4 = AES(key: keyString, iv: ivString, padding: padding) // BAD
 


### PR DESCRIPTION
Hardcoded keys should not be used for creating encryption ciphers. Data encrypted using hardcoded keys are more vulnerable to the possibility of recovering them.

The rule currently supports all ciphers that the CryptoSwift API provides, but we can always extend it further if more cophers are added.

I'd appreciate a review of the query itself, the accompanying tests, and the associated documentation.