### PR TITLE
qlpacks: libraryPathDependencies -> dependencies

### DIFF
--- a/csharp/ql/integration-tests/qlpack.yml
+++ b/csharp/ql/integration-tests/qlpack.yml
@@ -1,2 +1,2 @@
-libraryPathDependencies:
-  - codeql-csharp
+dependencies:
+  codeql/csharp-all: '*'

--- a/go/ql/config/legacy-support/qlpack.yml
+++ b/go/ql/config/legacy-support/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-go
 version: 0.0.0
-dependencies:
-  codeql/go-all: '*'
+# Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
+libraryPathDependencies: codeql-go

--- a/go/ql/config/legacy-support/qlpack.yml
+++ b/go/ql/config/legacy-support/qlpack.yml
@@ -1,3 +1,4 @@
 name: legacy-libraries-go
 version: 0.0.0
-libraryPathDependencies: codeql-go
+dependencies:
+  codeql/go-all: '*'

--- a/java/ql/consistency-queries/qlpack.yml
+++ b/java/ql/consistency-queries/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql-java-consistency-queries
 version: 0.0.0
-libraryPathDependencies:
-  - codeql-java
+dependencies:
+  codeql/java-all: '*'

--- a/java/ql/integration-tests/linux-only/kotlin/qlpack.yml
+++ b/java/ql/integration-tests/linux-only/kotlin/qlpack.yml
@@ -1,2 +1,2 @@
-libraryPathDependencies:
-  - codeql-java
+dependencies:
+  codeql/java-all: '*'

--- a/java/ql/integration-tests/posix-only/kotlin/qlpack.yml
+++ b/java/ql/integration-tests/posix-only/kotlin/qlpack.yml
@@ -1,4 +1,5 @@
-libraryPathDependencies:
-  - codeql-java
-  - codeql/java-tests
-  - codeql/java-queries
+dependencies:
+  codeql/java-all: '*'
+  codeql/java-tests: '*'
+  codeql/java-queries: '*'
+

--- a/misc/legacy-support/cpp/qlpack.yml
+++ b/misc/legacy-support/cpp/qlpack.yml
@@ -1,4 +1,5 @@
 name: legacy-libraries-cpp
 version: 0.0.0
-dependencies:
-  codeql/cpp-all: '*'
+# Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
+libraryPathDependencies:
+  - codeql/cpp-all

--- a/misc/legacy-support/cpp/qlpack.yml
+++ b/misc/legacy-support/cpp/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-cpp
 version: 0.0.0
-libraryPathDependencies:
-  - codeql/cpp-all
+dependencies:
+  codeql/cpp-all: '*'

--- a/misc/legacy-support/csharp/qlpack.yml
+++ b/misc/legacy-support/csharp/qlpack.yml
@@ -1,4 +1,5 @@
 name: legacy-libraries-csharp
 version: 0.0.0
-dependencies:
-  codeql/csharp-all: '*'
+# Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
+libraryPathDependencies:
+  - codeql/csharp-all

--- a/misc/legacy-support/csharp/qlpack.yml
+++ b/misc/legacy-support/csharp/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-csharp
 version: 0.0.0
-libraryPathDependencies:
-  - codeql/csharp-all
+dependencies:
+  codeql/csharp-all: '*'

--- a/misc/legacy-support/java/qlpack.yml
+++ b/misc/legacy-support/java/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-java
 version: 0.0.0
-libraryPathDependencies:
-  - codeql/java-all
+dependencies:
+  codeql/java-all: '*'

--- a/misc/legacy-support/java/qlpack.yml
+++ b/misc/legacy-support/java/qlpack.yml
@@ -1,4 +1,5 @@
 name: legacy-libraries-java
 version: 0.0.0
-dependencies:
-  codeql/java-all: '*'
+# Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
+libraryPathDependencies:
+  - codeql/java-all

--- a/misc/legacy-support/javascript/qlpack.yml
+++ b/misc/legacy-support/javascript/qlpack.yml
@@ -1,4 +1,5 @@
 name: legacy-libraries-javascript
 version: 0.0.0
-dependencies:
-  codeql/javascript-all: '*'
+# Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
+libraryPathDependencies:
+  - codeql-javascript

--- a/misc/legacy-support/javascript/qlpack.yml
+++ b/misc/legacy-support/javascript/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-javascript
 version: 0.0.0
-libraryPathDependencies:
-  - codeql-javascript
+dependencies:
+  codeql/javascript-all: '*'

--- a/misc/legacy-support/python/qlpack.yml
+++ b/misc/legacy-support/python/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-python
 version: 0.0.0
-libraryPathDependencies:
-  - codeql/python-all
+dependencies:
+  codeql/python-all: '*'

--- a/misc/legacy-support/python/qlpack.yml
+++ b/misc/legacy-support/python/qlpack.yml
@@ -1,4 +1,5 @@
 name: legacy-libraries-python
 version: 0.0.0
-dependencies:
-  codeql/python-all: '*'
+# Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
+libraryPathDependencies:
+  - codeql/python-all

--- a/python/tools/recorded-call-graph-metrics/ql/qlpack.yml
+++ b/python/tools/recorded-call-graph-metrics/ql/qlpack.yml
@@ -1,4 +1,5 @@
 name: codeql-python-recorded-call-graph-metrics
 version: 0.0.1
-libraryPathDependencies: codeql-python
 extractor: python
+dependencies:
+  codeql/python-all: '*'

--- a/ql/ql/test/callgraph/packs/other/qlpack.yml
+++ b/ql/ql/test/callgraph/packs/other/qlpack.yml
@@ -1,3 +1,4 @@
 name: ql-other-pack-thing
 version: 0.1.0
-libraryPathDependencies: ql-testing-src-pack
+dependencies:
+  ql-testing-src-pack: '*'

--- a/swift/integration-tests/qlpack.yml
+++ b/swift/integration-tests/qlpack.yml
@@ -1,5 +1,5 @@
 name: integration-tests-swift
 version: 0.0.0
-libraryPathDependencies: codeql/swift-all
 extractor: swift
-
+dependencies:
+  codeql/swift-all: '*'

--- a/swift/integration-tests/runner.py
+++ b/swift/integration-tests/runner.py
@@ -54,7 +54,7 @@ def main(opts):
         codeql_root = this_dir.parents[1]
         cmd = [
             "codeql", "test", "run",
-            f"--search-path={codeql_root}",
+            f"--additional-packs={codeql_root}",
             "--keep-databases",
             "--dataset=db/db-swift",
             f"--threads={opts.threads}",


### PR DESCRIPTION
This is an initial stab at just removing all references to the deprecated key. I note though that a bunch of these files are named `legacy-xyz` -- I don't know what these are doing or if they have a reason to use the deprecated key (compatibility with an old `codeql`?)