### PR TITLE
Kotlin: Ignore tags when comparing versions

### DIFF
--- a/java/kotlin-extractor/kotlin_plugin_versions.py
+++ b/java/kotlin-extractor/kotlin_plugin_versions.py
@@ -49,7 +49,7 @@ def get_single_version(fakeVersionOutput = None):
     matching_minor_versions.sort(reverse = True)
 
     for version in matching_minor_versions:
-        if version <= current_version:
+        if version[0:3] <= current_version[0:3]:
             return version_tuple_to_string(version)
 
     return version_tuple_to_string(matching_minor_versions[-1])


### PR DESCRIPTION
We thought that 1.7.20-Beta > 1.7.20, and so tried to use 1.7.0's extractor with 1.7.20.