### PR TITLE
Ruby: Content flow through captured variables

### DIFF
--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -727,16 +727,30 @@ module ExprNodes {
 
     override VariableAccess e;
 
-    final override VariableAccess getExpr() { result = ExprCfgNode.super.getExpr() }
+    override VariableAccess getExpr() { result = ExprCfgNode.super.getExpr() }
+
+    /** Gets the variable that is being accessed. */
+    Variable getVariable() { result = this.getExpr().getVariable() }
   }
 
   /** A control-flow node that wraps a `VariableReadAccess` AST expression. */
-  class VariableReadAccessCfgNode extends ExprCfgNode {
+  class VariableReadAccessCfgNode extends VariableAccessCfgNode {
     override string getAPrimaryQlClass() { result = "VariableReadAccessCfgNode" }
 
     override VariableReadAccess e;
 
-    final override VariableReadAccess getExpr() { result = ExprCfgNode.super.getExpr() }
+    override VariableReadAccess getExpr() { result = VariableAccessCfgNode.super.getExpr() }
+  }
+
+  /** A control-flow node that wraps a `LocalVariableReadAccess` AST expression. */
+  class LocalVariableReadAccessCfgNode extends VariableReadAccessCfgNode {
+    override string getAPrimaryQlClass() { result = "LocalVariableReadAccessCfgNode" }
+
+    override LocalVariableReadAccess e;
+
+    final override LocalVariableReadAccess getExpr() { result = super.getExpr() }
+
+    final override LocalVariable getVariable() { result = super.getVariable() }
   }
 
   private class InstanceVariableAccessMapping extends ExprChildMapping, InstanceVariableAccess {
@@ -762,21 +776,32 @@ module ExprNodes {
   }
 
   /** A control-flow node that wraps a `SelfVariableAccess` AST expression. */
-  class SelfVariableAccessCfgNode extends ExprCfgNode {
+  class SelfVariableAccessCfgNode extends VariableAccessCfgNode {
     final override string getAPrimaryQlClass() { result = "SelfVariableAccessCfgNode" }
 
     override SelfVariableAccessMapping e;
 
-    override SelfVariableAccess getExpr() { result = ExprCfgNode.super.getExpr() }
+    override SelfVariableAccess getExpr() { result = VariableAccessCfgNode.super.getExpr() }
   }
 
   /** A control-flow node that wraps a `VariableWriteAccess` AST expression. */
-  class VariableWriteAccessCfgNode extends ExprCfgNode {
+  class VariableWriteAccessCfgNode extends VariableAccessCfgNode {
     override string getAPrimaryQlClass() { result = "VariableWriteAccessCfgNode" }
 
     override VariableWriteAccess e;
 
-    final override VariableWriteAccess getExpr() { result = ExprCfgNode.super.getExpr() }
+    override VariableWriteAccess getExpr() { result = VariableAccessCfgNode.super.getExpr() }
+  }
+
+  /** A control-flow node that wraps a `LocalVariableWriteAccess` AST expression. */
+  class LocalVariableWriteAccessCfgNode extends VariableWriteAccessCfgNode {
+    override string getAPrimaryQlClass() { result = "LocalVariableWriteAccessCfgNode" }
+
+    override LocalVariableWriteAccess e;
+
+    final override LocalVariableWriteAccess getExpr() { result = super.getExpr() }
+
+    final override LocalVariable getVariable() { result = super.getVariable() }
   }
 
   /** A control-flow node that wraps a `ConstantReadAccess` AST expression. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/SSA.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/SSA.qll
@@ -178,6 +178,9 @@ module Ssa {
 
     /** Gets the location of this SSA definition. */
     Location getLocation() { result = this.getControlFlowNode().getLocation() }
+
+    /** Gets the scope of this SSA definition. */
+    CfgScope getScope() { result = this.getBasicBlock().getScope() }
   }
 
   /**
@@ -289,7 +292,7 @@ module Ssa {
       )
     }
 
-    final override string toString() { result = "<captured> " + this.getSourceVariable() }
+    final override string toString() { result = "<captured entry> " + this.getSourceVariable() }
 
     override Location getLocation() { result = this.getBasicBlock().getLocation() }
   }
@@ -324,7 +327,7 @@ module Ssa {
      */
     final Definition getPriorDefinition() { result = SsaImpl::uncertainWriteDefinitionInput(this) }
 
-    override string toString() { result = this.getControlFlowNode().toString() }
+    override string toString() { result = "<captured exit> " + this.getSourceVariable() }
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -661,7 +661,7 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     |
       def.getARead() = testedNode and
       guardChecks(g, testedNode, branch) and
-      SsaImpl::captureFlowIn(call, def, result) and
+      SsaImpl::captureFlowIn(call, def, _, _, result) and
       guardControlsBlock(g, call.getBasicBlock(), branch) and
       result.getBasicBlock().getScope() = call.getExpr().(MethodCall).getBlock()
     )
@@ -726,7 +726,7 @@ abstract deprecated class BarrierGuard extends CfgNodes::ExprCfgNode {
     |
       def.getARead() = testedNode and
       this.checks(testedNode, branch) and
-      SsaImpl::captureFlowIn(call, def, result) and
+      SsaImpl::captureFlowIn(call, def, _, _, result) and
       this.controlsBlock(call.getBasicBlock(), branch) and
       result.getBasicBlock().getScope() = call.getExpr().(MethodCall).getBlock()
     )

--- a/ruby/ql/lib/codeql/ruby/regexp/internal/DebugRegExpConfiguration.ql
+++ b/ruby/ql/lib/codeql/ruby/regexp/internal/DebugRegExpConfiguration.ql
@@ -7,6 +7,8 @@ import RegExpConfiguration
 import codeql.ruby.dataflow.internal.DataFlowImplForRegExp
 import PathGraph
 
+predicate stats = stageStats/8;
+
 from RegExpConfiguration c, PathNode source, PathNode sink
 where c.hasFlowPath(source, sink)
 select source.getNode(), source, sink, source.toString()

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -74,7 +74,7 @@ predicate simpleLocalFlowStep = DataFlowPrivate::localFlowStepTypeTracker/2;
 /**
  * Holds if data can flow from `node1` to `node2` in a way that discards call contexts.
  */
-predicate jumpStep = DataFlowPrivate::jumpStep/2;
+predicate jumpStep = DataFlowPrivate::jumpStepTypeTracker/2;
 
 /** Holds if there is direct flow from `param` to a return. */
 pragma[nomagic]

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -710,12 +710,10 @@ edges
 | array_flow.rb:399:10:399:10 | b [element 2] :  | array_flow.rb:399:10:399:13 | ...[...] |
 | array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:404:18:404:18 | a [element 2] :  |
 | array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:404:18:404:18 | a [element 2] :  |
-| array_flow.rb:404:9:406:7 | ... = ... :  | array_flow.rb:407:10:407:10 | x |
-| array_flow.rb:404:9:406:7 | ... = ... :  | array_flow.rb:407:10:407:10 | x |
+| array_flow.rb:404:9:406:7 | ... = ... :  | array_flow.rb:405:14:405:14 | x |
+| array_flow.rb:404:9:406:7 | ... = ... :  | array_flow.rb:405:14:405:14 | x |
 | array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:404:9:406:7 | ... = ... :  |
 | array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:404:9:406:7 | ... = ... :  |
-| array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:405:14:405:14 | x |
-| array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:405:14:405:14 | x |
 | array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:404:9:406:7 | __synth__0__1 :  |
 | array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:404:9:406:7 | __synth__0__1 :  |
 | array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:408:10:408:10 | b [element 2] :  |
@@ -4238,8 +4236,6 @@ nodes
 | array_flow.rb:404:18:404:18 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:405:14:405:14 | x | semmle.label | x |
 | array_flow.rb:405:14:405:14 | x | semmle.label | x |
-| array_flow.rb:407:10:407:10 | x | semmle.label | x |
-| array_flow.rb:407:10:407:10 | x | semmle.label | x |
 | array_flow.rb:408:10:408:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:408:10:408:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:408:10:408:13 | ...[...] | semmle.label | ...[...] |
@@ -7254,7 +7250,6 @@ subpaths
 | array_flow.rb:397:14:397:14 | x | array_flow.rb:395:16:395:25 | call to source :  | array_flow.rb:397:14:397:14 | x | $@ | array_flow.rb:395:16:395:25 | call to source :  | call to source :  |
 | array_flow.rb:399:10:399:13 | ...[...] | array_flow.rb:395:16:395:25 | call to source :  | array_flow.rb:399:10:399:13 | ...[...] | $@ | array_flow.rb:395:16:395:25 | call to source :  | call to source :  |
 | array_flow.rb:405:14:405:14 | x | array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:405:14:405:14 | x | $@ | array_flow.rb:403:16:403:25 | call to source :  | call to source :  |
-| array_flow.rb:407:10:407:10 | x | array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:407:10:407:10 | x | $@ | array_flow.rb:403:16:403:25 | call to source :  | call to source :  |
 | array_flow.rb:408:10:408:13 | ...[...] | array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:408:10:408:13 | ...[...] | $@ | array_flow.rb:403:16:403:25 | call to source :  | call to source :  |
 | array_flow.rb:414:14:414:19 | ( ... ) | array_flow.rb:412:16:412:25 | call to source :  | array_flow.rb:414:14:414:19 | ( ... ) | $@ | array_flow.rb:412:16:412:25 | call to source :  | call to source :  |
 | array_flow.rb:421:14:421:14 | x | array_flow.rb:419:16:419:25 | call to source :  | array_flow.rb:421:14:421:14 | x | $@ | array_flow.rb:419:16:419:25 | call to source :  | call to source :  |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -404,7 +404,7 @@ def m45
     b = for x in a # desugars to an `each` call
         sink x # $ hasValueFlow=45
     end
-    sink x # $ hasValueFlow=45
+    sink x # $ MISSING: hasValueFlow=45
     sink(b[2]) # $ hasValueFlow=45
 end
 

--- a/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
@@ -13,7 +13,6 @@
 | array_flow.rb:376:10:376:13 | ...[...] | Unexpected result: hasValueFlow=42.3 |
 | array_flow.rb:377:10:377:13 | ...[...] | Unexpected result: hasValueFlow=42.3 |
 | array_flow.rb:378:10:378:13 | ...[...] | Unexpected result: hasValueFlow=42.3 |
-| array_flow.rb:407:12:407:30 | # $ hasValueFlow=45 | Missing result:hasValueFlow=45 |
 | array_flow.rb:484:10:484:13 | ...[...] | Unexpected result: hasValueFlow=54.3 |
 | array_flow.rb:484:10:484:13 | ...[...] | Unexpected result: hasValueFlow=54.4 |
 | array_flow.rb:484:10:484:13 | ...[...] | Unexpected result: hasValueFlow=54.5 |

--- a/ruby/ql/test/library-tests/dataflow/capture-flow/CaptureFlow.expected
+++ b/ruby/ql/test/library-tests/dataflow/capture-flow/CaptureFlow.expected
@@ -1,7 +1,4 @@
 failures
-| capture_flow.rb:29:25:29:68 | # $ hasValueFlow=3 $ MISSING: hasValueFlow=4 | Missing result:hasValueFlow=3 |
-| capture_flow.rb:33:21:33:66 | # $ hasValueFlow=4 $ SPURIOUS: hasValueFlow=3  | Missing result:hasValueFlow=4 |
-| capture_flow.rb:44:21:44:38 | # $ hasValueFlow=5 | Missing result:hasValueFlow=5 |
 edges
 | capture_flow.rb:9:1:9:12 | ... = ... :  | capture_flow.rb:11:10:11:10 | x |
 | capture_flow.rb:9:1:9:12 | ... = ... :  | capture_flow.rb:11:10:11:10 | x |
@@ -21,16 +18,38 @@ edges
 | capture_flow.rb:22:16:22:21 | @field :  | capture_flow.rb:22:9:22:21 | return :  |
 | capture_flow.rb:22:16:22:21 | self [@field] :  | capture_flow.rb:22:16:22:21 | @field :  |
 | capture_flow.rb:22:16:22:21 | self [@field] :  | capture_flow.rb:22:16:22:21 | @field :  |
+| capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | capture_flow.rb:29:10:29:12 | foo [@field] :  |
+| capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | capture_flow.rb:29:10:29:12 | foo [@field] :  |
 | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | capture_flow.rb:33:6:33:8 | foo [@field] :  |
 | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | capture_flow.rb:33:6:33:8 | foo [@field] :  |
 | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  |
 | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  |
 | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  |
 | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  |
+| capture_flow.rb:29:10:29:12 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  |
+| capture_flow.rb:29:10:29:12 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  |
+| capture_flow.rb:29:10:29:12 | foo [@field] :  | capture_flow.rb:29:10:29:22 | call to get_field |
+| capture_flow.rb:29:10:29:12 | foo [@field] :  | capture_flow.rb:29:10:29:22 | call to get_field |
+| capture_flow.rb:30:5:30:7 | [post] foo [@field] :  | capture_flow.rb:33:6:33:8 | foo [@field] :  |
+| capture_flow.rb:30:5:30:7 | [post] foo [@field] :  | capture_flow.rb:33:6:33:8 | foo [@field] :  |
+| capture_flow.rb:30:19:30:26 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  |
+| capture_flow.rb:30:19:30:26 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  |
+| capture_flow.rb:30:19:30:26 | call to taint :  | capture_flow.rb:30:5:30:7 | [post] foo [@field] :  |
+| capture_flow.rb:30:19:30:26 | call to taint :  | capture_flow.rb:30:5:30:7 | [post] foo [@field] :  |
 | capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  |
 | capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  |
 | capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:33:6:33:18 | call to get_field |
 | capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:33:6:33:18 | call to get_field |
+| capture_flow.rb:40:9:40:11 | [post] foo [@field] :  | capture_flow.rb:44:6:44:8 | foo [@field] :  |
+| capture_flow.rb:40:9:40:11 | [post] foo [@field] :  | capture_flow.rb:44:6:44:8 | foo [@field] :  |
+| capture_flow.rb:40:23:40:30 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  |
+| capture_flow.rb:40:23:40:30 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  |
+| capture_flow.rb:40:23:40:30 | call to taint :  | capture_flow.rb:40:9:40:11 | [post] foo [@field] :  |
+| capture_flow.rb:40:23:40:30 | call to taint :  | capture_flow.rb:40:9:40:11 | [post] foo [@field] :  |
+| capture_flow.rb:44:6:44:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  |
+| capture_flow.rb:44:6:44:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  |
+| capture_flow.rb:44:6:44:8 | foo [@field] :  | capture_flow.rb:44:6:44:18 | call to get_field |
+| capture_flow.rb:44:6:44:8 | foo [@field] :  | capture_flow.rb:44:6:44:18 | call to get_field |
 nodes
 | capture_flow.rb:9:1:9:12 | ... = ... :  | semmle.label | ... = ... :  |
 | capture_flow.rb:9:1:9:12 | ... = ... :  | semmle.label | ... = ... :  |
@@ -62,16 +81,43 @@ nodes
 | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
 | capture_flow.rb:27:15:27:22 | call to taint :  | semmle.label | call to taint :  |
 | capture_flow.rb:27:15:27:22 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:29:10:29:12 | foo [@field] :  | semmle.label | foo [@field] :  |
+| capture_flow.rb:29:10:29:12 | foo [@field] :  | semmle.label | foo [@field] :  |
+| capture_flow.rb:29:10:29:22 | call to get_field | semmle.label | call to get_field |
+| capture_flow.rb:29:10:29:22 | call to get_field | semmle.label | call to get_field |
+| capture_flow.rb:30:5:30:7 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| capture_flow.rb:30:5:30:7 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| capture_flow.rb:30:19:30:26 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:30:19:30:26 | call to taint :  | semmle.label | call to taint :  |
 | capture_flow.rb:33:6:33:8 | foo [@field] :  | semmle.label | foo [@field] :  |
 | capture_flow.rb:33:6:33:8 | foo [@field] :  | semmle.label | foo [@field] :  |
 | capture_flow.rb:33:6:33:18 | call to get_field | semmle.label | call to get_field |
 | capture_flow.rb:33:6:33:18 | call to get_field | semmle.label | call to get_field |
+| capture_flow.rb:40:9:40:11 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| capture_flow.rb:40:9:40:11 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| capture_flow.rb:40:23:40:30 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:40:23:40:30 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:44:6:44:8 | foo [@field] :  | semmle.label | foo [@field] :  |
+| capture_flow.rb:44:6:44:8 | foo [@field] :  | semmle.label | foo [@field] :  |
+| capture_flow.rb:44:6:44:18 | call to get_field | semmle.label | call to get_field |
+| capture_flow.rb:44:6:44:18 | call to get_field | semmle.label | call to get_field |
 subpaths
 | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  |
 | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  |
+| capture_flow.rb:29:10:29:12 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:9:22:21 | return :  | capture_flow.rb:29:10:29:22 | call to get_field |
+| capture_flow.rb:29:10:29:12 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:9:22:21 | return :  | capture_flow.rb:29:10:29:22 | call to get_field |
+| capture_flow.rb:30:19:30:26 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  | capture_flow.rb:30:5:30:7 | [post] foo [@field] :  |
+| capture_flow.rb:30:19:30:26 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  | capture_flow.rb:30:5:30:7 | [post] foo [@field] :  |
 | capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:9:22:21 | return :  | capture_flow.rb:33:6:33:18 | call to get_field |
 | capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:9:22:21 | return :  | capture_flow.rb:33:6:33:18 | call to get_field |
+| capture_flow.rb:40:23:40:30 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  | capture_flow.rb:40:9:40:11 | [post] foo [@field] :  |
+| capture_flow.rb:40:23:40:30 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  | capture_flow.rb:40:9:40:11 | [post] foo [@field] :  |
+| capture_flow.rb:44:6:44:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:9:22:21 | return :  | capture_flow.rb:44:6:44:18 | call to get_field |
+| capture_flow.rb:44:6:44:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:9:22:21 | return :  | capture_flow.rb:44:6:44:18 | call to get_field |
 #select
 | capture_flow.rb:11:10:11:10 | x | capture_flow.rb:9:5:9:12 | call to taint :  | capture_flow.rb:11:10:11:10 | x | $@ | capture_flow.rb:9:5:9:12 | call to taint :  | call to taint :  |
 | capture_flow.rb:15:6:15:6 | x | capture_flow.rb:12:9:12:16 | call to taint :  | capture_flow.rb:15:6:15:6 | x | $@ | capture_flow.rb:12:9:12:16 | call to taint :  | call to taint :  |
+| capture_flow.rb:29:10:29:22 | call to get_field | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:29:10:29:22 | call to get_field | $@ | capture_flow.rb:27:15:27:22 | call to taint :  | call to taint :  |
 | capture_flow.rb:33:6:33:18 | call to get_field | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:33:6:33:18 | call to get_field | $@ | capture_flow.rb:27:15:27:22 | call to taint :  | call to taint :  |
+| capture_flow.rb:33:6:33:18 | call to get_field | capture_flow.rb:30:19:30:26 | call to taint :  | capture_flow.rb:33:6:33:18 | call to get_field | $@ | capture_flow.rb:30:19:30:26 | call to taint :  | call to taint :  |
+| capture_flow.rb:44:6:44:18 | call to get_field | capture_flow.rb:40:23:40:30 | call to taint :  | capture_flow.rb:44:6:44:18 | call to get_field | $@ | capture_flow.rb:40:23:40:30 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/capture-flow/CaptureFlow.expected
+++ b/ruby/ql/test/library-tests/dataflow/capture-flow/CaptureFlow.expected
@@ -1,0 +1,77 @@
+failures
+| capture_flow.rb:29:25:29:68 | # $ hasValueFlow=3 $ MISSING: hasValueFlow=4 | Missing result:hasValueFlow=3 |
+| capture_flow.rb:33:21:33:66 | # $ hasValueFlow=4 $ SPURIOUS: hasValueFlow=3  | Missing result:hasValueFlow=4 |
+| capture_flow.rb:44:21:44:38 | # $ hasValueFlow=5 | Missing result:hasValueFlow=5 |
+edges
+| capture_flow.rb:9:1:9:12 | ... = ... :  | capture_flow.rb:11:10:11:10 | x |
+| capture_flow.rb:9:1:9:12 | ... = ... :  | capture_flow.rb:11:10:11:10 | x |
+| capture_flow.rb:9:5:9:12 | call to taint :  | capture_flow.rb:9:1:9:12 | ... = ... :  |
+| capture_flow.rb:9:5:9:12 | call to taint :  | capture_flow.rb:9:1:9:12 | ... = ... :  |
+| capture_flow.rb:12:5:12:16 | ... = ... :  | capture_flow.rb:15:6:15:6 | x |
+| capture_flow.rb:12:5:12:16 | ... = ... :  | capture_flow.rb:15:6:15:6 | x |
+| capture_flow.rb:12:9:12:16 | call to taint :  | capture_flow.rb:12:5:12:16 | ... = ... :  |
+| capture_flow.rb:12:9:12:16 | call to taint :  | capture_flow.rb:12:5:12:16 | ... = ... :  |
+| capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:18:19:18 | x :  |
+| capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:18:19:18 | x :  |
+| capture_flow.rb:19:18:19:18 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  |
+| capture_flow.rb:19:18:19:18 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  |
+| capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:16:22:21 | self [@field] :  |
+| capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:16:22:21 | self [@field] :  |
+| capture_flow.rb:22:16:22:21 | @field :  | capture_flow.rb:22:9:22:21 | return :  |
+| capture_flow.rb:22:16:22:21 | @field :  | capture_flow.rb:22:9:22:21 | return :  |
+| capture_flow.rb:22:16:22:21 | self [@field] :  | capture_flow.rb:22:16:22:21 | @field :  |
+| capture_flow.rb:22:16:22:21 | self [@field] :  | capture_flow.rb:22:16:22:21 | @field :  |
+| capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | capture_flow.rb:33:6:33:8 | foo [@field] :  |
+| capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | capture_flow.rb:33:6:33:8 | foo [@field] :  |
+| capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  |
+| capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  |
+| capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  |
+| capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  |
+| capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  |
+| capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  |
+| capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:33:6:33:18 | call to get_field |
+| capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:33:6:33:18 | call to get_field |
+nodes
+| capture_flow.rb:9:1:9:12 | ... = ... :  | semmle.label | ... = ... :  |
+| capture_flow.rb:9:1:9:12 | ... = ... :  | semmle.label | ... = ... :  |
+| capture_flow.rb:9:5:9:12 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:9:5:9:12 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:11:10:11:10 | x | semmle.label | x |
+| capture_flow.rb:11:10:11:10 | x | semmle.label | x |
+| capture_flow.rb:12:5:12:16 | ... = ... :  | semmle.label | ... = ... :  |
+| capture_flow.rb:12:5:12:16 | ... = ... :  | semmle.label | ... = ... :  |
+| capture_flow.rb:12:9:12:16 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:12:9:12:16 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:15:6:15:6 | x | semmle.label | x |
+| capture_flow.rb:15:6:15:6 | x | semmle.label | x |
+| capture_flow.rb:18:19:18:19 | x :  | semmle.label | x :  |
+| capture_flow.rb:18:19:18:19 | x :  | semmle.label | x :  |
+| capture_flow.rb:19:9:19:14 | [post] self [@field] :  | semmle.label | [post] self [@field] :  |
+| capture_flow.rb:19:9:19:14 | [post] self [@field] :  | semmle.label | [post] self [@field] :  |
+| capture_flow.rb:19:18:19:18 | x :  | semmle.label | x :  |
+| capture_flow.rb:19:18:19:18 | x :  | semmle.label | x :  |
+| capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | semmle.label | self in get_field [@field] :  |
+| capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | semmle.label | self in get_field [@field] :  |
+| capture_flow.rb:22:9:22:21 | return :  | semmle.label | return :  |
+| capture_flow.rb:22:9:22:21 | return :  | semmle.label | return :  |
+| capture_flow.rb:22:16:22:21 | @field :  | semmle.label | @field :  |
+| capture_flow.rb:22:16:22:21 | @field :  | semmle.label | @field :  |
+| capture_flow.rb:22:16:22:21 | self [@field] :  | semmle.label | self [@field] :  |
+| capture_flow.rb:22:16:22:21 | self [@field] :  | semmle.label | self [@field] :  |
+| capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| capture_flow.rb:27:1:27:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| capture_flow.rb:27:15:27:22 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:27:15:27:22 | call to taint :  | semmle.label | call to taint :  |
+| capture_flow.rb:33:6:33:8 | foo [@field] :  | semmle.label | foo [@field] :  |
+| capture_flow.rb:33:6:33:8 | foo [@field] :  | semmle.label | foo [@field] :  |
+| capture_flow.rb:33:6:33:18 | call to get_field | semmle.label | call to get_field |
+| capture_flow.rb:33:6:33:18 | call to get_field | semmle.label | call to get_field |
+subpaths
+| capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  |
+| capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:18:19:18:19 | x :  | capture_flow.rb:19:9:19:14 | [post] self [@field] :  | capture_flow.rb:27:1:27:3 | [post] foo [@field] :  |
+| capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:9:22:21 | return :  | capture_flow.rb:33:6:33:18 | call to get_field |
+| capture_flow.rb:33:6:33:8 | foo [@field] :  | capture_flow.rb:21:5:23:7 | self in get_field [@field] :  | capture_flow.rb:22:9:22:21 | return :  | capture_flow.rb:33:6:33:18 | call to get_field |
+#select
+| capture_flow.rb:11:10:11:10 | x | capture_flow.rb:9:5:9:12 | call to taint :  | capture_flow.rb:11:10:11:10 | x | $@ | capture_flow.rb:9:5:9:12 | call to taint :  | call to taint :  |
+| capture_flow.rb:15:6:15:6 | x | capture_flow.rb:12:9:12:16 | call to taint :  | capture_flow.rb:15:6:15:6 | x | $@ | capture_flow.rb:12:9:12:16 | call to taint :  | call to taint :  |
+| capture_flow.rb:33:6:33:18 | call to get_field | capture_flow.rb:27:15:27:22 | call to taint :  | capture_flow.rb:33:6:33:18 | call to get_field | $@ | capture_flow.rb:27:15:27:22 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/capture-flow/CaptureFlow.expected
+++ b/ruby/ql/test/library-tests/dataflow/capture-flow/CaptureFlow.expected
@@ -1,9 +1,7 @@
 failures
 edges
-| capture_flow.rb:9:1:9:12 | ... = ... :  | capture_flow.rb:11:10:11:10 | x |
-| capture_flow.rb:9:1:9:12 | ... = ... :  | capture_flow.rb:11:10:11:10 | x |
-| capture_flow.rb:9:5:9:12 | call to taint :  | capture_flow.rb:9:1:9:12 | ... = ... :  |
-| capture_flow.rb:9:5:9:12 | call to taint :  | capture_flow.rb:9:1:9:12 | ... = ... :  |
+| capture_flow.rb:9:5:9:12 | call to taint :  | capture_flow.rb:11:10:11:10 | x |
+| capture_flow.rb:9:5:9:12 | call to taint :  | capture_flow.rb:11:10:11:10 | x |
 | capture_flow.rb:12:5:12:16 | ... = ... :  | capture_flow.rb:15:6:15:6 | x |
 | capture_flow.rb:12:5:12:16 | ... = ... :  | capture_flow.rb:15:6:15:6 | x |
 | capture_flow.rb:12:9:12:16 | call to taint :  | capture_flow.rb:12:5:12:16 | ... = ... :  |
@@ -51,8 +49,6 @@ edges
 | capture_flow.rb:44:6:44:8 | foo [@field] :  | capture_flow.rb:44:6:44:18 | call to get_field |
 | capture_flow.rb:44:6:44:8 | foo [@field] :  | capture_flow.rb:44:6:44:18 | call to get_field |
 nodes
-| capture_flow.rb:9:1:9:12 | ... = ... :  | semmle.label | ... = ... :  |
-| capture_flow.rb:9:1:9:12 | ... = ... :  | semmle.label | ... = ... :  |
 | capture_flow.rb:9:5:9:12 | call to taint :  | semmle.label | call to taint :  |
 | capture_flow.rb:9:5:9:12 | call to taint :  | semmle.label | call to taint :  |
 | capture_flow.rb:11:10:11:10 | x | semmle.label | x |

--- a/ruby/ql/test/library-tests/dataflow/capture-flow/CaptureFlow.ql
+++ b/ruby/ql/test/library-tests/dataflow/capture-flow/CaptureFlow.ql
@@ -1,0 +1,12 @@
+/**
+ * @kind path-problem
+ */
+
+import codeql.ruby.AST
+import codeql.ruby.DataFlow
+private import TestUtilities.InlineFlowTest
+import DataFlow::PathGraph
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultTaintFlowConf conf
+where conf.hasFlowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/capture-flow/capture_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/capture-flow/capture_flow.rb
@@ -1,0 +1,44 @@
+def taint x
+    x
+end
+
+def sink x
+    puts "SINK: #{x}"
+end
+
+x = taint(1)
+[1, 2, 3].each do |i|
+    sink x # $ hasValueFlow=1 $ MISSING: hasValueFlow=2
+    x = taint(2)
+end
+
+sink x # $ hasValueFlow=2
+
+class Foo
+    def set_field x
+        @field = x
+    end
+    def get_field
+        return @field
+    end
+end
+
+foo = Foo.new
+foo.set_field(taint(3))
+[1, 2, 3].each do |i|
+    sink(foo.get_field) # $ hasValueFlow=3 $ MISSING: hasValueFlow=4
+    foo.set_field(taint(4))
+end
+
+sink(foo.get_field) # $ hasValueFlow=4 $ SPURIOUS: hasValueFlow=3 
+
+foo = Foo.new
+if (rand() < 0) then
+    foo = Foo.new
+else
+    [1, 2, 3].each do |i|
+        foo.set_field(taint(5))
+    end
+end
+
+sink(foo.get_field) # $ hasValueFlow=5

--- a/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
@@ -1,5 +1,6 @@
 | local_dataflow.rb:1:1:7:3 | self (foo) | local_dataflow.rb:3:8:3:10 | self |
 | local_dataflow.rb:1:1:7:3 | self in foo | local_dataflow.rb:1:1:7:3 | self (foo) |
+| local_dataflow.rb:1:1:150:3 | self (local_dataflow.rb) | local_dataflow.rb:10:5:13:3 | captured argument self |
 | local_dataflow.rb:1:1:150:3 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:1:9:1:9 | a |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:2:7:2:7 | a |
@@ -26,12 +27,14 @@
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | ... = ... | local_dataflow.rb:12:5:12:5 | x |
-| local_dataflow.rb:10:5:13:3 | <captured> self | local_dataflow.rb:11:1:11:2 | self |
+| local_dataflow.rb:10:5:13:3 | <captured entry> self | local_dataflow.rb:11:1:11:2 | self |
+| local_dataflow.rb:10:5:13:3 | [post] captured argument self | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:5:13:3 | call to each | local_dataflow.rb:10:1:13:3 | ... = ... |
+| local_dataflow.rb:10:5:13:3 | captured parameter self of { ... } | local_dataflow.rb:10:5:13:3 | <captured entry> self |
 | local_dataflow.rb:10:14:10:18 | [post] array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:10:14:10:18 | array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:11:1:11:2 | [post] self | local_dataflow.rb:12:3:12:5 | self |
@@ -54,6 +57,7 @@
 | local_dataflow.rb:28:15:28:22 | "module" | local_dataflow.rb:28:5:28:26 | M |
 | local_dataflow.rb:30:5:30:24 | C | local_dataflow.rb:30:1:30:24 | ... = ... |
 | local_dataflow.rb:30:14:30:20 | "class" | local_dataflow.rb:30:5:30:24 | C |
+| local_dataflow.rb:32:1:32:25 | ... = ... | local_dataflow.rb:49:1:53:3 | captured argument x |
 | local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
 | local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
 | local_dataflow.rb:34:7:34:7 | x | local_dataflow.rb:34:7:34:7 | x |
@@ -65,7 +69,8 @@
 | local_dataflow.rb:45:10:45:10 | 6 | local_dataflow.rb:45:3:45:10 | return |
 | local_dataflow.rb:49:1:53:3 | [post] self | local_dataflow.rb:55:1:55:14 | self |
 | local_dataflow.rb:49:1:53:3 | self | local_dataflow.rb:55:1:55:14 | self |
-| local_dataflow.rb:49:3:53:3 | <captured> x | local_dataflow.rb:50:18:50:18 | x |
+| local_dataflow.rb:49:3:53:3 | <captured entry> x | local_dataflow.rb:50:18:50:18 | x |
+| local_dataflow.rb:49:3:53:3 | captured parameter x of do ... end | local_dataflow.rb:49:3:53:3 | <captured entry> x |
 | local_dataflow.rb:50:8:50:13 | "next" | local_dataflow.rb:50:3:50:13 | next |
 | local_dataflow.rb:50:18:50:18 | [post] x | local_dataflow.rb:51:20:51:20 | x |
 | local_dataflow.rb:50:18:50:18 | x | local_dataflow.rb:51:20:51:20 | x |
@@ -261,10 +266,14 @@
 | local_dataflow.rb:117:8:117:16 | [post] self | local_dataflow.rb:118:3:118:11 | self |
 | local_dataflow.rb:117:8:117:16 | call to source | local_dataflow.rb:117:8:117:23 | call to tap |
 | local_dataflow.rb:117:8:117:16 | self | local_dataflow.rb:118:3:118:11 | self |
+| local_dataflow.rb:118:3:118:11 | [post] self | local_dataflow.rb:118:3:118:31 | captured argument self |
 | local_dataflow.rb:118:3:118:11 | [post] self | local_dataflow.rb:119:3:119:31 | self |
 | local_dataflow.rb:118:3:118:11 | call to source | local_dataflow.rb:118:3:118:31 | call to tap |
+| local_dataflow.rb:118:3:118:11 | self | local_dataflow.rb:118:3:118:31 | captured argument self |
 | local_dataflow.rb:118:3:118:11 | self | local_dataflow.rb:119:3:119:31 | self |
-| local_dataflow.rb:118:17:118:31 | <captured> self | local_dataflow.rb:118:23:118:29 | self |
+| local_dataflow.rb:118:3:118:31 | [post] captured argument self | local_dataflow.rb:119:3:119:31 | self |
+| local_dataflow.rb:118:17:118:31 | <captured entry> self | local_dataflow.rb:118:23:118:29 | self |
+| local_dataflow.rb:118:17:118:31 | captured parameter self of { ... } | local_dataflow.rb:118:17:118:31 | <captured entry> self |
 | local_dataflow.rb:118:20:118:20 | x | local_dataflow.rb:118:20:118:20 | x |
 | local_dataflow.rb:118:20:118:20 | x | local_dataflow.rb:118:28:118:28 | x |
 | local_dataflow.rb:119:3:119:31 | [post] self | local_dataflow.rb:119:8:119:16 | self |
@@ -275,10 +284,13 @@
 | local_dataflow.rb:122:1:124:3 | self in dup_tap | local_dataflow.rb:122:1:124:3 | self (dup_tap) |
 | local_dataflow.rb:123:3:123:50 | [post] self | local_dataflow.rb:123:8:123:16 | self |
 | local_dataflow.rb:123:3:123:50 | self | local_dataflow.rb:123:8:123:16 | self |
+| local_dataflow.rb:123:8:123:16 | [post] self | local_dataflow.rb:123:8:123:45 | captured argument self |
 | local_dataflow.rb:123:8:123:16 | call to source | local_dataflow.rb:123:8:123:20 | call to dup |
+| local_dataflow.rb:123:8:123:16 | self | local_dataflow.rb:123:8:123:45 | captured argument self |
 | local_dataflow.rb:123:8:123:20 | call to dup | local_dataflow.rb:123:8:123:45 | call to tap |
 | local_dataflow.rb:123:8:123:45 | call to tap | local_dataflow.rb:123:8:123:49 | call to dup |
-| local_dataflow.rb:123:26:123:45 | <captured> self | local_dataflow.rb:123:32:123:43 | self |
+| local_dataflow.rb:123:26:123:45 | <captured entry> self | local_dataflow.rb:123:32:123:43 | self |
+| local_dataflow.rb:123:26:123:45 | captured parameter self of { ... } | local_dataflow.rb:123:26:123:45 | <captured entry> self |
 | local_dataflow.rb:126:1:128:3 | self (use) | local_dataflow.rb:127:3:127:8 | self |
 | local_dataflow.rb:126:1:128:3 | self in use | local_dataflow.rb:126:1:128:3 | self (use) |
 | local_dataflow.rb:130:1:150:3 | self (use_use_madness) | local_dataflow.rb:132:6:132:11 | self |

--- a/ruby/ql/test/library-tests/dataflow/local/Nodes.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/Nodes.expected
@@ -30,6 +30,7 @@ arg
 | local_dataflow.rb:9:10:9:10 | 1 | local_dataflow.rb:9:9:9:15 | call to [] | position 0 |
 | local_dataflow.rb:9:12:9:12 | 2 | local_dataflow.rb:9:9:9:15 | call to [] | position 1 |
 | local_dataflow.rb:9:14:9:14 | 3 | local_dataflow.rb:9:9:9:15 | call to [] | position 2 |
+| local_dataflow.rb:10:5:13:3 | captured argument self | local_dataflow.rb:10:5:13:3 | <captured> call to each | captured self |
 | local_dataflow.rb:10:5:13:3 | { ... } | local_dataflow.rb:10:5:13:3 | call to each | block |
 | local_dataflow.rb:10:14:10:18 | array | local_dataflow.rb:10:5:13:3 | call to each | self |
 | local_dataflow.rb:11:1:11:2 | self | local_dataflow.rb:11:1:11:2 | call to do | self |
@@ -45,6 +46,7 @@ arg
 | local_dataflow.rb:35:11:35:11 | 4 | local_dataflow.rb:35:6:35:11 | ... == ... | position 0 |
 | local_dataflow.rb:42:6:42:6 | x | local_dataflow.rb:42:6:42:11 | ... == ... | self |
 | local_dataflow.rb:42:11:42:11 | 4 | local_dataflow.rb:42:6:42:11 | ... == ... | position 0 |
+| local_dataflow.rb:49:1:53:3 | captured argument x | local_dataflow.rb:49:1:53:3 | <captured> call to m | captured x |
 | local_dataflow.rb:49:1:53:3 | self | local_dataflow.rb:49:1:53:3 | call to m | self |
 | local_dataflow.rb:49:3:53:3 | do ... end | local_dataflow.rb:49:1:53:3 | call to m | block |
 | local_dataflow.rb:50:18:50:18 | x | local_dataflow.rb:50:18:50:22 | ... < ... | self |
@@ -150,6 +152,7 @@ arg
 | local_dataflow.rb:117:22:117:23 | { ... } | local_dataflow.rb:117:8:117:23 | call to tap | block |
 | local_dataflow.rb:118:3:118:11 | call to source | local_dataflow.rb:118:3:118:31 | call to tap | self |
 | local_dataflow.rb:118:3:118:11 | self | local_dataflow.rb:118:3:118:11 | call to source | self |
+| local_dataflow.rb:118:3:118:31 | captured argument self | local_dataflow.rb:118:3:118:31 | <captured> call to tap | captured self |
 | local_dataflow.rb:118:10:118:10 | 1 | local_dataflow.rb:118:3:118:11 | call to source | position 0 |
 | local_dataflow.rb:118:17:118:31 | { ... } | local_dataflow.rb:118:3:118:31 | call to tap | block |
 | local_dataflow.rb:118:23:118:29 | self | local_dataflow.rb:118:23:118:29 | call to sink | self |
@@ -167,6 +170,7 @@ arg
 | local_dataflow.rb:123:8:123:16 | self | local_dataflow.rb:123:8:123:16 | call to source | self |
 | local_dataflow.rb:123:8:123:20 | call to dup | local_dataflow.rb:123:8:123:45 | call to tap | self |
 | local_dataflow.rb:123:8:123:45 | call to tap | local_dataflow.rb:123:8:123:49 | call to dup | self |
+| local_dataflow.rb:123:8:123:45 | captured argument self | local_dataflow.rb:123:8:123:45 | <captured> call to tap | captured self |
 | local_dataflow.rb:123:8:123:49 | call to dup | local_dataflow.rb:123:3:123:50 | call to sink | position 0 |
 | local_dataflow.rb:123:15:123:15 | 1 | local_dataflow.rb:123:8:123:16 | call to source | position 0 |
 | local_dataflow.rb:123:26:123:45 | { ... } | local_dataflow.rb:123:8:123:45 | call to tap | block |

--- a/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
@@ -28,6 +28,7 @@
 | file://:0:0:0:0 | parameter self of each(0) | file://:0:0:0:0 | [summary] read: argument self.any element in each(0) |
 | local_dataflow.rb:1:1:7:3 | self (foo) | local_dataflow.rb:3:8:3:10 | self |
 | local_dataflow.rb:1:1:7:3 | self in foo | local_dataflow.rb:1:1:7:3 | self (foo) |
+| local_dataflow.rb:1:1:150:3 | self (local_dataflow.rb) | local_dataflow.rb:10:5:13:3 | captured argument self |
 | local_dataflow.rb:1:1:150:3 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:1:9:1:9 | a |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:2:7:2:7 | a |
@@ -57,12 +58,14 @@
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | ... = ... | local_dataflow.rb:12:5:12:5 | x |
-| local_dataflow.rb:10:5:13:3 | <captured> self | local_dataflow.rb:11:1:11:2 | self |
+| local_dataflow.rb:10:5:13:3 | <captured entry> self | local_dataflow.rb:11:1:11:2 | self |
+| local_dataflow.rb:10:5:13:3 | [post] captured argument self | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:5:13:3 | call to each | local_dataflow.rb:10:1:13:3 | ... = ... |
+| local_dataflow.rb:10:5:13:3 | captured parameter self of { ... } | local_dataflow.rb:10:5:13:3 | <captured entry> self |
 | local_dataflow.rb:10:14:10:18 | [post] array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:10:14:10:18 | array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:11:1:11:2 | [post] self | local_dataflow.rb:12:3:12:5 | self |
@@ -87,6 +90,7 @@
 | local_dataflow.rb:28:15:28:22 | "module" | local_dataflow.rb:28:5:28:26 | M |
 | local_dataflow.rb:30:5:30:24 | C | local_dataflow.rb:30:1:30:24 | ... = ... |
 | local_dataflow.rb:30:14:30:20 | "class" | local_dataflow.rb:30:5:30:24 | C |
+| local_dataflow.rb:32:1:32:25 | ... = ... | local_dataflow.rb:49:1:53:3 | captured argument x |
 | local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
 | local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
 | local_dataflow.rb:34:7:34:7 | x | local_dataflow.rb:34:7:34:7 | x |
@@ -102,7 +106,8 @@
 | local_dataflow.rb:45:10:45:10 | 6 | local_dataflow.rb:45:3:45:10 | return |
 | local_dataflow.rb:49:1:53:3 | [post] self | local_dataflow.rb:55:1:55:14 | self |
 | local_dataflow.rb:49:1:53:3 | self | local_dataflow.rb:55:1:55:14 | self |
-| local_dataflow.rb:49:3:53:3 | <captured> x | local_dataflow.rb:50:18:50:18 | x |
+| local_dataflow.rb:49:3:53:3 | <captured entry> x | local_dataflow.rb:50:18:50:18 | x |
+| local_dataflow.rb:49:3:53:3 | captured parameter x of do ... end | local_dataflow.rb:49:3:53:3 | <captured entry> x |
 | local_dataflow.rb:50:8:50:13 | "next" | local_dataflow.rb:50:3:50:13 | next |
 | local_dataflow.rb:50:18:50:18 | [post] x | local_dataflow.rb:51:20:51:20 | x |
 | local_dataflow.rb:50:18:50:18 | x | local_dataflow.rb:50:18:50:22 | ... < ... |
@@ -314,10 +319,14 @@
 | local_dataflow.rb:117:8:117:16 | [post] self | local_dataflow.rb:118:3:118:11 | self |
 | local_dataflow.rb:117:8:117:16 | call to source | local_dataflow.rb:117:8:117:23 | call to tap |
 | local_dataflow.rb:117:8:117:16 | self | local_dataflow.rb:118:3:118:11 | self |
+| local_dataflow.rb:118:3:118:11 | [post] self | local_dataflow.rb:118:3:118:31 | captured argument self |
 | local_dataflow.rb:118:3:118:11 | [post] self | local_dataflow.rb:119:3:119:31 | self |
 | local_dataflow.rb:118:3:118:11 | call to source | local_dataflow.rb:118:3:118:31 | call to tap |
+| local_dataflow.rb:118:3:118:11 | self | local_dataflow.rb:118:3:118:31 | captured argument self |
 | local_dataflow.rb:118:3:118:11 | self | local_dataflow.rb:119:3:119:31 | self |
-| local_dataflow.rb:118:17:118:31 | <captured> self | local_dataflow.rb:118:23:118:29 | self |
+| local_dataflow.rb:118:3:118:31 | [post] captured argument self | local_dataflow.rb:119:3:119:31 | self |
+| local_dataflow.rb:118:17:118:31 | <captured entry> self | local_dataflow.rb:118:23:118:29 | self |
+| local_dataflow.rb:118:17:118:31 | captured parameter self of { ... } | local_dataflow.rb:118:17:118:31 | <captured entry> self |
 | local_dataflow.rb:118:20:118:20 | x | local_dataflow.rb:118:20:118:20 | x |
 | local_dataflow.rb:118:20:118:20 | x | local_dataflow.rb:118:28:118:28 | x |
 | local_dataflow.rb:119:3:119:31 | [post] self | local_dataflow.rb:119:8:119:16 | self |
@@ -328,10 +337,13 @@
 | local_dataflow.rb:122:1:124:3 | self in dup_tap | local_dataflow.rb:122:1:124:3 | self (dup_tap) |
 | local_dataflow.rb:123:3:123:50 | [post] self | local_dataflow.rb:123:8:123:16 | self |
 | local_dataflow.rb:123:3:123:50 | self | local_dataflow.rb:123:8:123:16 | self |
+| local_dataflow.rb:123:8:123:16 | [post] self | local_dataflow.rb:123:8:123:45 | captured argument self |
 | local_dataflow.rb:123:8:123:16 | call to source | local_dataflow.rb:123:8:123:20 | call to dup |
+| local_dataflow.rb:123:8:123:16 | self | local_dataflow.rb:123:8:123:45 | captured argument self |
 | local_dataflow.rb:123:8:123:20 | call to dup | local_dataflow.rb:123:8:123:45 | call to tap |
 | local_dataflow.rb:123:8:123:45 | call to tap | local_dataflow.rb:123:8:123:49 | call to dup |
-| local_dataflow.rb:123:26:123:45 | <captured> self | local_dataflow.rb:123:32:123:43 | self |
+| local_dataflow.rb:123:26:123:45 | <captured entry> self | local_dataflow.rb:123:32:123:43 | self |
+| local_dataflow.rb:123:26:123:45 | captured parameter self of { ... } | local_dataflow.rb:123:26:123:45 | <captured entry> self |
 | local_dataflow.rb:126:1:128:3 | self (use) | local_dataflow.rb:127:3:127:8 | self |
 | local_dataflow.rb:126:1:128:3 | self in use | local_dataflow.rb:126:1:128:3 | self (use) |
 | local_dataflow.rb:130:1:150:3 | self (use_use_madness) | local_dataflow.rb:132:6:132:11 | self |

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
@@ -201,8 +201,6 @@ edges
 | string_flow.rb:240:9:240:19 | call to scan [element] :  | string_flow.rb:242:10:242:10 | b [element] :  |
 | string_flow.rb:241:10:241:10 | b [element] :  | string_flow.rb:241:10:241:13 | ...[...] |
 | string_flow.rb:242:10:242:10 | b [element] :  | string_flow.rb:242:10:242:13 | ...[...] |
-| string_flow.rb:246:5:246:18 | ... = ... :  | string_flow.rb:250:26:250:26 | a :  |
-| string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:246:5:246:18 | ... = ... :  |
 | string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:247:10:247:10 | a :  |
 | string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:248:20:248:20 | a :  |
 | string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:249:5:249:5 | a :  |
@@ -211,14 +209,14 @@ edges
 | string_flow.rb:247:10:247:10 | a :  | string_flow.rb:247:10:247:21 | call to scrub |
 | string_flow.rb:248:20:248:20 | a :  | string_flow.rb:248:10:248:21 | call to scrub |
 | string_flow.rb:249:5:249:5 | a :  | string_flow.rb:249:16:249:16 | x :  |
+| string_flow.rb:249:5:249:5 | a :  | string_flow.rb:250:26:250:26 | a :  |
 | string_flow.rb:249:16:249:16 | x :  | string_flow.rb:249:24:249:24 | x |
 | string_flow.rb:250:26:250:26 | a :  | string_flow.rb:250:10:250:28 | call to scrub |
 | string_flow.rb:252:10:252:10 | a :  | string_flow.rb:252:10:252:22 | call to scrub! |
 | string_flow.rb:253:21:253:21 | a :  | string_flow.rb:253:10:253:22 | call to scrub! |
-| string_flow.rb:255:5:255:18 | ... = ... :  | string_flow.rb:258:27:258:27 | a :  |
-| string_flow.rb:255:9:255:18 | call to source :  | string_flow.rb:255:5:255:18 | ... = ... :  |
 | string_flow.rb:255:9:255:18 | call to source :  | string_flow.rb:256:5:256:5 | a :  |
 | string_flow.rb:256:5:256:5 | a :  | string_flow.rb:256:17:256:17 | x :  |
+| string_flow.rb:256:5:256:5 | a :  | string_flow.rb:258:27:258:27 | a :  |
 | string_flow.rb:256:17:256:17 | x :  | string_flow.rb:256:25:256:25 | x |
 | string_flow.rb:258:27:258:27 | a :  | string_flow.rb:258:10:258:29 | call to scrub! |
 | string_flow.rb:262:9:262:18 | call to source :  | string_flow.rb:263:10:263:10 | a :  |
@@ -527,7 +525,6 @@ nodes
 | string_flow.rb:241:10:241:13 | ...[...] | semmle.label | ...[...] |
 | string_flow.rb:242:10:242:10 | b [element] :  | semmle.label | b [element] :  |
 | string_flow.rb:242:10:242:13 | ...[...] | semmle.label | ...[...] |
-| string_flow.rb:246:5:246:18 | ... = ... :  | semmle.label | ... = ... :  |
 | string_flow.rb:246:9:246:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:247:10:247:10 | a :  | semmle.label | a :  |
 | string_flow.rb:247:10:247:21 | call to scrub | semmle.label | call to scrub |
@@ -542,7 +539,6 @@ nodes
 | string_flow.rb:252:10:252:22 | call to scrub! | semmle.label | call to scrub! |
 | string_flow.rb:253:10:253:22 | call to scrub! | semmle.label | call to scrub! |
 | string_flow.rb:253:21:253:21 | a :  | semmle.label | a :  |
-| string_flow.rb:255:5:255:18 | ... = ... :  | semmle.label | ... = ... :  |
 | string_flow.rb:255:9:255:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:256:5:256:5 | a :  | semmle.label | a :  |
 | string_flow.rb:256:17:256:17 | x :  | semmle.label | x :  |

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
@@ -209,16 +209,14 @@ edges
 | string_flow.rb:247:10:247:10 | a :  | string_flow.rb:247:10:247:21 | call to scrub |
 | string_flow.rb:248:20:248:20 | a :  | string_flow.rb:248:10:248:21 | call to scrub |
 | string_flow.rb:249:5:249:5 | a :  | string_flow.rb:249:16:249:16 | x :  |
-| string_flow.rb:249:5:249:5 | a :  | string_flow.rb:250:26:250:26 | a :  |
 | string_flow.rb:249:16:249:16 | x :  | string_flow.rb:249:24:249:24 | x |
-| string_flow.rb:250:26:250:26 | a :  | string_flow.rb:250:10:250:28 | call to scrub |
+| string_flow.rb:250:26:250:35 | call to source :  | string_flow.rb:250:10:250:37 | call to scrub |
 | string_flow.rb:252:10:252:10 | a :  | string_flow.rb:252:10:252:22 | call to scrub! |
 | string_flow.rb:253:21:253:21 | a :  | string_flow.rb:253:10:253:22 | call to scrub! |
 | string_flow.rb:255:9:255:18 | call to source :  | string_flow.rb:256:5:256:5 | a :  |
 | string_flow.rb:256:5:256:5 | a :  | string_flow.rb:256:17:256:17 | x :  |
-| string_flow.rb:256:5:256:5 | a :  | string_flow.rb:258:27:258:27 | a :  |
 | string_flow.rb:256:17:256:17 | x :  | string_flow.rb:256:25:256:25 | x |
-| string_flow.rb:258:27:258:27 | a :  | string_flow.rb:258:10:258:29 | call to scrub! |
+| string_flow.rb:258:27:258:36 | call to source :  | string_flow.rb:258:10:258:38 | call to scrub! |
 | string_flow.rb:262:9:262:18 | call to source :  | string_flow.rb:263:10:263:10 | a :  |
 | string_flow.rb:263:10:263:10 | a :  | string_flow.rb:263:10:263:22 | call to shellescape |
 | string_flow.rb:267:9:267:18 | call to source :  | string_flow.rb:268:9:268:9 | a :  |
@@ -533,8 +531,8 @@ nodes
 | string_flow.rb:249:5:249:5 | a :  | semmle.label | a :  |
 | string_flow.rb:249:16:249:16 | x :  | semmle.label | x :  |
 | string_flow.rb:249:24:249:24 | x | semmle.label | x |
-| string_flow.rb:250:10:250:28 | call to scrub | semmle.label | call to scrub |
-| string_flow.rb:250:26:250:26 | a :  | semmle.label | a :  |
+| string_flow.rb:250:10:250:37 | call to scrub | semmle.label | call to scrub |
+| string_flow.rb:250:26:250:35 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:252:10:252:10 | a :  | semmle.label | a :  |
 | string_flow.rb:252:10:252:22 | call to scrub! | semmle.label | call to scrub! |
 | string_flow.rb:253:10:253:22 | call to scrub! | semmle.label | call to scrub! |
@@ -543,8 +541,8 @@ nodes
 | string_flow.rb:256:5:256:5 | a :  | semmle.label | a :  |
 | string_flow.rb:256:17:256:17 | x :  | semmle.label | x :  |
 | string_flow.rb:256:25:256:25 | x | semmle.label | x |
-| string_flow.rb:258:10:258:29 | call to scrub! | semmle.label | call to scrub! |
-| string_flow.rb:258:27:258:27 | a :  | semmle.label | a :  |
+| string_flow.rb:258:10:258:38 | call to scrub! | semmle.label | call to scrub! |
+| string_flow.rb:258:27:258:36 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:262:9:262:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:263:10:263:10 | a :  | semmle.label | a :  |
 | string_flow.rb:263:10:263:22 | call to shellescape | semmle.label | call to shellescape |

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string_flow.rb
@@ -247,7 +247,7 @@ def m_scrub
     sink a.scrub("b") # $ hasTaintFlow=a
     sink "b".scrub(a) # $ hasTaintFlow=a
     a.scrub { |x| sink x } # $ hasTaintFlow=a
-    sink("b".scrub { |x| a }) # $ hasTaintFlow=a
+    sink("b".scrub { |x| source "a" }) # $ hasTaintFlow=a
 
     sink a.scrub!("b") # $ hasTaintFlow=a
     sink "b".scrub!(a) # $ hasTaintFlow=a
@@ -255,7 +255,7 @@ def m_scrub
     a = source "a"
     a.scrub! { |x| sink x } # $ hasTaintFlow=a
 
-    sink("b".scrub! { |x| a }) # $ hasTaintFlow=a
+    sink("b".scrub! { |x| source "a" }) # $ hasTaintFlow=a
 end
 
 def m_shellescape

--- a/ruby/ql/test/library-tests/variables/ssa.expected
+++ b/ruby/ql/test/library-tests/variables/ssa.expected
@@ -14,9 +14,9 @@ definition
 | instance_variables.rb:15:3:17:5 | self (m) | instance_variables.rb:15:3:17:5 | self |
 | instance_variables.rb:20:1:25:3 | self (M) | instance_variables.rb:20:1:25:3 | self |
 | instance_variables.rb:22:2:24:4 | self (n) | instance_variables.rb:22:2:24:4 | self |
-| instance_variables.rb:27:6:29:1 | <captured> self | instance_variables.rb:1:1:44:4 | self |
+| instance_variables.rb:27:6:29:1 | <captured entry> self | instance_variables.rb:1:1:44:4 | self |
 | instance_variables.rb:31:1:33:3 | self (bar) | instance_variables.rb:31:1:33:3 | self |
-| instance_variables.rb:32:10:32:21 | <captured> self | instance_variables.rb:31:1:33:3 | self |
+| instance_variables.rb:32:10:32:21 | <captured entry> self | instance_variables.rb:31:1:33:3 | self |
 | instance_variables.rb:35:1:44:4 | self (C) | instance_variables.rb:35:1:44:4 | self |
 | instance_variables.rb:37:3:43:5 | self (x) | instance_variables.rb:37:3:43:5 | self |
 | instance_variables.rb:38:4:40:6 | self (y) | instance_variables.rb:38:4:40:6 | self |
@@ -33,8 +33,8 @@ definition
 | nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a |
 | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:15:23:15:23 | a |
 | nested_scopes.rb:17:15:17:19 | ... = ... | nested_scopes.rb:16:29:16:29 | a |
-| nested_scopes.rb:18:23:18:36 | <captured> a | nested_scopes.rb:16:29:16:29 | a |
-| nested_scopes.rb:18:23:18:36 | <captured> self | nested_scopes.rb:12:9:21:11 | self |
+| nested_scopes.rb:18:23:18:36 | <captured entry> a | nested_scopes.rb:16:29:16:29 | a |
+| nested_scopes.rb:18:23:18:36 | <captured entry> self | nested_scopes.rb:12:9:21:11 | self |
 | nested_scopes.rb:22:9:24:11 | self (show_a2) | nested_scopes.rb:22:9:24:11 | self |
 | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:22:21:22:21 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self |
@@ -42,7 +42,7 @@ definition
 | nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a |
 | nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d |
 | parameters.rb:1:1:62:1 | self (parameters.rb) | parameters.rb:1:1:62:1 | self |
-| parameters.rb:1:9:5:3 | <captured> self | parameters.rb:1:1:62:1 | self |
+| parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x |
 | parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self |
@@ -50,7 +50,7 @@ definition
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas |
 | parameters.rb:15:1:19:3 | self (print_map) | parameters.rb:15:1:19:3 | self |
 | parameters.rb:15:17:15:19 | map | parameters.rb:15:17:15:19 | map |
-| parameters.rb:16:12:18:5 | <captured> self | parameters.rb:15:1:19:3 | self |
+| parameters.rb:16:12:18:5 | <captured entry> self | parameters.rb:15:1:19:3 | self |
 | parameters.rb:16:16:16:18 | key | parameters.rb:16:16:16:18 | key |
 | parameters.rb:16:21:16:25 | value | parameters.rb:16:21:16:25 | value |
 | parameters.rb:21:17:21:21 | block | parameters.rb:21:17:21:21 | block |
@@ -77,8 +77,8 @@ definition
 | parameters.rb:49:13:49:13 | a | parameters.rb:49:13:49:13 | a |
 | parameters.rb:49:15:49:15 | b | parameters.rb:49:15:49:15 | b |
 | parameters.rb:53:1:53:6 | ... = ... | parameters.rb:53:1:53:1 | x |
-| parameters.rb:54:9:57:3 | <captured> self | parameters.rb:1:1:62:1 | self |
-| parameters.rb:54:9:57:3 | <captured> x | parameters.rb:53:1:53:1 | x |
+| parameters.rb:54:9:57:3 | <captured entry> self | parameters.rb:1:1:62:1 | self |
+| parameters.rb:54:9:57:3 | <captured entry> x | parameters.rb:53:1:53:1 | x |
 | parameters.rb:54:14:54:14 | y | parameters.rb:54:14:54:14 | y |
 | parameters.rb:54:19:54:23 | ... = ... | parameters.rb:53:1:53:1 | x |
 | parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x |
@@ -87,11 +87,11 @@ definition
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c |
 | scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self |
-| scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self |
 | scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a |
 | scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a |
-| scopes.rb:9:9:18:3 | <captured> a | scopes.rb:7:1:7:1 | a |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self |
+| scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self |
 | scopes.rb:11:4:11:9 | ... = ... | scopes.rb:7:1:7:1 | a |
 | scopes.rb:13:4:13:4 | ... = ... | scopes.rb:7:1:7:1 | a |
 | scopes.rb:13:7:13:7 | ... = ... | scopes.rb:13:7:13:7 | b |
@@ -124,11 +124,11 @@ definition
 | ssa.rb:25:1:30:3 | self (m2) | ssa.rb:25:1:30:3 | self |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements |
 | ssa.rb:26:3:28:5 | ... = ... | ssa.rb:26:7:26:10 | elem |
-| ssa.rb:26:3:28:5 | <captured> self | ssa.rb:25:1:30:3 | self |
+| ssa.rb:26:3:28:5 | <captured entry> self | ssa.rb:25:1:30:3 | self |
+| ssa.rb:26:3:28:5 | <captured exit> elem | ssa.rb:26:7:26:10 | elem |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
-| ssa.rb:26:3:28:5 | call to each | ssa.rb:26:7:26:10 | elem |
 | ssa.rb:32:1:36:3 | self (m3) | ssa.rb:32:1:36:3 | self |
-| ssa.rb:33:16:35:5 | <captured> self | ssa.rb:32:1:36:3 | self |
+| ssa.rb:33:16:35:5 | <captured entry> self | ssa.rb:32:1:36:3 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self |
 | ssa.rb:40:3:40:9 | ... = ... | ssa.rb:40:3:40:4 | m3 |
@@ -150,20 +150,20 @@ definition
 | ssa.rb:64:1:72:3 | self (m9) | ssa.rb:64:1:72:3 | self |
 | ssa.rb:64:8:64:8 | a | ssa.rb:64:8:64:8 | a |
 | ssa.rb:65:3:65:15 | ... = ... | ssa.rb:65:3:65:10 | captured |
-| ssa.rb:66:3:70:5 | call to times | ssa.rb:65:3:65:10 | captured |
-| ssa.rb:66:11:70:5 | <captured> captured | ssa.rb:65:3:65:10 | captured |
-| ssa.rb:66:11:70:5 | <captured> self | ssa.rb:64:1:72:3 | self |
+| ssa.rb:66:3:70:5 | <captured exit> captured | ssa.rb:65:3:65:10 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> captured | ssa.rb:65:3:65:10 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> self | ssa.rb:64:1:72:3 | self |
 | ssa.rb:66:15:66:15 | a | ssa.rb:66:15:66:15 | a |
 | ssa.rb:69:5:69:17 | ... = ... | ssa.rb:65:3:65:10 | captured |
 | ssa.rb:74:1:79:3 | self (m10) | ssa.rb:74:1:79:3 | self |
 | ssa.rb:75:3:75:14 | ... = ... | ssa.rb:75:3:75:10 | captured |
-| ssa.rb:76:7:78:5 | <captured> captured | ssa.rb:75:3:75:10 | captured |
-| ssa.rb:76:7:78:5 | <captured> self | ssa.rb:74:1:79:3 | self |
+| ssa.rb:76:7:78:5 | <captured entry> captured | ssa.rb:75:3:75:10 | captured |
+| ssa.rb:76:7:78:5 | <captured entry> self | ssa.rb:74:1:79:3 | self |
 | ssa.rb:81:1:88:3 | self (m11) | ssa.rb:81:1:88:3 | self |
 | ssa.rb:82:3:82:14 | ... = ... | ssa.rb:82:3:82:10 | captured |
-| ssa.rb:83:7:87:5 | <captured> self | ssa.rb:81:1:88:3 | self |
-| ssa.rb:84:10:86:8 | <captured> captured | ssa.rb:82:3:82:10 | captured |
-| ssa.rb:84:10:86:8 | <captured> self | ssa.rb:81:1:88:3 | self |
+| ssa.rb:83:7:87:5 | <captured entry> self | ssa.rb:81:1:88:3 | self |
+| ssa.rb:84:10:86:8 | <captured entry> captured | ssa.rb:82:3:82:10 | captured |
+| ssa.rb:84:10:86:8 | <captured entry> self | ssa.rb:81:1:88:3 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self |
 | ssa.rb:90:9:90:10 | b1 | ssa.rb:90:9:90:10 | b1 |
 | ssa.rb:90:13:90:14 | b2 | ssa.rb:90:13:90:14 | b2 |
@@ -189,8 +189,8 @@ read
 | instance_variables.rb:15:3:17:5 | self (m) | instance_variables.rb:15:3:17:5 | self | instance_variables.rb:16:5:16:6 | self |
 | instance_variables.rb:20:1:25:3 | self (M) | instance_variables.rb:20:1:25:3 | self | instance_variables.rb:21:2:21:3 | self |
 | instance_variables.rb:22:2:24:4 | self (n) | instance_variables.rb:22:2:24:4 | self | instance_variables.rb:23:4:23:5 | self |
-| instance_variables.rb:27:6:29:1 | <captured> self | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:28:3:28:4 | self |
-| instance_variables.rb:32:10:32:21 | <captured> self | instance_variables.rb:31:1:33:3 | self | instance_variables.rb:32:12:32:13 | self |
+| instance_variables.rb:27:6:29:1 | <captured entry> self | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:28:3:28:4 | self |
+| instance_variables.rb:32:10:32:21 | <captured entry> self | instance_variables.rb:31:1:33:3 | self | instance_variables.rb:32:12:32:13 | self |
 | instance_variables.rb:35:1:44:4 | self (C) | instance_variables.rb:35:1:44:4 | self | instance_variables.rb:36:3:36:4 | self |
 | instance_variables.rb:37:3:43:5 | self (x) | instance_variables.rb:37:3:43:5 | self | instance_variables.rb:41:4:41:4 | self |
 | instance_variables.rb:37:3:43:5 | self (x) | instance_variables.rb:37:3:43:5 | self | instance_variables.rb:42:4:42:7 | self |
@@ -212,8 +212,8 @@ read
 | nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:15:11:15:11 | a |
 | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:16:13:16:13 | a |
 | nested_scopes.rb:17:15:17:19 | ... = ... | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
-| nested_scopes.rb:18:23:18:36 | <captured> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
-| nested_scopes.rb:18:23:18:36 | <captured> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
+| nested_scopes.rb:18:23:18:36 | <captured entry> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
+| nested_scopes.rb:18:23:18:36 | <captured entry> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
 | nested_scopes.rb:22:9:24:11 | self (show_a2) | nested_scopes.rb:22:9:24:11 | self | nested_scopes.rb:23:11:23:16 | self |
 | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:23:16:23:16 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:11:28:16 | self |
@@ -221,8 +221,8 @@ read
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:32:11:32:16 | self |
 | nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
 | nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
-| parameters.rb:1:9:5:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self |
-| parameters.rb:1:9:5:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:4:4:4:9 | self |
+| parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self |
+| parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:4:4:4:9 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x | parameters.rb:3:9:3:9 | x |
 | parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:9:5:9:33 | self |
@@ -232,7 +232,7 @@ read
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas | parameters.rb:8:6:8:11 | pizzas |
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas | parameters.rb:11:14:11:19 | pizzas |
 | parameters.rb:15:17:15:19 | map | parameters.rb:15:17:15:19 | map | parameters.rb:16:3:16:5 | map |
-| parameters.rb:16:12:18:5 | <captured> self | parameters.rb:15:1:19:3 | self | parameters.rb:17:5:17:28 | self |
+| parameters.rb:16:12:18:5 | <captured entry> self | parameters.rb:15:1:19:3 | self | parameters.rb:17:5:17:28 | self |
 | parameters.rb:16:16:16:18 | key | parameters.rb:16:16:16:18 | key | parameters.rb:17:13:17:15 | key |
 | parameters.rb:16:21:16:25 | value | parameters.rb:16:21:16:25 | value | parameters.rb:17:22:17:26 | value |
 | parameters.rb:21:17:21:21 | block | parameters.rb:21:17:21:21 | block | parameters.rb:22:3:22:7 | block |
@@ -256,8 +256,8 @@ read
 | parameters.rb:49:1:51:3 | self (tuples) | parameters.rb:49:1:51:3 | self | parameters.rb:50:3:50:18 | self |
 | parameters.rb:49:13:49:13 | a | parameters.rb:49:13:49:13 | a | parameters.rb:50:11:50:11 | a |
 | parameters.rb:49:15:49:15 | b | parameters.rb:49:15:49:15 | b | parameters.rb:50:16:50:16 | b |
-| parameters.rb:54:9:57:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:55:4:55:9 | self |
-| parameters.rb:54:9:57:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:56:4:56:9 | self |
+| parameters.rb:54:9:57:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:55:4:55:9 | self |
+| parameters.rb:54:9:57:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:56:4:56:9 | self |
 | parameters.rb:54:14:54:14 | y | parameters.rb:54:14:54:14 | y | parameters.rb:56:9:56:9 | y |
 | parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:55:9:55:9 | x |
 | parameters.rb:59:1:61:3 | self (tuples_nested) | parameters.rb:59:1:61:3 | self | parameters.rb:60:3:60:23 | self |
@@ -265,19 +265,19 @@ read
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b | parameters.rb:60:16:60:16 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
 | scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
-| scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self |
-| scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:9:3:9 | self |
-| scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:5:4:5:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:9:3:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:5:4:5:9 | self |
 | scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
 | scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
-| scopes.rb:9:9:18:3 | <captured> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a |
-| scopes.rb:9:9:18:3 | <captured> a | scopes.rb:7:1:7:1 | a | scopes.rb:11:4:11:4 | a |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:10:4:10:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:12:4:12:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:14:4:14:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:15:4:15:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:16:4:16:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:17:4:17:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a |
+| scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:11:4:11:4 | a |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:10:4:10:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:12:4:12:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:14:4:14:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:15:4:15:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:16:4:16:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:17:4:17:9 | self |
 | scopes.rb:11:4:11:9 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
 | scopes.rb:13:4:13:4 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
 | scopes.rb:13:7:13:7 | ... = ... | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
@@ -318,10 +318,10 @@ read
 | ssa.rb:25:1:30:3 | self (m2) | ssa.rb:25:1:30:3 | self | ssa.rb:29:3:29:11 | self |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements | ssa.rb:26:15:26:22 | elements |
 | ssa.rb:26:3:28:5 | ... = ... | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
-| ssa.rb:26:3:28:5 | <captured> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
+| ssa.rb:26:3:28:5 | <captured entry> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
+| ssa.rb:26:3:28:5 | <captured exit> elem | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
-| ssa.rb:26:3:28:5 | call to each | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
-| ssa.rb:33:16:35:5 | <captured> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
+| ssa.rb:33:16:35:5 | <captured entry> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x | ssa.rb:34:10:34:10 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:39:3:39:9 | self |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:39:8:39:9 | self |
@@ -340,19 +340,19 @@ read
 | ssa.rb:60:3:60:9 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
 | ssa.rb:64:1:72:3 | self (m9) | ssa.rb:64:1:72:3 | self | ssa.rb:71:3:71:15 | self |
 | ssa.rb:64:8:64:8 | a | ssa.rb:64:8:64:8 | a | ssa.rb:66:3:66:3 | a |
-| ssa.rb:66:3:70:5 | call to times | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
-| ssa.rb:66:11:70:5 | <captured> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:68:10:68:17 | captured |
-| ssa.rb:66:11:70:5 | <captured> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:69:5:69:12 | captured |
-| ssa.rb:66:11:70:5 | <captured> self | ssa.rb:64:1:72:3 | self | ssa.rb:67:5:67:10 | self |
-| ssa.rb:66:11:70:5 | <captured> self | ssa.rb:64:1:72:3 | self | ssa.rb:68:5:68:17 | self |
+| ssa.rb:66:3:70:5 | <captured exit> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:68:10:68:17 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:69:5:69:12 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> self | ssa.rb:64:1:72:3 | self | ssa.rb:67:5:67:10 | self |
+| ssa.rb:66:11:70:5 | <captured entry> self | ssa.rb:64:1:72:3 | self | ssa.rb:68:5:68:17 | self |
 | ssa.rb:66:15:66:15 | a | ssa.rb:66:15:66:15 | a | ssa.rb:67:10:67:10 | a |
 | ssa.rb:74:1:79:3 | self (m10) | ssa.rb:74:1:79:3 | self | ssa.rb:76:3:78:5 | self |
-| ssa.rb:76:7:78:5 | <captured> captured | ssa.rb:75:3:75:10 | captured | ssa.rb:77:15:77:22 | captured |
-| ssa.rb:76:7:78:5 | <captured> self | ssa.rb:74:1:79:3 | self | ssa.rb:77:6:77:23 | self |
+| ssa.rb:76:7:78:5 | <captured entry> captured | ssa.rb:75:3:75:10 | captured | ssa.rb:77:15:77:22 | captured |
+| ssa.rb:76:7:78:5 | <captured entry> self | ssa.rb:74:1:79:3 | self | ssa.rb:77:6:77:23 | self |
 | ssa.rb:81:1:88:3 | self (m11) | ssa.rb:81:1:88:3 | self | ssa.rb:83:3:87:5 | self |
-| ssa.rb:83:7:87:5 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:84:6:86:8 | self |
-| ssa.rb:84:10:86:8 | <captured> captured | ssa.rb:82:3:82:10 | captured | ssa.rb:85:15:85:22 | captured |
-| ssa.rb:84:10:86:8 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
+| ssa.rb:83:7:87:5 | <captured entry> self | ssa.rb:81:1:88:3 | self | ssa.rb:84:6:86:8 | self |
+| ssa.rb:84:10:86:8 | <captured entry> captured | ssa.rb:82:3:82:10 | captured | ssa.rb:85:15:85:22 | captured |
+| ssa.rb:84:10:86:8 | <captured entry> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:93:5:93:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:95:5:95:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:99:5:99:10 | self |
@@ -379,8 +379,8 @@ firstRead
 | instance_variables.rb:15:3:17:5 | self (m) | instance_variables.rb:15:3:17:5 | self | instance_variables.rb:16:5:16:6 | self |
 | instance_variables.rb:20:1:25:3 | self (M) | instance_variables.rb:20:1:25:3 | self | instance_variables.rb:21:2:21:3 | self |
 | instance_variables.rb:22:2:24:4 | self (n) | instance_variables.rb:22:2:24:4 | self | instance_variables.rb:23:4:23:5 | self |
-| instance_variables.rb:27:6:29:1 | <captured> self | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:28:3:28:4 | self |
-| instance_variables.rb:32:10:32:21 | <captured> self | instance_variables.rb:31:1:33:3 | self | instance_variables.rb:32:12:32:13 | self |
+| instance_variables.rb:27:6:29:1 | <captured entry> self | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:28:3:28:4 | self |
+| instance_variables.rb:32:10:32:21 | <captured entry> self | instance_variables.rb:31:1:33:3 | self | instance_variables.rb:32:12:32:13 | self |
 | instance_variables.rb:35:1:44:4 | self (C) | instance_variables.rb:35:1:44:4 | self | instance_variables.rb:36:3:36:4 | self |
 | instance_variables.rb:37:3:43:5 | self (x) | instance_variables.rb:37:3:43:5 | self | instance_variables.rb:41:4:41:4 | self |
 | instance_variables.rb:38:4:40:6 | self (y) | instance_variables.rb:38:4:40:6 | self | instance_variables.rb:39:6:39:7 | self |
@@ -397,15 +397,15 @@ firstRead
 | nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a |
 | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:16:13:16:13 | a |
 | nested_scopes.rb:17:15:17:19 | ... = ... | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
-| nested_scopes.rb:18:23:18:36 | <captured> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
-| nested_scopes.rb:18:23:18:36 | <captured> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
+| nested_scopes.rb:18:23:18:36 | <captured entry> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
+| nested_scopes.rb:18:23:18:36 | <captured entry> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
 | nested_scopes.rb:22:9:24:11 | self (show_a2) | nested_scopes.rb:22:9:24:11 | self | nested_scopes.rb:23:11:23:16 | self |
 | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:23:16:23:16 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:11:28:16 | self |
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:32:11:32:16 | self |
 | nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
 | nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
-| parameters.rb:1:9:5:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self |
+| parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x | parameters.rb:3:9:3:9 | x |
 | parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:9:5:9:33 | self |
@@ -414,7 +414,7 @@ firstRead
 | parameters.rb:7:17:7:22 | client | parameters.rb:7:17:7:22 | client | parameters.rb:11:41:11:46 | client |
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas | parameters.rb:8:6:8:11 | pizzas |
 | parameters.rb:15:17:15:19 | map | parameters.rb:15:17:15:19 | map | parameters.rb:16:3:16:5 | map |
-| parameters.rb:16:12:18:5 | <captured> self | parameters.rb:15:1:19:3 | self | parameters.rb:17:5:17:28 | self |
+| parameters.rb:16:12:18:5 | <captured entry> self | parameters.rb:15:1:19:3 | self | parameters.rb:17:5:17:28 | self |
 | parameters.rb:16:16:16:18 | key | parameters.rb:16:16:16:18 | key | parameters.rb:17:13:17:15 | key |
 | parameters.rb:16:21:16:25 | value | parameters.rb:16:21:16:25 | value | parameters.rb:17:22:17:26 | value |
 | parameters.rb:21:17:21:21 | block | parameters.rb:21:17:21:21 | block | parameters.rb:22:3:22:7 | block |
@@ -437,7 +437,7 @@ firstRead
 | parameters.rb:49:1:51:3 | self (tuples) | parameters.rb:49:1:51:3 | self | parameters.rb:50:3:50:18 | self |
 | parameters.rb:49:13:49:13 | a | parameters.rb:49:13:49:13 | a | parameters.rb:50:11:50:11 | a |
 | parameters.rb:49:15:49:15 | b | parameters.rb:49:15:49:15 | b | parameters.rb:50:16:50:16 | b |
-| parameters.rb:54:9:57:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:55:4:55:9 | self |
+| parameters.rb:54:9:57:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:55:4:55:9 | self |
 | parameters.rb:54:14:54:14 | y | parameters.rb:54:14:54:14 | y | parameters.rb:56:9:56:9 | y |
 | parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:55:9:55:9 | x |
 | parameters.rb:59:1:61:3 | self (tuples_nested) | parameters.rb:59:1:61:3 | self | parameters.rb:60:3:60:23 | self |
@@ -445,11 +445,11 @@ firstRead
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b | parameters.rb:60:16:60:16 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
 | scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
-| scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self |
 | scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
 | scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
-| scopes.rb:9:9:18:3 | <captured> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:10:4:10:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:10:4:10:9 | self |
 | scopes.rb:11:4:11:9 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
 | scopes.rb:13:4:13:4 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
 | scopes.rb:13:7:13:7 | ... = ... | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
@@ -472,10 +472,10 @@ firstRead
 | ssa.rb:25:1:30:3 | self (m2) | ssa.rb:25:1:30:3 | self | ssa.rb:29:3:29:11 | self |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements | ssa.rb:26:15:26:22 | elements |
 | ssa.rb:26:3:28:5 | ... = ... | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
-| ssa.rb:26:3:28:5 | <captured> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
+| ssa.rb:26:3:28:5 | <captured entry> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
+| ssa.rb:26:3:28:5 | <captured exit> elem | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
-| ssa.rb:26:3:28:5 | call to each | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
-| ssa.rb:33:16:35:5 | <captured> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
+| ssa.rb:33:16:35:5 | <captured entry> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x | ssa.rb:34:10:34:10 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:39:3:39:9 | self |
 | ssa.rb:40:3:40:9 | ... = ... | ssa.rb:40:3:40:4 | m3 | ssa.rb:41:8:41:9 | m3 |
@@ -492,17 +492,17 @@ firstRead
 | ssa.rb:60:3:60:9 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
 | ssa.rb:64:1:72:3 | self (m9) | ssa.rb:64:1:72:3 | self | ssa.rb:71:3:71:15 | self |
 | ssa.rb:64:8:64:8 | a | ssa.rb:64:8:64:8 | a | ssa.rb:66:3:66:3 | a |
-| ssa.rb:66:3:70:5 | call to times | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
-| ssa.rb:66:11:70:5 | <captured> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:68:10:68:17 | captured |
-| ssa.rb:66:11:70:5 | <captured> self | ssa.rb:64:1:72:3 | self | ssa.rb:67:5:67:10 | self |
+| ssa.rb:66:3:70:5 | <captured exit> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:68:10:68:17 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> self | ssa.rb:64:1:72:3 | self | ssa.rb:67:5:67:10 | self |
 | ssa.rb:66:15:66:15 | a | ssa.rb:66:15:66:15 | a | ssa.rb:67:10:67:10 | a |
 | ssa.rb:74:1:79:3 | self (m10) | ssa.rb:74:1:79:3 | self | ssa.rb:76:3:78:5 | self |
-| ssa.rb:76:7:78:5 | <captured> captured | ssa.rb:75:3:75:10 | captured | ssa.rb:77:15:77:22 | captured |
-| ssa.rb:76:7:78:5 | <captured> self | ssa.rb:74:1:79:3 | self | ssa.rb:77:6:77:23 | self |
+| ssa.rb:76:7:78:5 | <captured entry> captured | ssa.rb:75:3:75:10 | captured | ssa.rb:77:15:77:22 | captured |
+| ssa.rb:76:7:78:5 | <captured entry> self | ssa.rb:74:1:79:3 | self | ssa.rb:77:6:77:23 | self |
 | ssa.rb:81:1:88:3 | self (m11) | ssa.rb:81:1:88:3 | self | ssa.rb:83:3:87:5 | self |
-| ssa.rb:83:7:87:5 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:84:6:86:8 | self |
-| ssa.rb:84:10:86:8 | <captured> captured | ssa.rb:82:3:82:10 | captured | ssa.rb:85:15:85:22 | captured |
-| ssa.rb:84:10:86:8 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
+| ssa.rb:83:7:87:5 | <captured entry> self | ssa.rb:81:1:88:3 | self | ssa.rb:84:6:86:8 | self |
+| ssa.rb:84:10:86:8 | <captured entry> captured | ssa.rb:82:3:82:10 | captured | ssa.rb:85:15:85:22 | captured |
+| ssa.rb:84:10:86:8 | <captured entry> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:93:5:93:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:95:5:95:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:99:5:99:10 | self |
@@ -529,8 +529,8 @@ lastRead
 | instance_variables.rb:15:3:17:5 | self (m) | instance_variables.rb:15:3:17:5 | self | instance_variables.rb:16:5:16:6 | self |
 | instance_variables.rb:20:1:25:3 | self (M) | instance_variables.rb:20:1:25:3 | self | instance_variables.rb:21:2:21:3 | self |
 | instance_variables.rb:22:2:24:4 | self (n) | instance_variables.rb:22:2:24:4 | self | instance_variables.rb:23:4:23:5 | self |
-| instance_variables.rb:27:6:29:1 | <captured> self | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:28:3:28:4 | self |
-| instance_variables.rb:32:10:32:21 | <captured> self | instance_variables.rb:31:1:33:3 | self | instance_variables.rb:32:12:32:13 | self |
+| instance_variables.rb:27:6:29:1 | <captured entry> self | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:28:3:28:4 | self |
+| instance_variables.rb:32:10:32:21 | <captured entry> self | instance_variables.rb:31:1:33:3 | self | instance_variables.rb:32:12:32:13 | self |
 | instance_variables.rb:35:1:44:4 | self (C) | instance_variables.rb:35:1:44:4 | self | instance_variables.rb:36:3:36:4 | self |
 | instance_variables.rb:37:3:43:5 | self (x) | instance_variables.rb:37:3:43:5 | self | instance_variables.rb:42:6:42:7 | self |
 | instance_variables.rb:38:4:40:6 | self (y) | instance_variables.rb:38:4:40:6 | self | instance_variables.rb:39:6:39:7 | self |
@@ -547,15 +547,15 @@ lastRead
 | nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:15:11:15:11 | a |
 | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:16:13:16:13 | a |
 | nested_scopes.rb:17:15:17:19 | ... = ... | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
-| nested_scopes.rb:18:23:18:36 | <captured> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
-| nested_scopes.rb:18:23:18:36 | <captured> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
+| nested_scopes.rb:18:23:18:36 | <captured entry> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
+| nested_scopes.rb:18:23:18:36 | <captured entry> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
 | nested_scopes.rb:22:9:24:11 | self (show_a2) | nested_scopes.rb:22:9:24:11 | self | nested_scopes.rb:23:11:23:16 | self |
 | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:23:16:23:16 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:16:28:16 | self |
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:32:11:32:16 | self |
 | nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
 | nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
-| parameters.rb:1:9:5:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:4:4:4:9 | self |
+| parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:4:4:4:9 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x | parameters.rb:3:9:3:9 | x |
 | parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:9:5:9:33 | self |
@@ -565,7 +565,7 @@ lastRead
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas | parameters.rb:8:6:8:11 | pizzas |
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas | parameters.rb:11:14:11:19 | pizzas |
 | parameters.rb:15:17:15:19 | map | parameters.rb:15:17:15:19 | map | parameters.rb:16:3:16:5 | map |
-| parameters.rb:16:12:18:5 | <captured> self | parameters.rb:15:1:19:3 | self | parameters.rb:17:5:17:28 | self |
+| parameters.rb:16:12:18:5 | <captured entry> self | parameters.rb:15:1:19:3 | self | parameters.rb:17:5:17:28 | self |
 | parameters.rb:16:16:16:18 | key | parameters.rb:16:16:16:18 | key | parameters.rb:17:13:17:15 | key |
 | parameters.rb:16:21:16:25 | value | parameters.rb:16:21:16:25 | value | parameters.rb:17:22:17:26 | value |
 | parameters.rb:21:17:21:21 | block | parameters.rb:21:17:21:21 | block | parameters.rb:22:3:22:7 | block |
@@ -587,7 +587,7 @@ lastRead
 | parameters.rb:49:1:51:3 | self (tuples) | parameters.rb:49:1:51:3 | self | parameters.rb:50:3:50:18 | self |
 | parameters.rb:49:13:49:13 | a | parameters.rb:49:13:49:13 | a | parameters.rb:50:11:50:11 | a |
 | parameters.rb:49:15:49:15 | b | parameters.rb:49:15:49:15 | b | parameters.rb:50:16:50:16 | b |
-| parameters.rb:54:9:57:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:56:4:56:9 | self |
+| parameters.rb:54:9:57:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:56:4:56:9 | self |
 | parameters.rb:54:14:54:14 | y | parameters.rb:54:14:54:14 | y | parameters.rb:56:9:56:9 | y |
 | parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:55:9:55:9 | x |
 | parameters.rb:59:1:61:3 | self (tuples_nested) | parameters.rb:59:1:61:3 | self | parameters.rb:60:3:60:23 | self |
@@ -595,11 +595,11 @@ lastRead
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b | parameters.rb:60:16:60:16 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
 | scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
-| scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:5:4:5:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:5:4:5:9 | self |
 | scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
 | scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
-| scopes.rb:9:9:18:3 | <captured> a | scopes.rb:7:1:7:1 | a | scopes.rb:11:4:11:4 | a |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:17:4:17:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:11:4:11:4 | a |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:17:4:17:9 | self |
 | scopes.rb:11:4:11:9 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
 | scopes.rb:13:4:13:4 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
 | scopes.rb:13:7:13:7 | ... = ... | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
@@ -623,10 +623,10 @@ lastRead
 | ssa.rb:25:1:30:3 | self (m2) | ssa.rb:25:1:30:3 | self | ssa.rb:29:3:29:11 | self |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements | ssa.rb:26:15:26:22 | elements |
 | ssa.rb:26:3:28:5 | ... = ... | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
-| ssa.rb:26:3:28:5 | <captured> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
+| ssa.rb:26:3:28:5 | <captured entry> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
+| ssa.rb:26:3:28:5 | <captured exit> elem | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
-| ssa.rb:26:3:28:5 | call to each | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
-| ssa.rb:33:16:35:5 | <captured> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
+| ssa.rb:33:16:35:5 | <captured entry> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x | ssa.rb:34:10:34:10 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:41:3:41:13 | self |
 | ssa.rb:40:3:40:9 | ... = ... | ssa.rb:40:3:40:4 | m3 | ssa.rb:41:8:41:9 | m3 |
@@ -643,17 +643,17 @@ lastRead
 | ssa.rb:60:3:60:9 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
 | ssa.rb:64:1:72:3 | self (m9) | ssa.rb:64:1:72:3 | self | ssa.rb:71:3:71:15 | self |
 | ssa.rb:64:8:64:8 | a | ssa.rb:64:8:64:8 | a | ssa.rb:66:3:66:3 | a |
-| ssa.rb:66:3:70:5 | call to times | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
-| ssa.rb:66:11:70:5 | <captured> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:69:5:69:12 | captured |
-| ssa.rb:66:11:70:5 | <captured> self | ssa.rb:64:1:72:3 | self | ssa.rb:68:5:68:17 | self |
+| ssa.rb:66:3:70:5 | <captured exit> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:69:5:69:12 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> self | ssa.rb:64:1:72:3 | self | ssa.rb:68:5:68:17 | self |
 | ssa.rb:66:15:66:15 | a | ssa.rb:66:15:66:15 | a | ssa.rb:67:10:67:10 | a |
 | ssa.rb:74:1:79:3 | self (m10) | ssa.rb:74:1:79:3 | self | ssa.rb:76:3:78:5 | self |
-| ssa.rb:76:7:78:5 | <captured> captured | ssa.rb:75:3:75:10 | captured | ssa.rb:77:15:77:22 | captured |
-| ssa.rb:76:7:78:5 | <captured> self | ssa.rb:74:1:79:3 | self | ssa.rb:77:6:77:23 | self |
+| ssa.rb:76:7:78:5 | <captured entry> captured | ssa.rb:75:3:75:10 | captured | ssa.rb:77:15:77:22 | captured |
+| ssa.rb:76:7:78:5 | <captured entry> self | ssa.rb:74:1:79:3 | self | ssa.rb:77:6:77:23 | self |
 | ssa.rb:81:1:88:3 | self (m11) | ssa.rb:81:1:88:3 | self | ssa.rb:83:3:87:5 | self |
-| ssa.rb:83:7:87:5 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:84:6:86:8 | self |
-| ssa.rb:84:10:86:8 | <captured> captured | ssa.rb:82:3:82:10 | captured | ssa.rb:85:15:85:22 | captured |
-| ssa.rb:84:10:86:8 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
+| ssa.rb:83:7:87:5 | <captured entry> self | ssa.rb:81:1:88:3 | self | ssa.rb:84:6:86:8 | self |
+| ssa.rb:84:10:86:8 | <captured entry> captured | ssa.rb:82:3:82:10 | captured | ssa.rb:85:15:85:22 | captured |
+| ssa.rb:84:10:86:8 | <captured entry> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:93:5:93:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:95:5:95:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:99:5:99:10 | self |
@@ -679,19 +679,19 @@ adjacentReads
 | nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a | nested_scopes.rb:15:11:15:11 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:11:28:16 | self | nested_scopes.rb:28:16:28:16 | self |
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:30:16:30:19 | self | nested_scopes.rb:32:11:32:16 | self |
-| parameters.rb:1:9:5:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self | parameters.rb:4:4:4:9 | self |
+| parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self | parameters.rb:4:4:4:9 | self |
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas | parameters.rb:8:6:8:11 | pizzas | parameters.rb:11:14:11:19 | pizzas |
 | parameters.rb:25:1:28:3 | self (opt_param) | parameters.rb:25:1:28:3 | self | parameters.rb:26:3:26:11 | self | parameters.rb:27:3:27:11 | self |
 | parameters.rb:25:15:25:18 | name | parameters.rb:25:15:25:18 | name | parameters.rb:25:40:25:43 | name | parameters.rb:26:8:26:11 | name |
-| parameters.rb:54:9:57:3 | <captured> self | parameters.rb:1:1:62:1 | self | parameters.rb:55:4:55:9 | self | parameters.rb:56:4:56:9 | self |
-| scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self | scopes.rb:3:9:3:9 | self |
-| scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:9:3:9 | self | scopes.rb:5:4:5:9 | self |
-| scopes.rb:9:9:18:3 | <captured> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a | scopes.rb:11:4:11:4 | a |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:10:4:10:9 | self | scopes.rb:12:4:12:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:12:4:12:9 | self | scopes.rb:14:4:14:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:14:4:14:9 | self | scopes.rb:15:4:15:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:15:4:15:9 | self | scopes.rb:16:4:16:9 | self |
-| scopes.rb:9:9:18:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:16:4:16:9 | self | scopes.rb:17:4:17:9 | self |
+| parameters.rb:54:9:57:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:55:4:55:9 | self | parameters.rb:56:4:56:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self | scopes.rb:3:9:3:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:9:3:9 | self | scopes.rb:5:4:5:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a | scopes.rb:11:4:11:4 | a |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:10:4:10:9 | self | scopes.rb:12:4:12:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:12:4:12:9 | self | scopes.rb:14:4:14:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:14:4:14:9 | self | scopes.rb:15:4:15:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:15:4:15:9 | self | scopes.rb:16:4:16:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:16:4:16:9 | self | scopes.rb:17:4:17:9 | self |
 | scopes.rb:13:10:13:15 | ... = ... | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:11:13:11 | __synth__0__1 | scopes.rb:13:14:13:14 | __synth__0__1 |
 | scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:4:13:4 | __synth__0 | scopes.rb:13:7:13:7 | __synth__0 |
 | scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:7:13:7 | __synth__0 | scopes.rb:13:10:13:15 | __synth__0 |
@@ -714,8 +714,8 @@ adjacentReads
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:20:10:20:10 | x | ssa.rb:21:5:21:5 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:39:3:39:9 | self | ssa.rb:39:8:39:9 | self |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:39:8:39:9 | self | ssa.rb:41:3:41:13 | self |
-| ssa.rb:66:11:70:5 | <captured> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:68:10:68:17 | captured | ssa.rb:69:5:69:12 | captured |
-| ssa.rb:66:11:70:5 | <captured> self | ssa.rb:64:1:72:3 | self | ssa.rb:67:5:67:10 | self | ssa.rb:68:5:68:17 | self |
+| ssa.rb:66:11:70:5 | <captured entry> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:68:10:68:17 | captured | ssa.rb:69:5:69:12 | captured |
+| ssa.rb:66:11:70:5 | <captured entry> self | ssa.rb:64:1:72:3 | self | ssa.rb:67:5:67:10 | self | ssa.rb:68:5:68:17 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:93:5:93:10 | self | ssa.rb:99:5:99:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:93:5:93:10 | self | ssa.rb:101:5:101:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:95:5:95:10 | self | ssa.rb:99:5:99:10 | self |
@@ -729,7 +729,7 @@ phi
 | parameters.rb:37:3:37:18 | phi | parameters.rb:35:16:35:16 | b | parameters.rb:35:16:35:20 | ... = ... |
 | parameters.rb:42:3:42:18 | phi | parameters.rb:40:15:40:15 | e | parameters.rb:40:1:43:3 | <uninitialized> |
 | parameters.rb:42:3:42:18 | phi | parameters.rb:40:15:40:15 | e | parameters.rb:40:15:40:19 | ... = ... |
-| parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:54:9:57:3 | <captured> x |
+| parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:54:9:57:3 | <captured entry> x |
 | parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:54:19:54:23 | ... = ... |
 | ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:6:5:6:9 | ... = ... |
 | ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:10:5:10:9 | ... = ... |


### PR DESCRIPTION
We were previously supporting direct flow through captured variables:
```rb
x = taint1
[1, 2, 3].each do |i|
    sink x # `taint1` flows in
end

[1, 2, 3].each do |i|
    y = taint2
end

sink y # `taint2` flows out
```

However, we were not supporting flow through contents (e.g. fields) on captured variables:
```rb
class C
    def set_field x
        @field = x
    end
    def get_field
        return @field
    end
end

x = C.new
x.set_field(taint1)
[1, 2, 3].each do |i|
    sink(x.get_field) # `taint1` flows in
end

y = C.new
[1, 2, 3].each do |i|
    y.set_field(taint2)
end

sink(y.get_field) # `taint2` flows out
```

Luckily, the existing SSA library provides the bits that we need to also cover the cases above:
- The first call to `each` already gives rise to an implicit read of `c`, so instead of limiting flow in to be the SSA definition for the implicit read, we do like with normal SSA flow and consider all adjacent accesses (reads or the definition itself) to flow in (that is, it is no longer `x = C.new` that flows in, but instead the post-update node for `x` in `x.set_field(taint1)`).
- Again, the second call to `each` already gives rise to an implicit read of `c`, so we simply need to add flow from the post-update of `y` in `y.set_field(taint2)` to all adjacent reads/phi nodes that immediately follow the implicit read at the call to `each`.