### PR TITLE
Ruby: Call-context sensitivity for singleton method calls

### DIFF
--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,8 +1,4 @@
 failures
-| call_sensitivity.rb:71:10:71:10 | x | Unexpected result: hasValueFlow=22 |
-| call_sensitivity.rb:71:10:71:10 | x | Unexpected result: hasValueFlow=23 |
-| call_sensitivity.rb:71:10:71:10 | x | Unexpected result: hasValueFlow=24 |
-| call_sensitivity.rb:71:10:71:10 | x | Unexpected result: hasValueFlow=25 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
@@ -70,6 +66,10 @@ edges
 | call_sensitivity.rb:70:30:70:30 | x :  | call_sensitivity.rb:71:10:71:10 | x |
 | call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
 | call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
+| call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
+| call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
+| call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
 | call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
 | call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
 | call_sensitivity.rb:78:35:78:35 | x :  | call_sensitivity.rb:79:28:79:28 | x :  |
@@ -78,6 +78,10 @@ edges
 | call_sensitivity.rb:79:28:79:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
 | call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
 | call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
+| call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
+| call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
+| call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
 | call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
 | call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
 | call_sensitivity.rb:86:35:86:35 | x :  | call_sensitivity.rb:87:34:87:34 | x :  |
@@ -100,22 +104,6 @@ edges
 | call_sensitivity.rb:99:24:99:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
 | call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:86:35:86:35 | x :  |
 | call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:86:35:86:35 | x :  |
-| call_sensitivity.rb:119:35:119:35 | x :  | call_sensitivity.rb:120:28:120:28 | x :  |
-| call_sensitivity.rb:119:35:119:35 | x :  | call_sensitivity.rb:120:28:120:28 | x :  |
-| call_sensitivity.rb:120:28:120:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
-| call_sensitivity.rb:120:28:120:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
-| call_sensitivity.rb:123:35:123:35 | x :  | call_sensitivity.rb:124:34:124:34 | x :  |
-| call_sensitivity.rb:123:35:123:35 | x :  | call_sensitivity.rb:124:34:124:34 | x :  |
-| call_sensitivity.rb:124:34:124:34 | x :  | call_sensitivity.rb:82:33:82:33 | y :  |
-| call_sensitivity.rb:124:34:124:34 | x :  | call_sensitivity.rb:82:33:82:33 | y :  |
-| call_sensitivity.rb:134:21:134:28 | call to taint :  | call_sensitivity.rb:74:30:74:30 | x :  |
-| call_sensitivity.rb:134:21:134:28 | call to taint :  | call_sensitivity.rb:74:30:74:30 | x :  |
-| call_sensitivity.rb:135:26:135:33 | call to taint :  | call_sensitivity.rb:119:35:119:35 | x :  |
-| call_sensitivity.rb:135:26:135:33 | call to taint :  | call_sensitivity.rb:119:35:119:35 | x :  |
-| call_sensitivity.rb:136:24:136:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
-| call_sensitivity.rb:136:24:136:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
-| call_sensitivity.rb:137:26:137:33 | call to taint :  | call_sensitivity.rb:123:35:123:35 | x :  |
-| call_sensitivity.rb:137:26:137:33 | call to taint :  | call_sensitivity.rb:123:35:123:35 | x :  |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
@@ -197,6 +185,10 @@ nodes
 | call_sensitivity.rb:71:10:71:10 | x | semmle.label | x |
 | call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:78:35:78:35 | x :  | semmle.label | x :  |
@@ -205,6 +197,10 @@ nodes
 | call_sensitivity.rb:79:28:79:28 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
 | call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
 | call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
 | call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
 | call_sensitivity.rb:86:35:86:35 | x :  | semmle.label | x :  |
@@ -227,22 +223,6 @@ nodes
 | call_sensitivity.rb:99:24:99:32 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:100:26:100:33 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:100:26:100:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:119:35:119:35 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:119:35:119:35 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:120:28:120:28 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:120:28:120:28 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:123:35:123:35 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:123:35:123:35 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:124:34:124:34 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:124:34:124:34 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:134:21:134:28 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:134:21:134:28 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:135:26:135:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:135:26:135:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:136:24:136:32 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:136:24:136:32 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:137:26:137:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:137:26:137:33 | call to taint :  | semmle.label | call to taint :  |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint :  | call to taint :  |
@@ -258,18 +238,20 @@ subpaths
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:98:26:98:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:98:26:98:33 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:99:24:99:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:99:24:99:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:100:26:100:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:134:21:134:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:134:21:134:28 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:135:26:135:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:135:26:135:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:136:24:136:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:136:24:136:32 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:137:26:137:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:137:26:137:33 | call to taint :  | call to taint :  |
 mayBenefitFromCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:50:3:52:5 | method1 |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:54:3:56:5 | method2 |
 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:58:3:60:5 | call_method2 |
 | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:62:3:64:5 | method3 |
 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:66:3:68:5 | call_method3 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:74:3:76:5 | singleton_method2 |
+| call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:78:3:80:5 | call_singleton_method2 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:82:3:84:5 | singleton_method3 |
+| call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:86:3:88:5 | call_singleton_method3 |
 | call_sensitivity.rb:112:5:112:18 | call to method2 | call_sensitivity.rb:111:3:113:5 | call_method2 |
 | call_sensitivity.rb:116:5:116:25 | call to method3 | call_sensitivity.rb:115:3:117:5 | call_method3 |
+| call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:119:3:121:5 | call_singleton_method2 |
+| call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:123:3:125:5 | call_singleton_method3 |
 viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
@@ -288,19 +270,13 @@ viableImplInCallContext
 | call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
 | call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
 | call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:97:1:97:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:97:1:97:29 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
 | call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:134:1:134:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
 | call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:134:1:134:29 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
 | call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:98:1:98:34 | call to call_singleton_method2 | call_sensitivity.rb:74:3:76:5 | singleton_method2 |
 | call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
 | call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
 | call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:99:1:99:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:99:1:99:33 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
 | call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:136:1:136:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
 | call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:136:1:136:33 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
 | call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:100:1:100:34 | call to call_singleton_method3 | call_sensitivity.rb:82:3:84:5 | singleton_method3 |
 | call_sensitivity.rb:112:5:112:18 | call to method2 | call_sensitivity.rb:130:1:130:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,4 +1,8 @@
 failures
+| call_sensitivity.rb:71:10:71:10 | x | Unexpected result: hasValueFlow=22 |
+| call_sensitivity.rb:71:10:71:10 | x | Unexpected result: hasValueFlow=23 |
+| call_sensitivity.rb:71:10:71:10 | x | Unexpected result: hasValueFlow=24 |
+| call_sensitivity.rb:71:10:71:10 | x | Unexpected result: hasValueFlow=25 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
@@ -40,16 +44,78 @@ edges
 | call_sensitivity.rb:50:15:50:15 | x :  | call_sensitivity.rb:51:10:51:10 | x |
 | call_sensitivity.rb:54:15:54:15 | x :  | call_sensitivity.rb:55:13:55:13 | x :  |
 | call_sensitivity.rb:54:15:54:15 | x :  | call_sensitivity.rb:55:13:55:13 | x :  |
+| call_sensitivity.rb:54:15:54:15 | x :  | call_sensitivity.rb:55:13:55:13 | x :  |
+| call_sensitivity.rb:54:15:54:15 | x :  | call_sensitivity.rb:55:13:55:13 | x :  |
 | call_sensitivity.rb:55:13:55:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
 | call_sensitivity.rb:55:13:55:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
-| call_sensitivity.rb:58:18:58:18 | y :  | call_sensitivity.rb:59:15:59:15 | y :  |
-| call_sensitivity.rb:58:18:58:18 | y :  | call_sensitivity.rb:59:15:59:15 | y :  |
-| call_sensitivity.rb:59:15:59:15 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
-| call_sensitivity.rb:59:15:59:15 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
-| call_sensitivity.rb:64:11:64:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:64:11:64:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
-| call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:58:18:58:18 | y :  |
+| call_sensitivity.rb:55:13:55:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:55:13:55:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:58:20:58:20 | x :  | call_sensitivity.rb:59:18:59:18 | x :  |
+| call_sensitivity.rb:58:20:58:20 | x :  | call_sensitivity.rb:59:18:59:18 | x :  |
+| call_sensitivity.rb:59:18:59:18 | x :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:59:18:59:18 | x :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:62:18:62:18 | y :  | call_sensitivity.rb:63:15:63:15 | y :  |
+| call_sensitivity.rb:62:18:62:18 | y :  | call_sensitivity.rb:63:15:63:15 | y :  |
+| call_sensitivity.rb:62:18:62:18 | y :  | call_sensitivity.rb:63:15:63:15 | y :  |
+| call_sensitivity.rb:62:18:62:18 | y :  | call_sensitivity.rb:63:15:63:15 | y :  |
+| call_sensitivity.rb:63:15:63:15 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:63:15:63:15 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:63:15:63:15 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:63:15:63:15 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:66:20:66:20 | x :  | call_sensitivity.rb:67:24:67:24 | x :  |
+| call_sensitivity.rb:66:20:66:20 | x :  | call_sensitivity.rb:67:24:67:24 | x :  |
+| call_sensitivity.rb:67:24:67:24 | x :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:67:24:67:24 | x :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:70:30:70:30 | x :  | call_sensitivity.rb:71:10:71:10 | x |
+| call_sensitivity.rb:70:30:70:30 | x :  | call_sensitivity.rb:71:10:71:10 | x |
+| call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
+| call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
+| call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:78:35:78:35 | x :  | call_sensitivity.rb:79:28:79:28 | x :  |
+| call_sensitivity.rb:78:35:78:35 | x :  | call_sensitivity.rb:79:28:79:28 | x :  |
+| call_sensitivity.rb:79:28:79:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
+| call_sensitivity.rb:79:28:79:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
+| call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
+| call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
+| call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:86:35:86:35 | x :  | call_sensitivity.rb:87:34:87:34 | x :  |
+| call_sensitivity.rb:86:35:86:35 | x :  | call_sensitivity.rb:87:34:87:34 | x :  |
+| call_sensitivity.rb:87:34:87:34 | x :  | call_sensitivity.rb:82:33:82:33 | y :  |
+| call_sensitivity.rb:87:34:87:34 | x :  | call_sensitivity.rb:82:33:82:33 | y :  |
+| call_sensitivity.rb:92:11:92:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:92:11:92:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:93:16:93:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
+| call_sensitivity.rb:93:16:93:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
+| call_sensitivity.rb:94:14:94:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:94:14:94:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:95:16:95:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
+| call_sensitivity.rb:95:16:95:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
+| call_sensitivity.rb:97:21:97:28 | call to taint :  | call_sensitivity.rb:74:30:74:30 | x :  |
+| call_sensitivity.rb:97:21:97:28 | call to taint :  | call_sensitivity.rb:74:30:74:30 | x :  |
+| call_sensitivity.rb:98:26:98:33 | call to taint :  | call_sensitivity.rb:78:35:78:35 | x :  |
+| call_sensitivity.rb:98:26:98:33 | call to taint :  | call_sensitivity.rb:78:35:78:35 | x :  |
+| call_sensitivity.rb:99:24:99:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
+| call_sensitivity.rb:99:24:99:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
+| call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:86:35:86:35 | x :  |
+| call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:86:35:86:35 | x :  |
+| call_sensitivity.rb:119:35:119:35 | x :  | call_sensitivity.rb:120:28:120:28 | x :  |
+| call_sensitivity.rb:119:35:119:35 | x :  | call_sensitivity.rb:120:28:120:28 | x :  |
+| call_sensitivity.rb:120:28:120:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
+| call_sensitivity.rb:120:28:120:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
+| call_sensitivity.rb:123:35:123:35 | x :  | call_sensitivity.rb:124:34:124:34 | x :  |
+| call_sensitivity.rb:123:35:123:35 | x :  | call_sensitivity.rb:124:34:124:34 | x :  |
+| call_sensitivity.rb:124:34:124:34 | x :  | call_sensitivity.rb:82:33:82:33 | y :  |
+| call_sensitivity.rb:124:34:124:34 | x :  | call_sensitivity.rb:82:33:82:33 | y :  |
+| call_sensitivity.rb:134:21:134:28 | call to taint :  | call_sensitivity.rb:74:30:74:30 | x :  |
+| call_sensitivity.rb:134:21:134:28 | call to taint :  | call_sensitivity.rb:74:30:74:30 | x :  |
+| call_sensitivity.rb:135:26:135:33 | call to taint :  | call_sensitivity.rb:119:35:119:35 | x :  |
+| call_sensitivity.rb:135:26:135:33 | call to taint :  | call_sensitivity.rb:119:35:119:35 | x :  |
+| call_sensitivity.rb:136:24:136:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
+| call_sensitivity.rb:136:24:136:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
+| call_sensitivity.rb:137:26:137:33 | call to taint :  | call_sensitivity.rb:123:35:123:35 | x :  |
+| call_sensitivity.rb:137:26:137:33 | call to taint :  | call_sensitivity.rb:123:35:123:35 | x :  |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
@@ -103,16 +169,80 @@ nodes
 | call_sensitivity.rb:51:10:51:10 | x | semmle.label | x |
 | call_sensitivity.rb:54:15:54:15 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:54:15:54:15 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:54:15:54:15 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:54:15:54:15 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:55:13:55:13 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:55:13:55:13 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:58:18:58:18 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:58:18:58:18 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:59:15:59:15 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:59:15:59:15 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:64:11:64:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:64:11:64:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:65:14:65:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:65:14:65:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:55:13:55:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:55:13:55:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:58:20:58:20 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:58:20:58:20 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:59:18:59:18 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:59:18:59:18 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:62:18:62:18 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:62:18:62:18 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:62:18:62:18 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:62:18:62:18 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:63:15:63:15 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:63:15:63:15 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:63:15:63:15 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:63:15:63:15 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:66:20:66:20 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:66:20:66:20 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:67:24:67:24 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:67:24:67:24 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:70:30:70:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:70:30:70:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:71:10:71:10 | x | semmle.label | x |
+| call_sensitivity.rb:71:10:71:10 | x | semmle.label | x |
+| call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:78:35:78:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:78:35:78:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:79:28:79:28 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:79:28:79:28 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:86:35:86:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:86:35:86:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:87:34:87:34 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:87:34:87:34 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:92:11:92:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:92:11:92:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:93:16:93:23 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:93:16:93:23 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:94:14:94:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:94:14:94:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:95:16:95:24 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:95:16:95:24 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:97:21:97:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:97:21:97:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:98:26:98:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:98:26:98:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:99:24:99:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:99:24:99:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:100:26:100:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:100:26:100:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:119:35:119:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:119:35:119:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:120:28:120:28 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:120:28:120:28 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:123:35:123:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:123:35:123:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:124:34:124:34 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:124:34:124:34 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:134:21:134:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:134:21:134:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:135:26:135:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:135:26:135:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:136:24:136:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:136:24:136:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:137:26:137:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:137:26:137:33 | call to taint :  | semmle.label | call to taint :  |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint :  | call to taint :  |
@@ -120,16 +250,60 @@ subpaths
 | call_sensitivity.rb:31:27:31:27 | x | call_sensitivity.rb:32:25:32:32 | call to taint :  | call_sensitivity.rb:31:27:31:27 | x | $@ | call_sensitivity.rb:32:25:32:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:40:31:40:31 | x | call_sensitivity.rb:41:25:41:32 | call to taint :  | call_sensitivity.rb:40:31:40:31 | x | $@ | call_sensitivity.rb:41:25:41:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:43:32:43:32 | x | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:43:32:43:32 | x | $@ | call_sensitivity.rb:44:26:44:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:64:11:64:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:64:11:64:18 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:65:14:65:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:65:14:65:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:92:11:92:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:92:11:92:18 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:93:16:93:23 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:93:16:93:23 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:94:14:94:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:94:14:94:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:95:16:95:24 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:95:16:95:24 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:97:21:97:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:97:21:97:28 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:98:26:98:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:98:26:98:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:99:24:99:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:99:24:99:32 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:100:26:100:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:134:21:134:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:134:21:134:28 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:135:26:135:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:135:26:135:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:136:24:136:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:136:24:136:32 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:137:26:137:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:137:26:137:33 | call to taint :  | call to taint :  |
 mayBenefitFromCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:50:3:52:5 | method1 |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:54:3:56:5 | method2 |
-| call_sensitivity.rb:59:5:59:16 | call to method1 | call_sensitivity.rb:58:3:60:5 | method3 |
+| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:58:3:60:5 | call_method2 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:66:3:68:5 | call_method3 |
+| call_sensitivity.rb:112:5:112:18 | call to method2 | call_sensitivity.rb:111:3:113:5 | call_method2 |
+| call_sensitivity.rb:116:5:116:25 | call to method3 | call_sensitivity.rb:115:3:117:5 | call_method3 |
 viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
-| call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:59:5:59:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:64:1:64:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:74:1:74:19 | call to method2 | call_sensitivity.rb:68:3:70:5 | method1 |
-| call_sensitivity.rb:59:5:59:16 | call to method1 | call_sensitivity.rb:65:1:65:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:59:5:59:16 | call to method1 | call_sensitivity.rb:75:1:75:23 | call to method3 | call_sensitivity.rb:68:3:70:5 | method1 |
+| call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:103:3:105:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:92:1:92:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:112:5:112:18 | call to method2 | call_sensitivity.rb:103:3:105:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:129:1:129:19 | call to method2 | call_sensitivity.rb:103:3:105:5 | method1 |
+| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:93:1:93:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:103:3:105:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:94:1:94:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:116:5:116:25 | call to method3 | call_sensitivity.rb:103:3:105:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:131:1:131:23 | call to method3 | call_sensitivity.rb:103:3:105:5 | method1 |
+| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:95:1:95:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:97:1:97:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:97:1:97:29 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:134:1:134:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:134:1:134:29 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
+| call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:98:1:98:34 | call to call_singleton_method2 | call_sensitivity.rb:74:3:76:5 | singleton_method2 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:99:1:99:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:99:1:99:33 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:136:1:136:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:136:1:136:33 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
+| call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:100:1:100:34 | call to call_singleton_method3 | call_sensitivity.rb:82:3:84:5 | singleton_method3 |
+| call_sensitivity.rb:112:5:112:18 | call to method2 | call_sensitivity.rb:130:1:130:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:116:5:116:25 | call to method3 | call_sensitivity.rb:132:1:132:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:135:1:135:34 | call to call_singleton_method2 | call_sensitivity.rb:74:3:76:5 | singleton_method2 |
+| call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:137:1:137:34 | call to call_singleton_method3 | call_sensitivity.rb:82:3:84:5 | singleton_method3 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
@@ -48,28 +48,90 @@ apply_lambda(MY_LAMBDA2, taint(9))
 
 class A
   def method1 x
-    sink x # $ hasValueFlow=10 $ hasValueFlow=11
+    sink x # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13
   end
 
   def method2 x
     method1 x
   end
 
+  def call_method2 x
+    self.method2 x
+  end
+
   def method3(x, y)
     x.method1(y)
+  end
+
+  def call_method3 x
+    self.method3(self, x)
+  end
+
+  def self.singleton_method1 x
+    sink x # $ hasValueFlow=14 $ hasValueFlow=15 # $ hasValueFlow=16 $ hasValueFlow=17
+  end
+
+  def self.singleton_method2 x
+    singleton_method1 x
+  end
+
+  def self.call_singleton_method2 x
+    self.singleton_method2 x
+  end
+
+  def self.singleton_method3(x, y)
+    x.singleton_method1(y)
+  end
+
+  def self.call_singleton_method3 x
+    self.singleton_method3(self, x)
   end
 end
 
 a = A.new
 a.method2(taint 10)
-a.method3(a, taint(11))
+a.call_method2(taint 11)
+a.method3(a, taint(12))
+a.call_method3(taint(13))
+
+A.singleton_method2(taint 14)
+A.call_singleton_method2(taint 15)
+A.singleton_method3(A, taint(16))
+A.call_singleton_method3(taint 17)
 
 class B < A
   def method1 x
-    puts x
+    puts "NON SINK: #{x}"
+  end
+
+  def self.singleton_method1 x
+    puts "NON SINK: #{x}"
+  end
+
+  def call_method2 x
+    self.method2 x
+  end
+
+  def call_method3 x
+    self.method3(self, x)
+  end
+
+  def self.call_singleton_method2 x
+    self.singleton_method2 x
+  end
+
+  def self.call_singleton_method3 x
+    self.singleton_method3(self, x)
   end
 end
 
 b = B.new
-b.method2(taint 12)
-b.method3(b, taint(13))
+b.method2(taint 18)
+b.call_method2(taint 19)
+b.method3(b, taint(20))
+b.call_method3(taint(21))
+
+B.singleton_method2(taint 22)
+B.call_singleton_method2(taint 23)
+B.singleton_method3(B, taint(24))
+B.call_singleton_method3(taint 25)


### PR DESCRIPTION
The equivalent of https://github.com/github/codeql/pull/10358, but for singleton methods instead of instance methods. For example, in

```rb
class A
  def self.singleton_method1 x
    sink x
  end

  def self.singleton_method2 x
    singleton_method1 x
  end
end

class B < A
  def self.singleton_method1 x
    non_sink x
  end
end

B.singleton_method2 taint
```
we will no longer report flow from `taint` to `sink` (but still to `non_sink`).