### PR TITLE
Java: Add library support for activity-alias elements in AndroidManifest.qll

### DIFF
--- a/java/ql/lib/change-notes/2022-10-17-android-activity-alias.md
+++ b/java/ql/lib/change-notes/2022-10-17-android-activity-alias.md
@@ -1,8 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Added the `AndroidActivityAliasXmlElement` class to represent `<activity-alias>` components in Android manifests.
-* Added the `AndroidActivityXmlElement.getAnAlias` method to get the aliases of an `<activity>` element in an Android manifest.
-* Added the `AndroidIdentifierXmlAttribute` class to represent XML attributes representing component identifiers, such as `android:name` and `android:targetActivity`
-* Added the `AndroidComponentXmlElement.getResolvedIdentifier` method, for finding the fully qualified identifier from an identifier.
-* Added the `AndroidComponentXmlElement.getResolvedComponentName` method, for finding the fully qualified identifier of a component.
+* Added support for Android Manifest `<activity-aliases>` elements in data flow sources. 

--- a/java/ql/lib/change-notes/2022-10-17-android-activity-alias.md
+++ b/java/ql/lib/change-notes/2022-10-17-android-activity-alias.md
@@ -1,0 +1,8 @@
+---
+category: minorAnalysis
+---
+* Added the `AndroidActivityAliasXmlElement` class to represent `<activity-alias>` components in Android manifests.
+* Added the `AndroidActivityXmlElement.getAnAlias` method to get the aliases of an `<activity>` element in an Android manifest.
+* Added the `AndroidIdentifierXmlAttribute` class to represent XML attributes representing component identifiers, such as `android:name` and `android:targetActivity`
+* Added the `AndroidComponentXmlElement.getResolvedIdentifier` method, for finding the fully qualified identifier from an identifier.
+* Added the `AndroidComponentXmlElement.getResolvedComponentName` method, for finding the fully qualified identifier of a component.

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -57,6 +57,12 @@ class ExportableAndroidComponent extends AndroidComponent {
     or
     this.hasIntentFilter() and
     not this.getAndroidComponentXmlElement().isNotExported()
+    or
+    exists(AndroidActivityAliasXmlElement e |
+      e = this.getAndroidComponentXmlElement() and
+      not e.isNotExported() and
+      e.hasAnIntentFilterElement()
+    )
   }
 }
 

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -26,7 +26,12 @@ class AndroidComponent extends Class {
 
   /** The XML element corresponding to this Android component. */
   AndroidComponentXmlElement getAndroidComponentXmlElement() {
-    result.getResolvedComponentName() = this.getQualifiedName()
+    // Find an element with an identifier matching the qualified name of the component.
+    // Aliases have two identifiers (name and target), so check both identifiers (if present).
+    exists(AndroidIdentifierXmlAttribute identifier |
+      identifier = result.getAnAttribute() and
+      result.getResolvedIdentifier(identifier) = this.getQualifiedName()
+    )
   }
 
   /** Holds if this Android component is configured as `exported` in an `AndroidManifest.xml` file. */

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -262,18 +262,29 @@ class AndroidComponentXmlElement extends XmlElement {
   }
 
   /**
+   * Gets the value of an identifier attribute, and tries to resolve it into a fully qualified identifier.
+   */
+  string getResolvedIdentifier(AndroidIdentifierXmlAttribute identifier) {
+    exists(string name | name = identifier.getValue() |
+      if name.matches(".%")
+      then
+        result =
+          this.getParent()
+                .(XmlElement)
+                .getParent()
+                .(AndroidManifestXmlElement)
+                .getPackageAttributeValue() + name
+      else result = name
+    )
+  }
+
+  /**
    * Gets the resolved value of the `android:name` attribute of this component element.
    */
   string getResolvedComponentName() {
-    if this.getComponentName().matches(".%")
-    then
-      result =
-        this.getParent()
-              .(XmlElement)
-              .getParent()
-              .(AndroidManifestXmlElement)
-              .getPackageAttributeValue() + this.getComponentName()
-    else result = this.getComponentName()
+    exists(AndroidXmlAttribute attr | attr = this.getAnAttribute() and attr.getName() = "name" |
+      result = getResolvedIdentifier(attr)
+    )
   }
 
   /**

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -129,6 +129,13 @@ class AndroidApplicationXmlElement extends XmlElement {
  */
 class AndroidActivityXmlElement extends AndroidComponentXmlElement {
   AndroidActivityXmlElement() { this.getName() = "activity" }
+
+  /**
+   * Gets an `<activity-alias>` element aliasing the activity.
+   */
+  AndroidActivityAliasXmlElement getAnAlias() {
+    exists(AndroidActivityAliasXmlElement alias | this = alias.getTarget() | result = alias)
+  }
 }
 
 /**

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -213,6 +213,13 @@ class AndroidPermissionXmlAttribute extends XmlAttribute {
 }
 
 /**
+ * The attribute `android:name` or `android:targetActivity`.
+ */
+class AndroidIdentifierXmlAttribute extends AndroidXmlAttribute {
+  AndroidIdentifierXmlAttribute() { this.getName() = ["name", "targetActivity"] }
+}
+
+/**
  * The `<path-permission`> element of a `<provider>` in an Android manifest file.
  */
 class AndroidPathPermissionXmlElement extends XmlElement {

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -132,6 +132,35 @@ class AndroidActivityXmlElement extends AndroidComponentXmlElement {
 }
 
 /**
+ * An `<activity-alias>` element in an Android manifest file.
+ */
+class AndroidActivityAliasXmlElement extends AndroidComponentXmlElement {
+  AndroidActivityAliasXmlElement() { this.getName() = "activity-alias" }
+
+  /**
+   * Get and resolve the name of the target activity from the `android:targetActivity` attribute.
+   */
+  string getResolvedTargetActivityName() {
+    exists(AndroidXmlAttribute attr |
+      attr = this.getAnAttribute() and attr.getName() = "targetActivity"
+    |
+      result = getResolvedIdentifier(attr)
+    )
+  }
+
+  /**
+   * Gets the `<activity>` element referenced by the `android:targetActivity` attribute.
+   */
+  AndroidActivityXmlElement getTarget() {
+    exists(AndroidActivityXmlElement activity |
+      activity.getResolvedComponentName() = this.getResolvedTargetActivityName()
+    |
+      result = activity
+    )
+  }
+}
+
+/**
  * A `<service>` element in an Android manifest file.
  */
 class AndroidServiceXmlElement extends AndroidComponentXmlElement {
@@ -235,7 +264,7 @@ class AndroidPathPermissionXmlElement extends XmlElement {
 class AndroidComponentXmlElement extends XmlElement {
   AndroidComponentXmlElement() {
     this.getParent() instanceof AndroidApplicationXmlElement and
-    this.getName().regexpMatch("(activity|service|receiver|provider)")
+    this.getName().regexpMatch("(activity|activity-alias|service|receiver|provider)")
   }
 
   /**

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -151,7 +151,7 @@ class AndroidActivityAliasXmlElement extends AndroidComponentXmlElement {
     exists(AndroidXmlAttribute attr |
       attr = this.getAnAttribute() and attr.getName() = "targetActivity"
     |
-      result = getResolvedIdentifier(attr)
+      result = this.getResolvedIdentifier(attr)
     )
   }
 
@@ -319,7 +319,7 @@ class AndroidComponentXmlElement extends XmlElement {
    */
   string getResolvedComponentName() {
     exists(AndroidXmlAttribute attr | attr = this.getAnAttribute() and attr.getName() = "name" |
-      result = getResolvedIdentifier(attr)
+      result = this.getResolvedIdentifier(attr)
     )
   }
 

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/AndroidManifest.xml
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/AndroidManifest.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.myapplication">
+
+    <application
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+
+        android:theme="@style/Theme.MyApplication"
+        tools:targetApi="31">
+
+      <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.MyApplication.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".AnotherActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.MyApplication.NoActionBar">
+        </activity>
+
+
+        <activity-alias
+            android:name=".MainAlias"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:targetActivity=".MainActivity"></activity-alias>
+
+        <activity-alias
+            android:name=".SecondAlias"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:targetActivity=".MainActivity"></activity-alias>
+
+        <activity-alias
+            android:name=".AnotherAlias"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:targetActivity="com.example.myapplication.AnotherActivity"></activity-alias>
+
+    </application>
+
+</manifest>

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/AndroidManifest.xml
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/AndroidManifest.xml
@@ -52,7 +52,34 @@
             android:exported="true"
             android:label="@string/app_name"
             android:targetActivity="com.example.myapplication.AnotherActivity"></activity-alias>
+        <activity
+            android:name=".ExampleActivity"
+            android:exported="false"
+            android:label="@string/app_name"
+            ></activity>
 
+        <activity-alias
+            android:name=".ExampleAlias"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:targetActivity=".ExampleActivity">
+        </activity-alias>
+
+        <activity
+            android:name=".Example2Activity"
+            android:exported="false"
+            android:label="@string/app_name">
+        </activity>
+
+        <activity-alias
+            android:name=".Example2Alias"
+            android:label="@string/app_name"
+            android:targetActivity=".Example2Activity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"></action>
+                <action android:name="android.intent.category.LAUNCHER"></action>
+            </intent-filter>
+        </activity-alias>
     </application>
 
 </manifest>

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/Example2Activity.java
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/Example2Activity.java
@@ -1,0 +1,7 @@
+package com.example.myapplication;
+
+import android.app.Activity;
+
+public class Example2Activity extends Activity {
+
+}

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/ExampleActivity.java
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/ExampleActivity.java
@@ -1,0 +1,7 @@
+package com.example.myapplication;
+
+import android.app.Activity;
+
+public class ExampleActivity extends Activity {
+
+}

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAlias.expected
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAlias.expected
@@ -1,3 +1,5 @@
 | .AnotherAlias | .AnotherActivity |
+| .Example2Alias | .Example2Activity |
+| .ExampleAlias | .ExampleActivity |
 | .MainAlias | .MainActivity |
 | .SecondAlias | .MainActivity |

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAlias.expected
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAlias.expected
@@ -1,0 +1,3 @@
+| .AnotherAlias | .AnotherActivity |
+| .MainAlias | .MainActivity |
+| .SecondAlias | .MainActivity |

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAlias.ql
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAlias.ql
@@ -1,5 +1,4 @@
 import java
-
 import semmle.code.xml.AndroidManifest
 
 from AndroidActivityAliasXmlElement alias

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAlias.ql
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAlias.ql
@@ -1,0 +1,6 @@
+import java
+
+import semmle.code.xml.AndroidManifest
+
+from AndroidActivityAliasXmlElement alias
+select alias.getComponentName(), alias.getTarget().getComponentName()

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAliasExports.expected
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAliasExports.expected
@@ -1,0 +1,4 @@
+| Example2Activity.java:5:14:5:29 | Example2Activity | AndroidManifest.xml:68:9:72:20 | activity |
+| Example2Activity.java:5:14:5:29 | Example2Activity | AndroidManifest.xml:74:9:82:26 | activity-alias |
+| ExampleActivity.java:5:14:5:28 | ExampleActivity | AndroidManifest.xml:55:9:59:25 | activity |
+| ExampleActivity.java:5:14:5:28 | ExampleActivity | AndroidManifest.xml:61:9:66:26 | activity-alias |

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAliasExports.ql
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/TestActivityAliasExports.ql
@@ -1,0 +1,6 @@
+import java
+import semmle.code.java.frameworks.android.Android
+
+from ExportableAndroidComponent component
+where component.isExported()
+select component, component.getAndroidComponentXmlElement()

--- a/java/ql/test/library-tests/frameworks/android/activity-alias/options
+++ b/java/ql/test/library-tests/frameworks/android/activity-alias/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/google-android-9.0.0/


### PR DESCRIPTION
Android supports `<activity-alias>` elements which alias `<activity>` elements. This PR adds the `AndroidActivityAliasXmlElement` class to add support for activity aliases.