### PR TITLE
JS: remove some FPs in `js/password-in-configuration-file`

### DIFF
--- a/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
+++ b/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
@@ -27,9 +27,9 @@ where
     not val.regexpMatch("\\$.*|%.*%") and
     not PasswordHeuristics::isDummyPassword(val)
     or
-    key.toLowerCase() != "readme" and
-    // look for `password=...`, but exclude `password=;`, `password="$(...)"`,
+    not key.toLowerCase() = ["readme", "run"] and
+    // look for `password=...`, but exclude `password=;`, `password="$(...)"`, `password=foo()`
     // `password=%s` and `password==`
-    pwd = val.regexpCapture("(?is).*password\\s*=\\s*(?!;|\"?[$`]|%s|=)(\\S+).*", 1)
+    pwd = val.regexpCapture("(?is).*password\\s*=\\s*(?!;|\"?[$`]|%s|=|\\w+\\(.+\\))(\\S+).*", 1)
   )
 select valElement.(FirstLineOf), "Hard-coded password '" + pwd + "' in configuration file."

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst.yml
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst.yml
@@ -5,3 +5,8 @@ steps:
 username: <%= ENV['USERNAME'] %>
 password: <%= ENV['PASSWORD'] %>
 password: change_me
+query:
+- run : |
+    printf("This is some scripting")
+    password = os.env['PASSWORD']
+password: foo("blab")


### PR DESCRIPTION
From some FP reports shared on Slack. 

[Evaluation was uneventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-10988-0-javascript/reports).  