### PR TITLE
Ruby: Remove redundant additional flow step from `OrmTracking::Configuration`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -339,9 +339,6 @@ private module OrmTracking {
       or
       // Propagate flow through arbitrary method calls
       node2.(DataFlow2::CallNode).getReceiver() = node1
-      or
-      // Propagate flow through "or" expressions `or`/`||`
-      node2.asExpr().getExpr().(LogicalOrExpr).getAnOperand() = node1.asExpr().getExpr()
     }
   }
 }


### PR DESCRIPTION
No longer needed after https://github.com/github/codeql/pull/10559.