### PR TITLE
QL: prevent some cross-talk between modules

### DIFF
--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -25,6 +25,10 @@ class AstNode extends TAstNode {
   cached
   Location getLocation() { result = this.getFullLocation() } // overridden in some subclasses
 
+  /** Gets the file containing this AST node. */
+  cached
+  File getFile() { result = getFullLocation().getFile() }
+
   /** Gets the location that spans the entire AST node. */
   cached
   final Location getFullLocation() {

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -27,7 +27,7 @@ class AstNode extends TAstNode {
 
   /** Gets the file containing this AST node. */
   cached
-  File getFile() { result = getFullLocation().getFile() }
+  File getFile() { result = this.getFullLocation().getFile() }
 
   /** Gets the location that spans the entire AST node. */
   cached


### PR DESCRIPTION
This PR makes no difference now, but it will once I introduce the shared ReDoS pack.  

The problem comes e.g. from me importing `RegExpTreeView` (defined by each language) through some of the shared implementations.  
Because we collapse the instances of the parameterized modules there is no way of preventing that cross-talk between the modules.  

The consequence was e.g. that a reference `DataFlow::Configuration` in a Python query resolved too `DataFlow::Configuration` from JavaScript.  

The change is ugly, but it seems to work (the consistency queries are empty).  