### PR TITLE
Kotlin: exclude loop variables on ranges from 'unused locals' check

### DIFF
--- a/java/ql/src/Violations of Best Practice/Dead Code/UnreadLocal.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/UnreadLocal.ql
@@ -26,5 +26,10 @@ where
   not exists(getARead(v)) and
   // Discarded exceptions are covered by another query.
   not exists(CatchClause cc | cc.getVariable().getVariable() = v) and
+  // Exclude common Kotlin pattern to do something n times: `for(i in 1..n) { doSomething() }
+  not exists(EnhancedForStmt f |
+    f.getVariable().getVariable() = v and
+    f.getExpr().getType().(RefType).hasQualifiedName("kotlin.ranges", ["IntRange", "LongRange"])
+  ) and
   not readImplicitly(v)
 select v, "Variable '" + v + "' is never read."

--- a/java/ql/test/kotlin/query-tests/UnreadLocal/UnreadLocal.expected
+++ b/java/ql/test/kotlin/query-tests/UnreadLocal/UnreadLocal.expected
@@ -1,0 +1,3 @@
+| test.kt:8:10:8:10 | int e | Variable 'int e' is never read. |
+| test.kt:14:11:14:13 | int idx | Variable 'int idx' is never read. |
+| test.kt:14:16:14:16 | int e | Variable 'int e' is never read. |

--- a/java/ql/test/kotlin/query-tests/UnreadLocal/UnreadLocal.qlref
+++ b/java/ql/test/kotlin/query-tests/UnreadLocal/UnreadLocal.qlref
@@ -1,0 +1,1 @@
+Violations of Best Practice/Dead Code/UnreadLocal.ql

--- a/java/ql/test/kotlin/query-tests/UnreadLocal/test.kt
+++ b/java/ql/test/kotlin/query-tests/UnreadLocal/test.kt
@@ -1,0 +1,25 @@
+fun fn0(size: Int) {
+    for (idx in 1..size) {
+        println()
+    }
+}
+
+fun fn1(a: Array<Int>) {
+    for (e in a) {
+        println()
+    }
+}
+
+fun fn2(a: Array<Int>) {
+    for ((idx, e) in a.withIndex()) {
+        println()
+    }
+}
+
+fun fn3() {
+    for (i in 1 until 10) {
+        println()
+    }
+}
+
+// Diagnostic Matches: % Couldn't find a Java equivalent function to kotlin.Int.rangeTo in java.lang.Integer%


### PR DESCRIPTION
Based on https://github.com/github/codeql/pull/11014.