### PR TITLE
Kotlin: extract interface redeclarations of `Object` methods

### DIFF
--- a/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/Test.java
+++ b/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/Test.java
@@ -1,0 +1,5 @@
+public interface Test {
+  String toString();
+  int hashCode();
+  boolean equals(Object other);
+}

--- a/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/test.expected
+++ b/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/test.expected
@@ -1,0 +1,4 @@
+| equals | Test |
+| hashCode | Test |
+| toString | Test |
+| toString | java.lang.CharSequence |

--- a/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/test.py
+++ b/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/test.py
@@ -1,0 +1,4 @@
+from create_database_utils import *
+
+runSuccessfully(["javac", "Test.java", "-d", "bin"])
+run_codeql_database_create(["kotlinc user.kt -cp bin"], lang="java")

--- a/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/test.ql
+++ b/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/test.ql
@@ -1,0 +1,7 @@
+import java
+
+from Method m
+where
+  m.getDeclaringType().getName() = ["Test", "CharSequence"] and
+  m.getName() = ["toString", "equals", "hashCode"]
+select m.getName(), m.getDeclaringType().getQualifiedName()

--- a/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/user.kt
+++ b/java/ql/integration-tests/posix-only/kotlin/java-interface-redeclares-tostring/user.kt
@@ -1,0 +1,1 @@
+fun f(t: Test, cs: CharSequence) = t.toString() + cs.toString() + t.equals(1) + t.hashCode()

--- a/java/ql/test/kotlin/library-tests/java-kotlin-collection-type-generic-methods/test.expected
+++ b/java/ql/test/kotlin/library-tests/java-kotlin-collection-type-generic-methods/test.expected
@@ -110,6 +110,7 @@ methodWithDuplicate
 | Collection<E> | addAll | Collection<? extends E> |
 | Collection<E> | contains | Object |
 | Collection<E> | containsAll | Collection<?> |
+| Collection<E> | equals | Object |
 | Collection<E> | remove | Object |
 | Collection<E> | removeAll | Collection<?> |
 | Collection<E> | removeIf | Predicate<? super E> |
@@ -120,6 +121,7 @@ methodWithDuplicate
 | Collection<Entry<K,V>> | addAll | Collection<? extends Entry<K,V>> |
 | Collection<Entry<K,V>> | contains | Object |
 | Collection<Entry<K,V>> | containsAll | Collection<?> |
+| Collection<Entry<K,V>> | equals | Object |
 | Collection<Entry<K,V>> | remove | Object |
 | Collection<Entry<K,V>> | removeAll | Collection<?> |
 | Collection<Entry<K,V>> | removeIf | Predicate<? super Entry<K,V>> |
@@ -130,6 +132,7 @@ methodWithDuplicate
 | Collection<K> | addAll | Collection<? extends K> |
 | Collection<K> | contains | Object |
 | Collection<K> | containsAll | Collection<?> |
+| Collection<K> | equals | Object |
 | Collection<K> | remove | Object |
 | Collection<K> | removeAll | Collection<?> |
 | Collection<K> | removeIf | Predicate<? super K> |
@@ -151,6 +154,7 @@ methodWithDuplicate
 | Collection<V> | addAll | Collection<? extends V> |
 | Collection<V> | contains | Object |
 | Collection<V> | containsAll | Collection<?> |
+| Collection<V> | equals | Object |
 | Collection<V> | remove | Object |
 | Collection<V> | removeAll | Collection<?> |
 | Collection<V> | removeIf | Predicate<? super V> |
@@ -188,6 +192,7 @@ methodWithDuplicate
 | List<E> | contains | Object |
 | List<E> | containsAll | Collection<?> |
 | List<E> | copyOf | Collection<? extends E> |
+| List<E> | equals | Object |
 | List<E> | get | int |
 | List<E> | indexOf | Object |
 | List<E> | lastIndexOf | Object |
@@ -270,6 +275,7 @@ methodWithDuplicate
 | Map<Identity,Entry<?>> | copyOf | Map<? extends K,? extends V> |
 | Map<Identity,Entry<?>> | entry | K |
 | Map<Identity,Entry<?>> | entry | V |
+| Map<Identity,Entry<?>> | equals | Object |
 | Map<Identity,Entry<?>> | forEach | BiConsumer<? super Identity,? super Entry<?>> |
 | Map<Identity,Entry<?>> | get | Object |
 | Map<Identity,Entry<?>> | getOrDefault | Entry<?> |
@@ -300,6 +306,7 @@ methodWithDuplicate
 | Map<K,V> | copyOf | Map<? extends K,? extends V> |
 | Map<K,V> | entry | K |
 | Map<K,V> | entry | V |
+| Map<K,V> | equals | Object |
 | Map<K,V> | forEach | BiConsumer<? super K,? super V> |
 | Map<K,V> | get | Object |
 | Map<K,V> | getOrDefault | Object |
@@ -330,6 +337,7 @@ methodWithDuplicate
 | Map<Object,Object> | copyOf | Map<? extends K,? extends V> |
 | Map<Object,Object> | entry | K |
 | Map<Object,Object> | entry | V |
+| Map<Object,Object> | equals | Object |
 | Map<Object,Object> | forEach | BiConsumer<? super Object,? super Object> |
 | Map<Object,Object> | get | Object |
 | Map<Object,Object> | getOrDefault | Object |


### PR DESCRIPTION
Due to a probable compiler bug (?) the redeclaration looks like a fake symbol, leading to Java dispatching against a declaration that Kotlin doesn't believe exists.