### PR TITLE
Swift: Add and use ApplyExpr.getArgumentByParamName.

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
@@ -19,6 +19,17 @@ class ApplyExpr extends Generated::ApplyExpr {
   /** Gets the method qualifier, if this is applying a method */
   Expr getQualifier() { none() }
 
+  /**
+   * Gets the argument that has corresponding parameter name `paramName` (if
+   * any). If this call does not have a static target, there will be no result.
+   */
+  final Argument getArgumentByParamName(string paramName) {
+    exists(int arg |
+      this.getStaticTarget().getParam(pragma[only_bind_into](arg)).getName() = paramName and
+      this.getArgument(pragma[only_bind_into](arg)) = result
+    )
+  }
+
   override string toString() {
     result = "call to " + this.getStaticTarget().toString()
     or

--- a/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ApplyExpr.qll
@@ -19,17 +19,6 @@ class ApplyExpr extends Generated::ApplyExpr {
   /** Gets the method qualifier, if this is applying a method */
   Expr getQualifier() { none() }
 
-  /**
-   * Gets the argument that has corresponding parameter name `paramName` (if
-   * any). If this call does not have a static target, there will be no result.
-   */
-  final Argument getArgumentByParamName(string paramName) {
-    exists(int arg |
-      this.getStaticTarget().getParam(pragma[only_bind_into](arg)).getName() = paramName and
-      this.getArgument(pragma[only_bind_into](arg)) = result
-    )
-  }
-
   override string toString() {
     result = "call to " + this.getStaticTarget().toString()
     or

--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
@@ -26,30 +26,35 @@ class Sink extends DataFlow::Node {
   Expr baseUrl;
 
   Sink() {
-    exists(MethodDecl funcDecl, CallExpr call, string className, string funcName, string paramName |
+    exists(
+      MethodDecl funcDecl, CallExpr call, string className, string funcName, int arg, int baseArg
+    |
       // arguments to method calls...
       (
         // `loadHTMLString`
         className = ["UIWebView", "WKWebView"] and
         funcName = "loadHTMLString(_:baseURL:)" and
-        paramName = "string"
+        arg = 0 and
+        baseArg = 1
         or
         // `UIWebView.load`
         className = "UIWebView" and
         funcName = "load(_:mimeType:textEncodingName:baseURL:)" and
-        paramName = "data"
+        arg = 0 and
+        baseArg = 3
         or
         // `WKWebView.load`
         className = "WKWebView" and
         funcName = "load(_:mimeType:characterEncodingName:baseURL:)" and
-        paramName = "data"
+        arg = 0 and
+        baseArg = 3
       ) and
       call.getStaticTarget() = funcDecl and
       // match up `funcName`, `paramName`, `arg`, `node`.
       funcDecl.hasQualifiedName(className, funcName) and
-      call.getArgumentByParamName(paramName).getExpr() = this.asExpr() and
+      call.getArgument(arg).getExpr() = this.asExpr() and
       // match up `baseURLArg`
-      call.getArgumentByParamName("baseURL").getExpr() = baseUrl
+      call.getArgument(baseArg).getExpr() = baseUrl
     )
   }
 

--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.ql
@@ -26,10 +26,7 @@ class Sink extends DataFlow::Node {
   Expr baseUrl;
 
   Sink() {
-    exists(
-      MethodDecl funcDecl, CallExpr call, string className, string funcName, string paramName,
-      int arg, int baseUrlArg
-    |
+    exists(MethodDecl funcDecl, CallExpr call, string className, string funcName, string paramName |
       // arguments to method calls...
       (
         // `loadHTMLString`
@@ -50,11 +47,9 @@ class Sink extends DataFlow::Node {
       call.getStaticTarget() = funcDecl and
       // match up `funcName`, `paramName`, `arg`, `node`.
       funcDecl.hasQualifiedName(className, funcName) and
-      funcDecl.getParam(pragma[only_bind_into](arg)).getName() = paramName and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = this.asExpr() and
+      call.getArgumentByParamName(paramName).getExpr() = this.asExpr() and
       // match up `baseURLArg`
-      funcDecl.getParam(pragma[only_bind_into](baseUrlArg)).getName() = "baseURL" and
-      call.getArgument(pragma[only_bind_into](baseUrlArg)).getExpr() = baseUrl
+      call.getArgumentByParamName("baseURL").getExpr() = baseUrl
     )
   }
 

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -94,7 +94,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
    * that sink. We actually want to report incorrect flow states.
    */
   predicate isSinkImpl(DataFlow::Node node, string flowstate) {
-    exists(AbstractFunctionDecl funcDecl, CallExpr call, string funcName, string paramName |
+    exists(AbstractFunctionDecl funcDecl, CallExpr call, string funcName, int arg |
       (
         // arguments to method calls...
         exists(string className, ClassOrStructDecl c |
@@ -102,27 +102,27 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
             // `NSRange.init`
             className = "NSRange" and
             funcName = "init(location:length:)" and
-            paramName = ["location", "length"]
+            arg = [0, 1]
             or
             // `NSString.character`
             className = ["NSString", "NSMutableString"] and
             funcName = "character(at:)" and
-            paramName = "at"
+            arg = 0
             or
             // `NSString.character`
             className = ["NSString", "NSMutableString"] and
             funcName = "substring(from:)" and
-            paramName = "from"
+            arg = 0
             or
             // `NSString.character`
             className = ["NSString", "NSMutableString"] and
             funcName = "substring(to:)" and
-            paramName = "to"
+            arg = 0
             or
             // `NSMutableString.insert`
             className = "NSMutableString" and
             funcName = "insert(_:at:)" and
-            paramName = "at"
+            arg = 1
           ) and
           c.getName() = className and
           c.getABaseTypeDecl*().(ClassOrStructDecl).getAMember() = funcDecl and
@@ -133,7 +133,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
         // arguments to function calls...
         // `NSMakeRange`
         funcName = "NSMakeRange(_:_:)" and
-        paramName = ["loc", "len"] and
+        arg = [0, 1] and
         call.getStaticTarget() = funcDecl and
         flowstate = "NSString"
         or
@@ -141,30 +141,30 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
         (
           // `String.dropFirst`, `String.dropLast`, `String.removeFirst`, `String.removeLast`
           funcName = ["dropFirst(_:)", "dropLast(_:)", "removeFirst(_:)", "removeLast(_:)"] and
-          paramName = "k"
+          arg = 0
           or
           // `String.prefix`, `String.suffix`
           funcName = ["prefix(_:)", "suffix(_:)"] and
-          paramName = "maxLength"
+          arg = 0
           or
           // `String.Index.init`
           funcName = "init(encodedOffset:)" and
-          paramName = "offset"
+          arg = 0
           or
           // `String.index`
           funcName = ["index(_:offsetBy:)", "index(_:offsetBy:limitBy:)"] and
-          paramName = ["n", "distance"]
+          arg = [0, 1]
           or
           // `String.formIndex`
           funcName = ["formIndex(_:offsetBy:)", "formIndex(_:offsetBy:limitBy:)"] and
-          paramName = "distance"
+          arg = [0, 1]
         ) and
         call.getStaticTarget() = funcDecl and
         flowstate = "String"
       ) and
       // match up `funcName`, `paramName`, `arg`, `node`.
       funcDecl.getName() = funcName and
-      call.getArgumentByParamName(paramName).getExpr() = node.asExpr()
+      call.getArgument(arg).getExpr() = node.asExpr()
     )
   }
 

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -94,9 +94,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
    * that sink. We actually want to report incorrect flow states.
    */
   predicate isSinkImpl(DataFlow::Node node, string flowstate) {
-    exists(
-      AbstractFunctionDecl funcDecl, CallExpr call, string funcName, string paramName, int arg
-    |
+    exists(AbstractFunctionDecl funcDecl, CallExpr call, string funcName, string paramName |
       (
         // arguments to method calls...
         exists(string className, ClassOrStructDecl c |
@@ -166,8 +164,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
       ) and
       // match up `funcName`, `paramName`, `arg`, `node`.
       funcDecl.getName() = funcName and
-      funcDecl.getParam(pragma[only_bind_into](arg)).getName() = paramName and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = node.asExpr()
+      call.getArgumentByParamName(paramName).getExpr() = node.asExpr()
     )
   }
 


### PR DESCRIPTION
Add and use a predicate `ApplyExpr.getArgumentByParamName` (please say if you can think of a cleaner name for it).  This makes it easier to get an argument by its parameter name, rather than the argument name (which is often anonymous) or index (usually the preferred method, but sometimes varies across the functions of interest).

This will be used in a couple of upcoming queries in addition to the two I've updated here.