### PR TITLE
Swift: Add some summary queries.

### DIFF
--- a/swift/ql/src/queries/Summary/FlowSources.ql
+++ b/swift/ql/src/queries/Summary/FlowSources.ql
@@ -3,8 +3,10 @@
  * @description List all flow sources found in the database. Flow sources
  *              indicate data that originates from an untrusted source, such
  *              as as untrusted remote data.
- * @kind table
+ * @kind problem
+ * @problem.severity info
  * @id swift/summary/flow-sources
+ * @tags summary
  */
 
 import swift

--- a/swift/ql/src/queries/Summary/FlowSources.ql
+++ b/swift/ql/src/queries/Summary/FlowSources.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Flow Sources
+ * @description List all flow sources found in the database. Flow sources
+ *              indicate data that originates from an untrusted source, such
+ *              as as untrusted remote data.
+ * @kind table
+ * @id swift/summary/flow-sources
+ */
+
+import swift
+import codeql.swift.dataflow.FlowSources
+
+from RemoteFlowSource s
+select s, "Flow source: " + s.getSourceType()

--- a/swift/ql/src/queries/Summary/SensitiveExprs.ql
+++ b/swift/ql/src/queries/Summary/SensitiveExprs.ql
@@ -4,8 +4,10 @@
  *              Sensitive expressions are expressions that have been
  *              identified as potentially containing data that should not be
  *              leaked to an attacker.
- * @kind table
+ * @kind problem
+ * @problem.severity info
  * @id swift/summary/sensitive-expressions
+ * @tags summary
  */
 
 import swift

--- a/swift/ql/src/queries/Summary/SensitiveExprs.ql
+++ b/swift/ql/src/queries/Summary/SensitiveExprs.ql
@@ -1,0 +1,15 @@
+/**
+ * @name Sensitive Expressions
+ * @description List all sensitive expressions found in the database.
+ *              Sensitive expressions are expressions that have been
+ *              identified as potentially containing data that should not be
+ *              leaked to an attacker.
+ * @kind table
+ * @id swift/summary/sensitive-expressions
+ */
+
+import swift
+import codeql.swift.security.SensitiveExprs
+
+from SensitiveExpr e
+select e, "Sensitive expression: " + e.getSensitiveType()

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -5,6 +5,7 @@
  *              features interesting to analysis that have been found.
  * @kind table
  * @id swift/summary/summary-statistics
+ * @tags summary
  */
 
 import swift

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -13,7 +13,7 @@ import codeql.swift.security.SensitiveExprs
 predicate statistic(string what, int value) {
   what = "Files" and value = count(File f)
   or
-  what = "Expressions" and value = count(Expr e | e.getFile().getName() != "")
+  what = "Expressions" and value = count(Expr e | not e.getFile() instanceof UnknownFile)
   or
   what = "Remote flow sources" and value = count(RemoteFlowSource s)
   or

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -1,0 +1,26 @@
+/**
+ * @name Summary statistics
+ * @description A table of summary statistics about a database. Includes
+ *              values that measure its size, and the numbers of certain
+ *              features interesting to analysis that have been found.
+ * @kind table
+ * @id swift/summary/summary-statistics
+ */
+
+import swift
+import codeql.swift.dataflow.FlowSources
+import codeql.swift.security.SensitiveExprs
+
+predicate statistic(string what, int value) {
+  what = "Files" and value = count(File f)
+  or
+  what = "Expressions" and value = count(Expr e)
+  or
+  what = "Remote flow sources" and value = count(RemoteFlowSource s)
+  or
+  what = "Sensitive expressions" and value = count(SensitiveExpr e)
+}
+
+from string what, int value
+where statistic(what, value)
+select what, value

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -1,8 +1,6 @@
 /**
  * @name Summary statistics
- * @description A table of summary statistics about a database. Includes
- *              values that measure its size, and the numbers of certain
- *              features interesting to analysis that have been found.
+ * @description A table of summary statistics about a database.
  * @kind table
  * @id swift/summary/summary-statistics
  * @tags summary

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -13,7 +13,7 @@ import codeql.swift.security.SensitiveExprs
 predicate statistic(string what, int value) {
   what = "Files" and value = count(File f)
   or
-  what = "Expressions" and value = count(Expr e)
+  what = "Expressions" and value = count(Expr e | e.getFile().getName() != "")
   or
   what = "Remote flow sources" and value = count(RemoteFlowSource s)
   or


### PR DESCRIPTION
I wrote these queries to assess the progress we're making identifying flow sources and sensitive expressions in real world Swift snapshots.  I intend to track these things fairly often in the near-mid future, so it would be convenient to have the queries in the public repo.  I don't think there's any harm in letting curious users see them as well.

It might be nice to have `LinesOfCode.ql` and `LinesOfUserCode.ql` summary queries as well as all (?) other languages do, but I don't think we extract the data for them yet.