### PR TITLE
Swift: Fix flow out of summarized callables

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -269,7 +269,7 @@ class SummaryNode extends NodeImpl, TSummaryNode {
 
   SummaryNode() { this = TSummaryNode(c, state) }
 
-  override DataFlowCallable getEnclosingCallable() { result = TDataFlowFunc(c) }
+  override DataFlowCallable getEnclosingCallable() { result.asSummarizedCallable() = c }
 
   override UnknownLocation getLocationImpl() { any() }
 
@@ -430,6 +430,8 @@ private module OutNodes {
   }
 
   class SummaryOutNode extends OutNode, SummaryNode {
+    SummaryOutNode() { FlowSummaryImpl::Private::summaryOutNode(_, this, _) }
+
     override DataFlowCall getCall(ReturnKind kind) {
       FlowSummaryImpl::Private::summaryOutNode(result, this, kind)
     }

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
@@ -116,7 +116,7 @@ ExprNode exprNode(DataFlowExpr e) { result.asExpr() = e }
 /**
  * Gets the node corresponding to the value of parameter `p` at function entry.
  */
-ParameterNode parameterNode(DataFlowParameter p) { none() }
+ParameterNode parameterNode(DataFlowParameter p) { result.getParameter() = p }
 
 /**
  * Holds if data flows from `nodeFrom` to `nodeTo` in exactly one local

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -15,7 +15,7 @@ private import codeql.swift.controlflow.CfgNodes
 
 class SummarizedCallableBase = AbstractFunctionDecl;
 
-DataFlowCallable inject(SummarizedCallable c) { result = TDataFlowFunc(c) }
+DataFlowCallable inject(SummarizedCallable c) { result.getUnderlyingCallable() = c }
 
 /** Gets the parameter position of the instance parameter. */
 ArgumentPosition instanceParameterPosition() { result instanceof ThisArgumentPosition }

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -1,4 +1,5 @@
 edges
+| file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  |
 | file://:0:0:0:0 | self [a, x] :  | file://:0:0:0:0 | .a [x] :  |
 | file://:0:0:0:0 | self [x] :  | file://:0:0:0:0 | .x :  |
 | file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [x] :  |
@@ -100,10 +101,18 @@ edges
 | test.swift:225:14:225:21 | call to source() :  | test.swift:238:13:238:15 | .source_value |
 | test.swift:259:12:259:19 | call to source() :  | test.swift:263:13:263:28 | call to optionalSource() :  |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:264:15:264:16 | ...! |
+| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:266:15:266:16 | ...? :  |
+| test.swift:265:15:265:22 | call to source() :  | file://:0:0:0:0 | [summary param] this in signum() :  |
+| test.swift:265:15:265:22 | call to source() :  | test.swift:265:15:265:31 | call to signum() |
+| test.swift:266:15:266:16 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  |
+| test.swift:266:15:266:16 | ...? :  | test.swift:266:15:266:25 | call to signum() :  |
+| test.swift:266:15:266:25 | call to signum() :  | test.swift:266:15:266:25 | OptionalEvaluationExpr |
 nodes
 | file://:0:0:0:0 | .a [x] :  | semmle.label | .a [x] :  |
 | file://:0:0:0:0 | .x :  | semmle.label | .x :  |
 | file://:0:0:0:0 | [post] self [x] :  | semmle.label | [post] self [x] :  |
+| file://:0:0:0:0 | [summary param] this in signum() :  | semmle.label | [summary param] this in signum() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | semmle.label | [summary] to write: return (return) in signum() :  |
 | file://:0:0:0:0 | self [a, x] :  | semmle.label | self [a, x] :  |
 | file://:0:0:0:0 | self [x] :  | semmle.label | self [x] :  |
 | file://:0:0:0:0 | value :  | semmle.label | value :  |
@@ -213,6 +222,11 @@ nodes
 | test.swift:259:12:259:19 | call to source() :  | semmle.label | call to source() :  |
 | test.swift:263:13:263:28 | call to optionalSource() :  | semmle.label | call to optionalSource() :  |
 | test.swift:264:15:264:16 | ...! | semmle.label | ...! |
+| test.swift:265:15:265:22 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:265:15:265:31 | call to signum() | semmle.label | call to signum() |
+| test.swift:266:15:266:16 | ...? :  | semmle.label | ...? :  |
+| test.swift:266:15:266:25 | OptionalEvaluationExpr | semmle.label | OptionalEvaluationExpr |
+| test.swift:266:15:266:25 | call to signum() :  | semmle.label | call to signum() :  |
 subpaths
 | test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  | test.swift:75:31:75:32 | [post] &... :  |
 | test.swift:114:19:114:19 | arg :  | test.swift:109:9:109:14 | arg :  | test.swift:110:12:110:12 | arg :  | test.swift:114:12:114:22 | call to ... :  |
@@ -239,6 +253,8 @@ subpaths
 | test.swift:218:11:218:18 | call to source() :  | test.swift:169:12:169:22 | value :  | test.swift:170:5:170:5 | [post] self [x] :  | test.swift:218:3:218:5 | [post] getter for .a [x] :  |
 | test.swift:219:13:219:13 | b [a, x] :  | test.swift:185:7:185:7 | self [a, x] :  | file://:0:0:0:0 | .a [x] :  | test.swift:219:13:219:15 | .a [x] :  |
 | test.swift:219:13:219:15 | .a [x] :  | test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | .x :  | test.swift:219:13:219:17 | .x |
+| test.swift:265:15:265:22 | call to source() :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:265:15:265:31 | call to signum() |
+| test.swift:266:15:266:16 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:266:15:266:25 | call to signum() :  |
 #select
 | test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() :  | test.swift:7:15:7:15 | t1 | result |
 | test.swift:9:15:9:15 | t1 | test.swift:6:19:6:26 | call to source() :  | test.swift:9:15:9:15 | t1 | result |
@@ -269,3 +285,5 @@ subpaths
 | test.swift:235:13:235:15 | .source_value | test.swift:225:14:225:21 | call to source() :  | test.swift:235:13:235:15 | .source_value | result |
 | test.swift:238:13:238:15 | .source_value | test.swift:225:14:225:21 | call to source() :  | test.swift:238:13:238:15 | .source_value | result |
 | test.swift:264:15:264:16 | ...! | test.swift:259:12:259:19 | call to source() :  | test.swift:264:15:264:16 | ...! | result |
+| test.swift:265:15:265:31 | call to signum() | test.swift:265:15:265:22 | call to source() :  | test.swift:265:15:265:31 | call to signum() | result |
+| test.swift:266:15:266:25 | OptionalEvaluationExpr | test.swift:259:12:259:19 | call to source() :  | test.swift:266:15:266:25 | OptionalEvaluationExpr | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -262,8 +262,8 @@ func optionalSource() -> Int? {
 func test_optionals() {
     let x = optionalSource()
     sink(arg: x!) // $ flow=259
-    sink(arg: source().signum()) // $ MISSING: flow=259
-    sink(opt: x?.signum()) // $ MISSING: flow=259
+    sink(arg: source().signum()) // $ flow=265
+    sink(opt: x?.signum()) // $ flow=259
     sink(arg: x ?? 0) // $ MISSING: flow=259
     if let y = x {
         sink(arg: y) // $ MISSING: flow=259

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -16,13 +16,9 @@ edges
 | try.swift:15:17:15:24 | call to source() :  | try.swift:15:12:15:24 | try! ... |
 | try.swift:18:18:18:25 | call to source() :  | try.swift:18:12:18:27 | ...! |
 | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  |
-| url.swift:8:8:8:16 | string :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  |
 | url.swift:9:2:9:43 | [summary param] 0 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  |
-| url.swift:9:8:9:16 | string :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  |
-| url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | url.swift:43:2:46:55 | [summary param] 0 in dataTask(with:completionHandler:) :  | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
-| url.swift:44:5:44:15 | url :  | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
 | url.swift:57:16:57:23 | call to source() :  | url.swift:59:31:59:31 | tainted :  |
 | url.swift:57:16:57:23 | call to source() :  | url.swift:83:24:83:24 | tainted :  |
 | url.swift:57:16:57:23 | call to source() :  | url.swift:117:28:117:28 | tainted :  |
@@ -63,93 +59,69 @@ edges
 | url.swift:59:19:59:38 | call to init(string:) :  | url.swift:102:46:102:46 | urlTainted :  |
 | url.swift:59:19:59:38 | call to init(string:) :  | url.swift:120:46:120:46 | urlTainted :  |
 | url.swift:59:31:59:31 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  |
-| url.swift:59:31:59:31 | tainted :  | url.swift:8:8:8:16 | string :  |
 | url.swift:59:31:59:31 | tainted :  | url.swift:59:19:59:38 | call to init(string:) :  |
 | url.swift:83:12:83:48 | call to init(string:relativeTo:) :  | url.swift:83:12:83:49 | ...! |
 | url.swift:83:24:83:24 | tainted :  | url.swift:9:2:9:43 | [summary param] 0 in init(string:relativeTo:) :  |
-| url.swift:83:24:83:24 | tainted :  | url.swift:9:8:9:16 | string :  |
 | url.swift:83:24:83:24 | tainted :  | url.swift:83:12:83:48 | call to init(string:relativeTo:) :  |
 | url.swift:86:12:86:53 | call to init(string:relativeTo:) :  | url.swift:86:12:86:56 | .absoluteURL |
 | url.swift:86:43:86:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:86:43:86:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:86:43:86:43 | urlTainted :  | url.swift:86:12:86:53 | call to init(string:relativeTo:) :  |
 | url.swift:87:12:87:53 | call to init(string:relativeTo:) :  | url.swift:87:12:87:56 | .baseURL |
 | url.swift:87:43:87:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:87:43:87:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:87:43:87:43 | urlTainted :  | url.swift:87:12:87:53 | call to init(string:relativeTo:) :  |
 | url.swift:88:15:88:56 | call to init(string:relativeTo:) :  | url.swift:88:15:88:67 | ...! |
 | url.swift:88:46:88:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:88:46:88:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:88:46:88:46 | urlTainted :  | url.swift:88:15:88:56 | call to init(string:relativeTo:) :  |
 | url.swift:89:15:89:56 | call to init(string:relativeTo:) :  | url.swift:89:15:89:63 | ...! |
 | url.swift:89:46:89:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:89:46:89:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:89:46:89:46 | urlTainted :  | url.swift:89:15:89:56 | call to init(string:relativeTo:) :  |
 | url.swift:90:15:90:56 | call to init(string:relativeTo:) :  | url.swift:90:15:90:59 | .lastPathComponent |
 | url.swift:90:46:90:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:90:46:90:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:90:46:90:46 | urlTainted :  | url.swift:90:15:90:56 | call to init(string:relativeTo:) :  |
 | url.swift:91:15:91:56 | call to init(string:relativeTo:) :  | url.swift:91:15:91:59 | .path |
 | url.swift:91:46:91:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:91:46:91:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:91:46:91:46 | urlTainted :  | url.swift:91:15:91:56 | call to init(string:relativeTo:) :  |
 | url.swift:92:15:92:56 | call to init(string:relativeTo:) :  | url.swift:92:15:92:75 | ...[...] |
 | url.swift:92:46:92:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:92:46:92:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:92:46:92:46 | urlTainted :  | url.swift:92:15:92:56 | call to init(string:relativeTo:) :  |
 | url.swift:93:15:93:56 | call to init(string:relativeTo:) :  | url.swift:93:15:93:59 | .pathExtension |
 | url.swift:93:46:93:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:93:46:93:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:93:46:93:46 | urlTainted :  | url.swift:93:15:93:56 | call to init(string:relativeTo:) :  |
 | url.swift:94:12:94:53 | call to init(string:relativeTo:) :  | url.swift:94:12:94:60 | ...! |
 | url.swift:94:43:94:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:94:43:94:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:94:43:94:43 | urlTainted :  | url.swift:94:12:94:53 | call to init(string:relativeTo:) :  |
 | url.swift:95:15:95:56 | call to init(string:relativeTo:) :  | url.swift:95:15:95:64 | ...! |
 | url.swift:95:46:95:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:95:46:95:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:95:46:95:46 | urlTainted :  | url.swift:95:15:95:56 | call to init(string:relativeTo:) :  |
 | url.swift:96:15:96:56 | call to init(string:relativeTo:) :  | url.swift:96:15:96:59 | .relativePath |
 | url.swift:96:46:96:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:96:46:96:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:96:46:96:46 | urlTainted :  | url.swift:96:15:96:56 | call to init(string:relativeTo:) :  |
 | url.swift:97:15:97:56 | call to init(string:relativeTo:) :  | url.swift:97:15:97:59 | .relativeString |
 | url.swift:97:46:97:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:97:46:97:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:97:46:97:46 | urlTainted :  | url.swift:97:15:97:56 | call to init(string:relativeTo:) :  |
 | url.swift:98:15:98:56 | call to init(string:relativeTo:) :  | url.swift:98:15:98:65 | ...! |
 | url.swift:98:46:98:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:98:46:98:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:98:46:98:46 | urlTainted :  | url.swift:98:15:98:56 | call to init(string:relativeTo:) :  |
 | url.swift:99:12:99:53 | call to init(string:relativeTo:) :  | url.swift:99:12:99:56 | .standardized |
 | url.swift:99:43:99:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:99:43:99:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:99:43:99:43 | urlTainted :  | url.swift:99:12:99:53 | call to init(string:relativeTo:) :  |
 | url.swift:100:12:100:53 | call to init(string:relativeTo:) :  | url.swift:100:12:100:56 | .standardizedFileURL |
 | url.swift:100:43:100:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:100:43:100:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:100:43:100:43 | urlTainted :  | url.swift:100:12:100:53 | call to init(string:relativeTo:) :  |
 | url.swift:101:15:101:56 | call to init(string:relativeTo:) :  | url.swift:101:15:101:63 | ...! |
 | url.swift:101:46:101:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:101:46:101:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:101:46:101:46 | urlTainted :  | url.swift:101:15:101:56 | call to init(string:relativeTo:) :  |
 | url.swift:102:15:102:56 | call to init(string:relativeTo:) :  | url.swift:102:15:102:67 | ...! |
 | url.swift:102:46:102:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:102:46:102:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  |
 | url.swift:102:46:102:46 | urlTainted :  | url.swift:102:15:102:56 | call to init(string:relativeTo:) :  |
 | url.swift:117:16:117:35 | call to init(string:) :  | url.swift:118:12:118:12 | ...! |
 | url.swift:117:28:117:28 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  |
-| url.swift:117:28:117:28 | tainted :  | url.swift:8:8:8:16 | string :  |
 | url.swift:117:28:117:28 | tainted :  | url.swift:117:16:117:35 | call to init(string:) :  |
 | url.swift:120:46:120:46 | urlTainted :  | url.swift:43:2:46:55 | [summary param] 0 in dataTask(with:completionHandler:) :  |
-| url.swift:120:46:120:46 | urlTainted :  | url.swift:44:5:44:15 | url :  |
 | url.swift:120:61:120:61 | data :  | url.swift:121:15:121:19 | ...! |
 nodes
 | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  | semmle.label | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | semmle.label | [summary] to write: return (return) in init(string:) :  |
-| file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | semmle.label | [summary] to write: return (return) in init(string:) :  |
-| file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
-| file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | string.swift:5:11:5:18 | call to source() :  | semmle.label | call to source() :  |
@@ -175,13 +147,9 @@ nodes
 | try.swift:18:12:18:27 | ...! | semmle.label | ...! |
 | try.swift:18:18:18:25 | call to source() :  | semmle.label | call to source() :  |
 | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | semmle.label | [summary param] 0 in init(string:) :  |
-| url.swift:8:8:8:16 | string :  | semmle.label | string :  |
 | url.swift:9:2:9:43 | [summary param] 0 in init(string:relativeTo:) :  | semmle.label | [summary param] 0 in init(string:relativeTo:) :  |
 | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | semmle.label | [summary param] 1 in init(string:relativeTo:) :  |
-| url.swift:9:8:9:16 | string :  | semmle.label | string :  |
-| url.swift:9:24:9:39 | relativeTo :  | semmle.label | relativeTo :  |
 | url.swift:43:2:46:55 | [summary param] 0 in dataTask(with:completionHandler:) :  | semmle.label | [summary param] 0 in dataTask(with:completionHandler:) :  |
-| url.swift:44:5:44:15 | url :  | semmle.label | url :  |
 | url.swift:57:16:57:23 | call to source() :  | semmle.label | call to source() :  |
 | url.swift:59:19:59:38 | call to init(string:) :  | semmle.label | call to init(string:) :  |
 | url.swift:59:31:59:31 | tainted :  | semmle.label | tainted :  |
@@ -265,45 +233,25 @@ nodes
 | url.swift:121:15:121:19 | ...! | semmle.label | ...! |
 subpaths
 | url.swift:59:31:59:31 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:59:19:59:38 | call to init(string:) :  |
-| url.swift:59:31:59:31 | tainted :  | url.swift:8:8:8:16 | string :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:59:19:59:38 | call to init(string:) :  |
 | url.swift:83:24:83:24 | tainted :  | url.swift:9:2:9:43 | [summary param] 0 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:83:12:83:48 | call to init(string:relativeTo:) :  |
-| url.swift:83:24:83:24 | tainted :  | url.swift:9:8:9:16 | string :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:83:12:83:48 | call to init(string:relativeTo:) :  |
 | url.swift:86:43:86:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:86:12:86:53 | call to init(string:relativeTo:) :  |
-| url.swift:86:43:86:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:86:12:86:53 | call to init(string:relativeTo:) :  |
 | url.swift:87:43:87:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:87:12:87:53 | call to init(string:relativeTo:) :  |
-| url.swift:87:43:87:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:87:12:87:53 | call to init(string:relativeTo:) :  |
 | url.swift:88:46:88:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:88:15:88:56 | call to init(string:relativeTo:) :  |
-| url.swift:88:46:88:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:88:15:88:56 | call to init(string:relativeTo:) :  |
 | url.swift:89:46:89:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:89:15:89:56 | call to init(string:relativeTo:) :  |
-| url.swift:89:46:89:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:89:15:89:56 | call to init(string:relativeTo:) :  |
 | url.swift:90:46:90:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:90:15:90:56 | call to init(string:relativeTo:) :  |
-| url.swift:90:46:90:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:90:15:90:56 | call to init(string:relativeTo:) :  |
 | url.swift:91:46:91:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:91:15:91:56 | call to init(string:relativeTo:) :  |
-| url.swift:91:46:91:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:91:15:91:56 | call to init(string:relativeTo:) :  |
 | url.swift:92:46:92:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:92:15:92:56 | call to init(string:relativeTo:) :  |
-| url.swift:92:46:92:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:92:15:92:56 | call to init(string:relativeTo:) :  |
 | url.swift:93:46:93:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:93:15:93:56 | call to init(string:relativeTo:) :  |
-| url.swift:93:46:93:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:93:15:93:56 | call to init(string:relativeTo:) :  |
 | url.swift:94:43:94:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:94:12:94:53 | call to init(string:relativeTo:) :  |
-| url.swift:94:43:94:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:94:12:94:53 | call to init(string:relativeTo:) :  |
 | url.swift:95:46:95:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:95:15:95:56 | call to init(string:relativeTo:) :  |
-| url.swift:95:46:95:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:95:15:95:56 | call to init(string:relativeTo:) :  |
 | url.swift:96:46:96:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:96:15:96:56 | call to init(string:relativeTo:) :  |
-| url.swift:96:46:96:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:96:15:96:56 | call to init(string:relativeTo:) :  |
 | url.swift:97:46:97:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:97:15:97:56 | call to init(string:relativeTo:) :  |
-| url.swift:97:46:97:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:97:15:97:56 | call to init(string:relativeTo:) :  |
 | url.swift:98:46:98:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:98:15:98:56 | call to init(string:relativeTo:) :  |
-| url.swift:98:46:98:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:98:15:98:56 | call to init(string:relativeTo:) :  |
 | url.swift:99:43:99:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:99:12:99:53 | call to init(string:relativeTo:) :  |
-| url.swift:99:43:99:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:99:12:99:53 | call to init(string:relativeTo:) :  |
 | url.swift:100:43:100:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:100:12:100:53 | call to init(string:relativeTo:) :  |
-| url.swift:100:43:100:43 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:100:12:100:53 | call to init(string:relativeTo:) :  |
 | url.swift:101:46:101:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:101:15:101:56 | call to init(string:relativeTo:) :  |
-| url.swift:101:46:101:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:101:15:101:56 | call to init(string:relativeTo:) :  |
 | url.swift:102:46:102:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:102:15:102:56 | call to init(string:relativeTo:) :  |
-| url.swift:102:46:102:46 | urlTainted :  | url.swift:9:24:9:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:102:15:102:56 | call to init(string:relativeTo:) :  |
 | url.swift:117:28:117:28 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:117:16:117:35 | call to init(string:) :  |
-| url.swift:117:28:117:28 | tainted :  | url.swift:8:8:8:16 | string :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:117:16:117:35 | call to init(string:) :  |
 #select
 | string.swift:7:13:7:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:7:13:7:13 | "..." | result |
 | string.swift:9:13:9:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:9:13:9:13 | "..." | result |

--- a/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.expected
+++ b/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.expected
@@ -1,8 +1,6 @@
 edges
 | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  |
-| UnsafeWebViewFetch.swift:10:8:10:16 | string :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  |
 | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  |
-| UnsafeWebViewFetch.swift:11:24:11:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | UnsafeWebViewFetch.swift:120:25:120:39 | call to getRemoteData() |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  |
@@ -26,12 +24,10 @@ edges
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:153:85:153:94 | ...! |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:154:86:154:95 | ...! |
 | UnsafeWebViewFetch.swift:131:30:131:30 | remoteString :  | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  |
-| UnsafeWebViewFetch.swift:131:30:131:30 | remoteString :  | UnsafeWebViewFetch.swift:10:8:10:16 | string :  |
 | UnsafeWebViewFetch.swift:131:30:131:30 | remoteString :  | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  |
 | UnsafeWebViewFetch.swift:132:19:132:61 | call to init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:140:47:140:57 | ...! |
 | UnsafeWebViewFetch.swift:132:19:132:61 | call to init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:141:48:141:58 | ...! |
 | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:24:11:39 | relativeTo :  |
 | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  | UnsafeWebViewFetch.swift:132:19:132:61 | call to init(string:relativeTo:) :  |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:168:25:168:25 | remoteString |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:171:25:171:51 | ... .+(_:_:) ... |
@@ -47,20 +43,16 @@ edges
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:200:90:200:99 | ...! |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:201:91:201:100 | ...! |
 | UnsafeWebViewFetch.swift:178:30:178:30 | remoteString :  | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  |
-| UnsafeWebViewFetch.swift:178:30:178:30 | remoteString :  | UnsafeWebViewFetch.swift:10:8:10:16 | string :  |
 | UnsafeWebViewFetch.swift:178:30:178:30 | remoteString :  | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  |
 | UnsafeWebViewFetch.swift:179:19:179:61 | call to init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:187:47:187:57 | ...! |
 | UnsafeWebViewFetch.swift:179:19:179:61 | call to init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:188:48:188:58 | ...! |
 | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  |
-| UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:24:11:39 | relativeTo :  |
 | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  | UnsafeWebViewFetch.swift:179:19:179:61 | call to init(string:relativeTo:) :  |
 | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:210:25:210:25 | htmlData |
 | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:211:25:211:25 | htmlData |
 nodes
 | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  | semmle.label | [summary param] 0 in init(string:) :  |
-| UnsafeWebViewFetch.swift:10:8:10:16 | string :  | semmle.label | string :  |
 | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  | semmle.label | [summary param] 1 in init(string:relativeTo:) :  |
-| UnsafeWebViewFetch.swift:11:24:11:39 | relativeTo :  | semmle.label | relativeTo :  |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | semmle.label | try ... :  |
 | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | semmle.label | call to init(contentsOf:) :  |
 | UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | semmle.label | try! ... |
@@ -111,18 +103,12 @@ nodes
 | UnsafeWebViewFetch.swift:210:25:210:25 | htmlData | semmle.label | htmlData |
 | UnsafeWebViewFetch.swift:211:25:211:25 | htmlData | semmle.label | htmlData |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | semmle.label | [summary] to write: return (return) in init(string:) :  |
-| file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | semmle.label | [summary] to write: return (return) in init(string:) :  |
-| file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 subpaths
 | UnsafeWebViewFetch.swift:131:30:131:30 | remoteString :  | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  |
-| UnsafeWebViewFetch.swift:131:30:131:30 | remoteString :  | UnsafeWebViewFetch.swift:10:8:10:16 | string :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  |
 | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:132:19:132:61 | call to init(string:relativeTo:) :  |
-| UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:24:11:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:132:19:132:61 | call to init(string:relativeTo:) :  |
 | UnsafeWebViewFetch.swift:178:30:178:30 | remoteString :  | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  |
-| UnsafeWebViewFetch.swift:178:30:178:30 | remoteString :  | UnsafeWebViewFetch.swift:10:8:10:16 | string :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  |
 | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:179:19:179:61 | call to init(string:relativeTo:) :  |
-| UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:24:11:39 | relativeTo :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:179:19:179:61 | call to init(string:relativeTo:) :  |
 #select
 | UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | UnsafeWebViewFetch.swift:103:30:103:84 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:106:25:106:25 | data | UnsafeWebViewFetch.swift:105:18:105:72 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:106:25:106:25 | data | Tainted data is used in a WebView fetch without restricting the base URL. |


### PR DESCRIPTION
We had forgotten to generalize the code in a couple of places when we added flow through MaD summaries. This PR fixes these issues.

cc @atorralba this PR should make https://github.com/github/codeql/pull/10954 unnecessary.