### PR TITLE
C#: Fix flow steps into phi/uncertain def nodes

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -310,12 +310,27 @@ module LocalFlow {
    * Holds if `nodeFrom` is a last node referencing SSA definition `def`, which
    * can reach `next`.
    */
-  private predicate localFlowSsaInput(Node nodeFrom, Ssa::Definition def, Ssa::Definition next) {
-    exists(ControlFlow::BasicBlock bb, int i | SsaImpl::lastRefBeforeRedef(def, bb, i, next) |
+  private predicate localFlowSsaInputFromDef(
+    Node nodeFrom, Ssa::Definition def, Ssa::Definition next
+  ) {
+    exists(ControlFlow::BasicBlock bb, int i |
+      SsaImpl::lastRefBeforeRedef(def, bb, i, next) and
       def.definesAt(_, bb, i) and
       def = getSsaDefinition(nodeFrom)
-      or
-      nodeFrom.asExprAtNode(bb.getNode(i)) instanceof AssignableRead
+    )
+  }
+
+  /**
+   * Holds if `read` is a last node reading SSA definition `def`, which
+   * can reach `next`.
+   */
+  predicate localFlowSsaInputFromExpr(
+    ControlFlow::Node read, Ssa::Definition def, Ssa::Definition next
+  ) {
+    exists(ControlFlow::BasicBlock bb, int i |
+      SsaImpl::lastRefBeforeRedef(def, bb, i, next) and
+      read = bb.getNode(i) and
+      read.getElement() instanceof AssignableRead
     )
   }
 
@@ -351,18 +366,14 @@ module LocalFlow {
     // Flow from read to next read
     localSsaFlowStepUseUse(def, nodeFrom.(PostUpdateNode).getPreUpdateNode(), nodeTo)
     or
-    // Flow into phi node
-    exists(Ssa::PhiNode phi |
-      localFlowSsaInput(nodeFrom, def, phi) and
-      phi = nodeTo.(SsaDefinitionNode).getDefinition() and
-      def = phi.getAnInput()
-    )
-    or
-    // Flow into uncertain SSA definition
-    exists(LocalFlow::UncertainExplicitSsaDefinition uncertain |
-      localFlowSsaInput(nodeFrom, def, uncertain) and
-      uncertain = nodeTo.(SsaDefinitionNode).getDefinition() and
-      def = uncertain.getPriorDefinition()
+    // Flow into phi/uncertain SSA definition node from def
+    exists(Ssa::Definition next |
+      localFlowSsaInputFromDef(nodeFrom, def, next) and
+      next = nodeTo.(SsaDefinitionNode).getDefinition()
+    |
+      def = next.(Ssa::PhiNode).getAnInput()
+      or
+      def = next.(LocalFlow::UncertainExplicitSsaDefinition).getPriorDefinition()
     )
   }
 
@@ -519,9 +530,24 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
   or
   exists(Ssa::Definition def |
     LocalFlow::localSsaFlowStepUseUse(def, nodeFrom, nodeTo) and
-    not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom,
-      any(DataFlowSummarizedCallable sc)) and
+    not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom, _) and
     not LocalFlow::usesInstanceField(def)
+  )
+  or
+  // Flow into phi/uncertain SSA definition node from read
+  exists(Ssa::Definition def, ControlFlow::Node read, Ssa::Definition next |
+    LocalFlow::localFlowSsaInputFromExpr(read, def, next) and
+    next = nodeTo.(SsaDefinitionNode).getDefinition() and
+    def =
+      [
+        next.(Ssa::PhiNode).getAnInput(),
+        next.(LocalFlow::UncertainExplicitSsaDefinition).getPriorDefinition()
+      ]
+  |
+    exists(nodeFrom.asExprAtNode(read)) and
+    not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom, _)
+    or
+    exists(nodeFrom.(PostUpdateNode).getPreUpdateNode().asExprAtNode(read))
   )
   or
   LocalFlow::localFlowCapturedVarStep(nodeFrom, nodeTo)
@@ -857,6 +883,21 @@ private module Cached {
     exists(Ssa::Definition def |
       LocalFlow::localSsaFlowStep(def, nodeFrom, nodeTo) and
       LocalFlow::usesInstanceField(def)
+    )
+    or
+    // Flow into phi/uncertain SSA definition node from read
+    exists(Ssa::Definition def, ControlFlow::Node read, Ssa::Definition next |
+      LocalFlow::localFlowSsaInputFromExpr(read, def, next) and
+      next = nodeTo.(SsaDefinitionNode).getDefinition() and
+      def =
+        [
+          next.(Ssa::PhiNode).getAnInput(),
+          next.(LocalFlow::UncertainExplicitSsaDefinition).getPriorDefinition()
+        ]
+    |
+      exists(nodeFrom.asExprAtNode(read))
+      or
+      exists(nodeFrom.(PostUpdateNode).getPreUpdateNode().asExprAtNode(read))
     )
     or
     // Simple flow through library code is included in the exposed local

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1,6 +1,4 @@
 failures
-| J.cs:125:21:125:40 | // ... | Missing result:hasValueFlow=10 |
-| J.cs:140:14:140:17 | (...) ... | Unexpected result: hasValueFlow=11 |
 edges
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
@@ -920,14 +918,14 @@ edges
 | J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | J.cs:106:14:106:17 | access to property X |
 | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
 | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
-| J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 | J.cs:140:14:140:14 | access to local variable a [element] : Int32 |
-| J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 | J.cs:140:14:140:14 | access to local variable a [element] : Int32 |
-| J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 |
-| J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 |
-| J.cs:140:14:140:14 | access to local variable a [element] : Int32 | J.cs:140:14:140:17 | access to indexer : Int32 |
-| J.cs:140:14:140:14 | access to local variable a [element] : Int32 | J.cs:140:14:140:17 | access to indexer : Int32 |
-| J.cs:140:14:140:17 | access to indexer : Int32 | J.cs:140:14:140:17 | (...) ... |
-| J.cs:140:14:140:17 | access to indexer : Int32 | J.cs:140:14:140:17 | (...) ... |
+| J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 | J.cs:125:14:125:14 | access to local variable a [element] : Int32 |
+| J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 | J.cs:125:14:125:14 | access to local variable a [element] : Int32 |
+| J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 |
+| J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 |
+| J.cs:125:14:125:14 | access to local variable a [element] : Int32 | J.cs:125:14:125:17 | access to array element : Int32 |
+| J.cs:125:14:125:14 | access to local variable a [element] : Int32 | J.cs:125:14:125:17 | access to array element : Int32 |
+| J.cs:125:14:125:17 | access to array element : Int32 | J.cs:125:14:125:17 | (...) ... |
+| J.cs:125:14:125:17 | access to array element : Int32 | J.cs:125:14:125:17 | (...) ... |
 nodes
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
@@ -1935,16 +1933,16 @@ nodes
 | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | semmle.label | access to local variable a3 [property Y] : Object |
 | J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
 | J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
-| J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 | semmle.label | [post] access to local variable a [element] : Int32 |
-| J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 | semmle.label | [post] access to local variable a [element] : Int32 |
-| J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
-| J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
-| J.cs:140:14:140:14 | access to local variable a [element] : Int32 | semmle.label | access to local variable a [element] : Int32 |
-| J.cs:140:14:140:14 | access to local variable a [element] : Int32 | semmle.label | access to local variable a [element] : Int32 |
-| J.cs:140:14:140:17 | (...) ... | semmle.label | (...) ... |
-| J.cs:140:14:140:17 | (...) ... | semmle.label | (...) ... |
-| J.cs:140:14:140:17 | access to indexer : Int32 | semmle.label | access to indexer : Int32 |
-| J.cs:140:14:140:17 | access to indexer : Int32 | semmle.label | access to indexer : Int32 |
+| J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 | semmle.label | [post] access to local variable a [element] : Int32 |
+| J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 | semmle.label | [post] access to local variable a [element] : Int32 |
+| J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
+| J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
+| J.cs:125:14:125:14 | access to local variable a [element] : Int32 | semmle.label | access to local variable a [element] : Int32 |
+| J.cs:125:14:125:14 | access to local variable a [element] : Int32 | semmle.label | access to local variable a [element] : Int32 |
+| J.cs:125:14:125:17 | (...) ... | semmle.label | (...) ... |
+| J.cs:125:14:125:17 | (...) ... | semmle.label | (...) ... |
+| J.cs:125:14:125:17 | access to array element : Int32 | semmle.label | access to array element : Int32 |
+| J.cs:125:14:125:17 | access to array element : Int32 | semmle.label | access to array element : Int32 |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
@@ -2121,4 +2119,4 @@ subpaths
 | J.cs:102:14:102:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:102:14:102:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:106:14:106:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:106:14:106:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:107:14:107:17 | access to property Y | J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:107:14:107:17 | access to property Y | $@ | J.cs:105:32:105:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:140:14:140:17 | (...) ... | J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | J.cs:140:14:140:17 | (...) ... | $@ | J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | call to method Source<Int32> : Int32 |
+| J.cs:125:14:125:17 | (...) ... | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:125:14:125:17 | (...) ... | $@ | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | call to method Source<Int32> : Int32 |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1,4 +1,6 @@
 failures
+| J.cs:125:21:125:40 | // ... | Missing result:hasValueFlow=10 |
+| J.cs:140:14:140:17 | (...) ... | Unexpected result: hasValueFlow=11 |
 edges
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
@@ -918,6 +920,14 @@ edges
 | J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | J.cs:106:14:106:17 | access to property X |
 | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
 | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
+| J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 | J.cs:140:14:140:14 | access to local variable a [element] : Int32 |
+| J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 | J.cs:140:14:140:14 | access to local variable a [element] : Int32 |
+| J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 |
+| J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 |
+| J.cs:140:14:140:14 | access to local variable a [element] : Int32 | J.cs:140:14:140:17 | access to indexer : Int32 |
+| J.cs:140:14:140:14 | access to local variable a [element] : Int32 | J.cs:140:14:140:17 | access to indexer : Int32 |
+| J.cs:140:14:140:17 | access to indexer : Int32 | J.cs:140:14:140:17 | (...) ... |
+| J.cs:140:14:140:17 | access to indexer : Int32 | J.cs:140:14:140:17 | (...) ... |
 nodes
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
@@ -1925,6 +1935,16 @@ nodes
 | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | semmle.label | access to local variable a3 [property Y] : Object |
 | J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
 | J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
+| J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 | semmle.label | [post] access to local variable a [element] : Int32 |
+| J.cs:133:13:133:13 | [post] access to local variable a [element] : Int32 | semmle.label | [post] access to local variable a [element] : Int32 |
+| J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
+| J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
+| J.cs:140:14:140:14 | access to local variable a [element] : Int32 | semmle.label | access to local variable a [element] : Int32 |
+| J.cs:140:14:140:14 | access to local variable a [element] : Int32 | semmle.label | access to local variable a [element] : Int32 |
+| J.cs:140:14:140:17 | (...) ... | semmle.label | (...) ... |
+| J.cs:140:14:140:17 | (...) ... | semmle.label | (...) ... |
+| J.cs:140:14:140:17 | access to indexer : Int32 | semmle.label | access to indexer : Int32 |
+| J.cs:140:14:140:17 | access to indexer : Int32 | semmle.label | access to indexer : Int32 |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
@@ -2101,3 +2121,4 @@ subpaths
 | J.cs:102:14:102:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:102:14:102:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:106:14:106:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:106:14:106:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:107:14:107:17 | access to property Y | J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:107:14:107:17 | access to property Y | $@ | J.cs:105:32:105:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:140:14:140:17 | (...) ... | J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | J.cs:140:14:140:17 | (...) ... | $@ | J.cs:133:19:133:33 | call to method Source<Int32> : Int32 | call to method Source<Int32> : Int32 |

--- a/csharp/ql/test/library-tests/dataflow/fields/J.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/J.cs
@@ -111,6 +111,35 @@ public class J
         Sink(a4.Y); // no flow
     }
 
+    private void M6(bool b)
+    {
+        var a = new int[1];
+        if (b)
+        {
+            a[0] = Source<int>(10);
+        }
+        else
+        {
+            a = new int[1];
+        }
+        Sink(a[0]); // $ hasValueFlow=10
+    }
+
+    private void M7(bool b)
+    {
+        var a = new System.Collections.Generic.List<int>();
+        if (b)
+        {
+            a.Add(Source<int>(11));
+            a.Clear();
+        }
+        else
+        {
+            a = new System.Collections.Generic.List<int>();
+        }
+        Sink(a[0]);
+    }
+
     public static void Sink(object o) { }
 
     static T Source<T>(object source) => throw null;

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -65,6 +65,8 @@
 | LocalDataFlow.cs:84:31:84:35 | [b (line 48): false] access to local variable sink6 | LocalDataFlow.cs:84:21:84:35 | [b (line 48): false] ... ? ... : ... |
 | LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) | LocalDataFlow.cs:92:29:92:33 | access to local variable sink7 |
@@ -484,7 +486,9 @@
 | SSA.cs:37:24:37:31 | access to local variable ssaSink0 | SSA.cs:117:36:117:43 | access to local variable ssaSink0 |
 | SSA.cs:38:17:38:26 | [post] access to parameter nonTainted | SSA.cs:47:13:47:22 | access to parameter nonTainted |
 | SSA.cs:38:17:38:26 | access to parameter nonTainted | SSA.cs:47:13:47:22 | access to parameter nonTainted |
+| SSA.cs:39:21:39:28 | [post] access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
 | SSA.cs:39:21:39:28 | access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:41:21:41:28 | [post] access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
 | SSA.cs:41:21:41:28 | access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) | SSA.cs:43:15:43:22 | access to local variable ssaSink2 |
 | SSA.cs:46:16:46:28 | SSA def(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
@@ -499,15 +503,19 @@
 | SSA.cs:49:24:49:31 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | access to local variable nonSink0 |
 | SSA.cs:50:17:50:26 | [post] access to parameter nonTainted | SSA.cs:89:13:89:22 | access to parameter nonTainted |
 | SSA.cs:50:17:50:26 | access to parameter nonTainted | SSA.cs:89:13:89:22 | access to parameter nonTainted |
+| SSA.cs:51:21:51:28 | [post] access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
 | SSA.cs:51:21:51:28 | access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:53:21:53:28 | [post] access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
 | SSA.cs:53:21:53:28 | access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) | SSA.cs:55:15:55:22 | access to local variable nonSink2 |
 | SSA.cs:58:16:58:33 | SSA def(ssaSink3) | SSA.cs:59:23:59:30 | access to local variable ssaSink3 |
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:58:16:58:33 | SSA def(ssaSink3) |
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:67:32:67:38 | access to parameter tainted |
 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) | SSA.cs:60:15:60:22 | access to local variable ssaSink3 |
+| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:63:23:63:30 | SSA def(nonSink0) | SSA.cs:64:15:64:22 | access to local variable nonSink0 |
+| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
 | SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
 | SSA.cs:67:9:67:12 | [post] this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:12 | this access | SSA.cs:68:23:68:26 | this access |
@@ -520,6 +528,7 @@
 | SSA.cs:68:23:68:26 | this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:28 | SSA def(this.S) | SSA.cs:69:15:69:20 | access to field S |
 | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:69:15:69:34 | access to field SsaFieldSink0 |
+| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
 | SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
 | SSA.cs:69:15:69:18 | [post] this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:18 | this access | SSA.cs:72:9:72:12 | this access |
@@ -535,6 +544,7 @@
 | SSA.cs:73:23:73:26 | this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:28 | SSA def(this.S) | SSA.cs:74:15:74:20 | access to field S |
 | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:74:15:74:37 | access to field SsaFieldNonSink0 |
+| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:74:15:74:18 | [post] this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:18 | this access | SSA.cs:80:9:80:12 | this access |
@@ -584,10 +594,13 @@
 | SSA.cs:91:24:91:31 | access to local variable ssaSink0 | SSA.cs:117:36:117:43 | access to local variable ssaSink0 |
 | SSA.cs:92:17:92:26 | [post] access to parameter nonTainted | SSA.cs:102:13:102:22 | access to parameter nonTainted |
 | SSA.cs:92:17:92:26 | access to parameter nonTainted | SSA.cs:102:13:102:22 | access to parameter nonTainted |
+| SSA.cs:93:21:93:28 | [post] access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
 | SSA.cs:93:21:93:28 | access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:95:21:95:28 | [post] access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
 | SSA.cs:95:21:95:28 | access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) | SSA.cs:97:23:97:30 | access to local variable ssaSink4 |
 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) | SSA.cs:98:15:98:22 | access to local variable ssaSink4 |
+| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:101:16:101:28 | SSA def(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:101:27:101:28 | "" | SSA.cs:101:16:101:28 | SSA def(nonSink3) |
@@ -601,10 +614,13 @@
 | SSA.cs:104:24:104:31 | access to local variable nonSink0 | SSA.cs:130:39:130:46 | access to local variable nonSink0 |
 | SSA.cs:105:17:105:26 | [post] access to parameter nonTainted | SSA.cs:115:13:115:22 | access to parameter nonTainted |
 | SSA.cs:105:17:105:26 | access to parameter nonTainted | SSA.cs:115:13:115:22 | access to parameter nonTainted |
+| SSA.cs:106:21:106:28 | [post] access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:106:21:106:28 | access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:108:21:108:28 | [post] access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:108:21:108:28 | access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) | SSA.cs:110:23:110:30 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | SSA def(nonSink3) | SSA.cs:111:15:111:22 | access to local variable nonSink3 |
+| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:123:23:123:26 | this access |
@@ -637,17 +653,20 @@
 | SSA.cs:119:21:119:24 | this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:119:21:119:26 | [post] access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:119:21:119:26 | access to field S | SSA.cs:123:23:123:28 | access to field S |
+| SSA.cs:119:21:119:40 | [post] access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:119:21:119:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:121:21:121:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:121:21:121:24 | this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:121:21:121:26 | [post] access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:121:21:121:26 | access to field S | SSA.cs:123:23:123:28 | access to field S |
+| SSA.cs:121:21:121:40 | [post] access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:123:23:123:26 | [post] this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:26 | this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:28 | SSA def(this.S) | SSA.cs:124:15:124:20 | access to field S |
 | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:124:15:124:34 | access to field SsaFieldSink1 |
+| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:124:15:124:18 | [post] this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:18 | this access | SSA.cs:127:9:127:12 | this access |
@@ -680,17 +699,20 @@
 | SSA.cs:132:21:132:24 | this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:132:21:132:26 | [post] access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:132:21:132:26 | access to field S | SSA.cs:136:23:136:28 | access to field S |
+| SSA.cs:132:21:132:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:134:21:134:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:134:21:134:24 | this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:134:21:134:26 | [post] access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:134:21:134:26 | access to field S | SSA.cs:136:23:136:28 | access to field S |
+| SSA.cs:134:21:134:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:23:136:26 | [post] this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:26 | this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |
+| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
 | SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
 | SSA.cs:144:34:144:34 | t | SSA.cs:146:13:146:13 | access to parameter t |
 | SSA.cs:146:13:146:13 | access to parameter t | SSA.cs:146:13:146:13 | (...) ... |
@@ -718,6 +740,7 @@
 | SSA.cs:176:21:176:28 | [post] access to local variable ssaSink5 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 |
 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 |
 | SSA.cs:177:21:177:28 | [post] access to local variable ssaSink5 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 |
+| SSA.cs:177:21:177:28 | [post] access to local variable ssaSink5 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 |
 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) | SSA.cs:180:15:180:22 | access to local variable ssaSink5 |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -73,6 +73,8 @@
 | LocalDataFlow.cs:84:31:84:35 | [b (line 48): false] access to local variable sink6 | LocalDataFlow.cs:84:21:84:35 | [b (line 48): false] ... ? ... : ... |
 | LocalDataFlow.cs:85:15:85:19 | [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:85:15:85:19 | [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): false] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
+| LocalDataFlow.cs:85:15:85:19 | [post] [b (line 48): true] access to local variable sink7 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) |
 | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) | LocalDataFlow.cs:89:15:89:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:88:20:88:36 | ... ? ... : ... | LocalDataFlow.cs:88:9:88:36 | SSA def(nonSink0) |
 | LocalDataFlow.cs:88:20:88:36 | SSA phi(sink7) | LocalDataFlow.cs:92:29:92:33 | access to local variable sink7 |
@@ -598,7 +600,9 @@
 | SSA.cs:38:17:38:26 | [post] access to parameter nonTainted | SSA.cs:47:13:47:22 | access to parameter nonTainted |
 | SSA.cs:38:17:38:26 | access to parameter nonTainted | SSA.cs:47:13:47:22 | access to parameter nonTainted |
 | SSA.cs:38:17:38:33 | access to property Length | SSA.cs:38:17:38:37 | ... > ... |
+| SSA.cs:39:21:39:28 | [post] access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
 | SSA.cs:39:21:39:28 | access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
+| SSA.cs:41:21:41:28 | [post] access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
 | SSA.cs:41:21:41:28 | access to local variable ssaSink2 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) |
 | SSA.cs:43:9:43:24 | SSA phi(ssaSink2) | SSA.cs:43:15:43:22 | access to local variable ssaSink2 |
 | SSA.cs:46:16:46:28 | SSA def(nonSink2) | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
@@ -615,15 +619,19 @@
 | SSA.cs:50:17:50:26 | [post] access to parameter nonTainted | SSA.cs:89:13:89:22 | access to parameter nonTainted |
 | SSA.cs:50:17:50:26 | access to parameter nonTainted | SSA.cs:89:13:89:22 | access to parameter nonTainted |
 | SSA.cs:50:17:50:33 | access to property Length | SSA.cs:50:17:50:37 | ... > ... |
+| SSA.cs:51:21:51:28 | [post] access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
 | SSA.cs:51:21:51:28 | access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
+| SSA.cs:53:21:53:28 | [post] access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
 | SSA.cs:53:21:53:28 | access to local variable nonSink2 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) |
 | SSA.cs:55:9:55:24 | SSA phi(nonSink2) | SSA.cs:55:15:55:22 | access to local variable nonSink2 |
 | SSA.cs:58:16:58:33 | SSA def(ssaSink3) | SSA.cs:59:23:59:30 | access to local variable ssaSink3 |
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:58:16:58:33 | SSA def(ssaSink3) |
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:67:32:67:38 | access to parameter tainted |
 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) | SSA.cs:60:15:60:22 | access to local variable ssaSink3 |
+| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:63:23:63:30 | SSA def(nonSink0) | SSA.cs:64:15:64:22 | access to local variable nonSink0 |
+| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
 | SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
 | SSA.cs:67:9:67:12 | [post] this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:12 | this access | SSA.cs:68:23:68:26 | this access |
@@ -636,6 +644,7 @@
 | SSA.cs:68:23:68:26 | this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:28 | SSA def(this.S) | SSA.cs:69:15:69:20 | access to field S |
 | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:69:15:69:34 | access to field SsaFieldSink0 |
+| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
 | SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
 | SSA.cs:69:15:69:18 | [post] this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:18 | this access | SSA.cs:72:9:72:12 | this access |
@@ -651,6 +660,7 @@
 | SSA.cs:73:23:73:26 | this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:28 | SSA def(this.S) | SSA.cs:74:15:74:20 | access to field S |
 | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:74:15:74:37 | access to field SsaFieldNonSink0 |
+| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:74:15:74:18 | [post] this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:18 | this access | SSA.cs:80:9:80:12 | this access |
@@ -702,10 +712,13 @@
 | SSA.cs:92:17:92:26 | [post] access to parameter nonTainted | SSA.cs:102:13:102:22 | access to parameter nonTainted |
 | SSA.cs:92:17:92:26 | access to parameter nonTainted | SSA.cs:102:13:102:22 | access to parameter nonTainted |
 | SSA.cs:92:17:92:33 | access to property Length | SSA.cs:92:17:92:37 | ... > ... |
+| SSA.cs:93:21:93:28 | [post] access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
 | SSA.cs:93:21:93:28 | access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
+| SSA.cs:95:21:95:28 | [post] access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
 | SSA.cs:95:21:95:28 | access to local variable ssaSink4 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) | SSA.cs:97:23:97:30 | access to local variable ssaSink4 |
 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) | SSA.cs:98:15:98:22 | access to local variable ssaSink4 |
+| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:101:16:101:28 | SSA def(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:101:27:101:28 | "" | SSA.cs:101:16:101:28 | SSA def(nonSink3) |
@@ -721,10 +734,13 @@
 | SSA.cs:105:17:105:26 | [post] access to parameter nonTainted | SSA.cs:115:13:115:22 | access to parameter nonTainted |
 | SSA.cs:105:17:105:26 | access to parameter nonTainted | SSA.cs:115:13:115:22 | access to parameter nonTainted |
 | SSA.cs:105:17:105:33 | access to property Length | SSA.cs:105:17:105:37 | ... > ... |
+| SSA.cs:106:21:106:28 | [post] access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:106:21:106:28 | access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
+| SSA.cs:108:21:108:28 | [post] access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:108:21:108:28 | access to local variable nonSink3 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) | SSA.cs:110:23:110:30 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | SSA def(nonSink3) | SSA.cs:111:15:111:22 | access to local variable nonSink3 |
+| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:123:23:123:26 | this access |
@@ -759,17 +775,20 @@
 | SSA.cs:119:21:119:24 | this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:119:21:119:26 | [post] access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:119:21:119:26 | access to field S | SSA.cs:123:23:123:28 | access to field S |
+| SSA.cs:119:21:119:40 | [post] access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:119:21:119:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:121:21:121:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:121:21:121:24 | this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:121:21:121:26 | [post] access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:121:21:121:26 | access to field S | SSA.cs:123:23:123:28 | access to field S |
+| SSA.cs:121:21:121:40 | [post] access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:123:23:123:26 | [post] this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:26 | this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:28 | SSA def(this.S) | SSA.cs:124:15:124:20 | access to field S |
 | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:124:15:124:34 | access to field SsaFieldSink1 |
+| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:124:15:124:18 | [post] this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:18 | this access | SSA.cs:127:9:127:12 | this access |
@@ -804,17 +823,20 @@
 | SSA.cs:132:21:132:24 | this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:132:21:132:26 | [post] access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:132:21:132:26 | access to field S | SSA.cs:136:23:136:28 | access to field S |
+| SSA.cs:132:21:132:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:134:21:134:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:134:21:134:24 | this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:134:21:134:26 | [post] access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:134:21:134:26 | access to field S | SSA.cs:136:23:136:28 | access to field S |
+| SSA.cs:134:21:134:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:23:136:26 | [post] this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:26 | this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |
+| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
 | SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
 | SSA.cs:144:34:144:34 | t | SSA.cs:146:13:146:13 | access to parameter t |
 | SSA.cs:146:13:146:13 | (...) ... | SSA.cs:146:13:146:21 | ... == ... |
@@ -846,6 +868,7 @@
 | SSA.cs:176:21:176:28 | [post] access to local variable ssaSink5 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 |
 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 |
 | SSA.cs:177:21:177:28 | [post] access to local variable ssaSink5 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 |
+| SSA.cs:177:21:177:28 | [post] access to local variable ssaSink5 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 |
 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) | SSA.cs:180:15:180:22 | access to local variable ssaSink5 |


### PR DESCRIPTION
- Add missing flow from post-update nodes into phi nodes.
- Prevent flow from reads into phi nodes when use-use flow is prohibited.