### PR TITLE
Swift: show QL class in generated tests on collapsed hierarchies

### DIFF
--- a/swift/codegen/generators/qlgen.py
+++ b/swift/codegen/generators/qlgen.py
@@ -304,7 +304,10 @@ def generate(opts, renderer):
         total_props, partial_props = _partition(_get_all_properties_to_be_tested(c, data.classes),
                                                 lambda p: p.is_single or p.is_predicate)
         renderer.render(ql.ClassTester(class_name=c.name,
-                                       properties=total_props), test_dir / f"{c.name}.ql")
+                                       properties=total_props,
+                                       # in case of collapsed hierarchies we want to see the actual QL class in results
+                                       show_ql_class="qltest_collapse_hierarchy" in c.pragmas),
+                        test_dir / f"{c.name}.ql")
         for p in partial_props:
             renderer.render(ql.PropertyTester(class_name=c.name,
                                               property=p), test_dir / f"{c.name}_{p.getter}.ql")

--- a/swift/codegen/lib/ql.py
+++ b/swift/codegen/lib/ql.py
@@ -165,6 +165,7 @@ class ClassTester:
 
     class_name: str
     properties: List[PropertyForTest] = field(default_factory=list)
+    show_ql_class: bool = False
 
 
 @dataclass

--- a/swift/codegen/templates/ql_test_class.mustache
+++ b/swift/codegen/templates/ql_test_class.mustache
@@ -13,4 +13,4 @@ and {{getter}} = x.{{getter}}()
 and if x.{{getter}}() then {{getter}} = "yes" else {{getter}} = "no"
 {{/is_predicate}}
 {{/properties}}
-select x{{#properties}}, "{{getter}}:", {{getter}}{{/properties}}
+select x{{#show_ql_class}}, x.getPrimaryQlClasses(){{/show_ql_class}}{{#properties}}, "{{getter}}:", {{getter}}{{/properties}}

--- a/swift/codegen/test/test_qlgen.py
+++ b/swift/codegen/test/test_qlgen.py
@@ -584,7 +584,7 @@ def test_test_class_hierarchy_collapse(opts, generate_tests):
         schema.Class("D2", bases=["Base"], derived={"D3"}, properties=[schema.SingleProperty("y", "string")]),
         schema.Class("D3", bases=["D2"], properties=[schema.SingleProperty("z", "string")]),
     ]) == {
-        "Base/Base.ql": ql.ClassTester(class_name="Base"),
+        "Base/Base.ql": ql.ClassTester(class_name="Base", show_ql_class=True),
     }
 
 
@@ -598,7 +598,7 @@ def test_test_class_hierarchy_uncollapse(opts, generate_tests):
         schema.Class("D3", bases=["D2"]),
         schema.Class("D4", bases=["D2"]),
     ]) == {
-        "Base/Base.ql": ql.ClassTester(class_name="Base"),
+        "Base/Base.ql": ql.ClassTester(class_name="Base", show_ql_class=True),
         "D3/D3.ql": ql.ClassTester(class_name="D3"),
         "D4/D4.ql": ql.ClassTester(class_name="D4"),
     }
@@ -613,7 +613,7 @@ def test_test_class_hierarchy_uncollapse_at_final(opts, generate_tests):
         schema.Class("D2", bases=["Base"], derived={"D3"}),
         schema.Class("D3", bases=["D2"], pragmas=["qltest_uncollapse_hierarchy", "bar"]),
     ]) == {
-        "Base/Base.ql": ql.ClassTester(class_name="Base"),
+        "Base/Base.ql": ql.ClassTester(class_name="Base", show_ql_class=True),
         "D3/D3.ql": ql.ClassTester(class_name="D3"),
     }
 

--- a/swift/ql/test/extractor-tests/generated/File/File.expected
+++ b/swift/ql/test/extractor-tests/generated/File/File.expected
@@ -1,3 +1,3 @@
-| empty.swift:0:0:0:0 | empty.swift | getName: | empty.swift |
-| file://:0:0:0:0 |  | getName: |  |
-| non_empty.swift:0:0:0:0 | non_empty.swift | getName: | non_empty.swift |
+| empty.swift:0:0:0:0 | empty.swift | DbFile | getName: | empty.swift |
+| file://:0:0:0:0 |  | UnknownFile | getName: |  |
+| non_empty.swift:0:0:0:0 | non_empty.swift | DbFile | getName: | non_empty.swift |

--- a/swift/ql/test/extractor-tests/generated/File/File.ql
+++ b/swift/ql/test/extractor-tests/generated/File/File.ql
@@ -7,4 +7,4 @@ where
   toBeTested(x) and
   not x.isUnknown() and
   getName = x.getName()
-select x, "getName:", getName
+select x, x.getPrimaryQlClasses(), "getName:", getName

--- a/swift/ql/test/extractor-tests/generated/expr/ImplicitConversionExpr/ImplicitConversionExpr.expected
+++ b/swift/ql/test/extractor-tests/generated/expr/ImplicitConversionExpr/ImplicitConversionExpr.expected
@@ -1,3 +1,3 @@
-| implicit_conversions.swift:2:3:2:3 | (UnsafePointer<CChar>) ... | getSubExpr: | implicit_conversions.swift:2:3:2:3 | Hello |
-| implicit_conversions.swift:4:16:4:16 | (Int?) ... | getSubExpr: | implicit_conversions.swift:4:16:4:16 | 42 |
-| implicit_conversions.swift:5:25:5:25 | (Equatable) ... | getSubExpr: | implicit_conversions.swift:5:25:5:25 | 42 |
+| implicit_conversions.swift:2:3:2:3 | (UnsafePointer<CChar>) ... | StringToPointerExpr | getSubExpr: | implicit_conversions.swift:2:3:2:3 | Hello |
+| implicit_conversions.swift:4:16:4:16 | (Int?) ... | InjectIntoOptionalExpr | getSubExpr: | implicit_conversions.swift:4:16:4:16 | 42 |
+| implicit_conversions.swift:5:25:5:25 | (Equatable) ... | ErasureExpr | getSubExpr: | implicit_conversions.swift:5:25:5:25 | 42 |

--- a/swift/ql/test/extractor-tests/generated/expr/ImplicitConversionExpr/ImplicitConversionExpr.ql
+++ b/swift/ql/test/extractor-tests/generated/expr/ImplicitConversionExpr/ImplicitConversionExpr.ql
@@ -7,4 +7,4 @@ where
   toBeTested(x) and
   not x.isUnknown() and
   getSubExpr = x.getSubExpr()
-select x, "getSubExpr:", getSubExpr
+select x, x.getPrimaryQlClasses(), "getSubExpr:", getSubExpr

--- a/swift/ql/test/extractor-tests/generated/type/BuiltinType/BuiltinType.expected
+++ b/swift/ql/test/extractor-tests/generated/type/BuiltinType/BuiltinType.expected
@@ -1,9 +1,9 @@
-| Builtin.BridgeObject | getName: | Builtin.BridgeObject | getCanonicalType: | Builtin.BridgeObject |
-| Builtin.Executor | getName: | Builtin.Executor | getCanonicalType: | Builtin.Executor |
-| Builtin.FPIEEE32 | getName: | Builtin.FPIEEE32 | getCanonicalType: | Builtin.FPIEEE32 |
-| Builtin.FPIEEE64 | getName: | Builtin.FPIEEE64 | getCanonicalType: | Builtin.FPIEEE64 |
-| Builtin.IntLiteral | getName: | Builtin.IntLiteral | getCanonicalType: | Builtin.IntLiteral |
-| Builtin.Job | getName: | Builtin.Job | getCanonicalType: | Builtin.Job |
-| Builtin.NativeObject | getName: | Builtin.NativeObject | getCanonicalType: | Builtin.NativeObject |
-| Builtin.RawPointer | getName: | Builtin.RawPointer | getCanonicalType: | Builtin.RawPointer |
-| Builtin.RawUnsafeContinuation | getName: | Builtin.RawUnsafeContinuation | getCanonicalType: | Builtin.RawUnsafeContinuation |
+| Builtin.BridgeObject | BuiltinBridgeObjectType | getName: | Builtin.BridgeObject | getCanonicalType: | Builtin.BridgeObject |
+| Builtin.Executor | BuiltinExecutorType | getName: | Builtin.Executor | getCanonicalType: | Builtin.Executor |
+| Builtin.FPIEEE32 | BuiltinFloatType | getName: | Builtin.FPIEEE32 | getCanonicalType: | Builtin.FPIEEE32 |
+| Builtin.FPIEEE64 | BuiltinFloatType | getName: | Builtin.FPIEEE64 | getCanonicalType: | Builtin.FPIEEE64 |
+| Builtin.IntLiteral | BuiltinIntegerLiteralType | getName: | Builtin.IntLiteral | getCanonicalType: | Builtin.IntLiteral |
+| Builtin.Job | BuiltinJobType | getName: | Builtin.Job | getCanonicalType: | Builtin.Job |
+| Builtin.NativeObject | BuiltinNativeObjectType | getName: | Builtin.NativeObject | getCanonicalType: | Builtin.NativeObject |
+| Builtin.RawPointer | BuiltinRawPointerType | getName: | Builtin.RawPointer | getCanonicalType: | Builtin.RawPointer |
+| Builtin.RawUnsafeContinuation | BuiltinRawUnsafeContinuationType | getName: | Builtin.RawUnsafeContinuation | getCanonicalType: | Builtin.RawUnsafeContinuation |

--- a/swift/ql/test/extractor-tests/generated/type/BuiltinType/BuiltinType.ql
+++ b/swift/ql/test/extractor-tests/generated/type/BuiltinType/BuiltinType.ql
@@ -8,4 +8,4 @@ where
   not x.isUnknown() and
   getName = x.getName() and
   getCanonicalType = x.getCanonicalType()
-select x, "getName:", getName, "getCanonicalType:", getCanonicalType
+select x, x.getPrimaryQlClasses(), "getName:", getName, "getCanonicalType:", getCanonicalType


### PR DESCRIPTION
In those kinds of tests the results may have different final classes that are not necessarily visible (or tested) solely through the string representation. For better testing and reading of expected results, `getQlPrimaryClasses` is added in these cases.