### PR TITLE
Kotlin: Add test for useless null check on safe calls

### DIFF
--- a/java/ql/test/kotlin/query-tests/UselessNullCheck/Test.kt
+++ b/java/ql/test/kotlin/query-tests/UselessNullCheck/Test.kt
@@ -9,3 +9,10 @@ fun fn(x:Any?, y: Any?) {
         println("y not null")
     }
 }
+
+fun fn0(o: Any?) {
+    if (o != null) {
+        o?.toString()
+        o.toString()
+    }
+}

--- a/java/ql/test/kotlin/query-tests/UselessNullCheck/UselessNullCheck.expected
+++ b/java/ql/test/kotlin/query-tests/UselessNullCheck/UselessNullCheck.expected
@@ -1,0 +1,1 @@
+| Test.kt:15:12:15:21 | ... (value equals) ... | This check is useless. $@ cannot be null at this check, since it is guarded by $@. | Test.kt:15:9:15:9 | tmp0_safe_receiver | tmp0_safe_receiver | Test.kt:14:9:14:17 | ... (value not-equals) ... | ... (value not-equals) ... |


### PR DESCRIPTION
This PR adds a test case for the useless null check. An issue is correctly reported on the sample code, but the experience could be improved. The reported variable name doesn't exist in the code, it's a compiler generated variable. Also, the kotlin compiler already warns on this issue, which makes our finding somewhat redundant.
