### PR TITLE
Ruby: add dataflow for getters/setters defined using `alias_attribute`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -643,7 +643,7 @@ private DataFlow::Node trackInstanceRec(Module tp, TypeTracker t, boolean exact,
 }
 
 pragma[nomagic]
-private DataFlow::Node trackInstance(Module tp, boolean exact) {
+DataFlow::Node trackInstance(Module tp, boolean exact) {
   result = trackInstance(tp, exact, TypeTracker::end())
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
@@ -124,6 +124,96 @@ module ActiveSupport {
       }
       // TODO: index_by, index_with, pick, pluck (they require Hash dataflow)
     }
+
+    /** Extensions to the `Module` object. */
+    module Module {
+      private import codeql.ruby.dataflow.internal.DataFlowDispatch
+
+      /**
+       * Provides flow summaries for calls to setter methods that are defined using
+       * `alias_attribute`.
+       *
+       * ```rb
+       * class C
+       *   alias_attribute :foo, :bar
+       * end
+       * x = C.new
+       * x.foo = 123 # sets `bar`
+       * ```
+       */
+      private class AliasAttributeSetterSummary extends SummarizedCallable {
+        ClassDeclaration klass;
+        string aliasName;
+        string targetName;
+
+        AliasAttributeSetterSummary() {
+          exists(MethodCall aa | aa.getMethodName() = "alias_attribute" |
+            klass = aa.getEnclosingModule() and
+            aliasName = aa.getArgument(0).getConstantValue().getSymbol() and
+            targetName = aa.getArgument(1).getConstantValue().getSymbol() and
+            this = klass.getName() + "#" + aliasName + "="
+          )
+        }
+
+        override MethodCall getACall() {
+          // We're looking for a setter call using the alias name where the receiver
+          // is an instance of `klass`.
+          exists(Module m |
+            klass = m.getADeclaration() and
+            result.getReceiver() = trackInstance(m, true).asExpr().getExpr() and
+            result.(SetterMethodCall).getTargetName() = aliasName
+          )
+        }
+
+        override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+          input = "Argument[0]" and
+          output = "Argument[self].Field[@" + targetName + "]" and
+          preservesValue = true
+        }
+      }
+
+      /**
+       * Provides flow summaries for calls to getter methods that are defined using
+       * `alias_attribute`.
+       *
+       * ```rb
+       * class C
+       *   alias_attribute :foo, :bar
+       * end
+       * x = C.new
+       * x.foo # gets `bar`
+       * ```
+       */
+      private class AliasAttributeGetterSummary extends SummarizedCallable {
+        ClassDeclaration klass;
+        string aliasName;
+        string targetName;
+
+        AliasAttributeGetterSummary() {
+          exists(MethodCall aa | aa.getMethodName() = "alias_attribute" |
+            klass = aa.getEnclosingModule() and
+            aliasName = aa.getArgument(0).getConstantValue().getSymbol() and
+            targetName = aa.getArgument(1).getConstantValue().getSymbol() and
+            this = klass.getName() + "#" + aliasName
+          )
+        }
+
+        override MethodCall getACall() {
+          exists(Module m |
+            klass = m.getADeclaration() and
+            result.getReceiver() = trackInstance(m, true).asExpr().getExpr() and
+            result.getNumberOfArguments() = 0 and
+            result.getMethodName() = aliasName
+          )
+        }
+
+        override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+          input = "Argument[self].Field[@" + targetName + "]" and
+          output = "ReturnValue" and
+          preservesValue = true
+        }
+      }
+    }
   }
 
   /**

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
@@ -1,4 +1,6 @@
 failures
+| active_support.rb:219:8:219:15 | call to name | Unexpected result: hasValueFlow=a |
+| active_support.rb:220:8:220:19 | call to username | Unexpected result: hasValueFlow=a |
 edges
 | active_support.rb:9:9:9:18 | call to source :  | active_support.rb:10:10:10:10 | x :  |
 | active_support.rb:10:10:10:10 | x :  | active_support.rb:10:10:10:19 | call to camelize |
@@ -144,6 +146,36 @@ edges
 | active_support.rb:199:7:199:17 | call to existence :  | active_support.rb:201:7:201:7 | y :  |
 | active_support.rb:201:7:201:7 | y :  | active_support.rb:201:7:201:17 | call to existence :  |
 | active_support.rb:201:7:201:17 | call to existence :  | active_support.rb:202:8:202:8 | z |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | active_support.rb:214:8:214:10 | foo [@name] :  |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | active_support.rb:214:8:214:10 | foo [@name] :  |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | active_support.rb:215:8:215:10 | foo [@name] :  |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | active_support.rb:215:8:215:10 | foo [@name] :  |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | active_support.rb:219:8:219:10 | foo [@name] :  |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | active_support.rb:219:8:219:10 | foo [@name] :  |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | active_support.rb:220:8:220:10 | foo [@name] :  |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | active_support.rb:220:8:220:10 | foo [@name] :  |
+| active_support.rb:212:14:212:23 | call to source :  | active_support.rb:212:3:212:5 | [post] foo [@name] :  |
+| active_support.rb:212:14:212:23 | call to source :  | active_support.rb:212:3:212:5 | [post] foo [@name] :  |
+| active_support.rb:214:8:214:10 | foo [@name] :  | active_support.rb:214:8:214:15 | call to name |
+| active_support.rb:214:8:214:10 | foo [@name] :  | active_support.rb:214:8:214:15 | call to name |
+| active_support.rb:215:8:215:10 | foo [@name] :  | active_support.rb:215:8:215:19 | call to username |
+| active_support.rb:215:8:215:10 | foo [@name] :  | active_support.rb:215:8:215:19 | call to username |
+| active_support.rb:217:3:217:5 | [post] foo [@name] :  | active_support.rb:219:8:219:10 | foo [@name] :  |
+| active_support.rb:217:3:217:5 | [post] foo [@name] :  | active_support.rb:219:8:219:10 | foo [@name] :  |
+| active_support.rb:217:3:217:5 | [post] foo [@name] :  | active_support.rb:220:8:220:10 | foo [@name] :  |
+| active_support.rb:217:3:217:5 | [post] foo [@name] :  | active_support.rb:220:8:220:10 | foo [@name] :  |
+| active_support.rb:217:3:217:5 | [post] foo [@username] :  | active_support.rb:220:8:220:10 | foo [@username] :  |
+| active_support.rb:217:3:217:5 | [post] foo [@username] :  | active_support.rb:220:8:220:10 | foo [@username] :  |
+| active_support.rb:217:18:217:27 | call to source :  | active_support.rb:217:3:217:5 | [post] foo [@name] :  |
+| active_support.rb:217:18:217:27 | call to source :  | active_support.rb:217:3:217:5 | [post] foo [@name] :  |
+| active_support.rb:217:18:217:27 | call to source :  | active_support.rb:217:3:217:5 | [post] foo [@username] :  |
+| active_support.rb:217:18:217:27 | call to source :  | active_support.rb:217:3:217:5 | [post] foo [@username] :  |
+| active_support.rb:219:8:219:10 | foo [@name] :  | active_support.rb:219:8:219:15 | call to name |
+| active_support.rb:219:8:219:10 | foo [@name] :  | active_support.rb:219:8:219:15 | call to name |
+| active_support.rb:220:8:220:10 | foo [@name] :  | active_support.rb:220:8:220:19 | call to username |
+| active_support.rb:220:8:220:10 | foo [@name] :  | active_support.rb:220:8:220:19 | call to username |
+| active_support.rb:220:8:220:10 | foo [@username] :  | active_support.rb:220:8:220:19 | call to username |
+| active_support.rb:220:8:220:10 | foo [@username] :  | active_support.rb:220:8:220:19 | call to username |
 nodes
 | active_support.rb:9:9:9:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:10:10:10:10 | x :  | semmle.label | x :  |
@@ -327,6 +359,34 @@ nodes
 | active_support.rb:201:7:201:7 | y :  | semmle.label | y :  |
 | active_support.rb:201:7:201:17 | call to existence :  | semmle.label | call to existence :  |
 | active_support.rb:202:8:202:8 | z | semmle.label | z |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | semmle.label | [post] foo [@name] :  |
+| active_support.rb:212:3:212:5 | [post] foo [@name] :  | semmle.label | [post] foo [@name] :  |
+| active_support.rb:212:14:212:23 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:212:14:212:23 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:214:8:214:10 | foo [@name] :  | semmle.label | foo [@name] :  |
+| active_support.rb:214:8:214:10 | foo [@name] :  | semmle.label | foo [@name] :  |
+| active_support.rb:214:8:214:15 | call to name | semmle.label | call to name |
+| active_support.rb:214:8:214:15 | call to name | semmle.label | call to name |
+| active_support.rb:215:8:215:10 | foo [@name] :  | semmle.label | foo [@name] :  |
+| active_support.rb:215:8:215:10 | foo [@name] :  | semmle.label | foo [@name] :  |
+| active_support.rb:215:8:215:19 | call to username | semmle.label | call to username |
+| active_support.rb:215:8:215:19 | call to username | semmle.label | call to username |
+| active_support.rb:217:3:217:5 | [post] foo [@name] :  | semmle.label | [post] foo [@name] :  |
+| active_support.rb:217:3:217:5 | [post] foo [@name] :  | semmle.label | [post] foo [@name] :  |
+| active_support.rb:217:3:217:5 | [post] foo [@username] :  | semmle.label | [post] foo [@username] :  |
+| active_support.rb:217:3:217:5 | [post] foo [@username] :  | semmle.label | [post] foo [@username] :  |
+| active_support.rb:217:18:217:27 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:217:18:217:27 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:219:8:219:10 | foo [@name] :  | semmle.label | foo [@name] :  |
+| active_support.rb:219:8:219:10 | foo [@name] :  | semmle.label | foo [@name] :  |
+| active_support.rb:219:8:219:15 | call to name | semmle.label | call to name |
+| active_support.rb:219:8:219:15 | call to name | semmle.label | call to name |
+| active_support.rb:220:8:220:10 | foo [@name] :  | semmle.label | foo [@name] :  |
+| active_support.rb:220:8:220:10 | foo [@name] :  | semmle.label | foo [@name] :  |
+| active_support.rb:220:8:220:10 | foo [@username] :  | semmle.label | foo [@username] :  |
+| active_support.rb:220:8:220:10 | foo [@username] :  | semmle.label | foo [@username] :  |
+| active_support.rb:220:8:220:19 | call to username | semmle.label | call to username |
+| active_support.rb:220:8:220:19 | call to username | semmle.label | call to username |
 subpaths
 #select
 | active_support.rb:106:10:106:13 | ...[...] | active_support.rb:104:10:104:17 | call to source :  | active_support.rb:106:10:106:13 | ...[...] | $@ | active_support.rb:104:10:104:17 | call to source :  | call to source :  |
@@ -343,3 +403,9 @@ subpaths
 | active_support.rb:134:10:134:13 | ...[...] | active_support.rb:129:32:129:40 | call to source :  | active_support.rb:134:10:134:13 | ...[...] | $@ | active_support.rb:129:32:129:40 | call to source :  | call to source :  |
 | active_support.rb:135:10:135:13 | ...[...] | active_support.rb:129:21:129:29 | call to source :  | active_support.rb:135:10:135:13 | ...[...] | $@ | active_support.rb:129:21:129:29 | call to source :  | call to source :  |
 | active_support.rb:135:10:135:13 | ...[...] | active_support.rb:129:32:129:40 | call to source :  | active_support.rb:135:10:135:13 | ...[...] | $@ | active_support.rb:129:32:129:40 | call to source :  | call to source :  |
+| active_support.rb:214:8:214:15 | call to name | active_support.rb:212:14:212:23 | call to source :  | active_support.rb:214:8:214:15 | call to name | $@ | active_support.rb:212:14:212:23 | call to source :  | call to source :  |
+| active_support.rb:215:8:215:19 | call to username | active_support.rb:212:14:212:23 | call to source :  | active_support.rb:215:8:215:19 | call to username | $@ | active_support.rb:212:14:212:23 | call to source :  | call to source :  |
+| active_support.rb:219:8:219:15 | call to name | active_support.rb:212:14:212:23 | call to source :  | active_support.rb:219:8:219:15 | call to name | $@ | active_support.rb:212:14:212:23 | call to source :  | call to source :  |
+| active_support.rb:219:8:219:15 | call to name | active_support.rb:217:18:217:27 | call to source :  | active_support.rb:219:8:219:15 | call to name | $@ | active_support.rb:217:18:217:27 | call to source :  | call to source :  |
+| active_support.rb:220:8:220:19 | call to username | active_support.rb:212:14:212:23 | call to source :  | active_support.rb:220:8:220:19 | call to username | $@ | active_support.rb:212:14:212:23 | call to source :  | call to source :  |
+| active_support.rb:220:8:220:19 | call to username | active_support.rb:217:18:217:27 | call to source :  | active_support.rb:220:8:220:19 | call to username | $@ | active_support.rb:217:18:217:27 | call to source :  | call to source :  |

--- a/ruby/ql/test/library-tests/frameworks/active_support/active_support.rb
+++ b/ruby/ql/test/library-tests/frameworks/active_support/active_support.rb
@@ -201,3 +201,21 @@ def m_pathname_existence
   z = y.existence
   sink z # $hasTaintFlow=a
 end
+
+def m_alias_attribute
+  class ClassWithAlias
+    alias_attribute :username, :name
+  end
+
+  foo = ClassWithAlias.new
+      
+  foo.name = source "a"
+  
+  sink foo.name # $ hasValueFlow=a
+  sink foo.username # $ hasValueFlow=a
+  
+  foo.username = source "b"
+  
+  sink foo.name # $ hasValueFlow=b
+  sink foo.username # $ hasValueFlow=b
+end


### PR DESCRIPTION
Draft because
1. the updated test has two failures that need to be fixed
2. we probably don't want to expose `trackInstance` exactly like this