### PR TITLE
Go: Extract locations of successfully extracted files

### DIFF
--- a/go/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
+++ b/go/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
@@ -9,5 +9,6 @@
 import go
 
 from File f
-where not exists(Error e | e.getFile() = f)
-select f.getRelativePath()
+where not exists(Error e | e.getFile() = f) and
+  exists(f.getRelativePath())
+select f, ""

--- a/go/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
+++ b/go/ql/src/Diagnostics/SuccessfullyExtractedFiles.ql
@@ -9,6 +9,7 @@
 import go
 
 from File f
-where not exists(Error e | e.getFile() = f) and
+where
+  not exists(Error e | e.getFile() = f) and
   exists(f.getRelativePath())
 select f, ""

--- a/go/ql/test/query-tests/Diagnostics/SuccessfullyExtractedFiles.expected
+++ b/go/ql/test/query-tests/Diagnostics/SuccessfullyExtractedFiles.expected
@@ -1,1 +1,1 @@
-| query-tests/Diagnostics/util.go |
+| util.go:0:0:0:0 | util.go |  |


### PR DESCRIPTION
Switch the successfully extracted files query to the `location, message` results format so that we get rich location information when exporting the results of this query to SARIF.  Previously the query used the `message` results format, which meant the interpreted results lacked a location.