### PR TITLE
Swift: Give Location a useful toString

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/Location.qll
+++ b/swift/ql/lib/codeql/swift/elements/Location.qll
@@ -8,4 +8,15 @@ class Location extends LocationBase {
     el = getEndLine() and
     ec = getEndColumn()
   }
+
+  /**
+   * Gets a textual representation of this location.
+   */
+  override string toString() {
+    exists(string filePath, int startLine, int startColumn, int endLine, int endColumn |
+      this.hasLocationInfo(filePath, startLine, startColumn, endLine, endColumn)
+    |
+      toUrl(filePath, startLine, startColumn, endLine, endColumn, result)
+    )
+  }
 }

--- a/swift/ql/lib/codeql/swift/elements/Location.qll
+++ b/swift/ql/lib/codeql/swift/elements/Location.qll
@@ -1,12 +1,18 @@
 private import codeql.swift.generated.Location
 
+/**
+ * A location of a program element.
+ */
 class Location extends LocationBase {
-  predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
+  /**
+   * Holds if this location is described by `path`, `startLine`, `startColumn`, `endLine` and `endColumn`.
+   */
+  predicate hasLocationInfo(string path, int startLine, int startColumn, int endLine, int endColumn) {
     path = getFile().getFullName() and
-    sl = getStartLine() and
-    sc = getStartColumn() and
-    el = getEndLine() and
-    ec = getEndColumn()
+    startLine = getStartLine() and
+    startColumn = getStartColumn() and
+    endLine = getEndLine() and
+    endColumn = getEndColumn()
   }
 
   /**

--- a/swift/ql/lib/codeql/swift/elements/Location.qll
+++ b/swift/ql/lib/codeql/swift/elements/Location.qll
@@ -8,11 +8,11 @@ class Location extends LocationBase {
    * Holds if this location is described by `path`, `startLine`, `startColumn`, `endLine` and `endColumn`.
    */
   predicate hasLocationInfo(string path, int startLine, int startColumn, int endLine, int endColumn) {
-    path = getFile().getFullName() and
-    startLine = getStartLine() and
-    startColumn = getStartColumn() and
-    endLine = getEndLine() and
-    endColumn = getEndColumn()
+    path = this.getFile().getFullName() and
+    startLine = this.getStartLine() and
+    startColumn = this.getStartColumn() and
+    endLine = this.getEndLine() and
+    endColumn = this.getEndColumn()
   }
 
   /**

--- a/swift/ql/lib/codeql/swift/elements/UnknownLocation.qll
+++ b/swift/ql/lib/codeql/swift/elements/UnknownLocation.qll
@@ -12,4 +12,6 @@ class UnknownLocation extends UnknownLocationBase {
   override int getEndLine() { result = 0 }
 
   override int getEndColumn() { result = 0 }
+
+  override string toString() { result = "UnknownLocation" }
 }

--- a/swift/ql/lib/codeql/swift/elements/UnknownLocation.qll
+++ b/swift/ql/lib/codeql/swift/elements/UnknownLocation.qll
@@ -2,6 +2,9 @@ private import codeql.swift.generated.UnknownLocation
 private import codeql.swift.elements.UnknownFile
 private import codeql.swift.elements.File
 
+/**
+ * A `Location` that is given to something that is not associated with any position in the source code.
+ */
 class UnknownLocation extends UnknownLocationBase {
   override File getImmediateFile() { result instanceof UnknownFile }
 

--- a/swift/ql/test/library-tests/elements/location/location.expected
+++ b/swift/ql/test/library-tests/elements/location/location.expected
@@ -1,4 +1,4 @@
-| file://:0:0:0:0 | UnknownLocation |
-| location.swift:2:1:3:1 | DbLocation |
-| location.swift:2:11:2:14 | DbLocation |
-| location.swift:2:19:3:1 | DbLocation |
+| file://:0:0:0:0 | file://:0:0:0:0 |
+| location.swift:2:1:3:1 | location.swift:2:1:3:1 |
+| location.swift:2:11:2:14 | location.swift:2:11:2:14 |
+| location.swift:2:19:3:1 | location.swift:2:19:3:1 |

--- a/swift/ql/test/library-tests/elements/location/location.expected
+++ b/swift/ql/test/library-tests/elements/location/location.expected
@@ -1,4 +1,4 @@
-| file://:0:0:0:0 | file://:0:0:0:0 |
+| file://:0:0:0:0 | UnknownLocation |
 | location.swift:2:1:3:1 | location.swift:2:1:3:1 |
 | location.swift:2:11:2:14 | location.swift:2:11:2:14 |
 | location.swift:2:19:3:1 | location.swift:2:19:3:1 |

--- a/swift/ql/test/library-tests/elements/location/location.expected
+++ b/swift/ql/test/library-tests/elements/location/location.expected
@@ -1,0 +1,4 @@
+| file://:0:0:0:0 | UnknownLocation |
+| location.swift:2:1:3:1 | DbLocation |
+| location.swift:2:11:2:14 | DbLocation |
+| location.swift:2:19:3:1 | DbLocation |

--- a/swift/ql/test/library-tests/elements/location/location.ql
+++ b/swift/ql/test/library-tests/elements/location/location.ql
@@ -1,0 +1,4 @@
+import swift
+
+from Location l
+select l

--- a/swift/ql/test/library-tests/elements/location/location.swift
+++ b/swift/ql/test/library-tests/elements/location/location.swift
@@ -1,0 +1,3 @@
+
+func test(x: Int) {
+}


### PR DESCRIPTION
In a debug query I was outputting `Location.toString()` and just getting a bunch of strings `"DbLocation"` (from the base `Element.toString`).  This PR adds a `Location.toString()` implementation similar to what CPP and other languages have.