### PR TITLE
Dataflow: Add support for synthetic global fields in MaD.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1581,6 +1581,8 @@ predicate jumpStep(Node pred, Node succ) {
     jrk.getTarget() = call.getATarget(_) and
     succ = getAnOutNode(call, jrk.getTargetReturnKind())
   )
+  or
+  FlowSummaryImpl::Private::Steps::summaryJumpStep(pred, succ)
 }
 
 private class StoreStepConfiguration extends ControlFlowReachabilityConfiguration {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -91,6 +91,12 @@ DataFlowType getCallbackReturnType(DataFlowType t, ReturnKind rk) {
   )
 }
 
+/** Gets the type of synthetic global `sg`. */
+DataFlowType getSyntheticGlobalType(SummaryComponent::SyntheticGlobal sg) {
+  exists(sg) and
+  result = Gvn::getGlobalValueNumber(any(ObjectType t))
+}
+
 bindingset[provenance]
 private boolean isGenerated(string provenance) {
   provenance = "generated" and result = true

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -83,6 +83,8 @@ predicate jumpStep(Node node1, Node node2) {
   or
   any(AdditionalValueStep a).step(node1, node2) and
   node1.getEnclosingCallable() != node2.getEnclosingCallable()
+  or
+  FlowSummaryImpl::Private::Steps::summaryJumpStep(node1, node2)
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -55,6 +55,12 @@ DataFlowType getCallbackReturnType(DataFlowType t, ReturnKind rk) {
   exists(rk)
 }
 
+/** Gets the type of synthetic global `sg`. */
+DataFlowType getSyntheticGlobalType(SummaryComponent::SyntheticGlobal sg) {
+  exists(sg) and
+  result instanceof TypeObject
+}
+
 bindingset[provenance]
 private boolean isGenerated(string provenance) {
   provenance = "generated" and result = true

--- a/java/ql/test/library-tests/dataflow/synth-global/A.java
+++ b/java/ql/test/library-tests/dataflow/synth-global/A.java
@@ -1,0 +1,25 @@
+package my.qltest.synth;
+
+public class A {
+  void storeInArray(String x) { }
+  void storeTaintInArray(String x) { }
+  void storeValue(String x) { }
+
+  String readValue() { return null; }
+  String readArray() { return null; }
+
+  String source(String tag) { return "tainted"; }
+
+  void sink(Object o) { }
+
+  void stores() {
+    storeInArray(source("A"));
+    storeTaintInArray(source("B"));
+    storeValue(source("C"));
+  }
+
+  void reads() {
+    sink(readValue()); // $ hasValueFlow=C
+    sink(readArray()); // $ hasValueFlow=A hasTaintFlow=B hasTaintFlow=C
+  }
+}

--- a/java/ql/test/library-tests/dataflow/synth-global/test.expected
+++ b/java/ql/test/library-tests/dataflow/synth-global/test.expected
@@ -1,0 +1,2 @@
+failures
+invalidModelRow

--- a/java/ql/test/library-tests/dataflow/synth-global/test.ql
+++ b/java/ql/test/library-tests/dataflow/synth-global/test.ql
@@ -1,6 +1,5 @@
 import java
 import TestUtilities.InlineFlowTest
-import semmle.code.java.dataflow.ExternalFlow
 import CsvValidation
 
 class SummaryModelTest extends SummaryModelCsv {

--- a/java/ql/test/library-tests/dataflow/synth-global/test.ql
+++ b/java/ql/test/library-tests/dataflow/synth-global/test.ql
@@ -1,0 +1,17 @@
+import java
+import TestUtilities.InlineFlowTest
+import semmle.code.java.dataflow.ExternalFlow
+import CsvValidation
+
+class SummaryModelTest extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "my.qltest.synth;A;false;storeInArray;(String);;Argument[0];SyntheticGlobal[db1].ArrayElement;value;manual",
+        "my.qltest.synth;A;false;storeTaintInArray;(String);;Argument[0];SyntheticGlobal[db1].ArrayElement;taint;manual",
+        "my.qltest.synth;A;false;storeValue;(String);;Argument[0];SyntheticGlobal[db1];value;manual",
+        "my.qltest.synth;A;false;readValue;();;SyntheticGlobal[db1];ReturnValue;value;manual",
+        "my.qltest.synth;A;false;readArray;();;SyntheticGlobal[db1].ArrayElement;ReturnValue;value;manual",
+      ]
+  }
+}

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -453,6 +453,8 @@ predicate jumpStep(Node nodeFrom, Node nodeTo) {
   jumpStepSharedWithTypeTracker(nodeFrom, nodeTo)
   or
   jumpStepNotSharedWithTypeTracker(nodeFrom, nodeTo)
+  or
+  FlowSummaryImpl::Private::Steps::summaryJumpStep(nodeFrom, nodeTo)
 }
 
 /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImplSpecific.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImplSpecific.qll
@@ -73,6 +73,9 @@ DataFlowType getCallbackParameterType(DataFlowType t, int i) { any() }
  */
 DataFlowType getCallbackReturnType(DataFlowType t, ReturnKind rk) { any() }
 
+/** Gets the type of synthetic global `sg`. */
+DataFlowType getSyntheticGlobalType(SummaryComponent::SyntheticGlobal sg) { any() }
+
 /**
  * Holds if an external flow summary exists for `c` with input specification
  * `input`, output specification `output`, kind `kind`, and a flag `generated`

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1003,6 +1003,8 @@ predicate jumpStep(Node pred, Node succ) {
     succ.(SsaDefinitionNode).getDefinition())
   or
   succ.asExpr().getExpr().(ConstantReadAccess).getValue() = pred.asExpr().getExpr()
+  or
+  FlowSummaryImpl::Private::Steps::summaryJumpStep(pred, succ)
 }
 
 private ContentSet getKeywordContent(string name) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -44,6 +44,9 @@ DataFlowType getCallbackParameterType(DataFlowType t, ArgumentPosition pos) { an
  */
 DataFlowType getCallbackReturnType(DataFlowType t, ReturnKind rk) { any() }
 
+/** Gets the type of synthetic global `sg`. */
+DataFlowType getSyntheticGlobalType(SummaryComponent::SyntheticGlobal sg) { any() }
+
 /**
  * Holds if an external flow summary exists for `c` with input specification
  * `input`, output specification `output`, kind `kind`, and a flag `generated`

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -486,7 +486,9 @@ private module OutNodes {
 
 import OutNodes
 
-predicate jumpStep(Node pred, Node succ) { none() }
+predicate jumpStep(Node pred, Node succ) {
+  FlowSummaryImpl::Private::Steps::summaryJumpStep(pred, succ)
+}
 
 predicate storeStep(Node node1, ContentSet c, Node node2) {
   exists(MemberRefExpr ref, AssignExpr assign |

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -51,6 +51,9 @@ DataFlowType getCallbackReturnType(DataFlowType t, ReturnKind rk) {
   any() // TODO once we have type pruning
 }
 
+/** Gets the type of synthetic global `sg`. */
+DataFlowType getSyntheticGlobalType(SummaryComponent::SyntheticGlobal sg) { any() }
+
 /**
  * Holds if an external flow summary exists for `c` with input specification
  * `input`, output specification `output`, kind `kind`, and a flag `generated`


### PR DESCRIPTION
This allows MaD summaries that resp. reads or writes from some global state, e.g. a database, such that jump steps are inserted between the synthesized function bodies.

This allows us to add models for `storeInDb` and `readFromDb` such that we have flow in the following case even if there's no path between `foo` and `bar`:
```
foo() {
  storeInDb(tainted);
}

bar() {
  sink(readFromDb());
}
```