### PR TITLE
ATM/refactor endpoint filters to labels 1

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -25,10 +25,9 @@ module SinkEndpointFilter {
     or
     result = any(StandardEndpointLabels::Labels::LegacyModeledDbAccess l).getLabel(sinkCandidate)
     or
+    result = any(StandardEndpointLabels::Labels::LegacyModeledSink l).getLabel(sinkCandidate)
+    or
     exists(DataFlow::CallNode call | sinkCandidate = call.getAnArgument() |
-      CoreKnowledge::isArgumentToKnownLibrarySinkFunction(sinkCandidate) and
-      result = "modeled sink"
-      or
       // Remove common kinds of unlikely sinks
       CoreKnowledge::isKnownStepSrc(sinkCandidate) and
       result = "predecessor in a modeled flow step"

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -20,12 +20,12 @@ module SinkEndpointFilter {
    */
   string getAReasonSinkExcluded(DataFlow::Node sinkCandidate) {
     result =
-      any(StandardEndpointLabels::Labels::EndpointLabel l |
-        l instanceof StandardEndpointLabels::Labels::LegacyReasonSinkExcludedEndpointLabel or
-        l instanceof StandardEndpointLabels::Labels::LegacyModeledDbAccessEndpointLabel or
-        l instanceof StandardEndpointLabels::Labels::LegacyModeledSinkEndpointLabel or
-        l instanceof StandardEndpointLabels::Labels::LegacyModeledStepSourceEndpointLabel or
-        l instanceof StandardEndpointLabels::Labels::LegacyModeledHttpEndpointLabel
+      any(StandardEndpointLabels::Labels::EndpointLabeller l |
+        l instanceof StandardEndpointLabels::Labels::LegacyReasonSinkExcludedEndpointLabeller or
+        l instanceof StandardEndpointLabels::Labels::LegacyModeledDbAccessEndpointLabeller or
+        l instanceof StandardEndpointLabels::Labels::LegacyModeledSinkEndpointLabeller or
+        l instanceof StandardEndpointLabels::Labels::LegacyModeledStepSourceEndpointLabeller or
+        l instanceof StandardEndpointLabels::Labels::LegacyModeledHttpEndpointLabeller
       ).getLabel(sinkCandidate)
     or
     // TODO move this comment, and update it, when improving the endpoint filters.
@@ -59,7 +59,7 @@ module SinkEndpointFilter {
     // We can't reuse the class because importing that file would cause us to treat these
     // heuristic sinks as known sinks.
     not sinkCandidate =
-      StandardEndpointLabels::getALabeledEndpoint("legacy/likely-external-library-call")
+      StandardEndpointLabels::getALabeledEndpoint("legacy/likely-external-library-call/is")
           .(DataFlow::CallNode)
           .getAnArgument() and
     not (

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -9,7 +9,7 @@ private import semmle.javascript.heuristics.SyntacticHeuristics
 private import semmle.javascript.security.dataflow.NosqlInjectionCustomizations
 import AdaptiveThreatModeling
 private import CoreKnowledge as CoreKnowledge
-private import StandardEndpointFilters as StandardEndpointFilters
+private import StandardEndpointLabels as StandardEndpointLabels
 
 module SinkEndpointFilter {
   /**
@@ -19,7 +19,7 @@ module SinkEndpointFilter {
    * effective sink.
    */
   string getAReasonSinkExcluded(DataFlow::Node sinkCandidate) {
-    result = StandardEndpointFilters::getAReasonSinkExcluded(sinkCandidate)
+    "legacy/reason-sink-excluded/" + result = StandardEndpointLabels::getAnEndpointLabel(sinkCandidate)
     or
     exists(DataFlow::CallNode call | sinkCandidate = call.getAnArgument() |
       // additional databases accesses that aren't modeled yet
@@ -49,6 +49,8 @@ module SinkEndpointFilter {
       result = "receiver is a HTTP response expression"
     )
     or
+    // TODO move this comment, and update it, when improving the endpoint filters.
+    //
     // Require NoSQL injection sink candidates to be (a) direct arguments to external library calls
     // or (b) heuristic sinks for NoSQL injection.
     //
@@ -77,7 +79,7 @@ module SinkEndpointFilter {
     // `codeql/javascript/ql/src/semmle/javascript/heuristics/AdditionalSinks.qll`.
     // We can't reuse the class because importing that file would cause us to treat these
     // heuristic sinks as known sinks.
-    not sinkCandidate = StandardEndpointFilters::getALikelyExternalLibraryCall().getAnArgument() and
+    not sinkCandidate = StandardEndpointLabels::getALabeledEndpoint("legacy/likely-external-library-call").(DataFlow::CallNode).getAnArgument() and
     not (
       isAssignedToOrConcatenatedWith(sinkCandidate, "(?i)(nosql|query)") or
       isArgTo(sinkCandidate, "(?i)(query)")

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -19,7 +19,8 @@ module SinkEndpointFilter {
    * effective sink.
    */
   string getAReasonSinkExcluded(DataFlow::Node sinkCandidate) {
-    "legacy/reason-sink-excluded/" + result = StandardEndpointLabels::getAnEndpointLabel(sinkCandidate)
+    "legacy/reason-sink-excluded/" + result =
+      StandardEndpointLabels::getAnEndpointLabel(sinkCandidate)
     or
     exists(DataFlow::CallNode call | sinkCandidate = call.getAnArgument() |
       // additional databases accesses that aren't modeled yet
@@ -79,7 +80,10 @@ module SinkEndpointFilter {
     // `codeql/javascript/ql/src/semmle/javascript/heuristics/AdditionalSinks.qll`.
     // We can't reuse the class because importing that file would cause us to treat these
     // heuristic sinks as known sinks.
-    not sinkCandidate = StandardEndpointLabels::getALabeledEndpoint("legacy/likely-external-library-call").(DataFlow::CallNode).getAnArgument() and
+    not sinkCandidate =
+      StandardEndpointLabels::getALabeledEndpoint("legacy/likely-external-library-call")
+          .(DataFlow::CallNode)
+          .getAnArgument() and
     not (
       isAssignedToOrConcatenatedWith(sinkCandidate, "(?i)(nosql|query)") or
       isArgTo(sinkCandidate, "(?i)(query)")

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -23,13 +23,9 @@ module SinkEndpointFilter {
       any(StandardEndpointLabels::Labels::LegacyReasonSinkExcludedEndpointLabel l)
           .getLabel(sinkCandidate)
     or
+    result = any(StandardEndpointLabels::Labels::LegacyModeledDbAccess l).getLabel(sinkCandidate)
+    or
     exists(DataFlow::CallNode call | sinkCandidate = call.getAnArgument() |
-      // additional databases accesses that aren't modeled yet
-      call.(DataFlow::MethodCallNode).getMethodName() =
-        ["create", "createCollection", "createIndexes"] and
-      result = "matches database access call heuristic"
-      or
-      // Remove modeled sinks
       CoreKnowledge::isArgumentToKnownLibrarySinkFunction(sinkCandidate) and
       result = "modeled sink"
       or

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -20,18 +20,16 @@ module SinkEndpointFilter {
    */
   string getAReasonSinkExcluded(DataFlow::Node sinkCandidate) {
     result =
-      any(StandardEndpointLabels::Labels::LegacyReasonSinkExcludedEndpointLabel l)
-          .getLabel(sinkCandidate)
-    or
-    result = any(StandardEndpointLabels::Labels::LegacyModeledDbAccess l).getLabel(sinkCandidate)
-    or
-    result = any(StandardEndpointLabels::Labels::LegacyModeledSink l).getLabel(sinkCandidate)
+      any(StandardEndpointLabels::Labels::EndpointLabel l |
+        l.toString().matches("%" + [
+          "LegacyReasonSinkExcludedEndpointLabel", //
+          "LegacyModeledDbAccess", //
+          "LegacyModeledSink", //
+          "LegacyModeledStepSourceEndpointLabel", //
+        ] + "%")
+      ).getLabel(sinkCandidate)
     or
     exists(DataFlow::CallNode call | sinkCandidate = call.getAnArgument() |
-      // Remove common kinds of unlikely sinks
-      CoreKnowledge::isKnownStepSrc(sinkCandidate) and
-      result = "predecessor in a modeled flow step"
-      or
       // Remove modeled database calls. Arguments to modeled calls are very likely to be modeled
       // as sinks if they are true positives. Therefore arguments that are not modeled as sinks
       // are unlikely to be true positives.

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -19,8 +19,9 @@ module SinkEndpointFilter {
    * effective sink.
    */
   string getAReasonSinkExcluded(DataFlow::Node sinkCandidate) {
-    "legacy/reason-sink-excluded/" + result =
-      StandardEndpointLabels::getAnEndpointLabel(sinkCandidate)
+    result =
+      any(StandardEndpointLabels::Labels::LegacyReasonSinkExcludedEndpointLabel l)
+          .getLabel(sinkCandidate)
     or
     exists(DataFlow::CallNode call | sinkCandidate = call.getAnArgument() |
       // additional databases accesses that aren't modeled yet

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointFilters.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointFilters.qll
@@ -17,22 +17,22 @@ private import CoreKnowledge as CoreKnowledge
  * Provides a set of reasons why a given data flow node should be excluded as a sink candidate.
  */
 string getAReasonSinkExcluded(DataFlow::Node n) {
-  isArgumentToModeledFunction(n) and result = "argument to modeled function"
+  isArgumentToModeledFunction(n) and result = "legacy/reason-sink-excluded/argument to modeled function"
   or
-  isArgumentToSinklessLibrary(n) and result = "argument to sinkless library"
+  isArgumentToSinklessLibrary(n) and result = "legacy/reason-sink-excluded/argument to sinkless library"
   or
-  isSanitizer(n) and result = "sanitizer"
+  isSanitizer(n) and result = "legacy/reason-sink-excluded/sanitizer"
   or
-  isPredicate(n) and result = "predicate"
+  isPredicate(n) and result = "legacy/reason-sink-excluded/predicate"
   or
-  isHash(n) and result = "hash"
+  isHash(n) and result = "legacy/reason-sink-excluded/hash"
   or
-  isNumeric(n) and result = "numeric"
+  isNumeric(n) and result = "legacy/reason-sink-excluded/numeric"
   or
   // Ignore candidate sinks within externs, generated, library, and test code
   exists(string category | category = ["externs", "generated", "library", "test"] |
     ClassifyFiles::classify(n.getFile(), category) and
-    result = "in " + category + " file"
+    result = "legacy/reason-sink-excluded/in " + category + " file"
   )
 }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointFilters.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointFilters.qll
@@ -13,9 +13,9 @@ private import CoreKnowledge as CoreKnowledge
 
 /**
  * DEPRECATED: use StandardEndpointLabels instead.
- * 
+ *
  * Provides a set of reasons why a given data flow node should be excluded as a sink candidate.
- * */
+ */
 string getAReasonSinkExcluded(DataFlow::Node n) {
   isArgumentToModeledFunction(n) and result = "argument to modeled function"
   or

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointFilters.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointFilters.qll
@@ -11,7 +11,11 @@ private import semmle.javascript.filters.ClassifyFiles as ClassifyFiles
 private import semmle.javascript.heuristics.SyntacticHeuristics
 private import CoreKnowledge as CoreKnowledge
 
-/** Provides a set of reasons why a given data flow node should be excluded as a sink candidate. */
+/**
+ * DEPRECATED: use StandardEndpointLabels instead.
+ * 
+ * Provides a set of reasons why a given data flow node should be excluded as a sink candidate.
+ * */
 string getAReasonSinkExcluded(DataFlow::Node n) {
   isArgumentToModeledFunction(n) and result = "argument to modeled function"
   or

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointFilters.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointFilters.qll
@@ -17,9 +17,11 @@ private import CoreKnowledge as CoreKnowledge
  * Provides a set of reasons why a given data flow node should be excluded as a sink candidate.
  */
 string getAReasonSinkExcluded(DataFlow::Node n) {
-  isArgumentToModeledFunction(n) and result = "legacy/reason-sink-excluded/argument to modeled function"
+  isArgumentToModeledFunction(n) and
+  result = "legacy/reason-sink-excluded/argument to modeled function"
   or
-  isArgumentToSinklessLibrary(n) and result = "legacy/reason-sink-excluded/argument to sinkless library"
+  isArgumentToSinklessLibrary(n) and
+  result = "legacy/reason-sink-excluded/argument to sinkless library"
   or
   isSanitizer(n) and result = "legacy/reason-sink-excluded/sanitizer"
   or

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -10,6 +10,7 @@ private import javascript
 private import semmle.javascript.filters.ClassifyFiles as ClassifyFiles
 private import semmle.javascript.heuristics.SyntacticHeuristics
 private import CoreKnowledge as CoreKnowledge
+private import StandardEndpointFilters as StandardEndpointFilters
 
 module Labels {
   private newtype TEndpointLabel =
@@ -28,31 +29,24 @@ module Labels {
 
   class LikelyExternalLibraryCallEndpointLabel extends EndpointLabel,
     TLikelyExternalLibraryCallEndpointLabel {
-    override DataFlow::Node aNode() { result = getALikelyExternalLibraryCall() }
+    override DataFlow::Node aNode() { result = StandardEndpointFilters::getALikelyExternalLibraryCall() }
 
     override string getLabel() { result = "legacy/likely-external-library-call" }
   }
 
   class FlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel extends EndpointLabel,
     TFlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel {
-    override DataFlow::Node aNode() { flowsToArgumentOfLikelyExternalLibraryCall(result) }
+    override DataFlow::Node aNode() { StandardEndpointFilters::flowsToArgumentOfLikelyExternalLibraryCall(result) }
 
     override string getLabel() { result = "legacy/flows-to-argument-of-likely-external-library-call" }
   }
 
   class ReasonSinkExcludedEndpointLabel extends EndpointLabel, TReasonSinkExcludedEndpointLabel {
-    string reason;
-
-    ReasonSinkExcludedEndpointLabel() {
-      this = this and
-      reason = getAReasonSinkExcluded(any(DataFlow::Node n))
-    }
-
     override DataFlow::Node aNode() {
-      result = any(DataFlow::Node n | getAReasonSinkExcluded(n) = "legacy/reason-sink-excluded/"+reason)
+      result = any(DataFlow::Node n | exists(StandardEndpointFilters::getAReasonSinkExcluded(n)))
     }
 
-    override string getLabel() { result = reason }
+    override string getLabel() { result = "legacy/reason-sink-excluded/"+StandardEndpointFilters::getAReasonSinkExcluded(any(DataFlow::Node n)) }
   }
 }
 
@@ -61,125 +55,3 @@ string getAnEndpointLabel(DataFlow::Node n) {
 }
 
 DataFlow::Node getALabeledEndpoint(string label) { getAnEndpointLabel(result) = label }
-
-/** Provides a set of reasons why a given data flow node should be excluded as a sink candidate. */
-private string getAReasonSinkExcluded(DataFlow::Node n) {
-  isArgumentToModeledFunction(n) and result = "argument to modeled function"
-  or
-  isArgumentToSinklessLibrary(n) and result = "argument to sinkless library"
-  or
-  isSanitizer(n) and result = "sanitizer"
-  or
-  isPredicate(n) and result = "predicate"
-  or
-  isHash(n) and result = "hash"
-  or
-  isNumeric(n) and result = "numeric"
-  or
-  // Ignore candidate sinks within externs, generated, library, and test code
-  exists(string category | category = ["externs", "generated", "library", "test"] |
-    ClassifyFiles::classify(n.getFile(), category) and
-    result = "in " + category + " file"
-  )
-}
-
-/**
- * Holds if the node `n` is an argument to a function that has a manual model.
- */
-private predicate isArgumentToModeledFunction(DataFlow::Node n) {
-  exists(DataFlow::InvokeNode invk, DataFlow::Node known |
-    invk.getAnArgument() = n and invk.getAnArgument() = known and isSomeModeledArgument(known)
-  )
-}
-
-/**
- * Holds if the node `n` is an argument that has a manual model.
- */
-private predicate isSomeModeledArgument(DataFlow::Node n) {
-  CoreKnowledge::isKnownLibrarySink(n) or
-  CoreKnowledge::isKnownStepSrc(n) or
-  CoreKnowledge::isOtherModeledArgument(n, _)
-}
-
-/**
- * Holds if `n` appears to be a numeric value.
- */
-private predicate isNumeric(DataFlow::Node n) { isReadFrom(n, ".*index.*") }
-
-/**
- * Holds if `n` is an argument to a library without sinks.
- */
-private predicate isArgumentToSinklessLibrary(DataFlow::Node n) {
-  exists(DataFlow::InvokeNode invk, DataFlow::SourceNode commonSafeLibrary, string libraryName |
-    libraryName = ["slugify", "striptags", "marked"]
-  |
-    commonSafeLibrary = DataFlow::moduleImport(libraryName) and
-    invk = [commonSafeLibrary, commonSafeLibrary.getAPropertyRead()].getAnInvocation() and
-    n = invk.getAnArgument()
-  )
-}
-
-private predicate isSanitizer(DataFlow::Node n) {
-  exists(DataFlow::CallNode call | n = call.getAnArgument() |
-    call.getCalleeName().regexpMatch("(?i).*(escape|valid(ate)?|sanitize|purify).*")
-  )
-}
-
-private predicate isPredicate(DataFlow::Node n) {
-  exists(DataFlow::CallNode call | n = call.getAnArgument() |
-    call.getCalleeName().regexpMatch("(equals|(|is|has|can)(_|[A-Z])).*")
-  )
-}
-
-private predicate isHash(DataFlow::Node n) {
-  exists(DataFlow::CallNode call | n = call.getAnArgument() |
-    call.getCalleeName().regexpMatch("(?i)^(sha\\d*|md5|hash)$")
-  )
-}
-
-/**
- * Holds if the data flow node is a (possibly indirect) argument of a likely external library call.
- *
- * This includes direct arguments of likely external library calls as well as nested object
- * literals within those calls.
- */
-private predicate flowsToArgumentOfLikelyExternalLibraryCall(DataFlow::Node n) {
-  n = getACallWithoutCallee().getAnArgument()
-  or
-  exists(DataFlow::SourceNode src | flowsToArgumentOfLikelyExternalLibraryCall(src) |
-    n = src.getAPropertyWrite().getRhs()
-  )
-  or
-  exists(DataFlow::ArrayCreationNode arr | flowsToArgumentOfLikelyExternalLibraryCall(arr) |
-    n = arr.getAnElement()
-  )
-}
-
-/**
- * Get calls which are likely to be to external non-built-in libraries.
- */
-private DataFlow::CallNode getALikelyExternalLibraryCall() { result = getACallWithoutCallee() }
-
-/**
- * Gets a node that flows to callback-parameter `p`.
- */
-private DataFlow::SourceNode getACallback(DataFlow::ParameterNode p, DataFlow::TypeBackTracker t) {
-  t.start() and
-  result = p and
-  any(DataFlow::FunctionNode f).getLastParameter() = p and
-  exists(p.getACall())
-  or
-  exists(DataFlow::TypeBackTracker t2 | result = getACallback(p, t2).backtrack(t2, t))
-}
-
-/**
- * Get calls for which we do not have the callee (i.e. the definition of the called function). This
- * acts as a heuristic for identifying calls to external library functions.
- */
-private DataFlow::CallNode getACallWithoutCallee() {
-  forall(Function callee | callee = result.getACallee() | callee.getTopLevel().isExterns()) and
-  not exists(DataFlow::ParameterNode param, DataFlow::FunctionNode callback |
-    param.flowsTo(result.getCalleeNode()) and
-    callback = getACallback(param, DataFlow::TypeBackTracker::end())
-  )
-}

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -24,7 +24,7 @@ private module Labels {
   class LegacyLabel extends EndpointLabel, TLegacyEndpoint {
     override string getLabel(DataFlow::Node n) { legacyLabel(n, result) }
 
-    string toString() { result = "LegacyLabel" }
+    override string toString() { result = "LegacyLabel" }
   }
 
   predicate legacyLabel(DataFlow::Node n, string label) {

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -13,16 +13,18 @@ private import CoreKnowledge as CoreKnowledge
 private import StandardEndpointFilters as StandardEndpointFilters
 
 private module Labels {
-  class LabelledEndpoint extends DataFlow::Node {
-    abstract string getLabel();
+  newtype TEndpointLabel = TLegacyEndpoint()
+
+  class EndpointLabel extends TEndpointLabel {
+    abstract string getLabel(DataFlow::Node n);
+
+    abstract string toString();
   }
 
-  class LegacyLabel extends LabelledEndpoint {
-    string label;
+  class LegacyLabel extends EndpointLabel, TLegacyEndpoint {
+    override string getLabel(DataFlow::Node n) { legacyLabel(n, result) }
 
-    LegacyLabel() { legacyLabel(this, label) }
-
-    override string getLabel() { result = label }
+    string toString() { result = "LegacyLabel" }
   }
 
   predicate legacyLabel(DataFlow::Node n, string label) {
@@ -36,6 +38,6 @@ private module Labels {
   }
 }
 
-string getAnEndpointLabel(DataFlow::Node n) { result = n.(Labels::LabelledEndpoint).getLabel() }
+string getAnEndpointLabel(DataFlow::Node n) { result = any(Labels::EndpointLabel l).getLabel(n) }
 
 DataFlow::Node getALabeledEndpoint(string label) { getAnEndpointLabel(result) = label }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -12,56 +12,30 @@ private import semmle.javascript.heuristics.SyntacticHeuristics
 private import CoreKnowledge as CoreKnowledge
 private import StandardEndpointFilters as StandardEndpointFilters
 
-module Labels {
-  private newtype TEndpointLabel =
-    TLikelyExternalLibraryCallEndpointLabel() or
-    TFlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel() or
-    TReasonSinkExcludedEndpointLabel() or
-    TArgumentToModeledFunction()
-
-  class EndpointLabel extends TEndpointLabel {
-    abstract DataFlow::Node aNode();
-
+private module Labels {
+  class LabelledEndpoint extends DataFlow::Node {
     abstract string getLabel();
-
-    string toString() { result = getLabel() }
   }
 
-  class LikelyExternalLibraryCallEndpointLabel extends EndpointLabel,
-    TLikelyExternalLibraryCallEndpointLabel {
-    override DataFlow::Node aNode() {
-      result = StandardEndpointFilters::getALikelyExternalLibraryCall()
-    }
+  class LegacyLabel extends LabelledEndpoint {
+    string label;
 
-    override string getLabel() { result = "legacy/likely-external-library-call" }
+    LegacyLabel() { legacyLabel(this, label) }
+
+    override string getLabel() { result = label }
   }
 
-  class FlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel extends EndpointLabel,
-    TFlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel {
-    override DataFlow::Node aNode() {
-      StandardEndpointFilters::flowsToArgumentOfLikelyExternalLibraryCall(result)
-    }
-
-    override string getLabel() {
-      result = "legacy/flows-to-argument-of-likely-external-library-call"
-    }
-  }
-
-  class ReasonSinkExcludedEndpointLabel extends EndpointLabel, TReasonSinkExcludedEndpointLabel {
-    override DataFlow::Node aNode() {
-      result = any(DataFlow::Node n | exists(StandardEndpointFilters::getAReasonSinkExcluded(n)))
-    }
-
-    override string getLabel() {
-      result =
-        "legacy/reason-sink-excluded/" +
-          StandardEndpointFilters::getAReasonSinkExcluded(any(DataFlow::Node n))
-    }
+  predicate legacyLabel(DataFlow::Node n, string label) {
+    n = StandardEndpointFilters::getALikelyExternalLibraryCall() and
+    label = "legacy/likely-external-library-call"
+    or
+    StandardEndpointFilters::flowsToArgumentOfLikelyExternalLibraryCall(n) and
+    label = "legacy/flows-to-argument-of-likely-external-library-call"
+    or
+    label = "legacy/reason-sink-excluded/" + StandardEndpointFilters::getAReasonSinkExcluded(n)
   }
 }
 
-string getAnEndpointLabel(DataFlow::Node n) {
-  exists(Labels::EndpointLabel l | result = l.getLabel() and n = l.aNode())
-}
+string getAnEndpointLabel(DataFlow::Node n) { result = n.(Labels::LabelledEndpoint).getLabel() }
 
 DataFlow::Node getALabeledEndpoint(string label) { getAnEndpointLabel(result) = label }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -26,7 +26,8 @@ module Labels {
           "numeric", //
           "in " + ["externs", "generated", "library", "test"] + " file" //
         ]
-    }
+    } or
+    TLegacyModeledDbAccess()
 
   class EndpointLabel extends TEndpointLabel {
     abstract string getLabel(DataFlow::Node n);
@@ -59,9 +60,21 @@ module Labels {
 
     override string toString() {
       exists(string inner | this = TLegacyReasonSinkExcludedEndpointLabel(inner) |
-        result = "legacy/reason-sink-excluded/" + inner
+        result = "TLegacyReasonSinkExcludedEndpointLabel(" + inner + ")"
       )
     }
+  }
+
+  class LegacyModeledDbAccess extends EndpointLabel, TLegacyModeledDbAccess {
+    override string getLabel(DataFlow::Node n) {
+      exists(DataFlow::CallNode call | n = call.getAnArgument() |
+        call.(DataFlow::MethodCallNode).getMethodName() =
+          ["create", "createCollection", "createIndexes"] and
+        result = "legacy/modeled/db-access/matches database access call heuristic"
+      )
+    }
+
+    override string toString() { result = "LegacyModeledDbAccess" }
   }
 }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -1,0 +1,185 @@
+/**
+ * For internal use only.
+ *
+ * Provides classes and predicates that are useful for endpoint filters.
+ *
+ * The standard use of this library is to make use of `isPotentialEffectiveSink/1`
+ */
+
+private import javascript
+private import semmle.javascript.filters.ClassifyFiles as ClassifyFiles
+private import semmle.javascript.heuristics.SyntacticHeuristics
+private import CoreKnowledge as CoreKnowledge
+
+module Labels {
+  private newtype TEndpointLabel =
+    TLikelyExternalLibraryCallEndpointLabel() or
+    TFlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel() or
+    TReasonSinkExcludedEndpointLabel() or
+    TArgumentToModeledFunction()
+
+  class EndpointLabel extends TEndpointLabel {
+    abstract DataFlow::Node aNode();
+
+    abstract string getLabel();
+
+    string toString() { result = getLabel() }
+  }
+
+  class LikelyExternalLibraryCallEndpointLabel extends EndpointLabel,
+    TLikelyExternalLibraryCallEndpointLabel {
+    override DataFlow::Node aNode() { result = getALikelyExternalLibraryCall() }
+
+    override string getLabel() { result = "legacy/likely-external-library-call" }
+  }
+
+  class FlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel extends EndpointLabel,
+    TFlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel {
+    override DataFlow::Node aNode() { flowsToArgumentOfLikelyExternalLibraryCall(result) }
+
+    override string getLabel() { result = "legacy/flows-to-argument-of-likely-external-library-call" }
+  }
+
+  class ReasonSinkExcludedEndpointLabel extends EndpointLabel, TReasonSinkExcludedEndpointLabel {
+    string reason;
+
+    ReasonSinkExcludedEndpointLabel() {
+      this = this and
+      reason = getAReasonSinkExcluded(any(DataFlow::Node n))
+    }
+
+    override DataFlow::Node aNode() {
+      result = any(DataFlow::Node n | getAReasonSinkExcluded(n) = "legacy/reason-sink-excluded/"+reason)
+    }
+
+    override string getLabel() { result = reason }
+  }
+}
+
+string getAnEndpointLabel(DataFlow::Node n) {
+  exists(Labels::EndpointLabel l | result = l.getLabel() and n = l.aNode())
+}
+
+DataFlow::Node getALabeledEndpoint(string label) { getAnEndpointLabel(result) = label }
+
+/** Provides a set of reasons why a given data flow node should be excluded as a sink candidate. */
+private string getAReasonSinkExcluded(DataFlow::Node n) {
+  isArgumentToModeledFunction(n) and result = "argument to modeled function"
+  or
+  isArgumentToSinklessLibrary(n) and result = "argument to sinkless library"
+  or
+  isSanitizer(n) and result = "sanitizer"
+  or
+  isPredicate(n) and result = "predicate"
+  or
+  isHash(n) and result = "hash"
+  or
+  isNumeric(n) and result = "numeric"
+  or
+  // Ignore candidate sinks within externs, generated, library, and test code
+  exists(string category | category = ["externs", "generated", "library", "test"] |
+    ClassifyFiles::classify(n.getFile(), category) and
+    result = "in " + category + " file"
+  )
+}
+
+/**
+ * Holds if the node `n` is an argument to a function that has a manual model.
+ */
+private predicate isArgumentToModeledFunction(DataFlow::Node n) {
+  exists(DataFlow::InvokeNode invk, DataFlow::Node known |
+    invk.getAnArgument() = n and invk.getAnArgument() = known and isSomeModeledArgument(known)
+  )
+}
+
+/**
+ * Holds if the node `n` is an argument that has a manual model.
+ */
+private predicate isSomeModeledArgument(DataFlow::Node n) {
+  CoreKnowledge::isKnownLibrarySink(n) or
+  CoreKnowledge::isKnownStepSrc(n) or
+  CoreKnowledge::isOtherModeledArgument(n, _)
+}
+
+/**
+ * Holds if `n` appears to be a numeric value.
+ */
+private predicate isNumeric(DataFlow::Node n) { isReadFrom(n, ".*index.*") }
+
+/**
+ * Holds if `n` is an argument to a library without sinks.
+ */
+private predicate isArgumentToSinklessLibrary(DataFlow::Node n) {
+  exists(DataFlow::InvokeNode invk, DataFlow::SourceNode commonSafeLibrary, string libraryName |
+    libraryName = ["slugify", "striptags", "marked"]
+  |
+    commonSafeLibrary = DataFlow::moduleImport(libraryName) and
+    invk = [commonSafeLibrary, commonSafeLibrary.getAPropertyRead()].getAnInvocation() and
+    n = invk.getAnArgument()
+  )
+}
+
+private predicate isSanitizer(DataFlow::Node n) {
+  exists(DataFlow::CallNode call | n = call.getAnArgument() |
+    call.getCalleeName().regexpMatch("(?i).*(escape|valid(ate)?|sanitize|purify).*")
+  )
+}
+
+private predicate isPredicate(DataFlow::Node n) {
+  exists(DataFlow::CallNode call | n = call.getAnArgument() |
+    call.getCalleeName().regexpMatch("(equals|(|is|has|can)(_|[A-Z])).*")
+  )
+}
+
+private predicate isHash(DataFlow::Node n) {
+  exists(DataFlow::CallNode call | n = call.getAnArgument() |
+    call.getCalleeName().regexpMatch("(?i)^(sha\\d*|md5|hash)$")
+  )
+}
+
+/**
+ * Holds if the data flow node is a (possibly indirect) argument of a likely external library call.
+ *
+ * This includes direct arguments of likely external library calls as well as nested object
+ * literals within those calls.
+ */
+private predicate flowsToArgumentOfLikelyExternalLibraryCall(DataFlow::Node n) {
+  n = getACallWithoutCallee().getAnArgument()
+  or
+  exists(DataFlow::SourceNode src | flowsToArgumentOfLikelyExternalLibraryCall(src) |
+    n = src.getAPropertyWrite().getRhs()
+  )
+  or
+  exists(DataFlow::ArrayCreationNode arr | flowsToArgumentOfLikelyExternalLibraryCall(arr) |
+    n = arr.getAnElement()
+  )
+}
+
+/**
+ * Get calls which are likely to be to external non-built-in libraries.
+ */
+private DataFlow::CallNode getALikelyExternalLibraryCall() { result = getACallWithoutCallee() }
+
+/**
+ * Gets a node that flows to callback-parameter `p`.
+ */
+private DataFlow::SourceNode getACallback(DataFlow::ParameterNode p, DataFlow::TypeBackTracker t) {
+  t.start() and
+  result = p and
+  any(DataFlow::FunctionNode f).getLastParameter() = p and
+  exists(p.getACall())
+  or
+  exists(DataFlow::TypeBackTracker t2 | result = getACallback(p, t2).backtrack(t2, t))
+}
+
+/**
+ * Get calls for which we do not have the callee (i.e. the definition of the called function). This
+ * acts as a heuristic for identifying calls to external library functions.
+ */
+private DataFlow::CallNode getACallWithoutCallee() {
+  forall(Function callee | callee = result.getACallee() | callee.getTopLevel().isExterns()) and
+  not exists(DataFlow::ParameterNode param, DataFlow::FunctionNode callback |
+    param.flowsTo(result.getCalleeNode()) and
+    callback = getACallback(param, DataFlow::TypeBackTracker::end())
+  )
+}

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -43,7 +43,7 @@ module Labels {
       result = "legacy/flows-to-argument-of-likely-external-library-call"
     }
 
-    override string toString() { result = "LegacyLabel" }
+    override string toString() { result = "LegacyEndpointLabel" }
   }
 
   class LegacyReasonSinkExcludedEndpointLabel extends EndpointLabel,
@@ -59,7 +59,7 @@ module Labels {
 
     override string toString() {
       exists(string inner | this = TLegacyReasonSinkExcludedEndpointLabel(inner) |
-        result = "TLegacyReasonSinkExcludedEndpointLabel(" + inner + ")"
+        result = "legacy/reason-sink-excluded/" + inner
       )
     }
   }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -28,7 +28,8 @@ module Labels {
         ]
     } or
     TLegacyModeledDbAccess() or
-    TLegacyModeledSink()
+    TLegacyModeledSink() or
+    TLegacyModeledStepSource()
 
   class EndpointLabel extends TEndpointLabel {
     abstract string getLabel(DataFlow::Node n);
@@ -75,7 +76,7 @@ module Labels {
       )
     }
 
-    override string toString() { result = "LegacyModeledDbAccess" }
+    override string toString() { result = "LegacyModeledDbAccessEndpointLabel" }
   }
 
   class LegacyModeledSink extends Labels::EndpointLabel, TLegacyModeledSink {
@@ -84,7 +85,16 @@ module Labels {
       result = "modeled sink"
     }
 
-    override string toString() { result = "LegacyModeledSink" }
+    override string toString() { result = "LegacyModeledSinkEndpointLabel" }
+  }
+
+  class LegacyModeledStepSource extends Labels::EndpointLabel, TLegacyModeledStepSource {
+    override string getLabel(DataFlow::Node n) {
+      CoreKnowledge::isKnownStepSrc(n) and
+      result = "legacy/modeled/step-source"
+    }
+
+    override string toString() { result = "LegacyModeledStepSourceEndpointLabel" }
   }
 }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -29,16 +29,22 @@ module Labels {
 
   class LikelyExternalLibraryCallEndpointLabel extends EndpointLabel,
     TLikelyExternalLibraryCallEndpointLabel {
-    override DataFlow::Node aNode() { result = StandardEndpointFilters::getALikelyExternalLibraryCall() }
+    override DataFlow::Node aNode() {
+      result = StandardEndpointFilters::getALikelyExternalLibraryCall()
+    }
 
     override string getLabel() { result = "legacy/likely-external-library-call" }
   }
 
   class FlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel extends EndpointLabel,
     TFlowsToArgumentOfLikelyExternalLibraryCallEndpointLabel {
-    override DataFlow::Node aNode() { StandardEndpointFilters::flowsToArgumentOfLikelyExternalLibraryCall(result) }
+    override DataFlow::Node aNode() {
+      StandardEndpointFilters::flowsToArgumentOfLikelyExternalLibraryCall(result)
+    }
 
-    override string getLabel() { result = "legacy/flows-to-argument-of-likely-external-library-call" }
+    override string getLabel() {
+      result = "legacy/flows-to-argument-of-likely-external-library-call"
+    }
   }
 
   class ReasonSinkExcludedEndpointLabel extends EndpointLabel, TReasonSinkExcludedEndpointLabel {
@@ -46,7 +52,11 @@ module Labels {
       result = any(DataFlow::Node n | exists(StandardEndpointFilters::getAReasonSinkExcluded(n)))
     }
 
-    override string getLabel() { result = "legacy/reason-sink-excluded/"+StandardEndpointFilters::getAReasonSinkExcluded(any(DataFlow::Node n)) }
+    override string getLabel() {
+      result =
+        "legacy/reason-sink-excluded/" +
+          StandardEndpointFilters::getAReasonSinkExcluded(any(DataFlow::Node n))
+    }
   }
 }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -27,7 +27,8 @@ module Labels {
           "in " + ["externs", "generated", "library", "test"] + " file" //
         ]
     } or
-    TLegacyModeledDbAccess()
+    TLegacyModeledDbAccess() or
+    TLegacyModeledSink()
 
   class EndpointLabel extends TEndpointLabel {
     abstract string getLabel(DataFlow::Node n);
@@ -75,6 +76,15 @@ module Labels {
     }
 
     override string toString() { result = "LegacyModeledDbAccess" }
+  }
+
+  class LegacyModeledSink extends Labels::EndpointLabel, TLegacyModeledSink {
+    override string getLabel(DataFlow::Node n) {
+      CoreKnowledge::isArgumentToKnownLibrarySinkFunction(n) and
+      result = "modeled sink"
+    }
+
+    override string toString() { result = "LegacyModeledSink" }
   }
 }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StandardEndpointLabels.qll
@@ -53,13 +53,13 @@ module Labels {
         this = TLegacyReasonSinkExcludedEndpointLabel(inner) and
         inner = StandardEndpointFilters::getAReasonSinkExcluded(n)
       |
-        result = "legacy/reason-sink-excluded/" + inner
+        result = inner
       )
     }
 
     override string toString() {
       exists(string inner | this = TLegacyReasonSinkExcludedEndpointLabel(inner) |
-        result = "legacy/reason-sink/excluded/" + inner
+        result = "TLegacyReasonSinkExcludedEndpointLabel(" + inner + ")"
       )
     }
   }

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/EndpointLabelsAreInRange.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/EndpointLabelsAreInRange.ql
@@ -1,0 +1,10 @@
+import experimental.adaptivethreatmodeling.StandardEndpointLabels as StandardEndpointLabels
+
+query predicate endpointLabelsAreInRangeConsistency(string range, string label) {
+  exists(StandardEndpointLabels::Labels::EndpointLabeller labeller |
+    range = labeller.toString().replaceAll("/**", "") and
+    label = labeller.getLabel(_)
+  |
+    not (label.matches(range + "/%") or label = range)
+  )
+}

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
@@ -25,23 +25,28 @@ import experimental.adaptivethreatmodeling.XssATM as XssAtm
 query predicate nosqlFilteredTruePositives(DataFlow::Node endpoint, string reason) {
   endpoint instanceof NosqlInjection::Sink and
   reason = NosqlInjectionAtm::SinkEndpointFilter::getAReasonSinkExcluded(endpoint) and
-  not reason = ["argument to modeled function", "modeled sink", "legacy/modeled/db-access"]
+  not reason
+      .matches("%" +
+          [
+            "legacy/reason-sink-excluded/argument to modeled function", "legacy/modeled/sink",
+            "legacy/modeled/db-access/"
+          ] + "%")
 }
 
 query predicate sqlFilteredTruePositives(DataFlow::Node endpoint, string reason) {
   endpoint instanceof SqlInjection::Sink and
   reason = SqlInjectionAtm::SinkEndpointFilter::getAReasonSinkExcluded(endpoint) and
-  reason != "argument to modeled function"
+  reason != "legacy/reason-sink-excluded/argument to modeled function"
 }
 
 query predicate taintedPathFilteredTruePositives(DataFlow::Node endpoint, string reason) {
   endpoint instanceof TaintedPath::Sink and
   reason = TaintedPathAtm::SinkEndpointFilter::getAReasonSinkExcluded(endpoint) and
-  reason != "argument to modeled function"
+  reason != "legacy/reason-sink-excluded/argument to modeled function"
 }
 
 query predicate xssFilteredTruePositives(DataFlow::Node endpoint, string reason) {
   endpoint instanceof DomBasedXss::Sink and
   reason = XssAtm::SinkEndpointFilter::getAReasonSinkExcluded(endpoint) and
-  reason != "argument to modeled function"
+  reason != "legacy/reason-sink-excluded/argument to modeled function"
 }

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
@@ -25,7 +25,9 @@ import experimental.adaptivethreatmodeling.XssATM as XssAtm
 query predicate nosqlFilteredTruePositives(DataFlow::Node endpoint, string reason) {
   endpoint instanceof NosqlInjection::Sink and
   reason = NosqlInjectionAtm::SinkEndpointFilter::getAReasonSinkExcluded(endpoint) and
-  not reason = ["argument to modeled function", "modeled sink", "modeled database access"]
+  not reason
+      .matches("%" + ["argument to modeled function", "modeled sink", "modeled database access"] +
+          "%")
 }
 
 query predicate sqlFilteredTruePositives(DataFlow::Node endpoint, string reason) {

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
@@ -25,9 +25,7 @@ import experimental.adaptivethreatmodeling.XssATM as XssAtm
 query predicate nosqlFilteredTruePositives(DataFlow::Node endpoint, string reason) {
   endpoint instanceof NosqlInjection::Sink and
   reason = NosqlInjectionAtm::SinkEndpointFilter::getAReasonSinkExcluded(endpoint) and
-  not reason
-      .matches("%" + ["argument to modeled function", "modeled sink", "modeled database access"] +
-          "%")
+  not reason = ["argument to modeled function", "modeled sink", "modeled database access"]
 }
 
 query predicate sqlFilteredTruePositives(DataFlow::Node endpoint, string reason) {

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/FilteredTruePositives.ql
@@ -25,7 +25,7 @@ import experimental.adaptivethreatmodeling.XssATM as XssAtm
 query predicate nosqlFilteredTruePositives(DataFlow::Node endpoint, string reason) {
   endpoint instanceof NosqlInjection::Sink and
   reason = NosqlInjectionAtm::SinkEndpointFilter::getAReasonSinkExcluded(endpoint) and
-  not reason = ["argument to modeled function", "modeled sink", "modeled database access"]
+  not reason = ["argument to modeled function", "modeled sink", "legacy/modeled/db-access"]
 }
 
 query predicate sqlFilteredTruePositives(DataFlow::Node endpoint, string reason) {


### PR DESCRIPTION
This is the first of several refactoring PRs.

It introduces the standard endpoint LABELS module that still relies on the standard endpoint FILTERS module and updates the nosql query to rely on labels.

At the end of the refactoring, 
* ... the filters module will have been merged into the labels module.
* ... the choice which query selects/deselects which points will be made in one location and there will be consistency tests to make sure the choice is complete.
* ... I will no longer be using hard-coded constants for selecting endpoints, but rather something type-checkable for easier maintenance.

# Performance

Performance-Experiments for this PR:

| SHA | Experiment | Result | Comment |
|-----|-------|-----|-----|
| [6208071](https://github.com/github/codeql/commit/620807157540dc75d2f701b30a29fadfc94ee37f) | https://github.com/github/codeql-dca-main/issues/7969 | KR: 👍*) | this is a current `main` head |
| [5fa3242](https://github.com/github/codeql/pull/10834/commits/5fa32428aa2c75c3a181108baa10849d71b23adc) | https://github.com/github/codeql-dca-main/issues/7970 | KR: 👍*) | comparable to the current `main` |
| [99fa66c](https://github.com/github/codeql/pull/10834/commits/99fa66c213c4d43cab893412e7d222b291d1f214) | https://github.com/github/codeql-dca-main/issues/7980 | KR: 👍*) | comparable to the current `main`; this is the current `atm/refactor-endpoint-filters-to-labels-1` head |
| [b41daa5](https://github.com/github/codeql/commit/b41daa5146b8aa53d5457a6739655bf5730ca85b) | https://github.com/github/codeql-dca-main/issues/8026 | :+1: | |

*) these weren't run with the four minutes wiggle room that the KR uses.

# To do:

 - [ ] Make a unit test to test we're not changing the behaviour of `getAReasonSinkExcluded` by accident.
 - [ ] Document the new module.