### PR TITLE
CI: update actions/cache to v3

### DIFF
--- a/ruby/actions/create-extractor-pack/action.yml
+++ b/ruby/actions/create-extractor-pack/action.yml
@@ -3,7 +3,7 @@ description: Builds the Ruby CodeQL pack
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/registry


### PR DESCRIPTION
This fixes most `set-output` and `save-state` warnings in Ruby CI jobs. 