### PR TITLE
Swift: Add MethodDecl.hasQualifiedName

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/decl/AbstractFunctionDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/AbstractFunctionDecl.qll
@@ -2,4 +2,9 @@ private import codeql.swift.generated.decl.AbstractFunctionDecl
 
 class AbstractFunctionDecl extends AbstractFunctionDeclBase {
   override string toString() { result = this.getName() }
+
+  /**
+   * Holds if this function is called `funcName`.
+   */
+  predicate hasName(string funcName) { this.getName() = funcName }
 }

--- a/swift/ql/lib/codeql/swift/elements/decl/MethodDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/MethodDecl.qll
@@ -26,7 +26,8 @@ class MethodDecl extends AbstractFunctionDecl {
    * Holds if this function is called `funcName` and its a member of a
    * class, struct, extension, enum or protocol call `typeName`.
    */
-  cached predicate hasQualifiedName(string typeName, string funcName) {
+  cached
+  predicate hasQualifiedName(string typeName, string funcName) {
     this.getName() = funcName and
     (
       exists(NominalTypeDecl c |

--- a/swift/ql/lib/codeql/swift/elements/decl/MethodDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/MethodDecl.qll
@@ -26,7 +26,7 @@ class MethodDecl extends AbstractFunctionDecl {
    * Holds if this function is called `funcName` and its a member of a
    * class, struct, extension, enum or protocol call `typeName`.
    */
-  predicate hasQualifiedName(string typeName, string funcName) {
+  cached predicate hasQualifiedName(string typeName, string funcName) {
     this.getName() = funcName and
     (
       exists(NominalTypeDecl c |

--- a/swift/ql/lib/codeql/swift/elements/decl/MethodDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/MethodDecl.qll
@@ -21,4 +21,33 @@ class MethodDecl extends AbstractFunctionDecl {
     or
     this = getAMember(any(ProtocolDecl c))
   }
+
+  /**
+   * Holds if this function is called `funcName` and its a member of a
+   * class, struct, extension, enum or protocol call `typeName`.
+   */
+  predicate hasQualifiedName(string typeName, string funcName) {
+    this.getName() = funcName and
+    (
+      exists(NominalTypeDecl c |
+        c.getFullName() = typeName and
+        c.getAMember() = this
+      )
+      or
+      exists(ExtensionDecl e |
+        e.getExtendedTypeDecl().getFullName() = typeName and
+        e.getAMember() = this
+      )
+    )
+  }
+
+  /**
+   * Holds if this function is called `funcName` and its a member of a
+   * class, struct, extension, enum or protocol call `typeName` in a moduile
+   * called `moduleName`.
+   */
+  predicate hasQualifiedName(string moduleName, string typeName, string funcName) {
+    this.hasQualifiedName(typeName, funcName) and
+    this.getModule().getFullName() = moduleName
+  }
 }

--- a/swift/ql/lib/codeql/swift/elements/decl/MethodDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/MethodDecl.qll
@@ -43,7 +43,7 @@ class MethodDecl extends AbstractFunctionDecl {
 
   /**
    * Holds if this function is called `funcName` and its a member of a
-   * class, struct, extension, enum or protocol call `typeName` in a moduile
+   * class, struct, extension, enum or protocol call `typeName` in a module
    * called `moduleName`.
    */
   predicate hasQualifiedName(string moduleName, string typeName, string funcName) {

--- a/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
@@ -26,7 +26,7 @@ class TypeDecl extends TypeDeclBase {
    * The name and full name of `A` is `A`. The name of `B` is `B`, but the
    * full name of `B` is `A.B`.
    */
-  string getFullName() {
+  cached string getFullName() {
     not this.getEnclosingDecl() instanceof TypeDecl and
     result = this.getName()
     or

--- a/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
@@ -26,7 +26,8 @@ class TypeDecl extends TypeDeclBase {
    * The name and full name of `A` is `A`. The name of `B` is `B`, but the
    * full name of `B` is `A.B`.
    */
-  cached string getFullName() {
+  cached
+  string getFullName() {
     not this.getEnclosingDecl() instanceof TypeDecl and
     result = this.getName()
     or

--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
@@ -27,32 +27,29 @@ class Sink extends DataFlow::Node {
 
   Sink() {
     exists(
-      AbstractFunctionDecl funcDecl, CallExpr call, string funcName, string paramName, int arg,
-      int baseUrlArg
+      MethodDecl funcDecl, CallExpr call, string className, string funcName, string paramName,
+      int arg, int baseUrlArg
     |
       // arguments to method calls...
-      exists(string className, ClassOrStructDecl c |
-        (
-          // `loadHTMLString`
-          className = ["UIWebView", "WKWebView"] and
-          funcName = "loadHTMLString(_:baseURL:)" and
-          paramName = "string"
-          or
-          // `UIWebView.load`
-          className = "UIWebView" and
-          funcName = "load(_:mimeType:textEncodingName:baseURL:)" and
-          paramName = "data"
-          or
-          // `WKWebView.load`
-          className = "WKWebView" and
-          funcName = "load(_:mimeType:characterEncodingName:baseURL:)" and
-          paramName = "data"
-        ) and
-        c.getName() = className and
-        c.getAMember() = funcDecl and
-        call.getStaticTarget() = funcDecl
+      (
+        // `loadHTMLString`
+        className = ["UIWebView", "WKWebView"] and
+        funcName = "loadHTMLString(_:baseURL:)" and
+        paramName = "string"
+        or
+        // `UIWebView.load`
+        className = "UIWebView" and
+        funcName = "load(_:mimeType:textEncodingName:baseURL:)" and
+        paramName = "data"
+        or
+        // `WKWebView.load`
+        className = "WKWebView" and
+        funcName = "load(_:mimeType:characterEncodingName:baseURL:)" and
+        paramName = "data"
       ) and
+      call.getStaticTarget() = funcDecl and
       // match up `funcName`, `paramName`, `arg`, `node`.
+      funcDecl.hasQualifiedName(className, funcName) and
       funcDecl.getName() = funcName and
       funcDecl.getParam(pragma[only_bind_into](arg)).getName() = paramName and
       call.getArgument(pragma[only_bind_into](arg)).getExpr() = this.asExpr() and

--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
@@ -50,7 +50,6 @@ class Sink extends DataFlow::Node {
       call.getStaticTarget() = funcDecl and
       // match up `funcName`, `paramName`, `arg`, `node`.
       funcDecl.hasQualifiedName(className, funcName) and
-      funcDecl.getName() = funcName and
       funcDecl.getParam(pragma[only_bind_into](arg)).getName() = paramName and
       call.getArgument(pragma[only_bind_into](arg)).getExpr() = this.asExpr() and
       // match up `baseURLArg`

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.expected
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.expected
@@ -1,0 +1,8 @@
+| abstractfunctiondecl.swift:2:1:2:15 | func1() | getName:func1() |
+| abstractfunctiondecl.swift:5:2:5:16 | func2() | MethodDecl, getName:func2(), hasQualifiedName(2):Class1.func2(), hasQualifiedName(3):abstractfunctiondecl.Class1.func2() |
+| abstractfunctiondecl.swift:8:3:8:17 | func3() | MethodDecl, getName:func3(), hasQualifiedName(2):Class1.Class2.func3(), hasQualifiedName(3):abstractfunctiondecl.Class1.Class2.func3() |
+| abstractfunctiondecl.swift:13:2:13:13 | func4() | MethodDecl, getName:func4(), hasQualifiedName(2):Protocol1.func4(), hasQualifiedName(3):abstractfunctiondecl.Protocol1.func4() |
+| abstractfunctiondecl.swift:17:2:17:16 | func4() | MethodDecl, getName:func4(), hasQualifiedName(2):Class3.func4(), hasQualifiedName(3):abstractfunctiondecl.Class3.func4() |
+| abstractfunctiondecl.swift:21:2:21:16 | func5() | MethodDecl, getName:func5(), hasQualifiedName(2):Class3.func5(), hasQualifiedName(3):abstractfunctiondecl.Class3.func5() |
+| abstractfunctiondecl.swift:25:2:25:16 | func6() | MethodDecl, getName:func6(), hasQualifiedName(2):Struct1.func6(), hasQualifiedName(3):abstractfunctiondecl.Struct1.func6() |
+| abstractfunctiondecl.swift:31:2:31:16 | func7() | MethodDecl, getName:func7(), hasQualifiedName(2):Enum1.func7(), hasQualifiedName(3):abstractfunctiondecl.Enum1.func7() |

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.expected
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.expected
@@ -1,8 +1,8 @@
-| abstractfunctiondecl.swift:2:1:2:15 | func1() | getName:func1() |
-| abstractfunctiondecl.swift:5:2:5:16 | func2() | MethodDecl, getName:func2(), hasQualifiedName(2):Class1.func2(), hasQualifiedName(3):abstractfunctiondecl.Class1.func2() |
-| abstractfunctiondecl.swift:8:3:8:17 | func3() | MethodDecl, getName:func3(), hasQualifiedName(2):Class1.Class2.func3(), hasQualifiedName(3):abstractfunctiondecl.Class1.Class2.func3() |
-| abstractfunctiondecl.swift:13:2:13:13 | func4() | MethodDecl, getName:func4(), hasQualifiedName(2):Protocol1.func4(), hasQualifiedName(3):abstractfunctiondecl.Protocol1.func4() |
-| abstractfunctiondecl.swift:17:2:17:16 | func4() | MethodDecl, getName:func4(), hasQualifiedName(2):Class3.func4(), hasQualifiedName(3):abstractfunctiondecl.Class3.func4() |
-| abstractfunctiondecl.swift:21:2:21:16 | func5() | MethodDecl, getName:func5(), hasQualifiedName(2):Class3.func5(), hasQualifiedName(3):abstractfunctiondecl.Class3.func5() |
-| abstractfunctiondecl.swift:25:2:25:16 | func6() | MethodDecl, getName:func6(), hasQualifiedName(2):Struct1.func6(), hasQualifiedName(3):abstractfunctiondecl.Struct1.func6() |
-| abstractfunctiondecl.swift:31:2:31:16 | func7() | MethodDecl, getName:func7(), hasQualifiedName(2):Enum1.func7(), hasQualifiedName(3):abstractfunctiondecl.Enum1.func7() |
+| abstractfunctiondecl.swift:2:1:2:15 | func1() | getName:func1(), hasName:func1() |
+| abstractfunctiondecl.swift:5:2:5:16 | func2() | MethodDecl, getName:func2(), hasName:func2(), hasQualifiedName(2):Class1.func2(), hasQualifiedName(3):abstractfunctiondecl.Class1.func2() |
+| abstractfunctiondecl.swift:8:3:8:17 | func3() | MethodDecl, getName:func3(), hasName:func3(), hasQualifiedName(2):Class1.Class2.func3(), hasQualifiedName(3):abstractfunctiondecl.Class1.Class2.func3() |
+| abstractfunctiondecl.swift:13:2:13:13 | func4() | MethodDecl, getName:func4(), hasName:func4(), hasQualifiedName(2):Protocol1.func4(), hasQualifiedName(3):abstractfunctiondecl.Protocol1.func4() |
+| abstractfunctiondecl.swift:17:2:17:16 | func4() | MethodDecl, getName:func4(), hasName:func4(), hasQualifiedName(2):Class3.func4(), hasQualifiedName(3):abstractfunctiondecl.Class3.func4() |
+| abstractfunctiondecl.swift:21:2:21:16 | func5() | MethodDecl, getName:func5(), hasName:func5(), hasQualifiedName(2):Class3.func5(), hasQualifiedName(3):abstractfunctiondecl.Class3.func5() |
+| abstractfunctiondecl.swift:25:2:25:16 | func6() | MethodDecl, getName:func6(), hasName:func6(), hasQualifiedName(2):Struct1.func6(), hasQualifiedName(3):abstractfunctiondecl.Struct1.func6() |
+| abstractfunctiondecl.swift:31:2:31:16 | func7() | MethodDecl, getName:func7(), hasName:func7(), hasQualifiedName(2):Enum1.func7(), hasQualifiedName(3):abstractfunctiondecl.Enum1.func7() |

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.ql
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.ql
@@ -1,0 +1,25 @@
+import swift
+
+string describe(AbstractFunctionDecl f) {
+  result = "getName:" + f.getName()
+  or
+  (
+    result = "MethodDecl" and f instanceof MethodDecl
+  )
+  or
+  exists(string a, string b |
+    f.(MethodDecl).hasQualifiedName(a, b) and
+    result = "hasQualifiedName(2):" + a + "." + b
+  )
+  or
+  exists(string a, string b, string c |
+    f.(MethodDecl).hasQualifiedName(a, b, c) and
+    result = "hasQualifiedName(3):" + a + "." + b + "." + c
+  )
+}
+
+from AbstractFunctionDecl f
+where
+  not f.getFile() instanceof UnknownFile and
+  not f.getName().matches("%init%")
+select f, concat(describe(f), ", ")

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.ql
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.ql
@@ -2,14 +2,13 @@ import swift
 
 string describe(AbstractFunctionDecl f) {
   result = "getName:" + f.getName()
-  or exists(string a |
+  or
+  exists(string a |
     f.hasName(a) and
     result = "hasName:" + a
   )
   or
-  (
-    result = "MethodDecl" and f instanceof MethodDecl
-  )
+  result = "MethodDecl" and f instanceof MethodDecl
   or
   exists(string a, string b |
     f.(MethodDecl).hasQualifiedName(a, b) and

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.ql
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.ql
@@ -2,6 +2,10 @@ import swift
 
 string describe(AbstractFunctionDecl f) {
   result = "getName:" + f.getName()
+  or exists(string a |
+    f.hasName(a) and
+    result = "hasName:" + a
+  )
   or
   (
     result = "MethodDecl" and f instanceof MethodDecl

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.swift
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.swift
@@ -1,0 +1,32 @@
+
+func func1() {}
+
+class Class1 {
+	func func2() {}
+
+	class Class2 {
+		func func3() {}
+	}
+}
+
+protocol Protocol1 {
+	func func4()
+}
+
+class Class3: Class1, Protocol1 {
+	func func4() {}
+}
+
+extension Class3 {
+	func func5() {}
+}
+
+struct Struct1 {
+	func func6() {}
+}
+
+enum Enum1 {
+	case case1
+	case case2
+	func func7() {}
+}


### PR DESCRIPTION
Add `MethodDecl.hasQualifiedName` helper predicates (two variants) plus `AbstractFunctionDecl.hasName` (not so useful but feels like its missing).

There's a test to prove we do the right thing in some tricky cases like nested classes, protocols and extensions.  I have only _used_ the new predicates in one query so far (as a proof of concept), but I expect it to be useful in many more places and I intend to follow up with a PR updating existing queries.