### PR TITLE
Java: Add flow summaries for startActivities

### DIFF
--- a/java/ql/lib/change-notes/2022-10-19-android-startactivities-summaries.md
+++ b/java/ql/lib/change-notes/2022-10-19-android-startactivities-summaries.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added data flow summaries for tainted Android intents sent to activities via `Activity.startActivities`.

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSummary.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSummary.qll
@@ -26,6 +26,9 @@ module SummaryComponent {
   /** Gets a summary component for `Element`. */
   SummaryComponent element() { result = content(any(CollectionContent c)) }
 
+  /** Gets a summary component for `ArrayElement`. */
+  SummaryComponent arrayElement() { result = content(any(ArrayContent c)) }
+
   /** Gets a summary component for `MapValue`. */
   SummaryComponent mapValue() { result = content(any(MapValueContent c)) }
 
@@ -50,6 +53,11 @@ module SummaryComponentStack {
   /** Gets a stack representing `Element` of `object`. */
   SummaryComponentStack elementOf(SummaryComponentStack object) {
     result = push(SummaryComponent::element(), object)
+  }
+
+  /** Gets a stack representing `ArrayElement` of `object`. */
+  SummaryComponentStack arrayElementOf(SummaryComponentStack object) {
+    result = push(SummaryComponent::arrayElement(), object)
   }
 
   /** Gets a stack representing `MapValue` of `object`. */

--- a/java/ql/lib/semmle/code/java/frameworks/android/Intent.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Intent.qll
@@ -1,7 +1,10 @@
 import java
+private import semmle.code.java.frameworks.android.Android
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSteps
+private import semmle.code.java.dataflow.FlowSummary
+private import semmle.code.java.dataflow.internal.BaseSSA as BaseSSA
 
 /** The class `android.content.Intent`. */
 class TypeIntent extends Class {
@@ -242,17 +245,50 @@ private class StartComponentMethodAccess extends MethodAccess {
 
   /** Gets the intent argument of this call. */
   Argument getIntentArg() {
-    result.getType() instanceof TypeIntent and
+    (
+      result.getType() instanceof TypeIntent or
+      result.getType().(Array).getElementType() instanceof TypeIntent
+    ) and
     result = this.getAnArgument()
   }
 
   /** Holds if this targets a component of type `targetType`. */
-  predicate targetsComponentType(RefType targetType) {
+  predicate targetsComponentType(AndroidComponent targetType) {
     exists(NewIntent newIntent |
-      DataFlow::localExprFlow(newIntent, this.getIntentArg()) and
+      reaches(newIntent, this.getIntentArg()) and
       newIntent.getClassArg().getType().(ParameterizedType).getATypeArgument() = targetType
     )
   }
+}
+
+/**
+ * Holds if `src` reaches the intent argument `arg` of `StartComponentMethodAccess`
+ * through intra-procedural steps.
+ */
+private predicate reaches(Expr src, Argument arg) {
+  any(StartComponentMethodAccess ma).getIntentArg() = arg and
+  src = arg
+  or
+  exists(Expr mid, BaseSSA::BaseSsaVariable ssa, BaseSSA::BaseSsaUpdate upd |
+    reaches(mid, arg) and
+    mid = ssa.getAUse() and
+    upd = ssa.getAnUltimateLocalDefinition() and
+    src = upd.getDefiningExpr().(VariableAssign).getSource()
+  )
+  or
+  exists(CastingExpr e | e.getExpr() = src | reaches(e, arg))
+  or
+  exists(ChooseExpr e | e.getAResultExpr() = src | reaches(e, arg))
+  or
+  exists(AssignExpr e | e.getSource() = src | reaches(e, arg))
+  or
+  exists(ArrayCreationExpr e | e.getInit().getAnInit() = src | reaches(e, arg))
+  or
+  exists(StmtExpr e | e.getResultExpr() = src | reaches(e, arg))
+  or
+  exists(NotNullExpr e | e.getExpr() = src | reaches(e, arg))
+  or
+  exists(WhenExpr e | e.getBranch(_).getAResult() = src | reaches(e, arg))
 }
 
 /**
@@ -268,6 +304,87 @@ private class StartActivityIntentStep extends AdditionalValueStep {
       n1.asExpr() = startActivity.getIntentArg() and
       n2.asExpr() = getIntent
     )
+  }
+}
+
+/**
+ * Holds if `targetType` is targeted by an existing `StartComponentMethodAccess` call
+ * and it's identified by `id`.
+ */
+private predicate isTargetableType(AndroidComponent targetType, string id) {
+  exists(StartComponentMethodAccess ma | ma.targetsComponentType(targetType)) and
+  targetType.getQualifiedName() = id
+}
+
+private class StartActivitiesSyntheticCallable extends SyntheticCallable {
+  AndroidComponent targetType;
+
+  StartActivitiesSyntheticCallable() {
+    exists(string id |
+      this = "android.content.Activity.startActivities()+" + id and
+      isTargetableType(targetType, id)
+    )
+  }
+
+  override StartComponentMethodAccess getACall() {
+    result.getMethod().hasName("startActivities") and
+    result.targetsComponentType(targetType)
+  }
+
+  override predicate propagatesFlow(
+    SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
+  ) {
+    exists(ActivityIntentSyntheticGlobal glob | glob.getTargetType() = targetType |
+      input = SummaryComponentStack::arrayElementOf(SummaryComponentStack::argument(0)) and
+      output = SummaryComponentStack::singleton(SummaryComponent::syntheticGlobal(glob)) and
+      preservesValue = true
+    )
+  }
+}
+
+private class GetIntentSyntheticCallable extends SyntheticCallable {
+  AndroidComponent targetType;
+
+  GetIntentSyntheticCallable() {
+    exists(string id |
+      this = "android.content.Activity.getIntent()+" + id and
+      isTargetableType(targetType, id)
+    )
+  }
+
+  override Call getACall() {
+    result.getCallee() instanceof AndroidGetIntentMethod and
+    result.getEnclosingCallable().getDeclaringType() = targetType
+  }
+
+  override predicate propagatesFlow(
+    SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
+  ) {
+    exists(ActivityIntentSyntheticGlobal glob | glob.getTargetType() = targetType |
+      input = SummaryComponentStack::singleton(SummaryComponent::syntheticGlobal(glob)) and
+      output = SummaryComponentStack::return() and
+      preservesValue = true
+    )
+  }
+}
+
+private class ActivityIntentSyntheticGlobal extends SummaryComponent::SyntheticGlobal {
+  AndroidComponent targetType;
+
+  ActivityIntentSyntheticGlobal() {
+    exists(string id |
+      this = "ActivityIntentSyntheticGlobal+" + id and
+      isTargetableType(targetType, id)
+    )
+  }
+
+  AndroidComponent getTargetType() { result = targetType }
+}
+
+private class RequiredComponentStackForStartActivities extends RequiredSummaryComponentStack {
+  override predicate required(SummaryComponent head, SummaryComponentStack tail) {
+    head = SummaryComponent::element() and
+    tail = SummaryComponentStack::argument(0)
   }
 }
 

--- a/java/ql/lib/semmle/code/java/frameworks/android/Intent.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Intent.qll
@@ -4,7 +4,7 @@ private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSteps
 private import semmle.code.java.dataflow.FlowSummary
-private import semmle.code.java.dataflow.internal.BaseSSA as BaseSSA
+private import semmle.code.java.dataflow.internal.BaseSSA as BaseSsa
 
 /** The class `android.content.Intent`. */
 class TypeIntent extends Class {
@@ -269,7 +269,7 @@ private predicate reaches(Expr src, Argument arg) {
   any(StartComponentMethodAccess ma).getIntentArg() = arg and
   src = arg
   or
-  exists(Expr mid, BaseSSA::BaseSsaVariable ssa, BaseSSA::BaseSsaUpdate upd |
+  exists(Expr mid, BaseSsa::BaseSsaVariable ssa, BaseSsa::BaseSsaUpdate upd |
     reaches(mid, arg) and
     mid = ssa.getAUse() and
     upd = ssa.getAnUltimateLocalDefinition() and
@@ -383,7 +383,7 @@ private class ActivityIntentSyntheticGlobal extends SummaryComponent::SyntheticG
 
 private class RequiredComponentStackForStartActivities extends RequiredSummaryComponentStack {
   override predicate required(SummaryComponent head, SummaryComponentStack tail) {
-    head = SummaryComponent::element() and
+    head = SummaryComponent::arrayElement() and
     tail = SummaryComponentStack::argument(0)
   }
 }

--- a/java/ql/test/library-tests/frameworks/android/intent/TestStartActivityToGetIntent.java
+++ b/java/ql/test/library-tests/frameworks/android/intent/TestStartActivityToGetIntent.java
@@ -25,6 +25,12 @@ public class TestStartActivityToGetIntent {
             ctx.startActivities(intents);
         }
         {
+            Intent intent = new Intent(null, AnotherActivity.class);
+            intent.putExtra("data", (String) source("ctx-start-acts-2"));
+            Intent[] intents = new Intent[] {intent};
+            ctx.startActivities(intents);
+        }
+        {
             Intent intent = new Intent(null, SomeActivity.class);
             intent.putExtra("data", (String) source("act-start"));
             act.startActivity(intent);
@@ -32,6 +38,12 @@ public class TestStartActivityToGetIntent {
         {
             Intent intent = new Intent(null, SomeActivity.class);
             intent.putExtra("data", (String) source("act-start-acts"));
+            Intent[] intents = new Intent[] {intent};
+            act.startActivities(intents);
+        }
+        {
+            Intent intent = new Intent(null, Object.class);
+            intent.putExtra("data", (String) source("start-activities-should-not-reach"));
             Intent[] intents = new Intent[] {intent};
             act.startActivities(intents);
         }
@@ -79,9 +91,16 @@ public class TestStartActivityToGetIntent {
     static class SomeActivity extends Activity {
 
         public void test() {
-            sink(getIntent().getStringExtra("data")); // $ hasValueFlow=ctx-start hasValueFlow=act-start hasValueFlow=start-for-result hasValueFlow=start-if-needed hasValueFlow=start-matching hasValueFlow=start-from-child hasValueFlow=start-from-frag hasValueFlow=4-arg MISSING: hasValueFlow=ctx-start-acts hasValueFlow=act-start-acts
+            // @formatter:off
+            sink(getIntent().getStringExtra("data")); // $ hasValueFlow=ctx-start hasValueFlow=act-start hasValueFlow=start-for-result hasValueFlow=start-if-needed hasValueFlow=start-matching hasValueFlow=start-from-child hasValueFlow=start-from-frag hasValueFlow=4-arg hasValueFlow=ctx-start-acts hasValueFlow=act-start-acts
+            // @formatter:on
         }
+    }
 
+    static class AnotherActivity extends Activity {
+        public void test() {
+            sink(getIntent().getStringExtra("data")); // $ hasValueFlow=ctx-start-acts-2
+        }
     }
 
     static class SafeActivity extends Activity {


### PR DESCRIPTION
Uses `SyntheticCallable`s and `SyntheticGlobal`s to pair each `startActivities` call to `getIntent` calls in the components targeted by the intent(s).

Props to @aschackmull for this, which is the proper solution to the problem we discussed in https://github.com/github/codeql/pull/10660#discussion_r986814913.