### PR TITLE
Python: Promote improvements to `py/tarslip`

### DIFF
--- a/python/ql/test/experimental/dataflow/TestUtil/DataflowConfigTest.qll
+++ b/python/ql/test/experimental/dataflow/TestUtil/DataflowConfigTest.qll
@@ -1,0 +1,33 @@
+import python
+import experimental.dataflow.TestUtil.FlowTest
+private import semmle.python.dataflow.new.internal.PrintNode
+
+signature module FlowSig {
+  predicate hasFlow(DataFlow::Node source, DataFlow::Node sink);
+}
+
+module DataflowTest<FlowSig Flow> {
+  class DataFlowTest extends FlowTest {
+    DataFlowTest() { this = "DataFlowTest" }
+
+    override string flowTag() { result = "flow" }
+
+    override predicate relevantFlow(DataFlow::Node source, DataFlow::Node sink) {
+      Flow::hasFlow(source, sink)
+    }
+  }
+
+  query predicate missingAnnotationOnSink(Location location, string error, string element) {
+    error = "ERROR, you should add `# $ MISSING: flow` annotation" and
+    exists(DataFlow::Node sink |
+      location = sink.getLocation() and
+      element = prettyExpr(sink.asExpr()) and
+      not Flow::hasFlow(_, sink) and
+      not exists(FalseNegativeExpectation missingResult |
+        missingResult.getTag() = "flow" and
+        missingResult.getLocation().getFile() = location.getFile() and
+        missingResult.getLocation().getStartLine() = location.getStartLine()
+      )
+    )
+  }
+}

--- a/python/ql/test/query-tests/Security/CWE-022-TarSlip/DataFlowQueryTest.expected
+++ b/python/ql/test/query-tests/Security/CWE-022-TarSlip/DataFlowQueryTest.expected
@@ -1,0 +1,2 @@
+failures
+missingAnnotationOnSink

--- a/python/ql/test/query-tests/Security/CWE-022-TarSlip/DataFlowQueryTest.ql
+++ b/python/ql/test/query-tests/Security/CWE-022-TarSlip/DataFlowQueryTest.ql
@@ -1,0 +1,33 @@
+import python
+import experimental.dataflow.TestUtil.FlowTest
+import semmle.python.security.dataflow.TarSlipQuery
+private import semmle.python.dataflow.new.internal.PrintNode
+
+class DataFlowTest extends FlowTest {
+  DataFlowTest() { this = "DataFlowTest" }
+
+  override string flowTag() { result = "flow" }
+
+  override predicate relevantFlow(DataFlow::Node source, DataFlow::Node sink) {
+    exists(Configuration cfg | cfg.hasFlow(source, sink))
+  }
+}
+
+query predicate missingAnnotationOnSink(Location location, string error, string element) {
+  error = "ERROR, you should add `# $ MISSING: flow` annotation" and
+  exists(DataFlow::Node sink |
+    exists(DataFlow::CallCfgNode call |
+      // note: we only care about `SINK` and not `SINK_F`, so we have to reconstruct manually.
+      call.getFunction().asCfgNode().(NameNode).getId() = "SINK" and
+      (sink = call.getArg(_) or sink = call.getArgByName(_))
+    ) and
+    location = sink.getLocation() and
+    element = prettyExpr(sink.asExpr()) and
+    not any(Configuration config).hasFlow(_, sink) and
+    not exists(FalseNegativeExpectation missingResult |
+      missingResult.getTag() = "flow" and
+      missingResult.getLocation().getFile() = location.getFile() and
+      missingResult.getLocation().getStartLine() = location.getStartLine()
+    )
+  )
+}

--- a/python/ql/test/query-tests/Security/CWE-022-TarSlip/tarslip.py
+++ b/python/ql/test/query-tests/Security/CWE-022-TarSlip/tarslip.py
@@ -12,12 +12,12 @@ for entry in tar:
     tar.extract(entry)
 
 tar = tarfile.open(unsafe_filename_tar)
-tar.extractall()
+tar.extractall() # $flow="tarfile.open(..), l:-1 -> tar"
 tar.close()
 
 tar = tarfile.open(unsafe_filename_tar)
 for entry in tar:
-    tar.extract(entry)
+    tar.extract(entry) # $flow="tarfile.open(..), l:-2 -> entry"
 
 tar = tarfile.open(safe_filename_tar)
 tar.extractall()
@@ -36,11 +36,11 @@ tar = tarfile.open(unsafe_filename_tar)
 for entry in tar:
     if ".." in entry.name:
         raise ValueError("Illegal tar archive entry")
-    tar.extract(entry, "/tmp/unpack/")
+    tar.extract(entry, "/tmp/unpack/") # $flow="tarfile.open(..), l:-4 -> entry"
 
 #Unsanitized members
 tar = tarfile.open(unsafe_filename_tar)
-tar.extractall(members=tar)
+tar.extractall(members=tar) # $flow="tarfile.open(..), l:-1 -> tar"
 
 
 #Sanitize members
@@ -58,7 +58,7 @@ tar.extractall(members=safemembers(tar))
 tar = tarfile.open(unsafe_filename_tar)
 for entry in tar:
     if os.path.isabs(entry.name) or ".." in entry.name:
-        tar.extract(entry, "/tmp/unpack/")
+        tar.extract(entry, "/tmp/unpack/") # $flow="tarfile.open(..), l:-3 -> entry"
 
 
 # OK Sanitized using not


### PR DESCRIPTION
First commit,  "add inline query test", is interesting. I believe we can use this pattern to add inline test expectations to all our query tests.