### PR TITLE
C++: use explicit `this`

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -229,7 +229,7 @@ class Node extends TIRDataFlowNode {
   Expr asIndirectArgument() { result = this.asIndirectArgument(_) }
 
   /** Gets the positional parameter corresponding to this node, if any. */
-  Parameter asParameter() { result = asParameter(0) }
+  Parameter asParameter() { result = this.asParameter(0) }
 
   /**
    * Gets the uninitialized local variable corresponding to this node, if


### PR DESCRIPTION
I realise this is in experimental code, but it fixes a QL-for-QL alert that's showing up in other PRs under "Unchanged files with check annotations".