### PR TITLE
Ruby: treat render 'file:' argument as a file system access

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -71,6 +71,21 @@ module Rails {
 
   /** A render call that does not automatically set the HTTP response body. */
   class RenderToCall extends MethodCall instanceof RenderToCallImpl { }
+
+  /**
+   * A `render` call seen as a file system access.
+   */
+  private class RenderAsFileSystemAccess extends FileSystemAccess::Range, DataFlow::CallNode {
+    RenderAsFileSystemAccess() {
+      exists(MethodCall call | this.asExpr().getExpr() = call |
+        call instanceof RenderCall
+        or
+        call instanceof RenderToCall
+      )
+    }
+
+    override DataFlow::Node getAPathArgument() { result = this.getKeywordArgument("file") }
+  }
 }
 
 /**

--- a/ruby/ql/src/change-notes/2022-10-12-rails-render-file.md
+++ b/ruby/ql/src/change-notes/2022-10-12-rails-render-file.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `rb/path-injection` query now treats the `file:` argument of the Rails `render` method as a sink.


### PR DESCRIPTION
I came across this sink and noticed it wasn't modelled yet. Treats the `file:` keyword argument of the `render` method as a file system access, and thus a sink for path injection.

I ran [evaluation](https://github.com/github/codeql-dca-main/issues/7779) on some Rails projects, and it finds a couple of new sinks and some new path-injections alerts (in what seems to be intentionally-insecure code).