### PR TITLE
Bazel/CMake: make cmake runnable from outside the workspace

### DIFF
--- a/misc/bazel/cmake/README.md
+++ b/misc/bazel/cmake/README.md
@@ -1,0 +1,12 @@
+This directory contains a Bazel to CMake generator intended mainly for IDE integration.
+
+[`cmake.bzl`](./cmake.bzl) contains the Bazel side, with the `cmake_aspect` rule gathering the necessary information
+from `cc_*` rules and `generate_cmake` translating that information into CMake commands. `generate_cmake` targets also
+depend on all files that are either generated or fetched from external repositories, so that Bazel will fill in those
+dependencies before letting CMake to the C/C++ compilation.
+
+[`setup.cmake`](./setup.cmake) contains the generic CMake setup, setting up some Bazel related global variables and
+providing an `include_generated` macro to be used in `CMakeLists.txt` to include a specific `generate_cmake` Bazel
+target.
+
+See Swift's [`CMakeLists.txt`](../../../swift/CMakeLists.txt) file for an example usage.

--- a/misc/bazel/cmake/README.md
+++ b/misc/bazel/cmake/README.md
@@ -3,7 +3,7 @@ This directory contains a Bazel to CMake generator intended mainly for IDE integ
 [`cmake.bzl`](./cmake.bzl) contains the Bazel side, with the `cmake_aspect` rule gathering the necessary information
 from `cc_*` rules and `generate_cmake` translating that information into CMake commands. `generate_cmake` targets also
 depend on all files that are either generated or fetched from external repositories, so that Bazel will fill in those
-dependencies before letting CMake to the C/C++ compilation.
+dependencies before letting CMake do the C/C++ compilation.
 
 [`setup.cmake`](./setup.cmake) contains the generic CMake setup, setting up some Bazel related global variables and
 providing an `include_generated` macro to be used in `CMakeLists.txt` to include a specific `generate_cmake` Bazel

--- a/misc/bazel/cmake/setup.cmake
+++ b/misc/bazel/cmake/setup.cmake
@@ -6,7 +6,10 @@ if (CREATE_COMPILATION_DATABASE_LINK)
 endif ()
 
 macro(bazel)
-    execute_process(COMMAND bazel ${ARGN} COMMAND_ERROR_IS_FATAL ANY OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND bazel ${ARGN}
+            COMMAND_ERROR_IS_FATAL ANY
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endmacro()
 
 bazel(info workspace OUTPUT_VARIABLE BAZEL_WORKSPACE)


### PR DESCRIPTION
Also added a small `README.md` file.