### PR TITLE
Kotlin: ignore enhanced nullability when extracting primitive types

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -2,6 +2,7 @@ package com.github.codeql
 
 import com.github.codeql.utils.*
 import com.github.codeql.utils.versions.codeQlWithHasQuestionMark
+import com.github.codeql.utils.versions.getKotlinType
 import com.github.codeql.utils.versions.isRawType
 import com.semmle.extractor.java.OdasaOutput
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -671,7 +672,7 @@ open class KotlinUsesExtractor(
                           javaClass: IrClass,
                           kotlinPackageName: String, kotlinClassName: String): TypeResults {
             // Note the use of `hasEnhancedNullability` here covers cases like `@NotNull Integer`, which must be extracted as `Integer` not `int`.
-            val javaResult = if ((context == TypeContext.RETURN || (context == TypeContext.OTHER && otherIsPrimitive)) && !s.isNullable() && s.kotlinType?.hasEnhancedNullability() != true && primitiveName != null) {
+            val javaResult = if ((context == TypeContext.RETURN || (context == TypeContext.OTHER && otherIsPrimitive)) && !s.isNullable() && getKotlinType(s)?.hasEnhancedNullability() != true && primitiveName != null) {
                     val label: Label<DbPrimitive> = tw.getLabelFor("@\"type;$primitiveName\"", {
                         tw.writePrimitives(it, primitiveName)
                     })

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.load.java.BuiltinMethodsWithSpecialGenericSignature
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.load.java.sources.JavaSourceElement
 import org.jetbrains.kotlin.load.java.structure.*
+import org.jetbrains.kotlin.load.java.typeEnhancement.hasEnhancedNullability
 import org.jetbrains.kotlin.load.kotlin.getJvmModuleNameForDeserializedDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.NameUtils
@@ -669,7 +670,8 @@ open class KotlinUsesExtractor(
                           otherIsPrimitive: Boolean,
                           javaClass: IrClass,
                           kotlinPackageName: String, kotlinClassName: String): TypeResults {
-            val javaResult = if ((context == TypeContext.RETURN || (context == TypeContext.OTHER && otherIsPrimitive)) && !s.isNullable() && primitiveName != null) {
+            // Note the use of `hasEnhancedNullability` here covers cases like `@NotNull Integer`, which must be extracted as `Integer` not `int`.
+            val javaResult = if ((context == TypeContext.RETURN || (context == TypeContext.OTHER && otherIsPrimitive)) && !s.isNullable() && s.kotlinType?.hasEnhancedNullability() != true && primitiveName != null) {
                     val label: Label<DbPrimitive> = tw.getLabelFor("@\"type;$primitiveName\"", {
                         tw.writePrimitives(it, primitiveName)
                     })

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/getKotlinType.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/getKotlinType.kt
@@ -1,0 +1,6 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.impl.IrTypeBase
+
+fun getKotlinType(s: IrSimpleType) = (s as? IrTypeBase)?.kotlinType

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_7_0/getKotlinType.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_7_0/getKotlinType.kt
@@ -1,0 +1,5 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+
+fun getKotlinType(s: IrSimpleType) = s.kotlinType

--- a/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/NotNull.java
+++ b/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/NotNull.java
@@ -1,0 +1,6 @@
+package org.jetbrains.annotations;
+import java.lang.annotation.*;
+
+// Stub of @NotNull:
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull { }

--- a/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/Test.java
+++ b/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/Test.java
@@ -1,0 +1,7 @@
+import org.jetbrains.annotations.NotNull;
+
+public class Test {
+
+  public @NotNull Integer f(@NotNull Integer p) { return p; }
+
+}

--- a/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/test.expected
+++ b/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/test.expected
@@ -1,0 +1,14 @@
+exprs
+| Test.java:5:19:5:25 | Integer | Integer |
+| Test.java:5:38:5:44 | Integer | Integer |
+| Test.java:5:58:5:58 | p | Integer |
+| user.kt:2:3:2:16 | x | int |
+| user.kt:2:11:2:11 | t | Test |
+| user.kt:2:13:2:16 | <implicit not null> | int |
+| user.kt:2:13:2:16 | f(...) | Integer |
+| user.kt:2:13:2:16 | int | int |
+| user.kt:2:15:2:15 | 5 | int |
+| user.kt:3:10:3:10 | x | int |
+#select
+| Test.java:5:27:5:27 | f | Integer |
+| user.kt:1:1:4:1 | f | Test |

--- a/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/test.py
+++ b/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/test.py
@@ -1,0 +1,6 @@
+from create_database_utils import *
+import glob
+
+os.mkdir('build')
+runSuccessfully(["javac"] + glob.glob("*.java") + ["-d", "build"])
+run_codeql_database_create(["javac " + " ".join(glob.glob("*.java")) + " -d build", "kotlinc user.kt -cp build"], lang="java")

--- a/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/test.ql
+++ b/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/test.ql
@@ -1,0 +1,9 @@
+import java
+
+query predicate exprs(Expr e, string t) {
+  e.getEnclosingCallable().getDeclaringType().fromSource() and t = e.getType().toString()
+}
+
+from Method m
+where m.fromSource()
+select m, m.getAParamType().toString()

--- a/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/user.kt
+++ b/java/ql/integration-tests/posix-only/kotlin/enhanced-nullability/user.kt
@@ -1,0 +1,4 @@
+fun f(t: Test): Int {
+  val x = t.f(5)
+  return x
+}


### PR DESCRIPTION
Otherwise we'll mistake `@NotNull Integer` for `int` and similar, causing a mismatch vs. Java signatures.