### PR TITLE
JS: Do not track returned values out of the enclosing function

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
@@ -1197,7 +1197,8 @@ private predicate reachesReturn(
   exists(DataFlow::Node mid, PathSummary oldSummary, PathSummary newSummary |
     flowStep(read, cfg, mid, oldSummary) and
     reachesReturn(f, mid, cfg, newSummary) and
-    summary = oldSummary.append(newSummary)
+    summary = oldSummary.append(newSummary) and
+    pragma[only_bind_out](summary).isLevel()
   )
 }
 


### PR DESCRIPTION
`reachesReturn` would in some cases track the returned value out to call sites, which doesn't lead anywhere. It could also track into callees via return edges, but that's not useful either, since summaries take care of flow through callees.

This fixes a performance issue raised by https://github.com/github/codeql/issues/10937 (but it's possible there are more underlying issues to be fixed)

[Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/reaches-return-__default__code-scanning__1/reports) looks neutral