### PR TITLE
Swift: detect hash functions with low # of iterations

### DIFF
--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.qhelp
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.qhelp
@@ -7,11 +7,11 @@
   </overview>
 
   <recommendation>
-    <p>Use sufficient number of iterations (that is, greater than or equal 1000) for generating password-based keys.</p>
+    <p>Use sufficient number of iterations (that is, greater than or equal 120000) for generating password-based keys.</p>
   </recommendation>
 
   <example>
-    <p>The following example shows a few cases of instantiating a password-based key. In the 'BAD' cases, the key is initialized with insufficient iterations, making it susceptible to password cracking attacks. In the 'GOOD' cases, the key is initialized with at least 1000 iterations, which protects the encrypted data against recovery.</p>
+    <p>The following example shows a few cases of instantiating a password-based key. In the 'BAD' cases, the key is initialized with insufficient iterations, making it susceptible to password cracking attacks. In the 'GOOD' cases, the key is initialized with at least 120000 iterations, which protects the encrypted data against recovery.</p>
     <sample src="InsufficientHashIterations.swift" />
   </example>
 

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.qhelp
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.qhelp
@@ -7,11 +7,16 @@
   </overview>
 
   <recommendation>
-    <p>Use sufficient number of iterations (i.e., greater than or equal 1000) for generating password-based keys.</p>
+    <p>Use sufficient number of iterations (that is, greater than or equal 1000) for generating password-based keys.</p>
   </recommendation>
 
   <example>
     <p>The following example shows a few cases of instantiating a password-based key. In the 'BAD' cases, the key is initialized with insufficient iterations, making it susceptible to password cracking attacks. In the 'GOOD' cases, the key is initialized with at least 1000 iterations, which protects the encrypted data against recovery.</p>
     <sample src="InsufficientHashIterations.swift" />
   </example>
+
+  <references>
+    <li>Password-Based Cryptography Specification Version 2.0. 2000.<a href="https://www.rfc-editor.org/rfc/rfc2898">RFC2898</a>.</li>
+    <li>OWASP <a href="https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html">Password Storage Cheat Sheet.</a></li>
+  </references>
 </qhelp>

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.qhelp
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.qhelp
@@ -3,15 +3,16 @@
   "qhelp.dtd">
 <qhelp>
   <overview>
-    <p>Using hash functions with less than 1,000 iterations is not secure. That scheme is vulnerable to password cracking attacks due to having an insufficient level of computational effort.</p>
+    <p>Storing cryptographic hashes of passwords is standard security practice, but it is equally important to select the right hashing scheme. If an attacker obtains the hashed passwords of an application, the password hashing scheme should still prevent the attacker from easily obtaining the original cleartext passwords.</p>
+    <p>A good password hashing scheme requires a computation that cannot be done efficiently. Hashing schemes with low number of iterations are efficiently computable, and are therefore not suitable for password hashing.</p>
   </overview>
 
   <recommendation>
-    <p>Use sufficient number of iterations (that is, greater than or equal 120000) for generating password-based keys.</p>
+    <p>Use the OWASP recommendation for sufficient number of iterations (currently, that is greater than or equal to 120,000) for password hashing schemes.</p>
   </recommendation>
 
   <example>
-    <p>The following example shows a few cases of instantiating a password-based key. In the 'BAD' cases, the key is initialized with insufficient iterations, making it susceptible to password cracking attacks. In the 'GOOD' cases, the key is initialized with at least 120000 iterations, which protects the encrypted data against recovery.</p>
+    <p>The following example shows a few cases where a password hashing scheme is instantiated. In the 'BAD' cases, the scheme is initialized with insufficient iterations, making it susceptible to password cracking attacks. In the 'GOOD' cases, the scheme is initialized with at least 120,000 iterations, which protects the hashed data against recovery.</p>
     <sample src="InsufficientHashIterations.swift" />
   </example>
 

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.qhelp
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.qhelp
@@ -1,0 +1,17 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+  <overview>
+    <p>Using hash functions with less than 1,000 iterations is not secure. That scheme is vulnerable to password cracking attacks due to having an insufficient level of computational effort.</p>
+  </overview>
+
+  <recommendation>
+    <p>Use sufficient number of iterations (i.e., greater than or equal 1000) for generating password-based keys.</p>
+  </recommendation>
+
+  <example>
+    <p>The following example shows a few cases of instantiating a password-based key. In the 'BAD' cases, the key is initialized with insufficient iterations, making it susceptible to password cracking attacks. In the 'GOOD' cases, the key is initialized with at least 1000 iterations, which protects the encrypted data against recovery.</p>
+    <sample src="InsufficientHashIterations.swift" />
+  </example>
+</qhelp>

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
@@ -1,0 +1,76 @@
+/**
+ * @name Insufficient hash iterations
+ * @description Using hash functions with < 1000 iterations is not secure, because that scheme leads to password cracking attacks due to having an insufficient level of computational effort.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.8
+ * @precision high
+ * @id swift/insufficient-hash-iterations
+ * @tags security
+ *       external/cwe/cwe-916
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+/**
+ * An `Expr` that is used to initialize a password-based encryption key.
+ */
+abstract class IterationsSource extends Expr { }
+
+/**
+ * A literal integer that is 1000 or less is a source of taint for iterations.
+ */
+class IntLiteralSource extends IterationsSource instanceof IntegerLiteralExpr {
+  IntLiteralSource() { this.getStringValue().toInt() >= 1000 }
+}
+
+/**
+ * A class for all ways to set the iterations of hash function.
+ */
+class InsufficientHashIterationsSink extends Expr {
+  InsufficientHashIterationsSink() {
+    // `iterations` arg in `init` is a sink
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
+      c.getFullName() = "PKCS5.PBKDF1" and
+      c.getAMember() = f and
+      f.getName().matches("init(%iterations:%") and
+      call.getStaticTarget() = f and
+      call.getArgument(2).getExpr() = this
+    )
+    or
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
+      c.getFullName() = "PKCS5.PBKDF2" and
+      c.getAMember() = f and
+      f.getName().matches("init(%iterations:%") and
+      call.getStaticTarget() = f and
+      call.getArgument(3).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A dataflow configuration from the hash iterations source to expressions that use
+ * it to initialize hash functions.
+ */
+class InsufficientHashIterationsConfig extends TaintTracking::Configuration {
+  InsufficientHashIterationsConfig() { this = "InsufficientHashIterationsConfig" }
+
+  override predicate isSource(DataFlow::Node node) { node.asExpr() instanceof IterationsSource }
+
+  override predicate isSink(DataFlow::Node node) {
+    node.asExpr() instanceof InsufficientHashIterationsSink
+  }
+}
+
+// The query itself
+from
+  InsufficientHashIterationsConfig config, DataFlow::PathNode sourceNode,
+  DataFlow::PathNode sinkNode
+where config.hasFlowPath(sourceNode, sinkNode)
+select sinkNode.getNode(), sourceNode, sinkNode,
+  "The hash function '" + sinkNode.getNode().toString() +
+    "' has been initialized with an insufficient number of iterations from $@.", sourceNode,
+  sourceNode.getNode().toString()

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
@@ -1,6 +1,6 @@
 /**
  * @name Insufficient hash iterations
- * @description Using hash functions with < 1000 iterations is not secure, because that scheme leads to password cracking attacks due to having an insufficient level of computational effort.
+ * @description Using hash functions with less than 120,000 iterations is not secure, because that scheme leads to password cracking attacks due to having an insufficient level of computational effort.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 7.8
@@ -21,10 +21,10 @@ import DataFlow::PathGraph
 abstract class IterationsSource extends Expr { }
 
 /**
- * A literal integer that is 1000 or less is a source of taint for iterations.
+ * A literal integer that is 120,000 or less is a source of taint for iterations.
  */
 class IntLiteralSource extends IterationsSource instanceof IntegerLiteralExpr {
-  IntLiteralSource() { this.getStringValue().toInt() < 1000 }
+  IntLiteralSource() { this.getStringValue().toInt() < 120000 }
 }
 
 /**

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
@@ -64,6 +64,5 @@ from
   DataFlow::PathNode sinkNode
 where config.hasFlowPath(sourceNode, sinkNode)
 select sinkNode.getNode(), sourceNode, sinkNode,
-  "The variable '" + sinkNode.getNode().toString() +
-    "' is an insufficient number of iterations, which is not secure for hash functions.",
-  sourceNode, sourceNode.getNode().toString()
+  "The value '" + sourceNode.getNode().toString() +
+    "' is an insufficient number of iterations for secure password hashing."

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
@@ -1,6 +1,6 @@
 /**
  * @name Insufficient hash iterations
- * @description Using hash functions with less than 120,000 iterations is not secure, because that scheme leads to password cracking attacks due to having an insufficient level of computational effort.
+ * @description Using hash functions with fewer than 120,000 iterations is insufficient to protect passwords because a cracking attack will require a low level of computational effort.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 7.8

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.swift
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.swift
@@ -2,11 +2,11 @@
 func encrypt() {
 	// ...
 
-	// BAD: Using insufficient (i.e., < 120,000) hash iterations keys for encryption
+	// BAD: Using insufficient (that is, < 120,000) hash iterations keys for encryption
 	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 90000, keyLength: 0)
 	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 90000, keyLength: 0)
 
-	// GOOD: Using sufficient (i.e., >= 120,000) hash iterations keys for encryption
+	// GOOD: Using sufficient (that is, >= 120,000) hash iterations keys for encryption
 	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 120120, keyLength: 0)
 	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 120120, keyLength: 0)
 

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.swift
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.swift
@@ -1,14 +1,14 @@
 
-func encrypt() {
+func hash() {
 	// ...
 
-	// BAD: Using insufficient (that is, < 120,000) hash iterations keys for encryption
+	// BAD: Using insufficient (that is, < 120,000) iterations for password hashing
 	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 90000, keyLength: 0)
 	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 90000, keyLength: 0)
 
-	// GOOD: Using sufficient (that is, >= 120,000) hash iterations keys for encryption
+	// GOOD: Using sufficient (that is, >= 120,000) iterations for password hashing
 	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 120120, keyLength: 0)
-	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 120120, keyLength: 0)
+	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 310000, keyLength: 0)
 
 	// ...
 }

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.swift
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.swift
@@ -2,13 +2,13 @@
 func encrypt() {
 	// ...
 
-	// BAD: Using insufficient (i.e., < 1000) hash iterations keys for encryption
-	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 900, keyLength: 0)
-	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 900, keyLength: 0)
+	// BAD: Using insufficient (i.e., < 120,000) hash iterations keys for encryption
+	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 90000, keyLength: 0)
+	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 90000, keyLength: 0)
 
-	// GOOD: Using sufficient (i.e., >= 1000) hash iterations keys for encryption
-	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 1100, keyLength: 0)
-	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 1100, keyLength: 0)
+	// GOOD: Using sufficient (i.e., >= 120,000) hash iterations keys for encryption
+	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 120120, keyLength: 0)
+	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 120120, keyLength: 0)
 
 	// ...
 }

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.swift
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.swift
@@ -1,0 +1,14 @@
+
+func encrypt() {
+	// ...
+
+	// BAD: Using insufficient (i.e., < 1000) hash iterations keys for encryption
+	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 900, keyLength: 0)
+	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 900, keyLength: 0)
+
+	// GOOD: Using sufficient (i.e., >= 1000) hash iterations keys for encryption
+	_ = try PKCS5.PBKDF1(password: getRandomArray(), salt: getRandomArray(), iterations: 1100, keyLength: 0)
+	_ = try PKCS5.PBKDF2(password: getRandomArray(), salt: getRandomArray(), iterations: 1100, keyLength: 0)
+
+	// ...
+}

--- a/swift/ql/test/query-tests/Security/CWE-916/InsufficientHashIterations.expected
+++ b/swift/ql/test/query-tests/Security/CWE-916/InsufficientHashIterations.expected
@@ -11,7 +11,7 @@ nodes
 | test.swift:45:84:45:84 | 800 | semmle.label | 800 |
 subpaths
 #select
-| test.swift:37:84:37:84 | lowIterations | test.swift:20:45:20:45 | 999 :  | test.swift:37:84:37:84 | lowIterations | The variable 'lowIterations' is an insufficient number of iterations, which is not secure for hash functions. | test.swift:20:45:20:45 | 999 :  | 999 |
-| test.swift:38:84:38:84 | 800 | test.swift:38:84:38:84 | 800 | test.swift:38:84:38:84 | 800 | The variable '800' is an insufficient number of iterations, which is not secure for hash functions. | test.swift:38:84:38:84 | 800 | 800 |
-| test.swift:44:84:44:84 | lowIterations | test.swift:20:45:20:45 | 999 :  | test.swift:44:84:44:84 | lowIterations | The variable 'lowIterations' is an insufficient number of iterations, which is not secure for hash functions. | test.swift:20:45:20:45 | 999 :  | 999 |
-| test.swift:45:84:45:84 | 800 | test.swift:45:84:45:84 | 800 | test.swift:45:84:45:84 | 800 | The variable '800' is an insufficient number of iterations, which is not secure for hash functions. | test.swift:45:84:45:84 | 800 | 800 |
+| test.swift:37:84:37:84 | lowIterations | test.swift:20:45:20:45 | 999 :  | test.swift:37:84:37:84 | lowIterations | The value '999' is an insufficient number of iterations for secure password hashing. |
+| test.swift:38:84:38:84 | 800 | test.swift:38:84:38:84 | 800 | test.swift:38:84:38:84 | 800 | The value '800' is an insufficient number of iterations for secure password hashing. |
+| test.swift:44:84:44:84 | lowIterations | test.swift:20:45:20:45 | 999 :  | test.swift:44:84:44:84 | lowIterations | The value '999' is an insufficient number of iterations for secure password hashing. |
+| test.swift:45:84:45:84 | 800 | test.swift:45:84:45:84 | 800 | test.swift:45:84:45:84 | 800 | The value '800' is an insufficient number of iterations for secure password hashing. |

--- a/swift/ql/test/query-tests/Security/CWE-916/InsufficientHashIterations.expected
+++ b/swift/ql/test/query-tests/Security/CWE-916/InsufficientHashIterations.expected
@@ -1,0 +1,17 @@
+edges
+| test.swift:20:45:20:45 | 999 :  | test.swift:33:22:33:43 | call to getLowIterationCount() :  |
+| test.swift:33:22:33:43 | call to getLowIterationCount() :  | test.swift:37:84:37:84 | lowIterations |
+| test.swift:33:22:33:43 | call to getLowIterationCount() :  | test.swift:44:84:44:84 | lowIterations |
+nodes
+| test.swift:20:45:20:45 | 999 :  | semmle.label | 999 :  |
+| test.swift:33:22:33:43 | call to getLowIterationCount() :  | semmle.label | call to getLowIterationCount() :  |
+| test.swift:37:84:37:84 | lowIterations | semmle.label | lowIterations |
+| test.swift:38:84:38:84 | 800 | semmle.label | 800 |
+| test.swift:44:84:44:84 | lowIterations | semmle.label | lowIterations |
+| test.swift:45:84:45:84 | 800 | semmle.label | 800 |
+subpaths
+#select
+| test.swift:37:84:37:84 | lowIterations | test.swift:20:45:20:45 | 999 :  | test.swift:37:84:37:84 | lowIterations | The variable 'lowIterations' is an insufficient number of iterations, which is not secure for hash functions. | test.swift:20:45:20:45 | 999 :  | 999 |
+| test.swift:38:84:38:84 | 800 | test.swift:38:84:38:84 | 800 | test.swift:38:84:38:84 | 800 | The variable '800' is an insufficient number of iterations, which is not secure for hash functions. | test.swift:38:84:38:84 | 800 | 800 |
+| test.swift:44:84:44:84 | lowIterations | test.swift:20:45:20:45 | 999 :  | test.swift:44:84:44:84 | lowIterations | The variable 'lowIterations' is an insufficient number of iterations, which is not secure for hash functions. | test.swift:20:45:20:45 | 999 :  | 999 |
+| test.swift:45:84:45:84 | 800 | test.swift:45:84:45:84 | 800 | test.swift:45:84:45:84 | 800 | The variable '800' is an insufficient number of iterations, which is not secure for hash functions. | test.swift:45:84:45:84 | 800 | 800 |

--- a/swift/ql/test/query-tests/Security/CWE-916/InsufficientHashIterations.expected
+++ b/swift/ql/test/query-tests/Security/CWE-916/InsufficientHashIterations.expected
@@ -1,17 +1,17 @@
 edges
-| test.swift:20:45:20:45 | 999 :  | test.swift:33:22:33:43 | call to getLowIterationCount() :  |
+| test.swift:20:45:20:45 | 99999 :  | test.swift:33:22:33:43 | call to getLowIterationCount() :  |
 | test.swift:33:22:33:43 | call to getLowIterationCount() :  | test.swift:37:84:37:84 | lowIterations |
 | test.swift:33:22:33:43 | call to getLowIterationCount() :  | test.swift:44:84:44:84 | lowIterations |
 nodes
-| test.swift:20:45:20:45 | 999 :  | semmle.label | 999 :  |
+| test.swift:20:45:20:45 | 99999 :  | semmle.label | 99999 :  |
 | test.swift:33:22:33:43 | call to getLowIterationCount() :  | semmle.label | call to getLowIterationCount() :  |
 | test.swift:37:84:37:84 | lowIterations | semmle.label | lowIterations |
-| test.swift:38:84:38:84 | 800 | semmle.label | 800 |
+| test.swift:38:84:38:84 | 80000 | semmle.label | 80000 |
 | test.swift:44:84:44:84 | lowIterations | semmle.label | lowIterations |
-| test.swift:45:84:45:84 | 800 | semmle.label | 800 |
+| test.swift:45:84:45:84 | 80000 | semmle.label | 80000 |
 subpaths
 #select
-| test.swift:37:84:37:84 | lowIterations | test.swift:20:45:20:45 | 999 :  | test.swift:37:84:37:84 | lowIterations | The value '999' is an insufficient number of iterations for secure password hashing. |
-| test.swift:38:84:38:84 | 800 | test.swift:38:84:38:84 | 800 | test.swift:38:84:38:84 | 800 | The value '800' is an insufficient number of iterations for secure password hashing. |
-| test.swift:44:84:44:84 | lowIterations | test.swift:20:45:20:45 | 999 :  | test.swift:44:84:44:84 | lowIterations | The value '999' is an insufficient number of iterations for secure password hashing. |
-| test.swift:45:84:45:84 | 800 | test.swift:45:84:45:84 | 800 | test.swift:45:84:45:84 | 800 | The value '800' is an insufficient number of iterations for secure password hashing. |
+| test.swift:37:84:37:84 | lowIterations | test.swift:20:45:20:45 | 99999 :  | test.swift:37:84:37:84 | lowIterations | The value '99999' is an insufficient number of iterations for secure password hashing. |
+| test.swift:38:84:38:84 | 80000 | test.swift:38:84:38:84 | 80000 | test.swift:38:84:38:84 | 80000 | The value '80000' is an insufficient number of iterations for secure password hashing. |
+| test.swift:44:84:44:84 | lowIterations | test.swift:20:45:20:45 | 99999 :  | test.swift:44:84:44:84 | lowIterations | The value '99999' is an insufficient number of iterations for secure password hashing. |
+| test.swift:45:84:45:84 | 80000 | test.swift:45:84:45:84 | 80000 | test.swift:45:84:45:84 | 80000 | The value '80000' is an insufficient number of iterations for secure password hashing. |

--- a/swift/ql/test/query-tests/Security/CWE-916/InsufficientHashIterations.qlref
+++ b/swift/ql/test/query-tests/Security/CWE-916/InsufficientHashIterations.qlref
@@ -1,0 +1,1 @@
+queries/Security/CWE-916/InsufficientHashIterations.ql

--- a/swift/ql/test/query-tests/Security/CWE-916/test.swift
+++ b/swift/ql/test/query-tests/Security/CWE-916/test.swift
@@ -1,0 +1,48 @@
+
+// --- stubs ---
+
+// These stubs roughly follows the same structure as classes from CryptoSwift
+enum PKCS5 { }
+
+enum Variant { case md5, sha1, sha2, sha3 }
+
+extension PKCS5 {
+  struct PBKDF1 {
+	init(password: Array<UInt8>, salt: Array<UInt8>, variant: Variant = .sha1, iterations: Int = 4096, keyLength: Int? = nil) { }
+  }
+
+  struct PBKDF2 {
+	init(password: Array<UInt8>, salt: Array<UInt8>, iterations: Int = 4096, keyLength: Int? = nil, variant: Variant = .sha2) { }
+  }
+}
+
+// Helper functions
+func getLowIterationCount() -> Int { return 999 }
+
+func getEnoughIterationCount() -> Int { return 1000 }
+
+func getRandomArray() -> Array<UInt8> {
+	(0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+}
+
+// --- tests ---
+
+func test() {
+	let randomArray = getRandomArray()
+	let variant = Variant.sha2
+	let lowIterations = getLowIterationCount()
+	let enoughIterations = getEnoughIterationCount() 
+	
+	// PBKDF1 test cases
+	let pbkdf1b1 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: lowIterations, keyLength: 0) // BAD
+	let pbkdf1b2 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: 800, keyLength: 0) // BAD
+	let pbkdf1g1 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: enoughIterations, keyLength: 0) // GOOD
+	let pbkdf1g2 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: 1200, keyLength: 0) // GOOD
+
+
+	// PBKDF2 test cases
+	let pbkdf2b1 = try PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: lowIterations, keyLength: 0) // BAD
+	let pbkdf2b2 = try PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: 800, keyLength: 0) // BAD
+	let pbkdf2g1 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: enoughIterations, keyLength: 0) // GOOD
+	let pbkdf2g2 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: 1200, keyLength: 0) // GOOD
+}

--- a/swift/ql/test/query-tests/Security/CWE-916/test.swift
+++ b/swift/ql/test/query-tests/Security/CWE-916/test.swift
@@ -41,8 +41,8 @@ func test() {
 
 
 	// PBKDF2 test cases
-	let pbkdf2b1 = try PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: lowIterations, keyLength: 0) // BAD
-	let pbkdf2b2 = try PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: 800, keyLength: 0) // BAD
-	let pbkdf2g1 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: enoughIterations, keyLength: 0) // GOOD
-	let pbkdf2g2 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: 1200, keyLength: 0) // GOOD
+	let pbkdf2b1 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: lowIterations, keyLength: 0) // BAD
+	let pbkdf2b2 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: 800, keyLength: 0) // BAD
+	let pbkdf2g1 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: enoughIterations, keyLength: 0) // GOOD
+	let pbkdf2g2 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: 1200, keyLength: 0) // GOOD
 }

--- a/swift/ql/test/query-tests/Security/CWE-916/test.swift
+++ b/swift/ql/test/query-tests/Security/CWE-916/test.swift
@@ -17,9 +17,9 @@ extension PKCS5 {
 }
 
 // Helper functions
-func getLowIterationCount() -> Int { return 999 }
+func getLowIterationCount() -> Int { return 99999 }
 
-func getEnoughIterationCount() -> Int { return 1000 }
+func getEnoughIterationCount() -> Int { return 120120 }
 
 func getRandomArray() -> Array<UInt8> {
 	(0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
@@ -35,14 +35,14 @@ func test() {
 	
 	// PBKDF1 test cases
 	let pbkdf1b1 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: lowIterations, keyLength: 0) // BAD
-	let pbkdf1b2 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: 800, keyLength: 0) // BAD
+	let pbkdf1b2 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: 80000, keyLength: 0) // BAD
 	let pbkdf1g1 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: enoughIterations, keyLength: 0) // GOOD
-	let pbkdf1g2 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: 1200, keyLength: 0) // GOOD
+	let pbkdf1g2 = PKCS5.PBKDF1(password: randomArray, salt: randomArray, iterations: 120120, keyLength: 0) // GOOD
 
 
 	// PBKDF2 test cases
 	let pbkdf2b1 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: lowIterations, keyLength: 0) // BAD
-	let pbkdf2b2 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: 800, keyLength: 0) // BAD
+	let pbkdf2b2 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: 80000, keyLength: 0) // BAD
 	let pbkdf2g1 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: enoughIterations, keyLength: 0) // GOOD
-	let pbkdf2g2 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: 1200, keyLength: 0) // GOOD
+	let pbkdf2g2 = PKCS5.PBKDF2(password: randomArray, salt: randomArray, iterations: 120120, keyLength: 0) // GOOD
 }


### PR DESCRIPTION
Using hash functions with less than 1,000 iterations is not secure. That scheme is vulnerable to password cracking attacks due to having an insufficient level of computational effort.

The rule currently supports all ciphers that the CryptoSwift API provides, but we can always extend it further if more cophers are added.

I'd appreciate a review of the query itself, the accompanying tests, and the associated documentation.