### PR TITLE
Ruby: Fix flow steps into phi nodes

### DIFF
--- a/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.expected
@@ -1,22 +1,20 @@
 failures
-| ssa_flow.rb:16:16:16:33 | # $ hasValueFlow=1 | Missing result:hasValueFlow=1 |
-| ssa_flow.rb:29:10:29:13 | ...[...] | Unexpected result: hasValueFlow=2 |
 edges
-| ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  | ssa_flow.rb:29:10:29:10 | a [element 0] :  |
-| ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  | ssa_flow.rb:29:10:29:10 | a [element 0] :  |
-| ssa_flow.rb:24:16:24:23 | call to taint :  | ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  |
-| ssa_flow.rb:24:16:24:23 | call to taint :  | ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  |
-| ssa_flow.rb:29:10:29:10 | a [element 0] :  | ssa_flow.rb:29:10:29:13 | ...[...] |
-| ssa_flow.rb:29:10:29:10 | a [element 0] :  | ssa_flow.rb:29:10:29:13 | ...[...] |
+| ssa_flow.rb:12:9:12:9 | [post] a [element 0] :  | ssa_flow.rb:16:10:16:10 | a [element 0] :  |
+| ssa_flow.rb:12:9:12:9 | [post] a [element 0] :  | ssa_flow.rb:16:10:16:10 | a [element 0] :  |
+| ssa_flow.rb:12:16:12:23 | call to taint :  | ssa_flow.rb:12:9:12:9 | [post] a [element 0] :  |
+| ssa_flow.rb:12:16:12:23 | call to taint :  | ssa_flow.rb:12:9:12:9 | [post] a [element 0] :  |
+| ssa_flow.rb:16:10:16:10 | a [element 0] :  | ssa_flow.rb:16:10:16:13 | ...[...] |
+| ssa_flow.rb:16:10:16:10 | a [element 0] :  | ssa_flow.rb:16:10:16:13 | ...[...] |
 nodes
-| ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
-| ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
-| ssa_flow.rb:24:16:24:23 | call to taint :  | semmle.label | call to taint :  |
-| ssa_flow.rb:24:16:24:23 | call to taint :  | semmle.label | call to taint :  |
-| ssa_flow.rb:29:10:29:10 | a [element 0] :  | semmle.label | a [element 0] :  |
-| ssa_flow.rb:29:10:29:10 | a [element 0] :  | semmle.label | a [element 0] :  |
-| ssa_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
-| ssa_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
+| ssa_flow.rb:12:9:12:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
+| ssa_flow.rb:12:9:12:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
+| ssa_flow.rb:12:16:12:23 | call to taint :  | semmle.label | call to taint :  |
+| ssa_flow.rb:12:16:12:23 | call to taint :  | semmle.label | call to taint :  |
+| ssa_flow.rb:16:10:16:10 | a [element 0] :  | semmle.label | a [element 0] :  |
+| ssa_flow.rb:16:10:16:10 | a [element 0] :  | semmle.label | a [element 0] :  |
+| ssa_flow.rb:16:10:16:13 | ...[...] | semmle.label | ...[...] |
+| ssa_flow.rb:16:10:16:13 | ...[...] | semmle.label | ...[...] |
 subpaths
 #select
-| ssa_flow.rb:29:10:29:13 | ...[...] | ssa_flow.rb:24:16:24:23 | call to taint :  | ssa_flow.rb:29:10:29:13 | ...[...] | $@ | ssa_flow.rb:24:16:24:23 | call to taint :  | call to taint :  |
+| ssa_flow.rb:16:10:16:13 | ...[...] | ssa_flow.rb:12:16:12:23 | call to taint :  | ssa_flow.rb:16:10:16:13 | ...[...] | $@ | ssa_flow.rb:12:16:12:23 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.expected
@@ -1,0 +1,22 @@
+failures
+| ssa_flow.rb:16:16:16:33 | # $ hasValueFlow=1 | Missing result:hasValueFlow=1 |
+| ssa_flow.rb:29:10:29:13 | ...[...] | Unexpected result: hasValueFlow=2 |
+edges
+| ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  | ssa_flow.rb:29:10:29:10 | a [element 0] :  |
+| ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  | ssa_flow.rb:29:10:29:10 | a [element 0] :  |
+| ssa_flow.rb:24:16:24:23 | call to taint :  | ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  |
+| ssa_flow.rb:24:16:24:23 | call to taint :  | ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  |
+| ssa_flow.rb:29:10:29:10 | a [element 0] :  | ssa_flow.rb:29:10:29:13 | ...[...] |
+| ssa_flow.rb:29:10:29:10 | a [element 0] :  | ssa_flow.rb:29:10:29:13 | ...[...] |
+nodes
+| ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
+| ssa_flow.rb:24:9:24:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
+| ssa_flow.rb:24:16:24:23 | call to taint :  | semmle.label | call to taint :  |
+| ssa_flow.rb:24:16:24:23 | call to taint :  | semmle.label | call to taint :  |
+| ssa_flow.rb:29:10:29:10 | a [element 0] :  | semmle.label | a [element 0] :  |
+| ssa_flow.rb:29:10:29:10 | a [element 0] :  | semmle.label | a [element 0] :  |
+| ssa_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
+| ssa_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
+subpaths
+#select
+| ssa_flow.rb:29:10:29:13 | ...[...] | ssa_flow.rb:24:16:24:23 | call to taint :  | ssa_flow.rb:29:10:29:13 | ...[...] | $@ | ssa_flow.rb:24:16:24:23 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.ql
@@ -1,0 +1,11 @@
+/**
+ * @kind path-problem
+ */
+
+import codeql.ruby.AST
+import TestUtilities.InlineFlowTest
+import PathGraph
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
+where conf.hasFlowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa_flow.rb
@@ -1,0 +1,32 @@
+def taint x
+    x
+end
+
+def sink x
+    puts "SINK: #{x}"
+end
+
+def m1
+    a = Array.new
+    if rand() > 0 then
+        a[0] = taint(1)
+    else
+        a = nil
+    end
+    sink(a[0]) # $ hasValueFlow=1
+end
+
+m1
+
+def m2
+    a = Array.new
+    if rand() > 0 then
+        a[0] = taint(2)
+        a.clear
+    else
+        a = nil
+    end
+    sink(a[0])
+end
+
+m2


### PR DESCRIPTION
- Add missing flow from post-update nodes into phi nodes.
- Prevent flow from reads into phi nodes when use-use flow is prohibited.