### PR TITLE
Ruby: Model ActionDispatch::Response

### DIFF
--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -474,8 +474,8 @@ module Http {
      * extend `HeaderWriteAccess::Range` instead.
      */
     class HeaderWriteAccess extends DataFlow::Node instanceof HeaderWriteAccess::Range {
-      /** Gets the name of the header that is written to. */
-      string getName() { result = super.getName() }
+      /** Gets the (lower case) name of the header that is written to. */
+      string getName() { result = super.getName().toLowerCase() }
 
       /** Gets the value that is written to the header. */
       DataFlow::Node getValue() { result = super.getValue() }

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -468,7 +468,7 @@ module Http {
     }
 
     /**
-     * A data flow node that writes data to a header in a HTTP response.
+     * A data flow node that writes data to a header in an HTTP response.
      *
      * Extend this class to refine existing API models. If you want to model new APIs,
      * extend `HeaderWriteAccess::Range` instead.
@@ -484,7 +484,7 @@ module Http {
     /** Provides a class for modeling new HTTP header writes. */
     module HeaderWriteAccess {
       /**
-       * A data flow node that writes data to the a header in a HTTP response.
+       * A data flow node that writes data to the header in an HTTP response.
        *
        * Extend this class to model new APIs. If you want to refine existing API models,
        * extend `HeaderWriteAccess` instead.

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -468,6 +468,37 @@ module Http {
     }
 
     /**
+     * A data flow node that writes data to a header in a HTTP response.
+     *
+     * Extend this class to refine existing API models. If you want to model new APIs,
+     * extend `HeaderWriteAccess::Range` instead.
+     */
+    class HeaderWriteAccess extends DataFlow::Node instanceof HeaderWriteAccess::Range {
+      /** Gets the name of the header that is written to. */
+      string getName() { result = super.getName() }
+
+      /** Gets the value that is written to the header. */
+      DataFlow::Node getValue() { result = super.getValue() }
+    }
+
+    /** Provides a class for modeling new HTTP header writes. */
+    module HeaderWriteAccess {
+      /**
+       * A data flow node that writes data to the a header in a HTTP response.
+       *
+       * Extend this class to model new APIs. If you want to refine existing API models,
+       * extend `HeaderWriteAccess` instead.
+       */
+      abstract class Range extends DataFlow::Node {
+        /** Gets the name of the header that is written to. */
+        abstract string getName();
+
+        /** Gets the value that is written to the header. */
+        abstract DataFlow::Node getValue();
+      }
+    }
+
+    /**
      * A data-flow node that creates a HTTP response on a server.
      *
      * Note: we don't require that this response must be sent to a client (a kind of

--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -105,6 +105,11 @@ private module Shared {
     }
   }
 
+  /** A write to an HTTP response header, considered as a flow sink. */
+  class HeaderWriteAsSink extends Sink {
+    HeaderWriteAsSink() { this = any(Http::Server::HeaderWriteAccess a).getValue() }
+  }
+
   /**
    * An HTML escaping, considered as a sanitizer.
    */

--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -107,7 +107,13 @@ private module Shared {
 
   /** A write to an HTTP response header, considered as a flow sink. */
   class HeaderWriteAsSink extends Sink {
-    HeaderWriteAsSink() { this = any(Http::Server::HeaderWriteAccess a).getValue() }
+    HeaderWriteAsSink() {
+      exists(Http::Server::HeaderWriteAccess a |
+        a.getName() = ["content-type", "access-control-allow-origin"]
+      |
+        this = a.getValue()
+      )
+    }
   }
 
   /**

--- a/ruby/ql/src/change-notes/2022-10-14-actiondispatch-response.md
+++ b/ruby/ql/src/change-notes/2022-10-14-actiondispatch-response.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* HTTP response header and body writes via `ActionDispatch::Response` are now
+  recognised.

--- a/ruby/ql/src/change-notes/2022-10-14-actiondispatch-response.md
+++ b/ruby/ql/src/change-notes/2022-10-14-actiondispatch-response.md
@@ -2,4 +2,4 @@
 category: minorAnalysis
 ---
 * HTTP response header and body writes via `ActionDispatch::Response` are now
-  recognised.
+  recognized.

--- a/ruby/ql/test/library-tests/frameworks/ActionController.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionController.expected
@@ -6,7 +6,7 @@ actionControllerControllerClasses
 | active_record/ActiveRecord.rb:66:1:98:3 | BazController |
 | active_record/ActiveRecord.rb:100:1:108:3 | AnnotatedController |
 | active_storage/active_storage.rb:39:1:45:3 | PostsController |
-| app/controllers/comments_controller.rb:1:1:14:3 | CommentsController |
+| app/controllers/comments_controller.rb:1:1:40:3 | CommentsController |
 | app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController |
 | app/controllers/photos_controller.rb:1:1:4:3 | PhotosController |
 | app/controllers/posts_controller.rb:1:1:10:3 | PostsController |
@@ -61,8 +61,8 @@ actionControllerActionMethods
 | active_record/ActiveRecord.rb:101:3:103:5 | index |
 | active_record/ActiveRecord.rb:105:3:107:5 | unsafe_action |
 | active_storage/active_storage.rb:40:3:44:5 | create |
-| app/controllers/comments_controller.rb:2:3:10:5 | index |
-| app/controllers/comments_controller.rb:12:3:13:5 | show |
+| app/controllers/comments_controller.rb:2:3:36:5 | index |
+| app/controllers/comments_controller.rb:38:3:39:5 | show |
 | app/controllers/foo/bars_controller.rb:5:3:7:5 | index |
 | app/controllers/foo/bars_controller.rb:9:3:18:5 | show_debug |
 | app/controllers/foo/bars_controller.rb:20:3:24:5 | show |
@@ -370,3 +370,19 @@ getAssociatedControllerClasses
 controllerTemplateFiles
 | app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
 | app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |
+headerWriteAccesses
+| app/controllers/comments_controller.rb:15:5:15:35 | call to []= | Content-Type | app/controllers/comments_controller.rb:15:39:15:49 | ... = ... |
+| app/controllers/comments_controller.rb:16:5:16:46 | call to set_header | Content-Length | app/controllers/comments_controller.rb:16:43:16:45 | 100 |
+| app/controllers/comments_controller.rb:17:5:17:39 | call to []= | X-Custom-Header | app/controllers/comments_controller.rb:17:43:17:46 | ... = ... |
+| app/controllers/comments_controller.rb:18:5:18:39 | call to []= | X-Another-Custom-Header | app/controllers/comments_controller.rb:18:43:18:47 | ... = ... |
+| app/controllers/comments_controller.rb:19:5:19:49 | call to add_header | X-Yet-Another | app/controllers/comments_controller.rb:19:42:19:49 | "indeed" |
+| app/controllers/comments_controller.rb:25:5:25:21 | call to location= | location | app/controllers/comments_controller.rb:25:25:25:36 | ... = ... |
+| app/controllers/comments_controller.rb:26:5:26:26 | call to cache_control= | cache-control | app/controllers/comments_controller.rb:26:30:26:36 | ... = ... |
+| app/controllers/comments_controller.rb:27:5:27:27 | call to _cache_control= | cache-control | app/controllers/comments_controller.rb:27:31:27:37 | ... = ... |
+| app/controllers/comments_controller.rb:28:5:28:17 | call to etag= | etag | app/controllers/comments_controller.rb:28:21:28:27 | ... = ... |
+| app/controllers/comments_controller.rb:29:5:29:20 | call to charset= | content-type | app/controllers/comments_controller.rb:29:24:29:30 | ... = ... |
+| app/controllers/comments_controller.rb:30:5:30:25 | call to content_type= | content-type | app/controllers/comments_controller.rb:30:29:30:35 | ... = ... |
+| app/controllers/comments_controller.rb:32:5:32:17 | call to date= | date | app/controllers/comments_controller.rb:32:21:32:30 | ... = ... |
+| app/controllers/comments_controller.rb:33:5:33:26 | call to last_modified= | last-modified | app/controllers/comments_controller.rb:33:30:33:43 | ... = ... |
+| app/controllers/comments_controller.rb:34:5:34:22 | call to weak_etag= | etag | app/controllers/comments_controller.rb:34:26:34:32 | ... = ... |
+| app/controllers/comments_controller.rb:35:5:35:24 | call to strong_etag= | etag | app/controllers/comments_controller.rb:35:28:35:34 | ... = ... |

--- a/ruby/ql/test/library-tests/frameworks/ActionController.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionController.expected
@@ -371,11 +371,11 @@ controllerTemplateFiles
 | app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
 | app/controllers/foo/bars_controller.rb:3:1:46:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |
 headerWriteAccesses
-| app/controllers/comments_controller.rb:15:5:15:35 | call to []= | Content-Type | app/controllers/comments_controller.rb:15:39:15:49 | ... = ... |
-| app/controllers/comments_controller.rb:16:5:16:46 | call to set_header | Content-Length | app/controllers/comments_controller.rb:16:43:16:45 | 100 |
-| app/controllers/comments_controller.rb:17:5:17:39 | call to []= | X-Custom-Header | app/controllers/comments_controller.rb:17:43:17:46 | ... = ... |
-| app/controllers/comments_controller.rb:18:5:18:39 | call to []= | X-Another-Custom-Header | app/controllers/comments_controller.rb:18:43:18:47 | ... = ... |
-| app/controllers/comments_controller.rb:19:5:19:49 | call to add_header | X-Yet-Another | app/controllers/comments_controller.rb:19:42:19:49 | "indeed" |
+| app/controllers/comments_controller.rb:15:5:15:35 | call to []= | content-type | app/controllers/comments_controller.rb:15:39:15:49 | ... = ... |
+| app/controllers/comments_controller.rb:16:5:16:46 | call to set_header | content-length | app/controllers/comments_controller.rb:16:43:16:45 | 100 |
+| app/controllers/comments_controller.rb:17:5:17:39 | call to []= | x-custom-header | app/controllers/comments_controller.rb:17:43:17:46 | ... = ... |
+| app/controllers/comments_controller.rb:18:5:18:39 | call to []= | x-another-custom-header | app/controllers/comments_controller.rb:18:43:18:47 | ... = ... |
+| app/controllers/comments_controller.rb:19:5:19:49 | call to add_header | x-yet-another | app/controllers/comments_controller.rb:19:42:19:49 | "indeed" |
 | app/controllers/comments_controller.rb:25:5:25:21 | call to location= | location | app/controllers/comments_controller.rb:25:25:25:36 | ... = ... |
 | app/controllers/comments_controller.rb:26:5:26:26 | call to cache_control= | cache-control | app/controllers/comments_controller.rb:26:30:26:36 | ... = ... |
 | app/controllers/comments_controller.rb:27:5:27:27 | call to _cache_control= | cache-control | app/controllers/comments_controller.rb:27:31:27:37 | ... = ... |

--- a/ruby/ql/test/library-tests/frameworks/ActionController.ql
+++ b/ruby/ql/test/library-tests/frameworks/ActionController.ql
@@ -3,6 +3,7 @@ private import codeql.ruby.frameworks.ActionController
 private import codeql.ruby.frameworks.Rails
 private import codeql.ruby.frameworks.ActionView
 private import codeql.ruby.Concepts
+private import codeql.ruby.DataFlow
 
 query predicate actionControllerControllerClasses(ActionControllerControllerClass cls) { any() }
 
@@ -30,4 +31,10 @@ query predicate getAssociatedControllerClasses(ActionControllerControllerClass c
 
 query predicate controllerTemplateFiles(ActionControllerControllerClass cls, ErbFile templateFile) {
   controllerTemplateFile(cls, templateFile)
+}
+
+query predicate headerWriteAccesses(
+  Http::Server::HeaderWriteAccess a, string name, DataFlow::Node value
+) {
+  name = a.getName() and value = a.getValue()
 }

--- a/ruby/ql/test/library-tests/frameworks/ActionDispatch.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionDispatch.expected
@@ -36,8 +36,8 @@ actionDispatchRoutes
 actionDispatchControllerMethods
 | app/config/routes.rb:2:3:8:5 | call to resources | app/controllers/posts_controller.rb:2:3:3:5 | index |
 | app/config/routes.rb:2:3:8:5 | call to resources | app/controllers/posts_controller.rb:5:3:6:5 | show |
-| app/config/routes.rb:3:5:6:7 | call to resources | app/controllers/comments_controller.rb:2:3:10:5 | index |
-| app/config/routes.rb:3:5:6:7 | call to resources | app/controllers/comments_controller.rb:12:3:13:5 | show |
+| app/config/routes.rb:3:5:6:7 | call to resources | app/controllers/comments_controller.rb:2:3:36:5 | index |
+| app/config/routes.rb:3:5:6:7 | call to resources | app/controllers/comments_controller.rb:38:3:39:5 | show |
 | app/config/routes.rb:7:5:7:37 | call to post | app/controllers/posts_controller.rb:8:3:9:5 | upvote |
 | app/config/routes.rb:27:3:27:48 | call to match | app/controllers/photos_controller.rb:2:3:3:5 | show |
 | app/config/routes.rb:28:3:28:50 | call to match | app/controllers/photos_controller.rb:2:3:3:5 | show |

--- a/ruby/ql/test/library-tests/frameworks/ActionView.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionView.expected
@@ -24,6 +24,8 @@ renderToCalls
 linkToCalls
 | app/views/foo/bars/show.html.erb:33:5:33:41 | call to link_to |
 httpResponses
+| app/controllers/comments_controller.rb:11:5:11:17 | call to body= | app/controllers/comments_controller.rb:11:21:11:34 | ... = ... | text/http |
+| app/controllers/comments_controller.rb:21:5:21:37 | call to send_file | app/controllers/comments_controller.rb:21:24:21:36 | "my-file.ext" | application/octet-stream |
 | app/controllers/foo/bars_controller.rb:15:16:15:97 | call to render_to_string | app/controllers/foo/bars_controller.rb:15:33:15:47 | "foo/bars/show" | text/html |
 | app/controllers/foo/bars_controller.rb:23:5:23:76 | call to render | app/controllers/foo/bars_controller.rb:23:12:23:26 | "foo/bars/show" | text/html |
 | app/controllers/foo/bars_controller.rb:35:5:35:33 | call to render | app/controllers/foo/bars_controller.rb:35:18:35:33 | call to [] | application/json |

--- a/ruby/ql/test/library-tests/frameworks/app/controllers/comments_controller.rb
+++ b/ruby/ql/test/library-tests/frameworks/app/controllers/comments_controller.rb
@@ -7,6 +7,32 @@ class CommentsController < ApplicationController
     request.query_parameters
     request.request_parameters
     request.filtered_parameters
+
+    response.body = "some content"
+
+    response.status = 200
+
+    response.header["Content-Type"] = "text/html"
+    response.set_header("Content-Length", 100)
+    response.headers["X-Custom-Header"] = "hi"
+    response["X-Another-Custom-Header"] = "yes"
+    response.add_header "X-Yet-Another", "indeed"
+
+    response.send_file("my-file.ext")
+
+    response.request
+
+    response.location = "http://..." # relevant for url redirect query
+    response.cache_control = "value"
+    response._cache_control = "value"
+    response.etag = "value"
+    response.charset = "value" # sets the charset part of the content-type header
+    response.content_type = "value" # sets the main part of the content-type header
+
+    response.date = Date.today
+    response.last_modified = Date.yesterday
+    response.weak_etag = "value"
+    response.strong_etag = "value"
   end
 
   def show

--- a/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
@@ -10,15 +10,15 @@ edges
 | app/controllers/foo/bars_controller.rb:17:21:17:36 | ...[...] :  | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website |
 | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  |
-| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  |
+| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  |
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  | app/views/foo/bars/show.html.erb:41:3:41:16 | @instance_text |
 | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params :  | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... |
-| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text |
-| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] |
-| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] |
-| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:36:3:36:14 | call to display_text |
-| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:44:76:44:87 | call to display_text :  |
+| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text |
+| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] |
+| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] |
+| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | app/views/foo/bars/show.html.erb:36:3:36:14 | call to display_text |
+| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | app/views/foo/bars/show.html.erb:44:76:44:87 | call to display_text :  |
 | app/views/foo/bars/show.html.erb:44:64:44:87 | ... + ... :  | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text |
 | app/views/foo/bars/show.html.erb:44:64:44:87 | ... + ... :  | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] |
 | app/views/foo/bars/show.html.erb:44:76:44:87 | call to display_text :  | app/views/foo/bars/show.html.erb:44:64:44:87 | ... + ... :  |
@@ -40,7 +40,7 @@ nodes
 | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params :  | semmle.label | call to params :  |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | semmle.label | ... = ... |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  | semmle.label | ...[...] :  |
-| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | semmle.label | dt :  |
+| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | semmle.label | dt :  |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website | semmle.label | @user_website |

--- a/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
@@ -10,13 +10,15 @@ edges
 | app/controllers/foo/bars_controller.rb:17:21:17:36 | ...[...] :  | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website |
 | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  |
-| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:24:53:24:54 | dt :  |
+| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  |
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  | app/views/foo/bars/show.html.erb:41:3:41:16 | @instance_text |
-| app/controllers/foo/bars_controller.rb:24:53:24:54 | dt :  | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text |
-| app/controllers/foo/bars_controller.rb:24:53:24:54 | dt :  | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] |
-| app/controllers/foo/bars_controller.rb:24:53:24:54 | dt :  | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] |
-| app/controllers/foo/bars_controller.rb:24:53:24:54 | dt :  | app/views/foo/bars/show.html.erb:36:3:36:14 | call to display_text |
-| app/controllers/foo/bars_controller.rb:24:53:24:54 | dt :  | app/views/foo/bars/show.html.erb:44:76:44:87 | call to display_text :  |
+| app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params :  | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  |
+| app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... |
+| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text |
+| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] |
+| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] |
+| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:36:3:36:14 | call to display_text |
+| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | app/views/foo/bars/show.html.erb:44:76:44:87 | call to display_text :  |
 | app/views/foo/bars/show.html.erb:44:64:44:87 | ... + ... :  | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text |
 | app/views/foo/bars/show.html.erb:44:64:44:87 | ... + ... :  | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] |
 | app/views/foo/bars/show.html.erb:44:76:44:87 | call to display_text :  | app/views/foo/bars/show.html.erb:44:64:44:87 | ... + ... :  |
@@ -35,7 +37,10 @@ nodes
 | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | semmle.label | call to params :  |
 | app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  | semmle.label | dt :  |
-| app/controllers/foo/bars_controller.rb:24:53:24:54 | dt :  | semmle.label | dt :  |
+| app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params :  | semmle.label | call to params :  |
+| app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | semmle.label | ... = ... |
+| app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  | semmle.label | ...[...] :  |
+| app/controllers/foo/bars_controller.rb:25:53:25:54 | dt :  | semmle.label | dt :  |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website | semmle.label | @user_website |
@@ -58,6 +63,7 @@ nodes
 | app/views/foo/bars/show.html.erb:77:28:77:39 | ...[...] | semmle.label | ...[...] |
 subpaths
 #select
+| app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params :  | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | Cross-site scripting vulnerability due to a $@. | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params | user-provided value |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | Cross-site scripting vulnerability due to a $@. | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params | user-provided value |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | Cross-site scripting vulnerability due to a $@. | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params | user-provided value |
 | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website | app/controllers/foo/bars_controller.rb:17:21:17:26 | call to params :  | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website | Cross-site scripting vulnerability due to a $@. | app/controllers/foo/bars_controller.rb:17:21:17:26 | call to params | user-provided value |

--- a/ruby/ql/test/query-tests/security/cwe-079/app/controllers/foo/bars_controller.rb
+++ b/ruby/ql/test/query-tests/security/cwe-079/app/controllers/foo/bars_controller.rb
@@ -22,6 +22,7 @@ class BarsController < ApplicationController
     @html_escaped = ERB::Util.html_escape(params[:text])
     @header_escaped = ERB::Util.html_escape(cookies[:foo]) # OK - cookies not controllable by 3rd party
     response.header["content-type"] = params[:content_type]
+    response.header["x-customer-header"] = params[:bar] # OK - header not relevant to XSS
     render "foo/bars/show", locals: { display_text: dt, safe_text: "hello" }
   end
 end

--- a/ruby/ql/test/query-tests/security/cwe-079/app/controllers/foo/bars_controller.rb
+++ b/ruby/ql/test/query-tests/security/cwe-079/app/controllers/foo/bars_controller.rb
@@ -21,6 +21,7 @@ class BarsController < ApplicationController
     @safe_foo = "safe_foo"
     @html_escaped = ERB::Util.html_escape(params[:text])
     @header_escaped = ERB::Util.html_escape(cookies[:foo]) # OK - cookies not controllable by 3rd party
+    response.header["content-type"] = params[:content_type]
     render "foo/bars/show", locals: { display_text: dt, safe_text: "hello" }
   end
 end


### PR DESCRIPTION
Model the various methods on `ActionDispatch::Response` which set parts of the HTTP response. I've added a new concept `Http::Server::HeaderWriteAccess` which represents a write to a header in a HTTP response. The reason for this is that the existing concept, `HttpResponse`, describes an entire HTTP response, whereas these methods just set _part_ of the response.

There are currently no queries that use this concept, but that's just because I can't think off the top of my head which queries it would apply to.

Besides headers, we also model `response.body = ...` and `response.send_file ...`, which are regular `HttpResponse` instances.

