### PR TITLE
Python: Add failing ESSA use-use test

### DIFF
--- a/python/ql/test/library-tests/essa/ssa-compute/UseUse.ql
+++ b/python/ql/test/library-tests/essa/ssa-compute/UseUse.ql
@@ -1,0 +1,41 @@
+import python
+import semmle.python.essa.SsaCompute
+import TestUtilities.InlineExpectationsTest
+
+class UseTest extends InlineExpectationsTest {
+  UseTest() { this = "UseTest" }
+
+  override string getARelevantTag() { result in ["use-use", "def-use", "def"] }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(location.getFile().getRelativePath()) and
+    exists(string name | name in ["x", "y"] |
+      exists(NameNode nodeTo, Location prevLoc |
+        (
+          exists(NameNode nodeFrom | AdjacentUses::adjacentUseUse(nodeFrom, nodeTo) |
+            prevLoc = nodeFrom.getLocation() and
+            name = nodeFrom.getId() and
+            tag = "use-use"
+          )
+          or
+          exists(EssaVariable var | AdjacentUses::firstUse(var, nodeTo) |
+            prevLoc = var.getDefinition().getLocation() and
+            name = var.getName() and
+            tag = "def-use"
+          )
+        ) and
+        value = name + ":" + prevLoc.getStartLine() and
+        location = nodeTo.getLocation() and
+        element = nodeTo.toString()
+      )
+      or
+      exists(EssaVariable var | AdjacentUses::firstUse(var, _) |
+        value = var.getName() and
+        location = var.getDefinition().getLocation() and
+        element = var.getName() and
+        name = var.getName() and
+        tag = "def"
+      )
+    )
+  }
+}

--- a/python/ql/test/library-tests/essa/ssa-compute/UseUse.ql
+++ b/python/ql/test/library-tests/essa/ssa-compute/UseUse.ql
@@ -19,7 +19,7 @@ class UseTest extends InlineExpectationsTest {
           )
           or
           exists(EssaVariable var | AdjacentUses::firstUse(var, nodeTo) |
-            prevLoc = var.getDefinition().getLocation() and
+            prevLoc = var.getLocation() and
             name = var.getName() and
             tag = "def-use"
           )
@@ -31,7 +31,7 @@ class UseTest extends InlineExpectationsTest {
       or
       exists(EssaVariable var | AdjacentUses::firstUse(var, _) |
         value = var.getName() and
-        location = var.getDefinition().getLocation() and
+        location = var.getLocation() and
         element = var.getName() and
         name = var.getName() and
         tag = "def"

--- a/python/ql/test/library-tests/essa/ssa-compute/test.py
+++ b/python/ql/test/library-tests/essa/ssa-compute/test.py
@@ -1,0 +1,20 @@
+class X(object):
+    def foo(self, *args):
+        print("X.foo", args)
+
+
+def func(cond=True):
+    x = X() # $ def=x
+
+    print(x) # $ def-use=x:7
+
+    y = x # $ def=y use-use=x:9
+    print(y) # $ def-use=y:11
+
+    x.foo() # $ use-use=x:11
+
+    x.foo(1 if cond else 0) # $ use-use=x:14
+    x.foo() # $ MISSING: use-use=x:16
+    print(x) # $ use-use=x:17
+
+func()


### PR DESCRIPTION
I initially created this as a dataflow test, but then realized it could just be an ESSA test. I couldn't find any existing ESSA tests though :| so created a new dir for it.

@yoff let me know if you think this should actually be under our dataflow tests, since the adjacent use-use was only added to serve the new dataflow lib.