### PR TITLE
Swift: fix missing extraction of function bodies in SPM builds

### DIFF
--- a/swift/integration-tests/posix-only/hello-world/Bodies.expected
+++ b/swift/integration-tests/posix-only/hello-world/Bodies.expected
@@ -1,0 +1,1 @@
+| Sources/hello-world/hello_world.swift:4:12:5:5 | init() | Sources/hello-world/hello_world.swift:4:19:5:5 | { ... } |

--- a/swift/integration-tests/posix-only/hello-world/Bodies.ql
+++ b/swift/integration-tests/posix-only/hello-world/Bodies.ql
@@ -1,0 +1,5 @@
+import swift
+
+from StructDecl struct, ConstructorDecl decl, BraceStmt body
+where struct.getName() = "hello_world" and decl = struct.getAMember() and body = decl.getBody()
+select decl, body

--- a/swift/tools/tracing-config.lua
+++ b/swift/tools/tracing-config.lua
@@ -29,6 +29,7 @@ function RegisterExtractorPack(id)
       strip_unsupported_arg(args, '-emit-localized-strings', 0)
       strip_unsupported_arg(args, '-emit-localized-strings-path', 1)
       strip_unsupported_arg(args, '-stack-check', 0)
+      strip_unsupported_arg(args, '-experimental-skip-non-inlinable-function-bodies-without-types', 0)
     end
 
     -- xcodebuild does not always specify the -resource-dir in which case the compiler falls back


### PR DESCRIPTION
For some reason `-experimental-skip-non-inlinable-function-bodies-without-types`
is passed to the frontend, which will skip extraction of most bodies.

By suppressing that option the problem goes away.