### PR TITLE
Kotlin: fix method types when an inherited method implements a collection type

### DIFF
--- a/java/ql/test/kotlin/library-tests/inherited-collection-implementation/Test.java
+++ b/java/ql/test/kotlin/library-tests/inherited-collection-implementation/Test.java
@@ -1,0 +1,59 @@
+import java.util.*;
+
+public class Test {
+
+  public boolean contains(Object o) { return false; }
+
+}
+
+class SetImpl<T> extends Test implements Set<T> {
+
+    public int size() {
+        return 0;
+    }
+
+    public boolean isEmpty() {
+        return false;
+    }
+
+    public Iterator<T> iterator() {
+        return null;
+    }
+
+    public Object[] toArray() {
+        return new Object[0];
+    }
+
+    public <T1> T1[] toArray(T1[] a) {
+        return null;
+    }
+
+    public boolean add(T t) {
+        return false;
+    }
+
+    public boolean remove(Object o) {
+        return false;
+    }
+
+    public boolean containsAll(Collection<?> c) {
+        return false;
+    }
+
+    public boolean addAll(Collection<? extends T> c) {
+        return false;
+    }
+
+    public boolean retainAll(Collection<?> c) {
+        return false;
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        return false;
+    }
+
+    public void clear() {
+
+    }
+
+}

--- a/java/ql/test/kotlin/library-tests/inherited-collection-implementation/test.expected
+++ b/java/ql/test/kotlin/library-tests/inherited-collection-implementation/test.expected
@@ -1,0 +1,2 @@
+| user.kt:1:42:1:58 | contains(...) |
+| user.kt:1:63:1:74 | contains(...) |

--- a/java/ql/test/kotlin/library-tests/inherited-collection-implementation/test.ql
+++ b/java/ql/test/kotlin/library-tests/inherited-collection-implementation/test.ql
@@ -1,0 +1,5 @@
+import java
+
+from MethodAccess ma
+where ma.getEnclosingCallable().fromSource()
+select ma

--- a/java/ql/test/kotlin/library-tests/inherited-collection-implementation/user.kt
+++ b/java/ql/test/kotlin/library-tests/inherited-collection-implementation/user.kt
@@ -1,0 +1,1 @@
+private fun user(s: SetImpl<String>) = s.contains("Hello") && "world" in s


### PR DESCRIPTION
In this circumstance the compiler seems to generate a specialised version of the implementing function with its argument type replaced by the interface-implementing child class' type parameter. However it stores a back-pointer to the real declared function, which we should use as the call target.