### PR TITLE
Swift: Fix UrlRemoteFlowSource name clash

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -3,7 +3,7 @@ private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.ExternalFlow
 private import codeql.swift.dataflow.FlowSources
 
-private class UrlRemoteFlowSource extends SourceModelCsv {
+private class CustomUrlRemoteFlowSource extends SourceModelCsv {
   override predicate row(string row) {
     row =
       [

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -3,6 +3,10 @@ private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.ExternalFlow
 private import codeql.swift.dataflow.FlowSources
 
+/**
+ * A model for custom URL remote flow sources. iOS apps can receive arbitrary
+ * URLs from other apps in these functions if they register a custom URL scheme.
+ */
 private class CustomUrlRemoteFlowSource extends SourceModelCsv {
   override predicate row(string row) {
     row =


### PR DESCRIPTION
Fix `UrlRemoteFlowSource` name clash (with [`UrlRemoteFlowSource` in `Url.qll`](https://github.com/github/codeql/blob/main/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll#LL21)) and add qldoc comment.  I'm not aware of any consequences the name clash was having, but it can't be a good thing.