### PR TITLE
Ruby: use flow-insensitive capture flow in flowsTo and type tracking

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -109,7 +109,7 @@ module LocalFlow {
    * Holds if `nodeFrom` is a parameter node, and `nodeTo` is a corresponding SSA node.
    */
   predicate localFlowSsaParamInput(Node nodeFrom, Node nodeTo) {
-    nodeTo = getParameterDefNode(nodeFrom.(ParameterNode).getParameter())
+    nodeTo = getParameterDefNode(nodeFrom.(ParameterNodeImpl).getParameter())
     or
     nodeTo = getSelfParameterDefNode(nodeFrom.(SelfParameterNode).getMethod())
   }
@@ -299,7 +299,7 @@ private module Cached {
   predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
     LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)
     or
-    defaultValueFlow(nodeTo.(ParameterNode).getParameter(), nodeFrom)
+    defaultValueFlow(nodeTo.(ParameterNodeImpl).getParameter(), nodeFrom)
     or
     LocalFlow::localFlowSsaParamInput(nodeFrom, nodeTo)
     or
@@ -316,7 +316,7 @@ private module Cached {
   predicate localFlowStepImpl(Node nodeFrom, Node nodeTo) {
     LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)
     or
-    defaultValueFlow(nodeTo.(ParameterNode).getParameter(), nodeFrom)
+    defaultValueFlow(nodeTo.(ParameterNodeImpl).getParameter(), nodeFrom)
     or
     LocalFlow::localFlowSsaParamInput(nodeFrom, nodeTo)
     or
@@ -366,7 +366,7 @@ private module Cached {
 
   cached
   predicate isLocalSourceNode(Node n) {
-    n instanceof ParameterNode
+    n instanceof TParameterNode
     or
     // Expressions that can't be reached from another entry definition or expression
     n instanceof ExprNode and

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -327,7 +327,12 @@ private module Cached {
     FlowSummaryImpl::Private::Steps::summaryThroughStepValue(nodeFrom, nodeTo, _)
   }
 
-  /** This is the local flow predicate that is used in type tracking. */
+  /**
+   * This is the local flow predicate that is used in type tracking.
+   *
+   * This needs to exclude `localFlowSsaParamInput` due to a performance trick
+   * in type tracking, where such steps are treated as call steps.
+   */
   cached
   predicate localFlowStepTypeTracker(Node nodeFrom, Node nodeTo) {
     LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -199,9 +199,11 @@ private predicate hasLocalSource(Node sink, Node source) {
   source = sink and
   source instanceof LocalSourceNode
   or
-  exists(Node mid |
-    hasLocalSource(mid, source) and
+  exists(Node mid | hasLocalSource(mid, source) |
     localFlowStepTypeTracker(mid, sink)
+    or
+    // Explicitly include the SSA param input step as type-tracking omits this step.
+    LocalFlow::localFlowSsaParamInput(mid, sink)
   )
 }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -144,7 +144,7 @@ class ExprNode extends Node, TExprNode {
  * The value of a parameter at function entry, viewed as a node in a data
  * flow graph.
  */
-class ParameterNode extends Node, TParameterNode instanceof ParameterNodeImpl {
+class ParameterNode extends LocalSourceNode, TParameterNode instanceof ParameterNodeImpl {
   /** Gets the parameter corresponding to this node, if any. */
   final Parameter getParameter() { result = super.getParameter() }
 }

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -1,5 +1,17 @@
 failures
 edges
+| captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
+| captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
+| captured_variables.rb:5:20:5:30 | call to source :  | captured_variables.rb:1:24:1:24 | x :  |
+| captured_variables.rb:5:20:5:30 | call to source :  | captured_variables.rb:1:24:1:24 | x :  |
+| captured_variables.rb:21:33:21:33 | x :  | captured_variables.rb:23:14:23:14 | x |
+| captured_variables.rb:21:33:21:33 | x :  | captured_variables.rb:23:14:23:14 | x |
+| captured_variables.rb:27:29:27:39 | call to source :  | captured_variables.rb:21:33:21:33 | x :  |
+| captured_variables.rb:27:29:27:39 | call to source :  | captured_variables.rb:21:33:21:33 | x :  |
+| captured_variables.rb:32:31:32:31 | x :  | captured_variables.rb:34:14:34:14 | x |
+| captured_variables.rb:32:31:32:31 | x :  | captured_variables.rb:34:14:34:14 | x |
+| captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:32:31:32:31 | x :  |
+| captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:32:31:32:31 | x :  |
 | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:18:11:18 | x :  |
 | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:18:11:18 | x :  |
 | instance_variables.rb:11:18:11:18 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  |
@@ -152,6 +164,24 @@ edges
 | instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:84:6:84:20 | call to get_field |
 | instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:84:6:84:20 | call to get_field |
 nodes
+| captured_variables.rb:1:24:1:24 | x :  | semmle.label | x :  |
+| captured_variables.rb:1:24:1:24 | x :  | semmle.label | x :  |
+| captured_variables.rb:2:20:2:20 | x | semmle.label | x |
+| captured_variables.rb:2:20:2:20 | x | semmle.label | x |
+| captured_variables.rb:5:20:5:30 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:5:20:5:30 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:21:33:21:33 | x :  | semmle.label | x :  |
+| captured_variables.rb:21:33:21:33 | x :  | semmle.label | x :  |
+| captured_variables.rb:23:14:23:14 | x | semmle.label | x |
+| captured_variables.rb:23:14:23:14 | x | semmle.label | x |
+| captured_variables.rb:27:29:27:39 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:27:29:27:39 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:32:31:32:31 | x :  | semmle.label | x :  |
+| captured_variables.rb:32:31:32:31 | x :  | semmle.label | x :  |
+| captured_variables.rb:34:14:34:14 | x | semmle.label | x |
+| captured_variables.rb:34:14:34:14 | x | semmle.label | x |
+| captured_variables.rb:38:27:38:37 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:38:27:38:37 | call to source :  | semmle.label | call to source :  |
 | instance_variables.rb:10:19:10:19 | x :  | semmle.label | x :  |
 | instance_variables.rb:10:19:10:19 | x :  | semmle.label | x :  |
 | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | semmle.label | [post] self [@field] :  |
@@ -335,6 +365,9 @@ subpaths
 | instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:84:6:84:20 | call to get_field |
 | instance_variables.rb:84:6:84:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:84:6:84:20 | call to get_field |
 #select
+| captured_variables.rb:2:20:2:20 | x | captured_variables.rb:5:20:5:30 | call to source :  | captured_variables.rb:2:20:2:20 | x | $@ | captured_variables.rb:5:20:5:30 | call to source :  | call to source :  |
+| captured_variables.rb:23:14:23:14 | x | captured_variables.rb:27:29:27:39 | call to source :  | captured_variables.rb:23:14:23:14 | x | $@ | captured_variables.rb:27:29:27:39 | call to source :  | call to source :  |
+| captured_variables.rb:34:14:34:14 | x | captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:34:14:34:14 | x | $@ | captured_variables.rb:38:27:38:37 | call to source :  | call to source :  |
 | instance_variables.rb:20:10:20:13 | @foo | instance_variables.rb:19:12:19:21 | call to taint :  | instance_variables.rb:20:10:20:13 | @foo | $@ | instance_variables.rb:19:12:19:21 | call to taint :  | call to taint :  |
 | instance_variables.rb:25:6:25:18 | call to get_field | instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:25:6:25:18 | call to get_field | $@ | instance_variables.rb:24:15:24:23 | call to taint :  | call to taint :  |
 | instance_variables.rb:29:6:29:18 | call to inc_field | instance_variables.rb:28:15:28:22 | call to taint :  | instance_variables.rb:29:6:29:18 | call to inc_field | $@ | instance_variables.rb:28:15:28:22 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -12,6 +12,36 @@ edges
 | captured_variables.rb:32:31:32:31 | x :  | captured_variables.rb:34:14:34:14 | x |
 | captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:32:31:32:31 | x :  |
 | captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:32:31:32:31 | x :  |
+| captured_variables.rb:41:5:41:26 | ... = ... :  | captured_variables.rb:43:9:43:16 | captured :  |
+| captured_variables.rb:41:5:41:26 | ... = ... :  | captured_variables.rb:43:9:43:16 | captured :  |
+| captured_variables.rb:41:16:41:26 | call to source :  | captured_variables.rb:41:5:41:26 | ... = ... :  |
+| captured_variables.rb:41:16:41:26 | call to source :  | captured_variables.rb:41:5:41:26 | ... = ... :  |
+| captured_variables.rb:43:9:43:16 | captured :  | captured_variables.rb:45:5:45:11 | call to call :  |
+| captured_variables.rb:43:9:43:16 | captured :  | captured_variables.rb:45:5:45:11 | call to call :  |
+| captured_variables.rb:45:5:45:11 | call to call :  | captured_variables.rb:47:6:47:13 | call to capture6 |
+| captured_variables.rb:45:5:45:11 | call to call :  | captured_variables.rb:47:6:47:13 | call to capture6 |
+| captured_variables.rb:49:14:49:14 | x :  | captured_variables.rb:50:5:50:16 | ... = ... :  |
+| captured_variables.rb:49:14:49:14 | x :  | captured_variables.rb:50:5:50:16 | ... = ... :  |
+| captured_variables.rb:50:5:50:16 | ... = ... :  | captured_variables.rb:52:9:52:16 | captured :  |
+| captured_variables.rb:50:5:50:16 | ... = ... :  | captured_variables.rb:52:9:52:16 | captured :  |
+| captured_variables.rb:52:9:52:16 | captured :  | captured_variables.rb:54:5:54:11 | call to call :  |
+| captured_variables.rb:52:9:52:16 | captured :  | captured_variables.rb:54:5:54:11 | call to call :  |
+| captured_variables.rb:54:5:54:11 | call to call :  | captured_variables.rb:56:6:56:20 | call to capture7 |
+| captured_variables.rb:54:5:54:11 | call to call :  | captured_variables.rb:56:6:56:20 | call to capture7 |
+| captured_variables.rb:54:5:54:11 | call to call :  | captured_variables.rb:57:6:57:25 | call to capture7 |
+| captured_variables.rb:54:5:54:11 | call to call :  | captured_variables.rb:57:6:57:25 | call to capture7 |
+| captured_variables.rb:57:15:57:25 | call to source :  | captured_variables.rb:49:14:49:14 | x :  |
+| captured_variables.rb:57:15:57:25 | call to source :  | captured_variables.rb:49:14:49:14 | x :  |
+| captured_variables.rb:59:14:59:14 | x :  | captured_variables.rb:62:9:62:20 | ... = ... :  |
+| captured_variables.rb:59:14:59:14 | x :  | captured_variables.rb:62:9:62:20 | ... = ... :  |
+| captured_variables.rb:62:9:62:20 | ... = ... :  | captured_variables.rb:65:5:65:12 | captured :  |
+| captured_variables.rb:62:9:62:20 | ... = ... :  | captured_variables.rb:65:5:65:12 | captured :  |
+| captured_variables.rb:65:5:65:12 | captured :  | captured_variables.rb:67:6:67:20 | call to capture8 |
+| captured_variables.rb:65:5:65:12 | captured :  | captured_variables.rb:67:6:67:20 | call to capture8 |
+| captured_variables.rb:65:5:65:12 | captured :  | captured_variables.rb:68:6:68:25 | call to capture8 |
+| captured_variables.rb:65:5:65:12 | captured :  | captured_variables.rb:68:6:68:25 | call to capture8 |
+| captured_variables.rb:68:15:68:25 | call to source :  | captured_variables.rb:59:14:59:14 | x :  |
+| captured_variables.rb:68:15:68:25 | call to source :  | captured_variables.rb:59:14:59:14 | x :  |
 | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:18:11:18 | x :  |
 | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:18:11:18 | x :  |
 | instance_variables.rb:11:18:11:18 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  |
@@ -182,6 +212,42 @@ nodes
 | captured_variables.rb:34:14:34:14 | x | semmle.label | x |
 | captured_variables.rb:38:27:38:37 | call to source :  | semmle.label | call to source :  |
 | captured_variables.rb:38:27:38:37 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:41:5:41:26 | ... = ... :  | semmle.label | ... = ... :  |
+| captured_variables.rb:41:5:41:26 | ... = ... :  | semmle.label | ... = ... :  |
+| captured_variables.rb:41:16:41:26 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:41:16:41:26 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:43:9:43:16 | captured :  | semmle.label | captured :  |
+| captured_variables.rb:43:9:43:16 | captured :  | semmle.label | captured :  |
+| captured_variables.rb:45:5:45:11 | call to call :  | semmle.label | call to call :  |
+| captured_variables.rb:45:5:45:11 | call to call :  | semmle.label | call to call :  |
+| captured_variables.rb:47:6:47:13 | call to capture6 | semmle.label | call to capture6 |
+| captured_variables.rb:47:6:47:13 | call to capture6 | semmle.label | call to capture6 |
+| captured_variables.rb:49:14:49:14 | x :  | semmle.label | x :  |
+| captured_variables.rb:49:14:49:14 | x :  | semmle.label | x :  |
+| captured_variables.rb:50:5:50:16 | ... = ... :  | semmle.label | ... = ... :  |
+| captured_variables.rb:50:5:50:16 | ... = ... :  | semmle.label | ... = ... :  |
+| captured_variables.rb:52:9:52:16 | captured :  | semmle.label | captured :  |
+| captured_variables.rb:52:9:52:16 | captured :  | semmle.label | captured :  |
+| captured_variables.rb:54:5:54:11 | call to call :  | semmle.label | call to call :  |
+| captured_variables.rb:54:5:54:11 | call to call :  | semmle.label | call to call :  |
+| captured_variables.rb:56:6:56:20 | call to capture7 | semmle.label | call to capture7 |
+| captured_variables.rb:56:6:56:20 | call to capture7 | semmle.label | call to capture7 |
+| captured_variables.rb:57:6:57:25 | call to capture7 | semmle.label | call to capture7 |
+| captured_variables.rb:57:6:57:25 | call to capture7 | semmle.label | call to capture7 |
+| captured_variables.rb:57:15:57:25 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:57:15:57:25 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:59:14:59:14 | x :  | semmle.label | x :  |
+| captured_variables.rb:59:14:59:14 | x :  | semmle.label | x :  |
+| captured_variables.rb:62:9:62:20 | ... = ... :  | semmle.label | ... = ... :  |
+| captured_variables.rb:62:9:62:20 | ... = ... :  | semmle.label | ... = ... :  |
+| captured_variables.rb:65:5:65:12 | captured :  | semmle.label | captured :  |
+| captured_variables.rb:65:5:65:12 | captured :  | semmle.label | captured :  |
+| captured_variables.rb:67:6:67:20 | call to capture8 | semmle.label | call to capture8 |
+| captured_variables.rb:67:6:67:20 | call to capture8 | semmle.label | call to capture8 |
+| captured_variables.rb:68:6:68:25 | call to capture8 | semmle.label | call to capture8 |
+| captured_variables.rb:68:6:68:25 | call to capture8 | semmle.label | call to capture8 |
+| captured_variables.rb:68:15:68:25 | call to source :  | semmle.label | call to source :  |
+| captured_variables.rb:68:15:68:25 | call to source :  | semmle.label | call to source :  |
 | instance_variables.rb:10:19:10:19 | x :  | semmle.label | x :  |
 | instance_variables.rb:10:19:10:19 | x :  | semmle.label | x :  |
 | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | semmle.label | [post] self [@field] :  |
@@ -368,6 +434,11 @@ subpaths
 | captured_variables.rb:2:20:2:20 | x | captured_variables.rb:5:20:5:30 | call to source :  | captured_variables.rb:2:20:2:20 | x | $@ | captured_variables.rb:5:20:5:30 | call to source :  | call to source :  |
 | captured_variables.rb:23:14:23:14 | x | captured_variables.rb:27:29:27:39 | call to source :  | captured_variables.rb:23:14:23:14 | x | $@ | captured_variables.rb:27:29:27:39 | call to source :  | call to source :  |
 | captured_variables.rb:34:14:34:14 | x | captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:34:14:34:14 | x | $@ | captured_variables.rb:38:27:38:37 | call to source :  | call to source :  |
+| captured_variables.rb:47:6:47:13 | call to capture6 | captured_variables.rb:41:16:41:26 | call to source :  | captured_variables.rb:47:6:47:13 | call to capture6 | $@ | captured_variables.rb:41:16:41:26 | call to source :  | call to source :  |
+| captured_variables.rb:56:6:56:20 | call to capture7 | captured_variables.rb:57:15:57:25 | call to source :  | captured_variables.rb:56:6:56:20 | call to capture7 | $@ | captured_variables.rb:57:15:57:25 | call to source :  | call to source :  |
+| captured_variables.rb:57:6:57:25 | call to capture7 | captured_variables.rb:57:15:57:25 | call to source :  | captured_variables.rb:57:6:57:25 | call to capture7 | $@ | captured_variables.rb:57:15:57:25 | call to source :  | call to source :  |
+| captured_variables.rb:67:6:67:20 | call to capture8 | captured_variables.rb:68:15:68:25 | call to source :  | captured_variables.rb:67:6:67:20 | call to capture8 | $@ | captured_variables.rb:68:15:68:25 | call to source :  | call to source :  |
+| captured_variables.rb:68:6:68:25 | call to capture8 | captured_variables.rb:68:15:68:25 | call to source :  | captured_variables.rb:68:6:68:25 | call to capture8 | $@ | captured_variables.rb:68:15:68:25 | call to source :  | call to source :  |
 | instance_variables.rb:20:10:20:13 | @foo | instance_variables.rb:19:12:19:21 | call to taint :  | instance_variables.rb:20:10:20:13 | @foo | $@ | instance_variables.rb:19:12:19:21 | call to taint :  | call to taint :  |
 | instance_variables.rb:25:6:25:18 | call to get_field | instance_variables.rb:24:15:24:23 | call to taint :  | instance_variables.rb:25:6:25:18 | call to get_field | $@ | instance_variables.rb:24:15:24:23 | call to taint :  | call to taint :  |
 | instance_variables.rb:29:6:29:18 | call to inc_field | instance_variables.rb:28:15:28:22 | call to taint :  | instance_variables.rb:29:6:29:18 | call to inc_field | $@ | instance_variables.rb:28:15:28:22 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,0 +1,15 @@
+| instance_variables.rb:20:16:20:33 | # $ hasValueFlow=7 | Missing result:hasValueFlow=7 |
+| instance_variables.rb:25:21:25:39 | # $ hasValueFlow=42 | Missing result:hasValueFlow=42 |
+| instance_variables.rb:37:22:37:40 | # $ hasValueFlow=21 | Missing result:hasValueFlow=21 |
+| instance_variables.rb:41:18:41:36 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
+| instance_variables.rb:49:22:49:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
+| instance_variables.rb:53:22:53:40 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
+| instance_variables.rb:54:22:54:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
+| instance_variables.rb:55:22:55:40 | # $ hasValueFlow=25 | Missing result:hasValueFlow=25 |
+| instance_variables.rb:60:22:60:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
+| instance_variables.rb:61:22:61:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
+| instance_variables.rb:66:22:66:40 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
+| instance_variables.rb:67:23:67:41 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
+| instance_variables.rb:75:23:75:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:79:23:79:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:84:23:84:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,3 +1,5 @@
+| captured_variables.rb:9:14:9:14 | x | Fixed missing result:hasValueFlow=1.2 |
+| captured_variables.rb:16:14:16:14 | x | Fixed missing result:hasValueFlow=1.3 |
 | instance_variables.rb:20:16:20:33 | # $ hasValueFlow=7 | Missing result:hasValueFlow=7 |
 | instance_variables.rb:25:21:25:39 | # $ hasValueFlow=42 | Missing result:hasValueFlow=42 |
 | instance_variables.rb:37:22:37:40 | # $ hasValueFlow=21 | Missing result:hasValueFlow=21 |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,5 +1,8 @@
 | captured_variables.rb:9:14:9:14 | x | Fixed missing result:hasValueFlow=1.2 |
 | captured_variables.rb:16:14:16:14 | x | Fixed missing result:hasValueFlow=1.3 |
+| captured_variables.rb:47:16:47:35 | # $ hasValueFlow=1.6 | Missing result:hasValueFlow=1.6 |
+| captured_variables.rb:56:23:56:52 | # $ SPURIOUS: hasValueFlow=1.7 | Fixed spurious result:hasValueFlow=1.7 |
+| captured_variables.rb:67:23:67:52 | # $ SPURIOUS: hasValueFlow=1.8 | Fixed spurious result:hasValueFlow=1.8 |
 | instance_variables.rb:20:16:20:33 | # $ hasValueFlow=7 | Missing result:hasValueFlow=7 |
 | instance_variables.rb:25:21:25:39 | # $ hasValueFlow=42 | Missing result:hasValueFlow=42 |
 | instance_variables.rb:37:22:37:40 | # $ hasValueFlow=21 | Missing result:hasValueFlow=21 |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.ql
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.ql
@@ -1,0 +1,1 @@
+import TestUtilities.InlineTypeTrackingFlowTest

--- a/ruby/ql/test/library-tests/dataflow/global/captured_variables.rb
+++ b/ruby/ql/test/library-tests/dataflow/global/captured_variables.rb
@@ -1,0 +1,38 @@
+def capture_local_call x
+    fn = -> { sink(x) } # $ hasValueFlow=1.1
+    fn.call
+end
+capture_local_call source(1.1)
+
+def capture_escape_return1 x
+    -> {
+        sink(x) # $ MISSING: hasValueFlow=1.2
+    }
+end
+(capture_escape_return1 source(1.2)).call
+
+def capture_escape_return2 x
+    -> {
+        sink(x) # $ MISSING: hasValueFlow=1.3
+    }
+end
+Something.unknownMethod(capture_escape_return2 source(1.3))
+
+def capture_escape_unknown_call x
+    fn = -> {
+        sink(x) # $ hasValueFlow=1.4
+    }
+    Something.unknownMethod(fn)
+end
+capture_escape_unknown_call source(1.4)
+
+def call_it fn
+    fn.call
+end
+def capture_escape_known_call x
+    fn = -> {
+        sink(x) # $ hasValueFlow=1.5
+    }
+    call_it fn
+end
+capture_escape_known_call source(1.5)

--- a/ruby/ql/test/library-tests/dataflow/global/captured_variables.rb
+++ b/ruby/ql/test/library-tests/dataflow/global/captured_variables.rb
@@ -36,3 +36,33 @@ def capture_escape_known_call x
     call_it fn
 end
 capture_escape_known_call source(1.5)
+
+def capture6
+    captured = source(1.6)
+    fn = -> {
+        captured
+    }
+    fn.call
+end
+sink(capture6) # $ hasValueFlow=1.6
+
+def capture7 x
+    captured = x
+    fn = -> {
+        captured
+    }
+    fn.call
+end
+sink(capture7 'safe') # $ SPURIOUS: hasValueFlow=1.7
+sink(capture7 source(1.7)) # $ hasValueFlow=1.7
+
+def capture8 x
+    captured = nil
+    fn = -> {
+        captured = x
+    }
+    fn.call
+    captured
+end
+sink(capture8 'safe') # $ SPURIOUS: hasValueFlow=1.8
+sink(capture8 source(1.8)) # $ hasValueFlow=1.8


### PR DESCRIPTION
Migrating models from AST to DataFlow is blocked by some missing flow in `flowsTo`. I've factored out some semi-related changes into this PR:
- Ensures `ParameterNode` extends `LocalSourceNode`.
- Includes param -> SSA input step in `flowsTo`.
- Fixes a FN in `flowsTo` and type-tracking related to captured variables.
- Captured SSA definitions are no longer `LocalSourceNode`s (nor do they need to be after the other changes).

This PR introduces `CapturedVariableNode` similar to what we have in JavaScript. Currently in Ruby I've only used this to construct the flow-insensitive step relation. In JS we also make use of these nodes for summarising local calls that involve captured variables, though I haven't gone that far for Ruby.