### PR TITLE
Kotlin: fix wildcard suppression where the annotation applies to a parent type/argument.

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -691,7 +691,7 @@ open class KotlinFileExtractor(
                     null
             } ?: vp.type
             val javaType = (vp.parent as? IrFunction)?.let { getJavaCallable(it)?.let { jCallable -> getJavaValueParameterType(jCallable, idx) } }
-            val typeWithWildcards = addJavaLoweringWildcards(maybeAlteredType, !hasWildcardSuppressionAnnotation(vp), javaType)
+            val typeWithWildcards = addJavaLoweringWildcards(maybeAlteredType, !getInnermostWildcardSupppressionAnnotation(vp), javaType)
             val substitutedType = typeSubstitution?.let { it(typeWithWildcards, TypeContext.OTHER, pluginContext) } ?: typeWithWildcards
             val id = useValueParameter(vp, parent)
             if (extractTypeAccess) {

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -1231,7 +1231,7 @@ open class KotlinUsesExtractor(
     fun getInnermostWildcardSupppressionAnnotation(d: IrDeclaration) =
         getWildcardSuppressionDirective(d) ?:
         // Note not using `parentsWithSelf` as that only works if `d` is an IrDeclarationParent
-        d.parents.filterIsInstance<IrAnnotationContainer>().firstNotNullOfOrNull { getWildcardSuppressionDirective(it) } ?:
+        d.parents.filterIsInstance<IrAnnotationContainer>().mapNotNull { getWildcardSuppressionDirective(it) }.firstOrNull() ?:
         false
 
     /**

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -980,7 +980,7 @@ open class KotlinUsesExtractor(
 
     private fun addJavaLoweringArgumentWildcards(p: IrTypeParameter, t: IrTypeArgument, addByDefault: Boolean, javaType: JavaType?): IrTypeArgument =
         (t as? IrTypeProjection)?.let {
-            val newAddByDefault = getWildcardSuppressionDirective(it.type)?.let { b -> !b } ?: addByDefault
+            val newAddByDefault = getWildcardSuppressionDirective(it.type)?.not() ?: addByDefault
             val newBase = addJavaLoweringWildcards(it.type, newAddByDefault, javaType)
             // Note javaVariance == null means we don't have a Java type to conform to -- for example if this is a Kotlin source definition.
             val javaVariance = javaType?.let { jType ->
@@ -1015,7 +1015,7 @@ open class KotlinUsesExtractor(
 
     fun addJavaLoweringWildcards(t: IrType, addByDefault: Boolean, javaType: JavaType?): IrType =
         (t as? IrSimpleType)?.let {
-            val newAddByDefault = getWildcardSuppressionDirective(t)?.let { b -> !b } ?: addByDefault
+            val newAddByDefault = getWildcardSuppressionDirective(t)?.not() ?: addByDefault
             val typeParams = it.classOrNull?.owner?.typeParameters ?: return t
             val newArgs = typeParams.zip(it.arguments).mapIndexed { idx, pair ->
                 addJavaLoweringArgumentWildcards(

--- a/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_lowering_wildcards/JavaUser.java
+++ b/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_lowering_wildcards/JavaUser.java
@@ -49,6 +49,9 @@ public class JavaUser {
     KotlinDefnsSuppressedFn kdsf = new KotlinDefnsSuppressedFn();
     kdsf.outerFn((List<CharSequence>)null, (Comparable<CharSequence>)null);
 
+    kd.takesVariantTypesIndirectlySuppressedWildcards((List<CharSequence>)null, (Comparable<CharSequence>)null);
+    kd.takesVariantTypesComplexSuppressionWildcards((List<List<? extends List<? extends CharSequence>>>)null);
+
   }
 
 }

--- a/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_lowering_wildcards/kotlindefns.kt
+++ b/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_lowering_wildcards/kotlindefns.kt
@@ -33,6 +33,10 @@ class KotlinDefns {
 
   fun takesVariantTypesSuppressedWildcards(covar: List<@JvmSuppressWildcards CharSequence>, contravar: Comparable<@JvmSuppressWildcards CharSequence>) { }
 
+  fun takesVariantTypesIndirectlySuppressedWildcards(covar: @JvmSuppressWildcards List<CharSequence>, contravar: @JvmSuppressWildcards Comparable<CharSequence>) { }
+
+  fun takesVariantTypesComplexSuppressionWildcards(covar: @JvmSuppressWildcards(suppress = true) List<@JvmSuppressWildcards List<@JvmSuppressWildcards(suppress = false) List<CharSequence>>>) { }
+
   fun returnsInvar() : MutableList<CharSequence> = mutableListOf()
 
   fun returnsCovar(): List<CharSequence> = listOf()

--- a/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_lowering_wildcards/test.expected
+++ b/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_lowering_wildcards/test.expected
@@ -40,6 +40,9 @@
 | KotlinDefns | takesNestedType | invar | List<List<CharSequence>> |
 | KotlinDefns | takesNestedType | mixed1 | List<? extends Comparable<? super CharSequence>> |
 | KotlinDefns | takesNestedType | mixed2 | Comparable<? super List<? extends CharSequence>> |
+| KotlinDefns | takesVariantTypesComplexSuppressionWildcards | covar | List<List<? extends List<? extends CharSequence>>> |
+| KotlinDefns | takesVariantTypesIndirectlySuppressedWildcards | contravar | Comparable<CharSequence> |
+| KotlinDefns | takesVariantTypesIndirectlySuppressedWildcards | covar | List<CharSequence> |
 | KotlinDefns | takesVariantTypesSuppressedWildcards | contravar | Comparable<CharSequence> |
 | KotlinDefns | takesVariantTypesSuppressedWildcards | covar | List<CharSequence> |
 | KotlinDefnsSuppressedFn | outerFn | contravar | Comparable<CharSequence> |


### PR DESCRIPTION
In the process I also fix the missed case where suppression can be switched off using a parameterized annotation.