### PR TITLE
C#: Deprecate `AssignableRead::getAReachableRead`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Assignable.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Assignable.qll
@@ -111,6 +111,7 @@ class AssignableRead extends AssignableAccess {
    * - The reads of `i` on lines 7 and 8 are next to the read on line 6.
    * - The read of `this.Field` on line 11 is next to the read on line 10.
    */
+  pragma[nomagic]
   AssignableRead getANextRead() {
     forex(ControlFlow::Node cfn | cfn = result.getAControlFlowNode() |
       cfn = this.getAnAdjacentReadSameVar()
@@ -124,7 +125,7 @@ class AssignableRead extends AssignableAccess {
    *
    * This is the transitive closure of `getANextRead()`.
    */
-  AssignableRead getAReachableRead() { result = this.getANextRead+() }
+  deprecated AssignableRead getAReachableRead() { result = this.getANextRead+() }
 }
 
 /**
@@ -479,6 +480,7 @@ class AssignableDefinition extends TAssignableDefinition {
    * Subsequent reads can be found by following the steps defined by
    * `AssignableRead.getANextRead()`.
    */
+  pragma[nomagic]
   AssignableRead getAFirstRead() {
     forex(ControlFlow::Node cfn | cfn = result.getAControlFlowNode() |
       exists(Ssa::ExplicitDefinition def | result = def.getAFirstReadAtNode(cfn) |
@@ -494,7 +496,7 @@ class AssignableDefinition extends TAssignableDefinition {
    *
    * This is the equivalent with `getAFirstRead().getANextRead*()`.
    */
-  AssignableRead getAReachableRead() { result = this.getAFirstRead().getANextRead*() }
+  deprecated AssignableRead getAReachableRead() { result = this.getAFirstRead().getANextRead*() }
 
   /** Gets a textual representation of this assignable definition. */
   string toString() { none() }

--- a/csharp/ql/lib/semmle/code/csharp/exprs/Access.qll
+++ b/csharp/ql/lib/semmle/code/csharp/exprs/Access.qll
@@ -174,7 +174,9 @@ class VariableAccess extends AssignableAccess, @variable_access_expr {
 class VariableRead extends VariableAccess, AssignableRead {
   override VariableRead getANextRead() { result = AssignableRead.super.getANextRead() }
 
-  override VariableRead getAReachableRead() { result = AssignableRead.super.getAReachableRead() }
+  deprecated override VariableRead getAReachableRead() {
+    result = AssignableRead.super.getAReachableRead()
+  }
 }
 
 /**
@@ -200,7 +202,7 @@ class LocalScopeVariableAccess extends VariableAccess, @local_scope_variable_acc
 class LocalScopeVariableRead extends LocalScopeVariableAccess, VariableRead {
   override LocalScopeVariableRead getANextRead() { result = VariableRead.super.getANextRead() }
 
-  override LocalScopeVariableRead getAReachableRead() {
+  deprecated override LocalScopeVariableRead getAReachableRead() {
     result = VariableRead.super.getAReachableRead()
   }
 }
@@ -242,7 +244,7 @@ class ParameterAccess extends LocalScopeVariableAccess, @parameter_access_expr {
 class ParameterRead extends ParameterAccess, LocalScopeVariableRead {
   override ParameterRead getANextRead() { result = LocalScopeVariableRead.super.getANextRead() }
 
-  override ParameterRead getAReachableRead() {
+  deprecated override ParameterRead getAReachableRead() {
     result = LocalScopeVariableRead.super.getAReachableRead()
   }
 }
@@ -297,7 +299,7 @@ class LocalVariableAccess extends LocalScopeVariableAccess, @local_variable_acce
 class LocalVariableRead extends LocalVariableAccess, LocalScopeVariableRead {
   override LocalVariableRead getANextRead() { result = LocalScopeVariableRead.super.getANextRead() }
 
-  override LocalVariableRead getAReachableRead() {
+  deprecated override LocalVariableRead getAReachableRead() {
     result = LocalScopeVariableRead.super.getAReachableRead()
   }
 }
@@ -442,7 +444,9 @@ class PropertyAccess extends AssignableMemberAccess, PropertyAccessExpr {
 class PropertyRead extends PropertyAccess, AssignableRead {
   override PropertyRead getANextRead() { result = AssignableRead.super.getANextRead() }
 
-  override PropertyRead getAReachableRead() { result = AssignableRead.super.getAReachableRead() }
+  deprecated override PropertyRead getAReachableRead() {
+    result = AssignableRead.super.getAReachableRead()
+  }
 }
 
 /**
@@ -581,7 +585,9 @@ class IndexerAccess extends AssignableMemberAccess, ElementAccess, IndexerAccess
 class IndexerRead extends IndexerAccess, ElementRead {
   override IndexerRead getANextRead() { result = ElementRead.super.getANextRead() }
 
-  override IndexerRead getAReachableRead() { result = ElementRead.super.getAReachableRead() }
+  deprecated override IndexerRead getAReachableRead() {
+    result = ElementRead.super.getAReachableRead()
+  }
 }
 
 /**


### PR DESCRIPTION
`AssignableRead::getAReachableRead` is worst-case quadratic, so we should never attempt to evaluate it in full.

Significant speed-up on `dotnet/aspnetcore`:

source | a_m | a_std | b_m | b_std | diff | relative
-- | -- | -- | -- | -- | -- | --
Median (excl. partials) |   |   |   |   | -1 | -0.00814
Overall (excl. partials) | 9276 |   | 8595 |   | -680.7 | -0.0734
  |   |   |   |   |   |  
dotnet__aspnetcore | 1857 | 61.73 | 1226 | 36.5 | -630.7 | -0.34
dotnet__roslyn | 1124 | 0 | 1092 | 0 | -32 | -0.0285
dotnet__efcore | 1104 | 0 | 1075 | 0 | -29 | -0.0263
OrchardCMS__OrchardCore | 387 | 0 | 378 | 0 | -9 | -0.0233
DynamoDS__Dynamo | 172 | 0 | 168 | 0 | -4 | -0.0233
jerryhoff__WebGoat.NET | 58 | 0 | 57 | 0 | -1 | -0.0172
DeafLight__SilentLux.AutoFixture.Moq.Xunit2 | 133 | 0 | 131 | 0 | -2 | -0.0150
mcintyre321__OneOf | 183 | 0 | 181 | 0 | -2 | -0.0109
JetBrains__resharper-rider-plugin | 614 | 0 | 609 | 0 | -5 | -0.00814
ekolve__ai2thor-lgtm | 209 | 0 | 208 | 0 | -1 | -0.00478
rapPayne__WebGoat.Net | 85 | 0 | 85 | 0 | 0 | 0
urfnet__URF.Core | 103 | 0 | 103 | 0 | 0 | 0
dotnet__runtime | 891 | 0 | 896 | 0 | 5 | 0.00561
lboynton__VulnerableWebApp | 125 | 0 | 126 | 0 | 1 | 0.00800
PowerShell__PowerShell | 280 | 0 | 283 | 0 | 3 | 0.0107
mono__mono | 1511 | 0 | 1531 | 0 | 20 | 0.0132
microsoft__fhir-codegen | 440 | 0 | 446 | 0 | 6 | 0.0136

