### PR TITLE
C++: Prepare `FlowSources.qll` for IR-based use-use dataflow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
@@ -6,6 +6,7 @@ import cpp
 import semmle.code.cpp.ir.dataflow.DataFlow
 private import semmle.code.cpp.ir.IR
 import semmle.code.cpp.models.interfaces.FlowSource
+private import semmle.code.cpp.ir.dataflow.internal.ModelUtil
 
 /** A data flow source of user input, whether local or remote. */
 abstract class FlowSource extends DataFlow::Node {
@@ -19,68 +20,28 @@ abstract class RemoteFlowSource extends FlowSource { }
 /** A data flow source of local user input. */
 abstract class LocalFlowSource extends FlowSource { }
 
-private class RemoteReturnSource extends RemoteFlowSource {
+private class RemoteModelSource extends RemoteFlowSource {
   string sourceType;
 
-  RemoteReturnSource() {
-    exists(RemoteFlowSourceFunction func, CallInstruction instr, FunctionOutput output |
-      this.asInstruction() = instr and
-      instr.getStaticCallTarget() = func and
+  RemoteModelSource() {
+    exists(CallInstruction call, RemoteFlowSourceFunction func, FunctionOutput output |
+      call.getStaticCallTarget() = func and
       func.hasRemoteFlowSource(output, sourceType) and
-      (
-        output.isReturnValue()
-        or
-        output.isReturnValueDeref()
-      )
+      this = callOutput(call, output)
     )
   }
 
   override string getSourceType() { result = sourceType }
 }
 
-private class RemoteParameterSource extends RemoteFlowSource {
+private class LocalModelSource extends LocalFlowSource {
   string sourceType;
 
-  RemoteParameterSource() {
-    exists(RemoteFlowSourceFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
-      this.asInstruction() = instr and
-      instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
-      func.hasRemoteFlowSource(output, sourceType) and
-      output.isParameterDerefOrQualifierObject(instr.getIndex())
-    )
-  }
-
-  override string getSourceType() { result = sourceType }
-}
-
-private class LocalReturnSource extends LocalFlowSource {
-  string sourceType;
-
-  LocalReturnSource() {
-    exists(LocalFlowSourceFunction func, CallInstruction instr, FunctionOutput output |
-      this.asInstruction() = instr and
-      instr.getStaticCallTarget() = func and
+  LocalModelSource() {
+    exists(CallInstruction call, LocalFlowSourceFunction func, FunctionOutput output |
+      call.getStaticCallTarget() = func and
       func.hasLocalFlowSource(output, sourceType) and
-      (
-        output.isReturnValue()
-        or
-        output.isReturnValueDeref()
-      )
-    )
-  }
-
-  override string getSourceType() { result = sourceType }
-}
-
-private class LocalParameterSource extends LocalFlowSource {
-  string sourceType;
-
-  LocalParameterSource() {
-    exists(LocalFlowSourceFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
-      this.asInstruction() = instr and
-      instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
-      func.hasLocalFlowSource(output, sourceType) and
-      output.isParameterDerefOrQualifierObject(instr.getIndex())
+      this = callOutput(call, output)
     )
   }
 
@@ -109,18 +70,10 @@ private class RemoteParameterSink extends RemoteFlowSink {
   string sourceType;
 
   RemoteParameterSink() {
-    exists(RemoteFlowSinkFunction func, FunctionInput input, CallInstruction call, int index |
-      func.hasRemoteFlowSink(input, sourceType) and call.getStaticCallTarget() = func
-    |
-      exists(ReadSideEffectInstruction read |
-        call = read.getPrimaryInstruction() and
-        read.getIndex() = index and
-        this.asOperand() = read.getSideEffectOperand() and
-        input.isParameterDerefOrQualifierObject(index)
-      )
-      or
-      input.isParameterOrQualifierAddress(index) and
-      this.asOperand() = call.getArgumentOperand(index)
+    exists(CallInstruction call, RemoteFlowSinkFunction func, FunctionInput input |
+      call.getStaticCallTarget() = func and
+      func.hasRemoteFlowSink(input, sourceType) and
+      this = callInput(call, input)
     )
   }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/SAMATE/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/SAMATE/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -1,4 +1,8 @@
 edges
+| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | fgets output argument | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:20:52:23 | data |
 nodes
+| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | fgets output argument | semmle.label | fgets output argument |
+| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:20:52:23 | data | semmle.label | data |
 subpaths
 #select
+| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:20:52:23 | data | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | fgets output argument | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:20:52:23 | data | An array indexing expression depends on $@ that might be outside the bounds of the array. | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | fgets output argument | string read by fgets |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -5,31 +5,57 @@ edges
 | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:76:25:76:29 | start | test.cpp:80:18:80:28 | ... - ... |
+| test.cpp:76:25:76:29 | start indirection | test.cpp:80:18:80:28 | ... - ... |
+| test.cpp:76:38:76:40 | end | test.cpp:80:18:80:28 | ... - ... |
+| test.cpp:76:38:76:40 | end indirection | test.cpp:80:18:80:28 | ... - ... |
+| test.cpp:98:18:98:23 | fread output argument | test.cpp:102:17:102:22 | buffer |
+| test.cpp:98:18:98:23 | fread output argument | test.cpp:102:17:102:22 | buffer indirection |
+| test.cpp:98:18:98:23 | fread output argument | test.cpp:102:25:102:39 | ... + ... |
+| test.cpp:98:18:98:23 | fread output argument | test.cpp:102:25:102:39 | ... + ... indirection |
+| test.cpp:102:17:102:22 | buffer | test.cpp:76:25:76:29 | start |
+| test.cpp:102:17:102:22 | buffer indirection | test.cpp:76:25:76:29 | start indirection |
+| test.cpp:102:25:102:39 | ... + ... | test.cpp:76:38:76:40 | end |
+| test.cpp:102:25:102:39 | ... + ... indirection | test.cpp:76:38:76:40 | end indirection |
 | test.cpp:124:18:124:23 | call to getenv | test.cpp:125:29:125:32 | size |
 | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
+| test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:125:29:125:32 | size |
+| test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... |
 | test.cpp:125:29:125:32 | size | test.cpp:127:24:127:49 | ... * ... |
 | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
+| test.cpp:133:19:133:32 | call to getenv indirection | test.cpp:135:10:135:27 | ... * ... |
 | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
+| test.cpp:148:20:148:33 | call to getenv indirection | test.cpp:152:11:152:28 | ... * ... |
 | test.cpp:157:19:157:24 | call to getenv | test.cpp:161:11:161:28 | ... * ... |
+| test.cpp:157:19:157:32 | call to getenv indirection | test.cpp:161:11:161:28 | ... * ... |
 | test.cpp:184:19:184:24 | call to getenv | test.cpp:186:10:186:27 | ... * ... |
+| test.cpp:184:19:184:32 | call to getenv indirection | test.cpp:186:10:186:27 | ... * ... |
 | test.cpp:209:8:209:23 | VariableAddress indirection | test.cpp:241:9:241:24 | call to get_tainted_size |
 | test.cpp:211:14:211:19 | call to getenv | test.cpp:209:8:209:23 | VariableAddress indirection |
+| test.cpp:211:14:211:27 | call to getenv indirection | test.cpp:209:8:209:23 | VariableAddress indirection |
 | test.cpp:214:8:214:23 | VariableAddress indirection | test.cpp:242:9:242:24 | call to get_bounded_size |
 | test.cpp:216:18:216:23 | call to getenv | test.cpp:214:8:214:23 | VariableAddress indirection |
+| test.cpp:216:18:216:31 | call to getenv indirection | test.cpp:214:8:214:23 | VariableAddress indirection |
 | test.cpp:224:23:224:23 | s | test.cpp:225:21:225:21 | s |
 | test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:245:11:245:20 | local_size |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:247:10:247:19 | local_size |
+| test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:239:9:239:18 | local_size |
+| test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:245:11:245:20 | local_size |
+| test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:247:10:247:19 | local_size |
 | test.cpp:245:11:245:20 | local_size | test.cpp:224:23:224:23 | s |
 | test.cpp:247:10:247:19 | local_size | test.cpp:230:21:230:21 | s |
 | test.cpp:250:20:250:27 | Load indirection | test.cpp:289:17:289:20 | get_size output argument |
 | test.cpp:250:20:250:27 | Load indirection | test.cpp:305:18:305:21 | get_size output argument |
 | test.cpp:251:18:251:23 | call to getenv | test.cpp:250:20:250:27 | Load indirection |
+| test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:250:20:250:27 | Load indirection |
 | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
+| test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | test.cpp:308:10:308:27 | ... * ... |
 | test.cpp:331:15:331:20 | Call | test.cpp:334:9:334:14 | offset |
+| test.cpp:331:15:331:20 | Call indirection | test.cpp:334:9:334:14 | offset |
 nodes
 | test.cpp:40:21:40:24 | argv | semmle.label | argv |
 | test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
@@ -38,27 +64,45 @@ nodes
 | test.cpp:49:32:49:35 | size | semmle.label | size |
 | test.cpp:50:26:50:29 | size | semmle.label | size |
 | test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
+| test.cpp:76:25:76:29 | start | semmle.label | start |
+| test.cpp:76:25:76:29 | start indirection | semmle.label | start indirection |
+| test.cpp:76:38:76:40 | end | semmle.label | end |
+| test.cpp:76:38:76:40 | end indirection | semmle.label | end indirection |
+| test.cpp:80:18:80:28 | ... - ... | semmle.label | ... - ... |
+| test.cpp:98:18:98:23 | fread output argument | semmle.label | fread output argument |
+| test.cpp:102:17:102:22 | buffer | semmle.label | buffer |
+| test.cpp:102:17:102:22 | buffer indirection | semmle.label | buffer indirection |
+| test.cpp:102:25:102:39 | ... + ... | semmle.label | ... + ... |
+| test.cpp:102:25:102:39 | ... + ... indirection | semmle.label | ... + ... indirection |
 | test.cpp:124:18:124:23 | call to getenv | semmle.label | call to getenv |
+| test.cpp:124:18:124:31 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:125:29:125:32 | size | semmle.label | size |
 | test.cpp:127:24:127:49 | ... * ... | semmle.label | ... * ... |
 | test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
 | test.cpp:133:19:133:24 | call to getenv | semmle.label | call to getenv |
+| test.cpp:133:19:133:32 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:148:20:148:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:148:20:148:33 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:157:19:157:24 | call to getenv | semmle.label | call to getenv |
+| test.cpp:157:19:157:32 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:161:11:161:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:184:19:184:24 | call to getenv | semmle.label | call to getenv |
+| test.cpp:184:19:184:32 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:186:10:186:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:209:8:209:23 | VariableAddress indirection | semmle.label | VariableAddress indirection |
 | test.cpp:211:14:211:19 | call to getenv | semmle.label | call to getenv |
+| test.cpp:211:14:211:27 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:214:8:214:23 | VariableAddress indirection | semmle.label | VariableAddress indirection |
 | test.cpp:216:18:216:23 | call to getenv | semmle.label | call to getenv |
+| test.cpp:216:18:216:31 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:224:23:224:23 | s | semmle.label | s |
 | test.cpp:225:21:225:21 | s | semmle.label | s |
 | test.cpp:230:21:230:21 | s | semmle.label | s |
 | test.cpp:231:21:231:21 | s | semmle.label | s |
 | test.cpp:237:24:237:29 | call to getenv | semmle.label | call to getenv |
+| test.cpp:237:24:237:37 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
 | test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
 | test.cpp:242:9:242:24 | call to get_bounded_size | semmle.label | call to get_bounded_size |
@@ -66,13 +110,16 @@ nodes
 | test.cpp:247:10:247:19 | local_size | semmle.label | local_size |
 | test.cpp:250:20:250:27 | Load indirection | semmle.label | Load indirection |
 | test.cpp:251:18:251:23 | call to getenv | semmle.label | call to getenv |
+| test.cpp:251:18:251:31 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:259:20:259:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:259:20:259:33 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:331:15:331:20 | Call | semmle.label | Call |
+| test.cpp:331:15:331:20 | Call indirection | semmle.label | Call indirection |
 | test.cpp:334:9:334:14 | offset | semmle.label | offset |
 subpaths
 #select
@@ -82,18 +129,34 @@ subpaths
 | test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
 | test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
 | test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:80:9:80:29 | new[] | test.cpp:98:18:98:23 | fread output argument | test.cpp:80:18:80:28 | ... - ... | This allocation size is derived from $@ and might overflow. | test.cpp:98:18:98:23 | fread output argument | user input (String read by fread) |
 | test.cpp:127:17:127:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:127:24:127:49 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:23 | call to getenv | user input (an environment variable) |
+| test.cpp:127:17:127:22 | call to malloc | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:127:24:127:49 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:23 | call to getenv | user input (an environment variable) |
+| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:24 | call to getenv | user input (an environment variable) |
+| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:32 | call to getenv indirection | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:32 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:25 | call to getenv | user input (an environment variable) |
+| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:33 | call to getenv indirection | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:33 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:161:4:161:9 | call to malloc | test.cpp:157:19:157:24 | call to getenv | test.cpp:161:11:161:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:157:19:157:24 | call to getenv | user input (an environment variable) |
+| test.cpp:161:4:161:9 | call to malloc | test.cpp:157:19:157:32 | call to getenv indirection | test.cpp:161:11:161:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:157:19:157:32 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:186:3:186:8 | call to malloc | test.cpp:184:19:184:24 | call to getenv | test.cpp:186:10:186:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:184:19:184:24 | call to getenv | user input (an environment variable) |
+| test.cpp:186:3:186:8 | call to malloc | test.cpp:184:19:184:32 | call to getenv indirection | test.cpp:186:10:186:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:184:19:184:32 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:19 | call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:19 | call to getenv | user input (an environment variable) |
+| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:27 | call to getenv indirection | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:27 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:242:2:242:7 | call to malloc | test.cpp:216:18:216:23 | call to getenv | test.cpp:242:9:242:24 | call to get_bounded_size | This allocation size is derived from $@ and might overflow. | test.cpp:216:18:216:23 | call to getenv | user input (an environment variable) |
+| test.cpp:242:2:242:7 | call to malloc | test.cpp:216:18:216:31 | call to getenv indirection | test.cpp:242:9:242:24 | call to get_bounded_size | This allocation size is derived from $@ and might overflow. | test.cpp:216:18:216:31 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:25 | call to getenv | user input (an environment variable) |
+| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:33 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:23 | call to getenv | user input (an environment variable) |
+| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:23 | call to getenv | user input (an environment variable) |
+| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:334:2:334:7 | call to malloc | test.cpp:331:15:331:20 | Call | test.cpp:334:9:334:14 | offset | This allocation size is derived from $@ and might overflow. | test.cpp:331:15:331:20 | Call | user input (an environment variable) |
+| test.cpp:334:2:334:7 | call to malloc | test.cpp:331:15:331:20 | Call indirection | test.cpp:334:9:334:14 | offset | This allocation size is derived from $@ and might overflow. | test.cpp:331:15:331:20 | Call indirection | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
@@ -1,10 +1,13 @@
 edges
+| test2.cpp:110:8:110:15 | gets output argument | test2.cpp:110:3:110:6 | call to gets |
 | test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input |
 nodes
 | test2.cpp:110:3:110:6 | call to gets | semmle.label | call to gets |
+| test2.cpp:110:8:110:15 | gets output argument | semmle.label | gets output argument |
 | test.cpp:54:17:54:20 | argv | semmle.label | argv |
 | test.cpp:58:25:58:29 | input | semmle.label | input |
 subpaths
 #select
 | test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | call to gets | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:3:110:6 | call to gets | user input (String read by gets) |
+| test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:8:110:15 | gets output argument | test2.cpp:110:3:110:6 | call to gets | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:8:110:15 | gets output argument | user input (String read by gets) |
 | test.cpp:58:3:58:9 | call to sprintf | test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:54:17:54:20 | argv | user input (a command-line argument) |


### PR DESCRIPTION
This PR repairs the `FlowSources.qll` library for IR-based use-use dataflow. In fact, this PR is mostly just a cleanup of the library. Prior to this PR, the library basically re-implemented the mapping from `FunctionInput`/`FunctionOutput` to `DataFlow` nodes. This PR deletes all this re-implemented logic and forwards it to the implementation in `ModelUtil`.