### PR TITLE
Ruby: Add more frameworks to the list of supported frameworks

### DIFF
--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -271,5 +271,5 @@ and the CodeQL library pack ``codeql/ruby-all`` (`changelog <https://github.com/
    rest-client, HTTP client
    Ruby on Rails, Web framework
    rubyzip, Compression library
-   typohoeus, HTTP client
+   typhoeus, HTTP client
 

--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -260,4 +260,16 @@ and the CodeQL library pack ``codeql/ruby-all`` (`changelog <https://github.com/
    :widths: auto
 
    Name, Category
+   excon, HTTP client
+   faraday, HTTP client
+   http_client, HTTP client
+   httparty, HTTP client
+   libxml-ruby, XML processing library
+   nokogiri, XML processing library
+   open-uri, HTTP client
+   posix-spawn, Utility library
+   rest-client, HTTP client
    Ruby on Rails, Web framework
+   rubyzip, Compression library
+   typohoeus, HTTP client
+


### PR DESCRIPTION
I've added the suggested frameworks to this list, however these frameworks have *partial* support so it's not clear to me which if any of these should be added. Putting this PR up here for discussion, and I don't feel too strongly about whether this should be included in the GA release.