### PR TITLE
C++: Fix performance issue on cpp/comma-before-misleading-indentation

### DIFF
--- a/cpp/ql/src/Best Practices/Likely Errors/CommaBeforeMisleadingIndentation.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/CommaBeforeMisleadingIndentation.ql
@@ -20,7 +20,7 @@ import semmle.code.cpp.commons.Exclusions
  * Gets a child of `e`, including conversions but excluding call arguments.
  */
 pragma[inline]
-Expr childWithConversions(Expr e) {
+Expr getAChildWithConversions(Expr e) {
   result.getParentWithConversions() = e and
   not result = any(Call c).getAnArgument()
 }
@@ -31,7 +31,7 @@ Expr childWithConversions(Expr e) {
  */
 int getCandidateColumn(Expr e) {
   result = e.getLocation().getStartColumn() or
-  result = getCandidateColumn(childWithConversions(e))
+  result = getCandidateColumn(getAChildWithConversions(e))
 }
 
 /**
@@ -44,7 +44,7 @@ Expr normalizeExpr(Expr e) {
   result = e
   or
   not e.getLocation().getStartColumn() = min(getCandidateColumn(e)) and
-  result = normalizeExpr(childWithConversions(e)) and
+  result = normalizeExpr(getAChildWithConversions(e)) and
   result.getLocation().getStartColumn() = min(getCandidateColumn(e))
 }
 

--- a/cpp/ql/src/Best Practices/Likely Errors/CommaBeforeMisleadingIndentation.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/CommaBeforeMisleadingIndentation.ql
@@ -16,15 +16,36 @@
 import cpp
 import semmle.code.cpp.commons.Exclusions
 
-/** Gets the sub-expression of 'e' with the earliest-starting Location */
+/**
+ * Gets a child of `e`, including conversions but excluding call arguments.
+ */
+pragma[inline]
+Expr childWithConversions(Expr e) {
+  result.getParentWithConversions() = e and
+  not result = any(Call c).getAnArgument()
+}
+
+/**
+ * Gets the left-most column position of any transitive child of `e` (including
+ * conversions but excluding call arguments).
+ */
+int getCandidateColumn(Expr e) {
+  result = e.getLocation().getStartColumn() or
+  result = getCandidateColumn(childWithConversions(e))
+}
+
+/**
+ * Gets the transitive child of `e` (including conversions but excluding call
+ * arguments) at the left-most column position, preferring less deeply nested
+ * expressions if there is a choice.
+ */
 Expr normalizeExpr(Expr e) {
-  result =
-    min(Expr child |
-      child.getParentWithConversions*() = e.getFullyConverted() and
-      not child.getParentWithConversions*() = any(Call c).getAnArgument()
-    |
-      child order by child.getLocation().getStartColumn(), count(child.getParentWithConversions*())
-    )
+  e.getLocation().getStartColumn() = min(getCandidateColumn(e)) and
+  result = e
+  or
+  not e.getLocation().getStartColumn() = min(getCandidateColumn(e)) and
+  result = normalizeExpr(childWithConversions(e)) and
+  result.getLocation().getStartColumn() = min(getCandidateColumn(e))
 }
 
 predicate isParenthesized(CommaExpr ce) {
@@ -43,8 +64,8 @@ from CommaExpr ce, Expr left, Expr right, Location leftLoc, Location rightLoc
 where
   ce.fromSource() and
   not isFromMacroDefinition(ce) and
-  left = normalizeExpr(ce.getLeftOperand()) and
-  right = normalizeExpr(ce.getRightOperand()) and
+  left = normalizeExpr(ce.getLeftOperand().getFullyConverted()) and
+  right = normalizeExpr(ce.getRightOperand().getFullyConverted()) and
   leftLoc = left.getLocation() and
   rightLoc = right.getLocation() and
   not isParenthesized(ce) and


### PR DESCRIPTION
C++: Fix rare performance issue on `cpp/comma-before-misleading-indentation`.  The issue was `_Call#39248e3c::Call::getAnArgument#0#dispred#ff__Expr#ef463c5d::Expr::getFullyConverted#0#dispred#f__#higher_order_body` exploding (found on `nba-emu_NanoBoyAdvance`), which I interpret to mean that `normalizeExpr` was just getting too big on deep `Expr` trees (probably with lots of co-located hidden `Expr`s).

The new solution calculates the lowest relevant column number first (`min(getCandidateColumn(e))`), which should be less affected by co-located `Expr`s.  Then in the main calculation that follows a lot of `Expr`s can be culled early using this relation.

Its unfortunately more code than before but I've tried to explain in the comments.

I'll run DCA on this, but here are some local stats:
```
BEFORE                                               RESULTS  TIME
nba-emu_NanoBoyAdvance (clean cache)                 TIMEOUT
MongoDB-2.2.3 (clean cache)                          0        13s
abseil-cpp (cache warmed up by `cpp/dead-code-goto`) 0        31s
torvalds_linux (cache warmed up ")                   0        49s

AFTER                                                RESULTS  TIME
nba-emu_NanoBoyAdvance (clean cache)                 0        33s
MongoDB-2.2.3 (clean cache)                          0        15s
abseil-cpp (cache warmed up by `cpp/dead-code-goto`) 0        38s
torvalds_linux (cache warmed up ")                   0        54s
```

@MathiasVP 