### PR TITLE
Python: ESSA: Do not count refinements as definitions

### DIFF
--- a/python/ql/lib/semmle/python/essa/SsaCompute.qll
+++ b/python/ql/lib/semmle/python/essa/SsaCompute.qll
@@ -172,7 +172,7 @@ private module SsaComputeImpl {
 
   cached
   predicate variableDef(SsaSourceVariable v, ControlFlowNode n, BasicBlock b, int i) {
-    variableDefine(v, n, b, i) or variableRefine(v, n, b, i)
+    variableDefine(v, n, b, i)
   }
 
   /**

--- a/python/ql/test/library-tests/essa/ssa-compute/UseUse.ql
+++ b/python/ql/test/library-tests/essa/ssa-compute/UseUse.ql
@@ -1,0 +1,41 @@
+import python
+import semmle.python.essa.SsaCompute
+import TestUtilities.InlineExpectationsTest
+
+class UseTest extends InlineExpectationsTest {
+  UseTest() { this = "UseTest" }
+
+  override string getARelevantTag() { result in ["use-use", "def-use", "def"] }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(location.getFile().getRelativePath()) and
+    exists(string name | name in ["x", "y"] |
+      exists(NameNode nodeTo, Location prevLoc |
+        (
+          exists(NameNode nodeFrom | AdjacentUses::adjacentUseUse(nodeFrom, nodeTo) |
+            prevLoc = nodeFrom.getLocation() and
+            name = nodeFrom.getId() and
+            tag = "use-use"
+          )
+          or
+          exists(EssaVariable var | AdjacentUses::firstUse(var, nodeTo) |
+            prevLoc = var.getDefinition().getLocation() and
+            name = var.getName() and
+            tag = "def-use"
+          )
+        ) and
+        value = name + ":" + prevLoc.getStartLine() and
+        location = nodeTo.getLocation() and
+        element = nodeTo.toString()
+      )
+      or
+      exists(EssaVariable var | AdjacentUses::firstUse(var, _) |
+        value = var.getName() and
+        location = var.getDefinition().getLocation() and
+        element = var.getName() and
+        name = var.getName() and
+        tag = "def"
+      )
+    )
+  }
+}

--- a/python/ql/test/library-tests/essa/ssa-compute/test.py
+++ b/python/ql/test/library-tests/essa/ssa-compute/test.py
@@ -1,0 +1,20 @@
+class X(object):
+    def foo(self, *args):
+        print("X.foo", args)
+
+
+def func(cond=True):
+    x = X() # $ def=x
+
+    print(x) # $ def-use=x:7
+
+    y = x # $ def=y use-use=x:9
+    print(y) # $ def-use=y:11
+
+    x.foo() # $ use-use=x:11
+
+    x.foo(1 if cond else 0) # $ use-use=x:14
+    x.foo() # $ MISSING: use-use=x:16
+    print(x) # $ use-use=x:17
+
+func()

--- a/python/ql/test/library-tests/essa/ssa-compute/test.py
+++ b/python/ql/test/library-tests/essa/ssa-compute/test.py
@@ -14,7 +14,7 @@ def func(cond=True):
     x.foo() # $ use-use=x:11
 
     x.foo(1 if cond else 0) # $ use-use=x:14
-    x.foo() # $ MISSING: use-use=x:16
+    x.foo() # $ use-use=x:16
     print(x) # $ use-use=x:17
 
 func()


### PR DESCRIPTION
I discovered this problem when working on the new call graph, where I noticed that there was no use-use flow between the `x` in `x.foo` to the `x` in `x.bar` :confused:

```py
def func(cond=True):
    x = X()
    x.foo(1 if cond else 0) # $ pt,tt=X.foo
    x.bar() # $ pt=X.bar MISSING: tt=X.bar
```

The way the basic blocks are constructed, are as follows:

1. From the beginning of the function to part of the `x.foo` call. What is included is the attribute lookup on `x` AND the evaluation of `cond`.
2. The `1` part of the inline if-then-else expression
3. The `0` part of the inline if-then-else expression
4. The overall result of the if-then-else expression, the actual call to `x.foo`, and the rest of the function (including `x.bar`)

The reason we don't have use-use flow is due to the fact that we (wrongly) think that the first use/def of `x` in BasicBlock (4) is a definition, because the attribute part of `x.foo()` is in BasicBlock (1), and a method call is considered a definition of `x`, because it is a refinement. The more detailed explanation is:

> we (wrongly) don't consider `x` [live](https://github.com/github/codeql/blob/b2cc91369a66c4a7afe11355b10a8662e456ef43/python/ql/lib/semmle/python/essa/SsaCompute.qll#L289) at the exit of BasicBlock (1). We don't do so because [`defRank`](https://github.com/github/codeql/blob/b2cc91369a66c4a7afe11355b10a8662e456ef43/python/ql/lib/semmle/python/essa/SsaCompute.qll#L194) holds in BasicBlock (4) for the `x.foo()` call with `rankix=1` because `variableDef` is [defined](https://github.com/github/codeql/blob/b2cc91369a66c4a7afe11355b10a8662e456ef43/python/ql/lib/semmle/python/essa/SsaCompute.qll#L175) to also contain variable refinement nodes, and method calls are [considered a refinement](https://github.com/github/codeql/blob/bb210f4172364889a05aa5633718b7f0bf8136fa/python/ql/lib/semmle/python/essa/Definitions.qll#122), [specifically](https://github.com/github/codeql/blob/ff73dbc35c0c4ac556cf55c1534023f7e53817b7/python/ql/lib/semmle/python/essa/SsaDefinitions.qll#L13) the `use` part is the attribute, and the `def` part is the call.

I'll admit that I haven't figured out why refinements were included in the first place (there might be a good reason that I'm overlooking, meaning this is a bad approach to solve the problem). The QLDocs and code comments (or lack thereof) doesn't really suggest anything to me, but maybe you know something about this @tausbn?

This PR makes a broad change so refinements are not considered a definition in ESSA -- it's a draft PR to see how big of an impact this has.

---

I also want to question whether the [`def = this.getScopeEntryDefinition()`](https://github.com/github/codeql/blob/bb210f4172364889a05aa5633718b7f0bf8136fa/python/ql/lib/semmle/python/essa/Definitions.qll#L58) part of `hasDefiningNode` is valid. In the example above, we treat the `Entry node for Function func` as the first defining node for `x`. Is that reasonable?
