### PR TITLE
Rb: add case-when expressions as a sink to rb/polynomial-redos

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSCustomizations.qll
@@ -106,6 +106,14 @@ module PolynomialReDoS {
             regexp.asExpr() = call.getReceiver() and
             this.asExpr() = call.getArgument(0)
           )
+          or
+          // a case-when statement
+          exists(CfgNodes::ExprNodes::CaseExprCfgNode caseWhen |
+            matchNode.asExpr() = caseWhen and
+            this.asExpr() = caseWhen.getValue() and
+            regexp.asExpr() =
+              caseWhen.getBranch(_).(CfgNodes::ExprNodes::WhenClauseCfgNode).getPattern(_)
+          )
         )
       )
     }

--- a/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSCustomizations.qll
@@ -110,9 +110,13 @@ module PolynomialReDoS {
           // a case-when statement
           exists(CfgNodes::ExprNodes::CaseExprCfgNode caseWhen |
             matchNode.asExpr() = caseWhen and
-            this.asExpr() = caseWhen.getValue() and
+            this.asExpr() = caseWhen.getValue()
+          |
             regexp.asExpr() =
               caseWhen.getBranch(_).(CfgNodes::ExprNodes::WhenClauseCfgNode).getPattern(_)
+            or
+            regexp.asExpr() =
+              caseWhen.getBranch(_).(CfgNodes::ExprNodes::InClauseCfgNode).getPattern()
           )
         )
       )

--- a/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.expected
@@ -15,6 +15,7 @@ edges
 | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:22:5:22:8 | name |
 | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:23:17:23:20 | name |
 | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:24:18:24:21 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:42:10:42:13 | name |
 | PolynomialReDoS.rb:27:9:27:14 | call to params :  | PolynomialReDoS.rb:27:9:27:18 | ...[...] :  |
 | PolynomialReDoS.rb:27:9:27:18 | ...[...] :  | PolynomialReDoS.rb:28:5:28:5 | a |
 | PolynomialReDoS.rb:29:9:29:14 | call to params :  | PolynomialReDoS.rb:29:9:29:18 | ...[...] :  |
@@ -48,6 +49,7 @@ nodes
 | PolynomialReDoS.rb:31:9:31:14 | call to params :  | semmle.label | call to params :  |
 | PolynomialReDoS.rb:31:9:31:18 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:32:5:32:5 | c | semmle.label | c |
+| PolynomialReDoS.rb:42:10:42:13 | name | semmle.label | name |
 subpaths
 #select
 | PolynomialReDoS.rb:10:5:10:17 | ... =~ ... | PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:10:5:10:8 | name | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:4:12:4:17 | call to params | user-provided value |
@@ -68,3 +70,4 @@ subpaths
 | PolynomialReDoS.rb:28:5:28:21 | call to gsub! | PolynomialReDoS.rb:27:9:27:14 | call to params :  | PolynomialReDoS.rb:28:5:28:5 | a | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:27:9:27:14 | call to params | user-provided value |
 | PolynomialReDoS.rb:30:5:30:18 | call to slice! | PolynomialReDoS.rb:29:9:29:14 | call to params :  | PolynomialReDoS.rb:30:5:30:5 | b | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:29:9:29:14 | call to params | user-provided value |
 | PolynomialReDoS.rb:32:5:32:20 | call to sub! | PolynomialReDoS.rb:31:9:31:14 | call to params :  | PolynomialReDoS.rb:32:5:32:5 | c | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:31:9:31:14 | call to params | user-provided value |
+| PolynomialReDoS.rb:42:5:45:7 | case ... | PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:42:10:42:13 | name | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:4:12:4:17 | call to params | user-provided value |

--- a/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.expected
@@ -16,6 +16,7 @@ edges
 | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:23:17:23:20 | name |
 | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:24:18:24:21 | name |
 | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:42:10:42:13 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:47:10:47:13 | name |
 | PolynomialReDoS.rb:27:9:27:14 | call to params :  | PolynomialReDoS.rb:27:9:27:18 | ...[...] :  |
 | PolynomialReDoS.rb:27:9:27:18 | ...[...] :  | PolynomialReDoS.rb:28:5:28:5 | a |
 | PolynomialReDoS.rb:29:9:29:14 | call to params :  | PolynomialReDoS.rb:29:9:29:18 | ...[...] :  |
@@ -50,6 +51,7 @@ nodes
 | PolynomialReDoS.rb:31:9:31:18 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:32:5:32:5 | c | semmle.label | c |
 | PolynomialReDoS.rb:42:10:42:13 | name | semmle.label | name |
+| PolynomialReDoS.rb:47:10:47:13 | name | semmle.label | name |
 subpaths
 #select
 | PolynomialReDoS.rb:10:5:10:17 | ... =~ ... | PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:10:5:10:8 | name | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:4:12:4:17 | call to params | user-provided value |
@@ -71,3 +73,4 @@ subpaths
 | PolynomialReDoS.rb:30:5:30:18 | call to slice! | PolynomialReDoS.rb:29:9:29:14 | call to params :  | PolynomialReDoS.rb:30:5:30:5 | b | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:29:9:29:14 | call to params | user-provided value |
 | PolynomialReDoS.rb:32:5:32:20 | call to sub! | PolynomialReDoS.rb:31:9:31:14 | call to params :  | PolynomialReDoS.rb:32:5:32:5 | c | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:31:9:31:14 | call to params | user-provided value |
 | PolynomialReDoS.rb:42:5:45:7 | case ... | PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:42:10:42:13 | name | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:7:19:7:21 | \\s+ | regular expression | PolynomialReDoS.rb:4:12:4:17 | call to params | user-provided value |
+| PolynomialReDoS.rb:47:5:50:7 | case ... | PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:47:10:47:13 | name | This $@ that depends on a $@ may run slow on strings with many repetitions of ' '. | PolynomialReDoS.rb:48:14:48:16 | \\s+ | regular expression | PolynomialReDoS.rb:4:12:4:17 | call to params | user-provided value |

--- a/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.rb
+++ b/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.rb
@@ -38,5 +38,10 @@ class FooController < ActionController::Base
 
     # GOOD - regex does not suffer from polynomial backtracking (regression test)
     params[:foo] =~ /\A[bc].*\Z/
+
+    case name # NOT GOOD
+    when regex 
+      puts "foo"
+    end
   end
 end

--- a/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.rb
+++ b/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.rb
@@ -43,5 +43,10 @@ class FooController < ActionController::Base
     when regex 
       puts "foo"
     end
+
+    case name # NOT GOOD
+    in /^\s+|\s+$/ then 
+      puts "foo"
+    end
   end
 end


### PR DESCRIPTION
CVE-2021-22880: Recognizes the sink (TP with https://github.com/github/codeql/pull/10782). 
CVE-2022-30122: One step closer to the sink. 

[Evaluation looks OK](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-10798-0-ruby/reports).  
There is a hint towards a performance regression, but I couldn't replicate locally.  
And [a repeat](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-10798-0-ruby__1/reports) shows a smaller regression, and in other projects 🤷 