### PR TITLE
Swift: WebView JS-native bridge sources

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -82,6 +82,7 @@ private module Frameworks {
   private import codeql.swift.frameworks.StandardLibrary.String
   private import codeql.swift.frameworks.StandardLibrary.Url
   private import codeql.swift.frameworks.StandardLibrary.UrlSession
+  private import codeql.swift.frameworks.StandardLibrary.WebView
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -574,6 +574,14 @@ private module PostUpdateNodes {
 
     override DataFlowCallable getEnclosingCallable() { result = TDataFlowFunc(n.getScope()) }
   }
+
+  class SummaryPostUpdateNode extends SummaryNode, PostUpdateNodeImpl {
+    SummaryPostUpdateNode() { FlowSummaryImpl::Private::summaryPostUpdateNode(this, _) }
+
+    override Node getPreUpdateNode() {
+      FlowSummaryImpl::Private::summaryPostUpdateNode(this, result)
+    }
+  }
 }
 
 private import PostUpdateNodes

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -125,7 +125,7 @@ private class JsExportedSource extends RemoteFlowSource {
       base.getEnclosingDecl() instanceof JsExportedProto and
       adopter.getEnclosingDecl() instanceof JsExportedType
     |
-      this.asDefinition().getSourceVariable() = adopter and adopter.getName() = base.getName()
+      this.asExpr().(MemberRefExpr).getMember() = adopter and adopter.getName() = base.getName()
     )
   }
 

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -4,7 +4,12 @@ private import codeql.swift.dataflow.ExternalFlow
 private import codeql.swift.dataflow.FlowSources
 private import codeql.swift.dataflow.FlowSteps
 
-private class WKScriptMessageSource extends SourceModelCsv {
+/**
+ * A model for WKScriptMessage sources. Classes implementing the `WKScriptMessageHandler` protocol
+ * act as a bridge between JavaScript and native code. The messages sent from JavaScript code are
+ * stored in the `message` parameter of `userContentController`.
+ */
+private class WKScriptMessageSources extends SourceModelCsv {
   override predicate row(string row) {
     row = ";WKScriptMessageHandler;true;userContentController(_:didReceive:);;;Parameter[1];remote"
   }
@@ -26,4 +31,99 @@ private class WKScriptMessageBodyInheritsTaint extends TaintInheritingContent,
       f.getName() = "body"
     )
   }
+}
+
+/**
+ * A model for `JSContext` sources. `JSContext` acts as a bridge between JavaScript and
+ * native code, so any object obtained from it has the potential of being tainted by a malicious
+ * website visited in the WebView.
+ */
+private class JsContextSources extends SourceModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";JSContext;true;globalObject;;;;remote",
+        ";JSContext;true;objectAtIndexedSubscript(_:);;;ReturnValue;remote",
+        ";JSContext;true;objectForKeyedSubscript(_:);;;ReturnValue;remote"
+      ]
+  }
+}
+
+/**
+ * A model for `JSValue` summaries. If a `JSValue` is tainted, any object it is converted into
+ * is also tainted.
+ */
+private class JsValueSummaries extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";JSValue;true;init(object:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;init(bool:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;init(double:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;init(int32:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;init(uInt32:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;init(point:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;init(range:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;init(rect:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;init(size:in:);;;Argument[0];ReturnValue;taint",
+        ";JSValue;true;toObject();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toObjectOf(_:);;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toBool();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toDouble();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toInt32();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toUInt32();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toNumber();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toString();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toDate();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toArray();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toDictionary();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toPoint();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toRange();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toRect();;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;toSize();;;Argument[-1];ReturnValue;taint",
+        // TODO: These models could use content flow to be more precise
+        ";JSValue;true;atIndex(_:);;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;defineProperty(_:descriptor:);;;Argument[1];Argument[-1];taint",
+        ";JSValue;true;forProperty(_:);;;Argument[-1];ReturnValue;taint",
+        ";JSValue;true;setValue(_:at:);;;Argument[0];Argument[-1];taint",
+        ";JSValue;true;setValue(_:forProperty:);;;Argument[0];Argument[-1];taint"
+      ]
+  }
+}
+
+/** The class `JSContext`. */
+private class JsContextDecl extends ClassDecl {
+  JsContextDecl() { this.getName() = "JSContext" }
+}
+
+/** The type of an object exposed to JavaScript through `JSContext.setObject`. */
+private class TypeExposedThroughJsContext extends Type {
+  TypeExposedThroughJsContext() {
+    exists(ApplyExpr c, FuncDecl f |
+      c.getStaticTarget() = f and
+      f.getEnclosingDecl() instanceof JsContextDecl and
+      f.getName() = "setObject(_:forKeyedSubscript)"
+    |
+      c.getArgument(0).getExpr().getType() = this
+    )
+  }
+}
+
+/**
+ * The members (fields and parameters of functions) of a class or struct
+ * an instance of which is exposed to JavaScript through `JSContext.setObject`.
+ */
+private class ExposedThroughJsContextSource extends RemoteFlowSource {
+  ExposedThroughJsContextSource() {
+    exists(ParamDecl p | this.(DataFlow::ParameterNode).getParameter() = p |
+      p.getDeclaringFunction().getEnclosingDecl().(ClassOrStructDecl).getType() instanceof
+        TypeExposedThroughJsContext
+    )
+    or
+    exists(FieldDecl f | this.asDefinition().getSourceVariable() = f |
+      f.getEnclosingDecl().(ClassOrStructDecl).getType() instanceof TypeExposedThroughJsContext
+    )
+  }
+
+  override string getSourceType() { result = "Member of a type exposed through JSContext" }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -1,0 +1,29 @@
+import swift
+private import codeql.swift.dataflow.DataFlow
+private import codeql.swift.dataflow.ExternalFlow
+private import codeql.swift.dataflow.FlowSources
+private import codeql.swift.dataflow.FlowSteps
+
+private class WKScriptMessageSource extends SourceModelCsv {
+  override predicate row(string row) {
+    row = ";WKScriptMessageHandler;true;userContentController(_:didReceive:);;;Parameter[1];remote"
+  }
+}
+
+/** The class `WKScriptMessage`. */
+private class WKScriptMessageDecl extends ClassDecl {
+  WKScriptMessageDecl() { this.getName() = "WKScriptMessage" }
+}
+
+/**
+ * A content implying that, if a `WKScriptMessage` is tainted, its `body` field is tainted.
+ */
+private class WKScriptMessageBodyInheritsTaint extends TaintInheritingContent,
+  DataFlow::Content::FieldContent {
+  WKScriptMessageBodyInheritsTaint() {
+    exists(FieldDecl f | this.getField() = f |
+      f.getEnclosingDecl() instanceof WKScriptMessageDecl and
+      f.getName() = "body"
+    )
+  }
+}

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -11,6 +11,7 @@
 | webview.swift:20:82:20:102 | message | external |
 | webview.swift:25:5:25:13 | .globalObject | external |
 | webview.swift:26:5:26:39 | call to objectForKeyedSubscript(_:) | external |
-| webview.swift:38:10:38:10 | self | Member of a type exposed through JSExport |
-| webview.swift:38:18:38:24 | arg1 | Member of a type exposed through JSExport |
-| webview.swift:38:29:38:35 | arg2 | Member of a type exposed through JSExport |
+| webview.swift:39:9:39:9 | .tainted | Member of a type exposed through JSExport |
+| webview.swift:43:10:43:10 | self | Member of a type exposed through JSExport |
+| webview.swift:43:18:43:24 | arg1 | Member of a type exposed through JSExport |
+| webview.swift:43:29:43:35 | arg2 | Member of a type exposed through JSExport |

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -8,4 +8,6 @@
 | url.swift:53:15:53:19 | .resourceBytes | external |
 | url.swift:60:15:60:19 | .lines | external |
 | url.swift:67:16:67:22 | .lines | external |
-| webview.swift:11:82:11:102 | message | external |
+| webview.swift:19:82:19:102 | message | external |
+| webview.swift:24:5:24:13 | .globalObject | external |
+| webview.swift:25:5:25:39 | call to objectForKeyedSubscript(_:) | external |

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -8,3 +8,4 @@
 | url.swift:53:15:53:19 | .resourceBytes | external |
 | url.swift:60:15:60:19 | .lines | external |
 | url.swift:67:16:67:22 | .lines | external |
+| webview.swift:11:82:11:102 | message | external |

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -8,6 +8,9 @@
 | url.swift:53:15:53:19 | .resourceBytes | external |
 | url.swift:60:15:60:19 | .lines | external |
 | url.swift:67:16:67:22 | .lines | external |
-| webview.swift:19:82:19:102 | message | external |
-| webview.swift:24:5:24:13 | .globalObject | external |
-| webview.swift:25:5:25:39 | call to objectForKeyedSubscript(_:) | external |
+| webview.swift:20:82:20:102 | message | external |
+| webview.swift:25:5:25:13 | .globalObject | external |
+| webview.swift:26:5:26:39 | call to objectForKeyedSubscript(_:) | external |
+| webview.swift:38:10:38:10 | self | Member of a type exposed through JSExport |
+| webview.swift:38:18:38:24 | arg1 | Member of a type exposed through JSExport |
+| webview.swift:38:29:38:35 | arg2 | Member of a type exposed through JSExport |

--- a/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
@@ -1,0 +1,13 @@
+
+// --- stubs ---
+class WKUserContentController {}
+class WKScriptMessage {}
+protocol WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage)
+}
+
+// --- tests ---
+class TestMessageHandler: WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) { // SOURCE
+    }
+}

--- a/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
@@ -31,9 +31,14 @@ protocol Exported : JSExport {
     func tainted(arg1: Any, arg2: Any)
 }
 class ExportedImpl : Exported {
-    var tainted: Any { get { return "" } } // SOURCE
+    var tainted: Any { get { return "" } }
 
     var notTainted: Any { get { return ""} }
+
+    func readFields() {
+        tainted // SOURCE
+        notTainted
+    }
 
     func tainted(arg1: Any, arg2: Any) { // SOURCES
     }

--- a/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
@@ -5,9 +5,31 @@ class WKScriptMessage {}
 protocol WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage)
 }
+protocol NSCopying {}
+protocol NSObjectProtocol {}
+class JSValue {}
+class JSContext {
+    var globalObject: JSValue { get { return JSValue() } }
+    func objectForKeyedSubscript(_: Any!) -> JSValue! { return JSValue() } 
+    func setObject(_: Any, forKeyedSubscript: (NSCopying & NSObjectProtocol) ) {}
+}
 
 // --- tests ---
 class TestMessageHandler: WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) { // SOURCE
     }
 }
+
+func testJsContext(context: JSContext) {
+    context.globalObject // SOURCE
+    context.objectForKeyedSubscript("") // SOURCE
+    context.setObject(Exposed.self, forKeyedSubscript: "exposed" as! NSCopying & NSObjectProtocol)
+}
+
+class Exposed {
+    var tainted: Any { get { return "" } } // SOURCE
+
+    func tainted(arg1: Any, arg2: Any) { // SOURCES
+
+    }
+} 

--- a/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
@@ -13,6 +13,7 @@ class JSContext {
     func objectForKeyedSubscript(_: Any!) -> JSValue! { return JSValue() } 
     func setObject(_: Any, forKeyedSubscript: (NSCopying & NSObjectProtocol) ) {}
 }
+protocol JSExport {}
 
 // --- tests ---
 class TestMessageHandler: WKScriptMessageHandler {
@@ -23,13 +24,20 @@ class TestMessageHandler: WKScriptMessageHandler {
 func testJsContext(context: JSContext) {
     context.globalObject // SOURCE
     context.objectForKeyedSubscript("") // SOURCE
-    context.setObject(Exposed.self, forKeyedSubscript: "exposed" as! NSCopying & NSObjectProtocol)
 }
 
-class Exposed {
+protocol Exported : JSExport {
+    var tainted: Any { get }
+    func tainted(arg1: Any, arg2: Any)
+}
+class ExportedImpl : Exported {
     var tainted: Any { get { return "" } } // SOURCE
 
-    func tainted(arg1: Any, arg2: Any) { // SOURCES
+    var notTainted: Any { get { return ""} }
 
+    func tainted(arg1: Any, arg2: Any) { // SOURCES
+    }
+
+    func notTainted(arg1: Any, arg2: Any) {
     }
 } 

--- a/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
@@ -161,3 +161,4 @@
 | url.swift:100:12:100:54 | ...! | url.swift:100:12:100:56 | .standardizedFileURL |
 | url.swift:101:15:101:57 | ...! | url.swift:101:15:101:59 | .user |
 | url.swift:102:15:102:57 | ...! | url.swift:102:15:102:59 | .password |
+| webview.swift:12:13:12:20 | call to source() | webview.swift:12:13:12:22 | .body |

--- a/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
@@ -161,4 +161,4 @@
 | url.swift:100:12:100:54 | ...! | url.swift:100:12:100:56 | .standardizedFileURL |
 | url.swift:101:15:101:57 | ...! | url.swift:101:15:101:59 | .user |
 | url.swift:102:15:102:57 | ...! | url.swift:102:15:102:59 | .password |
-| webview.swift:12:13:12:20 | call to source() | webview.swift:12:13:12:22 | .body |
+| webview.swift:52:11:52:18 | call to source() | webview.swift:52:10:52:41 | .body |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -119,12 +119,142 @@ edges
 | url.swift:117:28:117:28 | tainted :  | url.swift:117:16:117:35 | call to init(string:) :  |
 | url.swift:120:46:120:46 | urlTainted :  | url.swift:43:2:46:55 | [summary param] 0 in dataTask(with:completionHandler:) :  |
 | url.swift:120:61:120:61 | data :  | url.swift:121:15:121:19 | ...! |
-| webview.swift:12:13:12:20 | call to source() :  | webview.swift:12:13:12:22 | .body |
+| webview.swift:16:5:16:39 | [summary param] 0 in init(object:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(object:in:) :  |
+| webview.swift:17:5:17:38 | [summary param] 0 in init(bool:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bool:in:) :  |
+| webview.swift:18:5:18:42 | [summary param] 0 in init(double:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(double:in:) :  |
+| webview.swift:19:5:19:40 | [summary param] 0 in init(int32:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(int32:in:) :  |
+| webview.swift:20:5:20:42 | [summary param] 0 in init(uInt32:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(uInt32:in:) :  |
+| webview.swift:21:5:21:42 | [summary param] 0 in init(point:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(point:in:) :  |
+| webview.swift:22:5:22:42 | [summary param] 0 in init(range:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(range:in:) :  |
+| webview.swift:23:5:23:40 | [summary param] 0 in init(rect:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(rect:in:) :  |
+| webview.swift:24:5:24:40 | [summary param] 0 in init(size:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(size:in:) :  |
+| webview.swift:25:5:25:41 | [summary param] this in toObject() :  | file://:0:0:0:0 | [summary] to write: return (return) in toObject() :  |
+| webview.swift:26:5:26:55 | [summary param] this in toObjectOf(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in toObjectOf(_:) :  |
+| webview.swift:27:5:27:42 | [summary param] this in toBool() :  | file://:0:0:0:0 | [summary] to write: return (return) in toBool() :  |
+| webview.swift:28:5:28:44 | [summary param] this in toDouble() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDouble() :  |
+| webview.swift:29:5:29:40 | [summary param] this in toInt32() :  | file://:0:0:0:0 | [summary] to write: return (return) in toInt32() :  |
+| webview.swift:30:5:30:42 | [summary param] this in toUInt32() :  | file://:0:0:0:0 | [summary] to write: return (return) in toUInt32() :  |
+| webview.swift:31:5:31:62 | [summary param] this in toNumber() :  | file://:0:0:0:0 | [summary] to write: return (return) in toNumber() :  |
+| webview.swift:32:5:32:44 | [summary param] this in toString() :  | file://:0:0:0:0 | [summary] to write: return (return) in toString() :  |
+| webview.swift:33:5:33:44 | [summary param] this in toDate() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDate() :  |
+| webview.swift:34:5:34:44 | [summary param] this in toArray() :  | file://:0:0:0:0 | [summary] to write: return (return) in toArray() :  |
+| webview.swift:35:5:35:65 | [summary param] this in toDictionary() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDictionary() :  |
+| webview.swift:36:5:36:50 | [summary param] this in toPoint() :  | file://:0:0:0:0 | [summary] to write: return (return) in toPoint() :  |
+| webview.swift:37:5:37:50 | [summary param] this in toRange() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRange() :  |
+| webview.swift:38:5:38:47 | [summary param] this in toRect() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRect() :  |
+| webview.swift:39:5:39:47 | [summary param] this in toSize() :  | file://:0:0:0:0 | [summary] to write: return (return) in toSize() :  |
+| webview.swift:40:5:40:84 | [summary param] this in atIndex(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in atIndex(_:) :  |
+| webview.swift:42:5:42:89 | [summary param] this in forProperty(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  |
+| webview.swift:52:11:52:18 | call to source() :  | webview.swift:52:10:52:41 | .body |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:59:10:59:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:60:10:60:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:61:10:61:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:62:10:62:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:63:10:63:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:64:10:64:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:65:10:65:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:66:10:66:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:67:10:67:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:68:10:68:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:69:10:69:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:70:10:70:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:71:10:71:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:72:10:72:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:73:10:73:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:74:10:74:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:75:10:75:10 | source :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:78:26:78:26 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:79:24:79:24 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:80:26:80:26 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:81:25:81:25 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:82:26:82:26 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:83:25:83:25 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:84:25:84:25 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:85:24:85:24 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:86:24:86:24 | s :  |
+| webview.swift:59:10:59:10 | source :  | webview.swift:25:5:25:41 | [summary param] this in toObject() :  |
+| webview.swift:59:10:59:10 | source :  | webview.swift:59:10:59:26 | call to toObject() |
+| webview.swift:60:10:60:10 | source :  | webview.swift:26:5:26:55 | [summary param] this in toObjectOf(_:) :  |
+| webview.swift:60:10:60:10 | source :  | webview.swift:60:10:60:41 | call to toObjectOf(_:) |
+| webview.swift:61:10:61:10 | source :  | webview.swift:27:5:27:42 | [summary param] this in toBool() :  |
+| webview.swift:61:10:61:10 | source :  | webview.swift:61:10:61:24 | call to toBool() |
+| webview.swift:62:10:62:10 | source :  | webview.swift:28:5:28:44 | [summary param] this in toDouble() :  |
+| webview.swift:62:10:62:10 | source :  | webview.swift:62:10:62:26 | call to toDouble() |
+| webview.swift:63:10:63:10 | source :  | webview.swift:29:5:29:40 | [summary param] this in toInt32() :  |
+| webview.swift:63:10:63:10 | source :  | webview.swift:63:10:63:25 | call to toInt32() |
+| webview.swift:64:10:64:10 | source :  | webview.swift:30:5:30:42 | [summary param] this in toUInt32() :  |
+| webview.swift:64:10:64:10 | source :  | webview.swift:64:10:64:26 | call to toUInt32() |
+| webview.swift:65:10:65:10 | source :  | webview.swift:31:5:31:62 | [summary param] this in toNumber() :  |
+| webview.swift:65:10:65:10 | source :  | webview.swift:65:10:65:26 | call to toNumber() |
+| webview.swift:66:10:66:10 | source :  | webview.swift:32:5:32:44 | [summary param] this in toString() :  |
+| webview.swift:66:10:66:10 | source :  | webview.swift:66:10:66:26 | call to toString() |
+| webview.swift:67:10:67:10 | source :  | webview.swift:33:5:33:44 | [summary param] this in toDate() :  |
+| webview.swift:67:10:67:10 | source :  | webview.swift:67:10:67:24 | call to toDate() |
+| webview.swift:68:10:68:10 | source :  | webview.swift:34:5:34:44 | [summary param] this in toArray() :  |
+| webview.swift:68:10:68:10 | source :  | webview.swift:68:10:68:25 | call to toArray() |
+| webview.swift:69:10:69:10 | source :  | webview.swift:35:5:35:65 | [summary param] this in toDictionary() :  |
+| webview.swift:69:10:69:10 | source :  | webview.swift:69:10:69:30 | call to toDictionary() |
+| webview.swift:70:10:70:10 | source :  | webview.swift:36:5:36:50 | [summary param] this in toPoint() :  |
+| webview.swift:70:10:70:10 | source :  | webview.swift:70:10:70:25 | call to toPoint() |
+| webview.swift:71:10:71:10 | source :  | webview.swift:37:5:37:50 | [summary param] this in toRange() :  |
+| webview.swift:71:10:71:10 | source :  | webview.swift:71:10:71:25 | call to toRange() |
+| webview.swift:72:10:72:10 | source :  | webview.swift:38:5:38:47 | [summary param] this in toRect() :  |
+| webview.swift:72:10:72:10 | source :  | webview.swift:72:10:72:24 | call to toRect() |
+| webview.swift:73:10:73:10 | source :  | webview.swift:39:5:39:47 | [summary param] this in toSize() :  |
+| webview.swift:73:10:73:10 | source :  | webview.swift:73:10:73:24 | call to toSize() |
+| webview.swift:74:10:74:10 | source :  | webview.swift:40:5:40:84 | [summary param] this in atIndex(_:) :  |
+| webview.swift:74:10:74:10 | source :  | webview.swift:74:10:74:26 | call to atIndex(_:) |
+| webview.swift:75:10:75:10 | source :  | webview.swift:42:5:42:89 | [summary param] this in forProperty(_:) :  |
+| webview.swift:75:10:75:10 | source :  | webview.swift:75:10:75:31 | call to forProperty(_:) |
+| webview.swift:78:26:78:26 | s :  | webview.swift:16:5:16:39 | [summary param] 0 in init(object:in:) :  |
+| webview.swift:78:26:78:26 | s :  | webview.swift:78:10:78:47 | call to init(object:in:) |
+| webview.swift:79:24:79:24 | s :  | webview.swift:17:5:17:38 | [summary param] 0 in init(bool:in:) :  |
+| webview.swift:79:24:79:24 | s :  | webview.swift:79:10:79:47 | call to init(bool:in:) |
+| webview.swift:80:26:80:26 | s :  | webview.swift:18:5:18:42 | [summary param] 0 in init(double:in:) :  |
+| webview.swift:80:26:80:26 | s :  | webview.swift:80:10:80:51 | call to init(double:in:) |
+| webview.swift:81:25:81:25 | s :  | webview.swift:19:5:19:40 | [summary param] 0 in init(int32:in:) :  |
+| webview.swift:81:25:81:25 | s :  | webview.swift:81:10:81:49 | call to init(int32:in:) |
+| webview.swift:82:26:82:26 | s :  | webview.swift:20:5:20:42 | [summary param] 0 in init(uInt32:in:) :  |
+| webview.swift:82:26:82:26 | s :  | webview.swift:82:10:82:51 | call to init(uInt32:in:) |
+| webview.swift:83:25:83:25 | s :  | webview.swift:21:5:21:42 | [summary param] 0 in init(point:in:) :  |
+| webview.swift:83:25:83:25 | s :  | webview.swift:83:10:83:51 | call to init(point:in:) |
+| webview.swift:84:25:84:25 | s :  | webview.swift:22:5:22:42 | [summary param] 0 in init(range:in:) :  |
+| webview.swift:84:25:84:25 | s :  | webview.swift:84:10:84:51 | call to init(range:in:) |
+| webview.swift:85:24:85:24 | s :  | webview.swift:23:5:23:40 | [summary param] 0 in init(rect:in:) :  |
+| webview.swift:85:24:85:24 | s :  | webview.swift:85:10:85:49 | call to init(rect:in:) |
+| webview.swift:86:24:86:24 | s :  | webview.swift:24:5:24:40 | [summary param] 0 in init(size:in:) :  |
+| webview.swift:86:24:86:24 | s :  | webview.swift:86:10:86:49 | call to init(size:in:) |
 nodes
 | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  | semmle.label | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in atIndex(_:) :  | semmle.label | [summary] to write: return (return) in atIndex(_:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  | semmle.label | [summary] to write: return (return) in forProperty(_:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(bool:in:) :  | semmle.label | [summary] to write: return (return) in init(bool:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(double:in:) :  | semmle.label | [summary] to write: return (return) in init(double:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(int32:in:) :  | semmle.label | [summary] to write: return (return) in init(int32:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(object:in:) :  | semmle.label | [summary] to write: return (return) in init(object:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(point:in:) :  | semmle.label | [summary] to write: return (return) in init(point:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(range:in:) :  | semmle.label | [summary] to write: return (return) in init(range:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(rect:in:) :  | semmle.label | [summary] to write: return (return) in init(rect:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(size:in:) :  | semmle.label | [summary] to write: return (return) in init(size:in:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | semmle.label | [summary] to write: return (return) in init(string:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(uInt32:in:) :  | semmle.label | [summary] to write: return (return) in init(uInt32:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toArray() :  | semmle.label | [summary] to write: return (return) in toArray() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toBool() :  | semmle.label | [summary] to write: return (return) in toBool() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toDate() :  | semmle.label | [summary] to write: return (return) in toDate() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toDictionary() :  | semmle.label | [summary] to write: return (return) in toDictionary() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toDouble() :  | semmle.label | [summary] to write: return (return) in toDouble() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toInt32() :  | semmle.label | [summary] to write: return (return) in toInt32() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toNumber() :  | semmle.label | [summary] to write: return (return) in toNumber() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toObject() :  | semmle.label | [summary] to write: return (return) in toObject() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toObjectOf(_:) :  | semmle.label | [summary] to write: return (return) in toObjectOf(_:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toPoint() :  | semmle.label | [summary] to write: return (return) in toPoint() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toRange() :  | semmle.label | [summary] to write: return (return) in toRange() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toRect() :  | semmle.label | [summary] to write: return (return) in toRect() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toSize() :  | semmle.label | [summary] to write: return (return) in toSize() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toString() :  | semmle.label | [summary] to write: return (return) in toString() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in toUInt32() :  | semmle.label | [summary] to write: return (return) in toUInt32() :  |
 | string.swift:5:11:5:18 | call to source() :  | semmle.label | call to source() :  |
 | string.swift:7:13:7:13 | "..." | semmle.label | "..." |
 | string.swift:9:13:9:13 | "..." | semmle.label | "..." |
@@ -232,8 +362,87 @@ nodes
 | url.swift:120:46:120:46 | urlTainted :  | semmle.label | urlTainted :  |
 | url.swift:120:61:120:61 | data :  | semmle.label | data :  |
 | url.swift:121:15:121:19 | ...! | semmle.label | ...! |
-| webview.swift:12:13:12:20 | call to source() :  | semmle.label | call to source() :  |
-| webview.swift:12:13:12:22 | .body | semmle.label | .body |
+| webview.swift:16:5:16:39 | [summary param] 0 in init(object:in:) :  | semmle.label | [summary param] 0 in init(object:in:) :  |
+| webview.swift:17:5:17:38 | [summary param] 0 in init(bool:in:) :  | semmle.label | [summary param] 0 in init(bool:in:) :  |
+| webview.swift:18:5:18:42 | [summary param] 0 in init(double:in:) :  | semmle.label | [summary param] 0 in init(double:in:) :  |
+| webview.swift:19:5:19:40 | [summary param] 0 in init(int32:in:) :  | semmle.label | [summary param] 0 in init(int32:in:) :  |
+| webview.swift:20:5:20:42 | [summary param] 0 in init(uInt32:in:) :  | semmle.label | [summary param] 0 in init(uInt32:in:) :  |
+| webview.swift:21:5:21:42 | [summary param] 0 in init(point:in:) :  | semmle.label | [summary param] 0 in init(point:in:) :  |
+| webview.swift:22:5:22:42 | [summary param] 0 in init(range:in:) :  | semmle.label | [summary param] 0 in init(range:in:) :  |
+| webview.swift:23:5:23:40 | [summary param] 0 in init(rect:in:) :  | semmle.label | [summary param] 0 in init(rect:in:) :  |
+| webview.swift:24:5:24:40 | [summary param] 0 in init(size:in:) :  | semmle.label | [summary param] 0 in init(size:in:) :  |
+| webview.swift:25:5:25:41 | [summary param] this in toObject() :  | semmle.label | [summary param] this in toObject() :  |
+| webview.swift:26:5:26:55 | [summary param] this in toObjectOf(_:) :  | semmle.label | [summary param] this in toObjectOf(_:) :  |
+| webview.swift:27:5:27:42 | [summary param] this in toBool() :  | semmle.label | [summary param] this in toBool() :  |
+| webview.swift:28:5:28:44 | [summary param] this in toDouble() :  | semmle.label | [summary param] this in toDouble() :  |
+| webview.swift:29:5:29:40 | [summary param] this in toInt32() :  | semmle.label | [summary param] this in toInt32() :  |
+| webview.swift:30:5:30:42 | [summary param] this in toUInt32() :  | semmle.label | [summary param] this in toUInt32() :  |
+| webview.swift:31:5:31:62 | [summary param] this in toNumber() :  | semmle.label | [summary param] this in toNumber() :  |
+| webview.swift:32:5:32:44 | [summary param] this in toString() :  | semmle.label | [summary param] this in toString() :  |
+| webview.swift:33:5:33:44 | [summary param] this in toDate() :  | semmle.label | [summary param] this in toDate() :  |
+| webview.swift:34:5:34:44 | [summary param] this in toArray() :  | semmle.label | [summary param] this in toArray() :  |
+| webview.swift:35:5:35:65 | [summary param] this in toDictionary() :  | semmle.label | [summary param] this in toDictionary() :  |
+| webview.swift:36:5:36:50 | [summary param] this in toPoint() :  | semmle.label | [summary param] this in toPoint() :  |
+| webview.swift:37:5:37:50 | [summary param] this in toRange() :  | semmle.label | [summary param] this in toRange() :  |
+| webview.swift:38:5:38:47 | [summary param] this in toRect() :  | semmle.label | [summary param] this in toRect() :  |
+| webview.swift:39:5:39:47 | [summary param] this in toSize() :  | semmle.label | [summary param] this in toSize() :  |
+| webview.swift:40:5:40:84 | [summary param] this in atIndex(_:) :  | semmle.label | [summary param] this in atIndex(_:) :  |
+| webview.swift:42:5:42:89 | [summary param] this in forProperty(_:) :  | semmle.label | [summary param] this in forProperty(_:) :  |
+| webview.swift:52:10:52:41 | .body | semmle.label | .body |
+| webview.swift:52:11:52:18 | call to source() :  | semmle.label | call to source() :  |
+| webview.swift:56:13:56:20 | call to source() :  | semmle.label | call to source() :  |
+| webview.swift:59:10:59:10 | source :  | semmle.label | source :  |
+| webview.swift:59:10:59:26 | call to toObject() | semmle.label | call to toObject() |
+| webview.swift:60:10:60:10 | source :  | semmle.label | source :  |
+| webview.swift:60:10:60:41 | call to toObjectOf(_:) | semmle.label | call to toObjectOf(_:) |
+| webview.swift:61:10:61:10 | source :  | semmle.label | source :  |
+| webview.swift:61:10:61:24 | call to toBool() | semmle.label | call to toBool() |
+| webview.swift:62:10:62:10 | source :  | semmle.label | source :  |
+| webview.swift:62:10:62:26 | call to toDouble() | semmle.label | call to toDouble() |
+| webview.swift:63:10:63:10 | source :  | semmle.label | source :  |
+| webview.swift:63:10:63:25 | call to toInt32() | semmle.label | call to toInt32() |
+| webview.swift:64:10:64:10 | source :  | semmle.label | source :  |
+| webview.swift:64:10:64:26 | call to toUInt32() | semmle.label | call to toUInt32() |
+| webview.swift:65:10:65:10 | source :  | semmle.label | source :  |
+| webview.swift:65:10:65:26 | call to toNumber() | semmle.label | call to toNumber() |
+| webview.swift:66:10:66:10 | source :  | semmle.label | source :  |
+| webview.swift:66:10:66:26 | call to toString() | semmle.label | call to toString() |
+| webview.swift:67:10:67:10 | source :  | semmle.label | source :  |
+| webview.swift:67:10:67:24 | call to toDate() | semmle.label | call to toDate() |
+| webview.swift:68:10:68:10 | source :  | semmle.label | source :  |
+| webview.swift:68:10:68:25 | call to toArray() | semmle.label | call to toArray() |
+| webview.swift:69:10:69:10 | source :  | semmle.label | source :  |
+| webview.swift:69:10:69:30 | call to toDictionary() | semmle.label | call to toDictionary() |
+| webview.swift:70:10:70:10 | source :  | semmle.label | source :  |
+| webview.swift:70:10:70:25 | call to toPoint() | semmle.label | call to toPoint() |
+| webview.swift:71:10:71:10 | source :  | semmle.label | source :  |
+| webview.swift:71:10:71:25 | call to toRange() | semmle.label | call to toRange() |
+| webview.swift:72:10:72:10 | source :  | semmle.label | source :  |
+| webview.swift:72:10:72:24 | call to toRect() | semmle.label | call to toRect() |
+| webview.swift:73:10:73:10 | source :  | semmle.label | source :  |
+| webview.swift:73:10:73:24 | call to toSize() | semmle.label | call to toSize() |
+| webview.swift:74:10:74:10 | source :  | semmle.label | source :  |
+| webview.swift:74:10:74:26 | call to atIndex(_:) | semmle.label | call to atIndex(_:) |
+| webview.swift:75:10:75:10 | source :  | semmle.label | source :  |
+| webview.swift:75:10:75:31 | call to forProperty(_:) | semmle.label | call to forProperty(_:) |
+| webview.swift:78:10:78:47 | call to init(object:in:) | semmle.label | call to init(object:in:) |
+| webview.swift:78:26:78:26 | s :  | semmle.label | s :  |
+| webview.swift:79:10:79:47 | call to init(bool:in:) | semmle.label | call to init(bool:in:) |
+| webview.swift:79:24:79:24 | s :  | semmle.label | s :  |
+| webview.swift:80:10:80:51 | call to init(double:in:) | semmle.label | call to init(double:in:) |
+| webview.swift:80:26:80:26 | s :  | semmle.label | s :  |
+| webview.swift:81:10:81:49 | call to init(int32:in:) | semmle.label | call to init(int32:in:) |
+| webview.swift:81:25:81:25 | s :  | semmle.label | s :  |
+| webview.swift:82:10:82:51 | call to init(uInt32:in:) | semmle.label | call to init(uInt32:in:) |
+| webview.swift:82:26:82:26 | s :  | semmle.label | s :  |
+| webview.swift:83:10:83:51 | call to init(point:in:) | semmle.label | call to init(point:in:) |
+| webview.swift:83:25:83:25 | s :  | semmle.label | s :  |
+| webview.swift:84:10:84:51 | call to init(range:in:) | semmle.label | call to init(range:in:) |
+| webview.swift:84:25:84:25 | s :  | semmle.label | s :  |
+| webview.swift:85:10:85:49 | call to init(rect:in:) | semmle.label | call to init(rect:in:) |
+| webview.swift:85:24:85:24 | s :  | semmle.label | s :  |
+| webview.swift:86:10:86:49 | call to init(size:in:) | semmle.label | call to init(size:in:) |
+| webview.swift:86:24:86:24 | s :  | semmle.label | s :  |
 subpaths
 | url.swift:59:31:59:31 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:59:19:59:38 | call to init(string:) :  |
 | url.swift:83:24:83:24 | tainted :  | url.swift:9:2:9:43 | [summary param] 0 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:83:12:83:48 | call to init(string:relativeTo:) :  |
@@ -255,6 +464,32 @@ subpaths
 | url.swift:101:46:101:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:101:15:101:56 | call to init(string:relativeTo:) :  |
 | url.swift:102:46:102:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:102:15:102:56 | call to init(string:relativeTo:) :  |
 | url.swift:117:28:117:28 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:117:16:117:35 | call to init(string:) :  |
+| webview.swift:59:10:59:10 | source :  | webview.swift:25:5:25:41 | [summary param] this in toObject() :  | file://:0:0:0:0 | [summary] to write: return (return) in toObject() :  | webview.swift:59:10:59:26 | call to toObject() |
+| webview.swift:60:10:60:10 | source :  | webview.swift:26:5:26:55 | [summary param] this in toObjectOf(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in toObjectOf(_:) :  | webview.swift:60:10:60:41 | call to toObjectOf(_:) |
+| webview.swift:61:10:61:10 | source :  | webview.swift:27:5:27:42 | [summary param] this in toBool() :  | file://:0:0:0:0 | [summary] to write: return (return) in toBool() :  | webview.swift:61:10:61:24 | call to toBool() |
+| webview.swift:62:10:62:10 | source :  | webview.swift:28:5:28:44 | [summary param] this in toDouble() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDouble() :  | webview.swift:62:10:62:26 | call to toDouble() |
+| webview.swift:63:10:63:10 | source :  | webview.swift:29:5:29:40 | [summary param] this in toInt32() :  | file://:0:0:0:0 | [summary] to write: return (return) in toInt32() :  | webview.swift:63:10:63:25 | call to toInt32() |
+| webview.swift:64:10:64:10 | source :  | webview.swift:30:5:30:42 | [summary param] this in toUInt32() :  | file://:0:0:0:0 | [summary] to write: return (return) in toUInt32() :  | webview.swift:64:10:64:26 | call to toUInt32() |
+| webview.swift:65:10:65:10 | source :  | webview.swift:31:5:31:62 | [summary param] this in toNumber() :  | file://:0:0:0:0 | [summary] to write: return (return) in toNumber() :  | webview.swift:65:10:65:26 | call to toNumber() |
+| webview.swift:66:10:66:10 | source :  | webview.swift:32:5:32:44 | [summary param] this in toString() :  | file://:0:0:0:0 | [summary] to write: return (return) in toString() :  | webview.swift:66:10:66:26 | call to toString() |
+| webview.swift:67:10:67:10 | source :  | webview.swift:33:5:33:44 | [summary param] this in toDate() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDate() :  | webview.swift:67:10:67:24 | call to toDate() |
+| webview.swift:68:10:68:10 | source :  | webview.swift:34:5:34:44 | [summary param] this in toArray() :  | file://:0:0:0:0 | [summary] to write: return (return) in toArray() :  | webview.swift:68:10:68:25 | call to toArray() |
+| webview.swift:69:10:69:10 | source :  | webview.swift:35:5:35:65 | [summary param] this in toDictionary() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDictionary() :  | webview.swift:69:10:69:30 | call to toDictionary() |
+| webview.swift:70:10:70:10 | source :  | webview.swift:36:5:36:50 | [summary param] this in toPoint() :  | file://:0:0:0:0 | [summary] to write: return (return) in toPoint() :  | webview.swift:70:10:70:25 | call to toPoint() |
+| webview.swift:71:10:71:10 | source :  | webview.swift:37:5:37:50 | [summary param] this in toRange() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRange() :  | webview.swift:71:10:71:25 | call to toRange() |
+| webview.swift:72:10:72:10 | source :  | webview.swift:38:5:38:47 | [summary param] this in toRect() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRect() :  | webview.swift:72:10:72:24 | call to toRect() |
+| webview.swift:73:10:73:10 | source :  | webview.swift:39:5:39:47 | [summary param] this in toSize() :  | file://:0:0:0:0 | [summary] to write: return (return) in toSize() :  | webview.swift:73:10:73:24 | call to toSize() |
+| webview.swift:74:10:74:10 | source :  | webview.swift:40:5:40:84 | [summary param] this in atIndex(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in atIndex(_:) :  | webview.swift:74:10:74:26 | call to atIndex(_:) |
+| webview.swift:75:10:75:10 | source :  | webview.swift:42:5:42:89 | [summary param] this in forProperty(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  | webview.swift:75:10:75:31 | call to forProperty(_:) |
+| webview.swift:78:26:78:26 | s :  | webview.swift:16:5:16:39 | [summary param] 0 in init(object:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(object:in:) :  | webview.swift:78:10:78:47 | call to init(object:in:) |
+| webview.swift:79:24:79:24 | s :  | webview.swift:17:5:17:38 | [summary param] 0 in init(bool:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bool:in:) :  | webview.swift:79:10:79:47 | call to init(bool:in:) |
+| webview.swift:80:26:80:26 | s :  | webview.swift:18:5:18:42 | [summary param] 0 in init(double:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(double:in:) :  | webview.swift:80:10:80:51 | call to init(double:in:) |
+| webview.swift:81:25:81:25 | s :  | webview.swift:19:5:19:40 | [summary param] 0 in init(int32:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(int32:in:) :  | webview.swift:81:10:81:49 | call to init(int32:in:) |
+| webview.swift:82:26:82:26 | s :  | webview.swift:20:5:20:42 | [summary param] 0 in init(uInt32:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(uInt32:in:) :  | webview.swift:82:10:82:51 | call to init(uInt32:in:) |
+| webview.swift:83:25:83:25 | s :  | webview.swift:21:5:21:42 | [summary param] 0 in init(point:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(point:in:) :  | webview.swift:83:10:83:51 | call to init(point:in:) |
+| webview.swift:84:25:84:25 | s :  | webview.swift:22:5:22:42 | [summary param] 0 in init(range:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(range:in:) :  | webview.swift:84:10:84:51 | call to init(range:in:) |
+| webview.swift:85:24:85:24 | s :  | webview.swift:23:5:23:40 | [summary param] 0 in init(rect:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(rect:in:) :  | webview.swift:85:10:85:49 | call to init(rect:in:) |
+| webview.swift:86:24:86:24 | s :  | webview.swift:24:5:24:40 | [summary param] 0 in init(size:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(size:in:) :  | webview.swift:86:10:86:49 | call to init(size:in:) |
 #select
 | string.swift:7:13:7:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:7:13:7:13 | "..." | result |
 | string.swift:9:13:9:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:9:13:9:13 | "..." | result |
@@ -309,4 +544,30 @@ subpaths
 | url.swift:102:15:102:67 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:102:15:102:67 | ...! | result |
 | url.swift:118:12:118:12 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:118:12:118:12 | ...! | result |
 | url.swift:121:15:121:19 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:121:15:121:19 | ...! | result |
-| webview.swift:12:13:12:22 | .body | webview.swift:12:13:12:20 | call to source() :  | webview.swift:12:13:12:22 | .body | result |
+| webview.swift:52:10:52:41 | .body | webview.swift:52:11:52:18 | call to source() :  | webview.swift:52:10:52:41 | .body | result |
+| webview.swift:59:10:59:26 | call to toObject() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:59:10:59:26 | call to toObject() | result |
+| webview.swift:60:10:60:41 | call to toObjectOf(_:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:60:10:60:41 | call to toObjectOf(_:) | result |
+| webview.swift:61:10:61:24 | call to toBool() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:61:10:61:24 | call to toBool() | result |
+| webview.swift:62:10:62:26 | call to toDouble() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:62:10:62:26 | call to toDouble() | result |
+| webview.swift:63:10:63:25 | call to toInt32() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:63:10:63:25 | call to toInt32() | result |
+| webview.swift:64:10:64:26 | call to toUInt32() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:64:10:64:26 | call to toUInt32() | result |
+| webview.swift:65:10:65:26 | call to toNumber() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:65:10:65:26 | call to toNumber() | result |
+| webview.swift:66:10:66:26 | call to toString() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:66:10:66:26 | call to toString() | result |
+| webview.swift:67:10:67:24 | call to toDate() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:67:10:67:24 | call to toDate() | result |
+| webview.swift:68:10:68:25 | call to toArray() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:68:10:68:25 | call to toArray() | result |
+| webview.swift:69:10:69:30 | call to toDictionary() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:69:10:69:30 | call to toDictionary() | result |
+| webview.swift:70:10:70:25 | call to toPoint() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:70:10:70:25 | call to toPoint() | result |
+| webview.swift:71:10:71:25 | call to toRange() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:71:10:71:25 | call to toRange() | result |
+| webview.swift:72:10:72:24 | call to toRect() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:72:10:72:24 | call to toRect() | result |
+| webview.swift:73:10:73:24 | call to toSize() | webview.swift:56:13:56:20 | call to source() :  | webview.swift:73:10:73:24 | call to toSize() | result |
+| webview.swift:74:10:74:26 | call to atIndex(_:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:74:10:74:26 | call to atIndex(_:) | result |
+| webview.swift:75:10:75:31 | call to forProperty(_:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:75:10:75:31 | call to forProperty(_:) | result |
+| webview.swift:78:10:78:47 | call to init(object:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:78:10:78:47 | call to init(object:in:) | result |
+| webview.swift:79:10:79:47 | call to init(bool:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:79:10:79:47 | call to init(bool:in:) | result |
+| webview.swift:80:10:80:51 | call to init(double:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:80:10:80:51 | call to init(double:in:) | result |
+| webview.swift:81:10:81:49 | call to init(int32:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:81:10:81:49 | call to init(int32:in:) | result |
+| webview.swift:82:10:82:51 | call to init(uInt32:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:82:10:82:51 | call to init(uInt32:in:) | result |
+| webview.swift:83:10:83:51 | call to init(point:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:83:10:83:51 | call to init(point:in:) | result |
+| webview.swift:84:10:84:51 | call to init(range:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:84:10:84:51 | call to init(range:in:) | result |
+| webview.swift:85:10:85:49 | call to init(rect:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:85:10:85:49 | call to init(rect:in:) | result |
+| webview.swift:86:10:86:49 | call to init(size:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:86:10:86:49 | call to init(size:in:) | result |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -144,7 +144,10 @@ edges
 | webview.swift:38:5:38:47 | [summary param] this in toRect() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRect() :  |
 | webview.swift:39:5:39:47 | [summary param] this in toSize() :  | file://:0:0:0:0 | [summary] to write: return (return) in toSize() :  |
 | webview.swift:40:5:40:84 | [summary param] this in atIndex(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in atIndex(_:) :  |
+| webview.swift:41:5:41:53 | [summary param] 1 in defineProperty(_:descriptor:) :  | file://:0:0:0:0 | [summary] to write: argument this in defineProperty(_:descriptor:) :  |
 | webview.swift:42:5:42:89 | [summary param] this in forProperty(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  |
+| webview.swift:43:5:43:38 | [summary param] 0 in setValue(_:at:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:at:) :  |
+| webview.swift:44:5:44:48 | [summary param] 0 in setValue(_:forProperty:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:forProperty:) :  |
 | webview.swift:52:11:52:18 | call to source() :  | webview.swift:52:10:52:41 | .body |
 | webview.swift:56:13:56:20 | call to source() :  | webview.swift:59:10:59:10 | source :  |
 | webview.swift:56:13:56:20 | call to source() :  | webview.swift:60:10:60:10 | source :  |
@@ -172,6 +175,9 @@ edges
 | webview.swift:56:13:56:20 | call to source() :  | webview.swift:84:25:84:25 | s :  |
 | webview.swift:56:13:56:20 | call to source() :  | webview.swift:85:24:85:24 | s :  |
 | webview.swift:56:13:56:20 | call to source() :  | webview.swift:86:24:86:24 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:89:39:89:39 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:93:17:93:17 | s :  |
+| webview.swift:56:13:56:20 | call to source() :  | webview.swift:97:17:97:17 | s :  |
 | webview.swift:59:10:59:10 | source :  | webview.swift:25:5:25:41 | [summary param] this in toObject() :  |
 | webview.swift:59:10:59:10 | source :  | webview.swift:59:10:59:26 | call to toObject() |
 | webview.swift:60:10:60:10 | source :  | webview.swift:26:5:26:55 | [summary param] this in toObjectOf(_:) :  |
@@ -224,8 +230,20 @@ edges
 | webview.swift:85:24:85:24 | s :  | webview.swift:85:10:85:49 | call to init(rect:in:) |
 | webview.swift:86:24:86:24 | s :  | webview.swift:24:5:24:40 | [summary param] 0 in init(size:in:) :  |
 | webview.swift:86:24:86:24 | s :  | webview.swift:86:10:86:49 | call to init(size:in:) |
+| webview.swift:89:5:89:5 | [post] v1 :  | webview.swift:90:10:90:10 | v1 |
+| webview.swift:89:39:89:39 | s :  | webview.swift:41:5:41:53 | [summary param] 1 in defineProperty(_:descriptor:) :  |
+| webview.swift:89:39:89:39 | s :  | webview.swift:89:5:89:5 | [post] v1 :  |
+| webview.swift:93:5:93:5 | [post] v2 :  | webview.swift:94:10:94:10 | v2 |
+| webview.swift:93:17:93:17 | s :  | webview.swift:43:5:43:38 | [summary param] 0 in setValue(_:at:) :  |
+| webview.swift:93:17:93:17 | s :  | webview.swift:93:5:93:5 | [post] v2 :  |
+| webview.swift:97:5:97:5 | [post] v3 :  | webview.swift:98:10:98:10 | v3 |
+| webview.swift:97:17:97:17 | s :  | webview.swift:44:5:44:48 | [summary param] 0 in setValue(_:forProperty:) :  |
+| webview.swift:97:17:97:17 | s :  | webview.swift:97:5:97:5 | [post] v3 :  |
 nodes
 | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  | semmle.label | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
+| file://:0:0:0:0 | [summary] to write: argument this in defineProperty(_:descriptor:) :  | semmle.label | [summary] to write: argument this in defineProperty(_:descriptor:) :  |
+| file://:0:0:0:0 | [summary] to write: argument this in setValue(_:at:) :  | semmle.label | [summary] to write: argument this in setValue(_:at:) :  |
+| file://:0:0:0:0 | [summary] to write: argument this in setValue(_:forProperty:) :  | semmle.label | [summary] to write: argument this in setValue(_:forProperty:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in atIndex(_:) :  | semmle.label | [summary] to write: return (return) in atIndex(_:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  | semmle.label | [summary] to write: return (return) in forProperty(_:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(bool:in:) :  | semmle.label | [summary] to write: return (return) in init(bool:in:) :  |
@@ -387,7 +405,10 @@ nodes
 | webview.swift:38:5:38:47 | [summary param] this in toRect() :  | semmle.label | [summary param] this in toRect() :  |
 | webview.swift:39:5:39:47 | [summary param] this in toSize() :  | semmle.label | [summary param] this in toSize() :  |
 | webview.swift:40:5:40:84 | [summary param] this in atIndex(_:) :  | semmle.label | [summary param] this in atIndex(_:) :  |
+| webview.swift:41:5:41:53 | [summary param] 1 in defineProperty(_:descriptor:) :  | semmle.label | [summary param] 1 in defineProperty(_:descriptor:) :  |
 | webview.swift:42:5:42:89 | [summary param] this in forProperty(_:) :  | semmle.label | [summary param] this in forProperty(_:) :  |
+| webview.swift:43:5:43:38 | [summary param] 0 in setValue(_:at:) :  | semmle.label | [summary param] 0 in setValue(_:at:) :  |
+| webview.swift:44:5:44:48 | [summary param] 0 in setValue(_:forProperty:) :  | semmle.label | [summary param] 0 in setValue(_:forProperty:) :  |
 | webview.swift:52:10:52:41 | .body | semmle.label | .body |
 | webview.swift:52:11:52:18 | call to source() :  | semmle.label | call to source() :  |
 | webview.swift:56:13:56:20 | call to source() :  | semmle.label | call to source() :  |
@@ -443,6 +464,15 @@ nodes
 | webview.swift:85:24:85:24 | s :  | semmle.label | s :  |
 | webview.swift:86:10:86:49 | call to init(size:in:) | semmle.label | call to init(size:in:) |
 | webview.swift:86:24:86:24 | s :  | semmle.label | s :  |
+| webview.swift:89:5:89:5 | [post] v1 :  | semmle.label | [post] v1 :  |
+| webview.swift:89:39:89:39 | s :  | semmle.label | s :  |
+| webview.swift:90:10:90:10 | v1 | semmle.label | v1 |
+| webview.swift:93:5:93:5 | [post] v2 :  | semmle.label | [post] v2 :  |
+| webview.swift:93:17:93:17 | s :  | semmle.label | s :  |
+| webview.swift:94:10:94:10 | v2 | semmle.label | v2 |
+| webview.swift:97:5:97:5 | [post] v3 :  | semmle.label | [post] v3 :  |
+| webview.swift:97:17:97:17 | s :  | semmle.label | s :  |
+| webview.swift:98:10:98:10 | v3 | semmle.label | v3 |
 subpaths
 | url.swift:59:31:59:31 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:59:19:59:38 | call to init(string:) :  |
 | url.swift:83:24:83:24 | tainted :  | url.swift:9:2:9:43 | [summary param] 0 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:83:12:83:48 | call to init(string:relativeTo:) :  |
@@ -490,6 +520,9 @@ subpaths
 | webview.swift:84:25:84:25 | s :  | webview.swift:22:5:22:42 | [summary param] 0 in init(range:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(range:in:) :  | webview.swift:84:10:84:51 | call to init(range:in:) |
 | webview.swift:85:24:85:24 | s :  | webview.swift:23:5:23:40 | [summary param] 0 in init(rect:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(rect:in:) :  | webview.swift:85:10:85:49 | call to init(rect:in:) |
 | webview.swift:86:24:86:24 | s :  | webview.swift:24:5:24:40 | [summary param] 0 in init(size:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(size:in:) :  | webview.swift:86:10:86:49 | call to init(size:in:) |
+| webview.swift:89:39:89:39 | s :  | webview.swift:41:5:41:53 | [summary param] 1 in defineProperty(_:descriptor:) :  | file://:0:0:0:0 | [summary] to write: argument this in defineProperty(_:descriptor:) :  | webview.swift:89:5:89:5 | [post] v1 :  |
+| webview.swift:93:17:93:17 | s :  | webview.swift:43:5:43:38 | [summary param] 0 in setValue(_:at:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:at:) :  | webview.swift:93:5:93:5 | [post] v2 :  |
+| webview.swift:97:17:97:17 | s :  | webview.swift:44:5:44:48 | [summary param] 0 in setValue(_:forProperty:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:forProperty:) :  | webview.swift:97:5:97:5 | [post] v3 :  |
 #select
 | string.swift:7:13:7:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:7:13:7:13 | "..." | result |
 | string.swift:9:13:9:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:9:13:9:13 | "..." | result |
@@ -571,3 +604,6 @@ subpaths
 | webview.swift:84:10:84:51 | call to init(range:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:84:10:84:51 | call to init(range:in:) | result |
 | webview.swift:85:10:85:49 | call to init(rect:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:85:10:85:49 | call to init(rect:in:) | result |
 | webview.swift:86:10:86:49 | call to init(size:in:) | webview.swift:56:13:56:20 | call to source() :  | webview.swift:86:10:86:49 | call to init(size:in:) | result |
+| webview.swift:90:10:90:10 | v1 | webview.swift:56:13:56:20 | call to source() :  | webview.swift:90:10:90:10 | v1 | result |
+| webview.swift:94:10:94:10 | v2 | webview.swift:56:13:56:20 | call to source() :  | webview.swift:94:10:94:10 | v2 | result |
+| webview.swift:98:10:98:10 | v3 | webview.swift:56:13:56:20 | call to source() :  | webview.swift:98:10:98:10 | v3 | result |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -119,6 +119,7 @@ edges
 | url.swift:117:28:117:28 | tainted :  | url.swift:117:16:117:35 | call to init(string:) :  |
 | url.swift:120:46:120:46 | urlTainted :  | url.swift:43:2:46:55 | [summary param] 0 in dataTask(with:completionHandler:) :  |
 | url.swift:120:61:120:61 | data :  | url.swift:121:15:121:19 | ...! |
+| webview.swift:12:13:12:20 | call to source() :  | webview.swift:12:13:12:22 | .body |
 nodes
 | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  | semmle.label | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | semmle.label | [summary] to write: return (return) in init(string:) :  |
@@ -231,6 +232,8 @@ nodes
 | url.swift:120:46:120:46 | urlTainted :  | semmle.label | urlTainted :  |
 | url.swift:120:61:120:61 | data :  | semmle.label | data :  |
 | url.swift:121:15:121:19 | ...! | semmle.label | ...! |
+| webview.swift:12:13:12:20 | call to source() :  | semmle.label | call to source() :  |
+| webview.swift:12:13:12:22 | .body | semmle.label | .body |
 subpaths
 | url.swift:59:31:59:31 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:59:19:59:38 | call to init(string:) :  |
 | url.swift:83:24:83:24 | tainted :  | url.swift:9:2:9:43 | [summary param] 0 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:83:12:83:48 | call to init(string:relativeTo:) :  |
@@ -306,3 +309,4 @@ subpaths
 | url.swift:102:15:102:67 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:102:15:102:67 | ...! | result |
 | url.swift:118:12:118:12 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:118:12:118:12 | ...! | result |
 | url.swift:121:15:121:19 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:121:15:121:19 | ...! | result |
+| webview.swift:12:13:12:22 | .body | webview.swift:12:13:12:20 | call to source() :  | webview.swift:12:13:12:22 | .body | result |

--- a/swift/ql/test/library-tests/dataflow/taint/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/webview.swift
@@ -87,13 +87,13 @@ func testJsValue() {
     
     let v1 = JSValue(object: "", in: context)
     v1.defineProperty("", descriptor: s as Any)
-    sink(v1) // $ MISSING: tainted=56
+    sink(v1) // $ tainted=56
 
     let v2 = JSValue(object: "", in: context)
     v2.setValue(s as Any, at: 0)
-    sink(v2) // $ MISSING: tainted=56
+    sink(v2) // $ tainted=56
 
     let v3 = JSValue(object: "", in: context)
-    v2.setValue(s as Any, forProperty: "")
-    sink(v3) // $ MISSING: tainted=56
+    v3.setValue(s as Any, forProperty: "")
+    sink(v3) // $ tainted=56
 }

--- a/swift/ql/test/library-tests/dataflow/taint/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/webview.swift
@@ -1,0 +1,13 @@
+
+// --- stubs ---
+class WKScriptMessage {
+    open var body: Any { get { return "" } }
+}
+
+// --- tests ---
+func source() -> WKScriptMessage { return WKScriptMessage() }
+func sink(s: Any) {}
+
+func testInheritBodyTaint() {
+    sink(s: source().body) // $ tainted=12
+}

--- a/swift/ql/test/library-tests/dataflow/taint/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/webview.swift
@@ -3,11 +3,97 @@
 class WKScriptMessage {
     open var body: Any { get { return "" } }
 }
+class NSNumber {
+    init(value: Int) {}
+}
+class Date {}
+class CGPoint {}
+class NSRange {}
+class CGRect {}
+class CGSize{}
+class JSContext {}
+class JSValue {
+    init(object: Any, in: JSContext) {}
+    init(bool: Bool, in: JSContext) {}
+    init(double: Double, in: JSContext) {}
+    init(int32: Int32, in: JSContext) {}
+    init(uInt32: UInt32, in: JSContext) {}
+    init(point: CGPoint, in: JSContext) {}
+    init(range: NSRange, in: JSContext) {}
+    init(rect: CGRect, in: JSContext) {}
+    init(size: CGSize, in: JSContext) {}
+    func toObject() -> Any! { return "" }
+    func toObjectOf(_: AnyClass!) -> Any! { return "" }
+    func toBool() -> Bool { return false }
+    func toDouble() -> Double { return 0.0 }
+    func toInt32() -> Int32 { return 0 }
+    func toUInt32() -> UInt32 { return 0 }
+    func toNumber() -> NSNumber! { return NSNumber(value: 0) }
+    func toString() -> String! { return "" }
+    func toDate() -> Date! { return Date() }
+    func toArray() -> [Any]! { return [""] }
+    func toDictionary() -> [AnyHashable: Any]! { return ["": ""]}
+    func toPoint() -> CGPoint { return CGPoint() }
+    func toRange() -> NSRange { return NSRange() }
+    func toRect() -> CGRect { return CGRect() }
+    func toSize() -> CGSize { return CGSize() }
+    func atIndex(_: Int) -> JSValue! { return JSValue(object: "", in: JSContext()) }
+    func defineProperty(_: Any!, descriptor: Any!) {}
+    func forProperty(_: Any!) -> JSValue! { return JSValue(object: "", in: JSContext()) }
+    func setValue(_: Any!, at: Int) {}
+    func setValue(_: Any!, forProperty: Any!) {}
+}
 
 // --- tests ---
-func source() -> WKScriptMessage { return WKScriptMessage() }
-func sink(s: Any) {}
+func source() -> Any { return "" }
+func sink(_: Any) {}
 
 func testInheritBodyTaint() {
-    sink(s: source().body) // $ tainted=12
+    sink((source() as! WKScriptMessage).body) // $ tainted=52
+}
+
+func testJsValue() {
+    let s = source()
+    
+    let source = s as! JSValue
+    sink(source.toObject() as Any) // $ tainted=56
+    sink(source.toObjectOf(NSNumber.self) as Any) // $ tainted=56
+    sink(source.toBool()) // $ tainted=56
+    sink(source.toDouble()) // $ tainted=56
+    sink(source.toInt32()) // $ tainted=56
+    sink(source.toUInt32()) // $ tainted=56
+    sink(source.toNumber() as Any) // $ tainted=56
+    sink(source.toString() as Any) // $ tainted=56
+    sink(source.toDate() as Any) // $ tainted=56
+    sink(source.toArray() as Any) // $ tainted=56
+    sink(source.toDictionary() as Any) // $ tainted=56
+    sink(source.toPoint()) // $ tainted=56
+    sink(source.toRange()) // $ tainted=56
+    sink(source.toRect()) // $ tainted=56
+    sink(source.toSize()) // $ tainted=56
+    sink(source.atIndex(0) as Any) // $ tainted=56
+    sink(source.forProperty("") as Any) // $ tainted=56
+
+    let context = JSContext()
+    sink(JSValue(object: s as Any, in: context)) // $ tainted=56
+    sink(JSValue(bool: s as! Bool, in: context)) // $ tainted=56
+    sink(JSValue(double: s as! Double, in: context)) // $ tainted=56
+    sink(JSValue(int32: s as! Int32, in: context)) // $ tainted=56
+    sink(JSValue(uInt32: s as! UInt32, in: context)) // $ tainted=56
+    sink(JSValue(point: s as! CGPoint, in: context)) // $ tainted=56
+    sink(JSValue(range: s as! NSRange, in: context)) // $ tainted=56
+    sink(JSValue(rect: s as! CGRect, in: context)) // $ tainted=56
+    sink(JSValue(size: s as! CGSize, in: context)) // $ tainted=56
+    
+    let v1 = JSValue(object: "", in: context)
+    v1.defineProperty("", descriptor: s as Any)
+    sink(v1) // $ MISSING: tainted=56
+
+    let v2 = JSValue(object: "", in: context)
+    v2.setValue(s as Any, at: 0)
+    sink(v2) // $ MISSING: tainted=56
+
+    let v3 = JSValue(object: "", in: context)
+    v2.setValue(s as Any, forProperty: "")
+    sink(v3) // $ MISSING: tainted=56
 }


### PR DESCRIPTION
Adds taint sources for JS-native bridges in WebViews. These are objects where JavaScript running in the WebView can execute native code, which can be exploited by malicious websites, or external attackers through XSS vulnerabilities, if it performs sensitive actions.