### PR TITLE
Swift: detect the use of constant passwords for password-based encryption

### DIFF
--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.qhelp
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.qhelp
@@ -17,5 +17,6 @@
 
   <references>
     <li><a href="https://www.okta.com/blog/2019/03/what-are-salted-passwords-and-password-hashing/">What are Salted Passwords and Password Hashing?</a></li>
+    <li><a href="https://www.rfc-editor.org/rfc/rfc2898">Password-Based Cryptography Specification</a></li>
   </references>
 </qhelp>

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.qhelp
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.qhelp
@@ -1,0 +1,21 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+  <overview>
+    <p>Deriving password-based encryption keys using hard-coded passwords is insecure, because the generated key may be easily discovered. Data hashed using constant salts are vulnerable to dictionary attacks, enabling attackers to recover the original input.</p>
+  </overview>
+
+  <recommendation>
+    <p>Use randomly generated passwords to securely derive a password-based encryption key.</p>
+  </recommendation>
+
+  <example>
+    <p>The following example shows a few cases of hashing input data. In the 'BAD' cases, the password is constant, making the derived key vulnerable to dictionary attakcs.  In the 'GOOD' cases, the password is randomly generated, which protects the hashed data against recovery.</p>
+    <sample src="ConstantPassword.swift" />
+  </example>
+
+  <references>
+    <li><a href="https://www.okta.com/blog/2019/03/what-are-salted-passwords-and-password-hashing/">What are Salted Passwords and Password Hashing?</a></li>
+  </references>
+</qhelp>

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.qhelp
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.qhelp
@@ -3,7 +3,7 @@
   "qhelp.dtd">
 <qhelp>
   <overview>
-    <p>Deriving password-based encryption keys using hard-coded passwords is insecure, because the generated key may be easily discovered. Data hashed using constant salts are vulnerable to dictionary attacks, enabling attackers to recover the original input.</p>
+    <p>Deriving password-based encryption keys using hardcoded passwords is insecure, because the generated key may be easily discovered. Data hashed using constant salts is vulnerable to dictionary attacks, enabling attackers to recover the original input.</p>
     <p>In particular, constant passwords would enable easier recovery of the key, even in the presence of a salt. If that salt is random enough, then key recovery is not as easy as just looking up a hardcoded credential in the source code.</p>
   </overview>
 
@@ -17,7 +17,7 @@
   </example>
 
   <references>
-    <li><a href="https://www.okta.com/blog/2019/03/what-are-salted-passwords-and-password-hashing/">What are Salted Passwords and Password Hashing?</a></li>
-    <li><a href="https://www.rfc-editor.org/rfc/rfc2898">Password-Based Cryptography Specification</a></li>
+    <li>Okta blog: <a href="https://www.okta.com/blog/2019/03/what-are-salted-passwords-and-password-hashing/">What are Salted Passwords and Password Hashing?</a></li>
+    <li>RFC 2898: <a href="https://www.rfc-editor.org/rfc/rfc2898">Password-Based Cryptography Specification</a>.</li>
   </references>
 </qhelp>

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.qhelp
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.qhelp
@@ -4,6 +4,7 @@
 <qhelp>
   <overview>
     <p>Deriving password-based encryption keys using hard-coded passwords is insecure, because the generated key may be easily discovered. Data hashed using constant salts are vulnerable to dictionary attacks, enabling attackers to recover the original input.</p>
+    <p>In particular, constant passwords would enable easier recovery of the key, even in the presence of a salt. If that salt is random enough, then key recovery is not as easy as just looking up a hardcoded credential in the source code.</p>
   </overview>
 
   <recommendation>

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
@@ -17,7 +17,7 @@ import codeql.swift.dataflow.FlowSteps
 import DataFlow::PathGraph
 
 /**
- * A constant salt is created through either a byte array or string literals.
+ * A constant password is created through either a byte array or string literals.
  */
 class ConstantPasswordSource extends Expr {
   ConstantPasswordSource() {
@@ -45,7 +45,7 @@ class ConstantPasswordSink extends Expr {
 
 /**
  * A taint configuration from the source of constants passwords to expressions that use
- * them to initialize password-based enecryption keys.
+ * them to initialize password-based encryption keys.
  */
 class ConstantPasswordConfig extends TaintTracking::Configuration {
   ConstantPasswordConfig() { this = "ConstantPasswordConfig" }

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
@@ -1,0 +1,64 @@
+/**
+ * @name Constant password
+ * @description Using constant passwords is not secure, because potential attackers can easily recover them from the source code.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 6.8
+ * @precision high
+ * @id swift/constant-password
+ * @tags security
+ *       external/cwe/cwe-259
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.dataflow.FlowSteps
+import DataFlow::PathGraph
+
+/**
+ * A constant salt is created through either a byte array or string literals.
+ */
+class ConstantPasswordSource extends Expr {
+  ConstantPasswordSource() {
+    this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") or
+    this instanceof StringLiteralExpr
+  }
+}
+
+/**
+ * A class for all ways to use a constant password.
+ */
+class ConstantPasswordSink extends Expr {
+  ConstantPasswordSink() {
+    // `password` arg in `init` is a sink
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call, int arg |
+      c.getFullName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
+      c.getAMember() = f and
+      f.getName().matches("%init(%password:%") and
+      call.getStaticTarget() = f and
+      f.getParam(pragma[only_bind_into](arg)).getName() = "password" and
+      call.getArgument(pragma[only_bind_into](arg)).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A taint configuration from the source of constants passwords to expressions that use
+ * them to initialize password-based enecryption keys.
+ */
+class ConstantPasswordConfig extends TaintTracking::Configuration {
+  ConstantPasswordConfig() { this = "ConstantPasswordConfig" }
+
+  override predicate isSource(DataFlow::Node node) {
+    node.asExpr() instanceof ConstantPasswordSource
+  }
+
+  override predicate isSink(DataFlow::Node node) { node.asExpr() instanceof ConstantPasswordSink }
+}
+
+// The query itself
+from ConstantPasswordConfig config, DataFlow::PathNode sourceNode, DataFlow::PathNode sinkNode
+where config.hasFlowPath(sourceNode, sinkNode)
+select sinkNode.getNode(), sourceNode, sinkNode,
+  "The value '" + sourceNode.getNode().toString() + "' is used as a constant password."

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.swift
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.swift
@@ -1,0 +1,22 @@
+
+func encrypt(padding : Padding) {
+	// ...
+
+	// BAD: Using constant passwords for hashing
+	let password: Array<UInt8> = [0x2a, 0x3a, 0x80, 0x05]
+	let randomArray = (0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+	_ = try HKDF(password: password, salt: randomArray, info: randomArray, keyLength: 0, variant: Variant.sha2)
+	_ = try PKCS5.PBKDF1(password: password, salt: randomArray, iterations: 120120, keyLength: 0)
+	_ = try PKCS5.PBKDF2(password: password, salt: randomArray, iterations: 120120, keyLength: 0)
+	_ = try Scrypt(password: password, salt: randomArray, dkLen: 64, N: 16384, r: 8, p: 1)
+
+	// GOOD: Using randomly generated passwords for hashing
+	let password = (0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+	let randomArray = (0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+	_ = try HKDF(password: password, salt: randomArray, info: randomArray, keyLength: 0, variant: Variant.sha2)
+	_ = try PKCS5.PBKDF1(password: password, salt: randomArray, iterations: 120120, keyLength: 0)
+	_ = try PKCS5.PBKDF2(password: password, salt: randomArray, iterations: 120120, keyLength: 0)
+	_ = try Scrypt(password: password, salt: randomArray, dkLen: 64, N: 16384, r: 8, p: 1)
+
+	// ...
+}

--- a/swift/ql/test/query-tests/Security/CWE-259/ConstantPassword.expected
+++ b/swift/ql/test/query-tests/Security/CWE-259/ConstantPassword.expected
@@ -1,0 +1,17 @@
+edges
+| test.swift:43:39:43:134 | [...] :  | test.swift:51:30:51:30 | constantPassword |
+| test.swift:43:39:43:134 | [...] :  | test.swift:56:40:56:40 | constantPassword |
+| test.swift:43:39:43:134 | [...] :  | test.swift:62:40:62:40 | constantPassword |
+| test.swift:43:39:43:134 | [...] :  | test.swift:67:34:67:34 | constantPassword |
+nodes
+| test.swift:43:39:43:134 | [...] :  | semmle.label | [...] :  |
+| test.swift:51:30:51:30 | constantPassword | semmle.label | constantPassword |
+| test.swift:56:40:56:40 | constantPassword | semmle.label | constantPassword |
+| test.swift:62:40:62:40 | constantPassword | semmle.label | constantPassword |
+| test.swift:67:34:67:34 | constantPassword | semmle.label | constantPassword |
+subpaths
+#select
+| test.swift:51:30:51:30 | constantPassword | test.swift:43:39:43:134 | [...] :  | test.swift:51:30:51:30 | constantPassword | The value '[...]' is used as a constant password. |
+| test.swift:56:40:56:40 | constantPassword | test.swift:43:39:43:134 | [...] :  | test.swift:56:40:56:40 | constantPassword | The value '[...]' is used as a constant password. |
+| test.swift:62:40:62:40 | constantPassword | test.swift:43:39:43:134 | [...] :  | test.swift:62:40:62:40 | constantPassword | The value '[...]' is used as a constant password. |
+| test.swift:67:34:67:34 | constantPassword | test.swift:43:39:43:134 | [...] :  | test.swift:67:34:67:34 | constantPassword | The value '[...]' is used as a constant password. |

--- a/swift/ql/test/query-tests/Security/CWE-259/ConstantPassword.qlref
+++ b/swift/ql/test/query-tests/Security/CWE-259/ConstantPassword.qlref
@@ -1,0 +1,1 @@
+queries/Security/CWE-259/ConstantPassword.ql

--- a/swift/ql/test/query-tests/Security/CWE-259/test.swift
+++ b/swift/ql/test/query-tests/Security/CWE-259/test.swift
@@ -1,0 +1,70 @@
+
+// --- stubs ---
+
+// These stubs roughly follows the same structure as classes from CryptoSwift
+enum PKCS5 { }
+
+enum Variant { case md5, sha1, sha2, sha3 }
+
+extension PKCS5 {
+  struct PBKDF1 {
+	init(password: Array<UInt8>, salt: Array<UInt8>, variant: Variant = .sha1, iterations: Int = 4096, keyLength: Int? = nil) { }
+  }
+
+  struct PBKDF2 {
+	init(password: Array<UInt8>, salt: Array<UInt8>, iterations: Int = 4096, keyLength: Int? = nil, variant: Variant = .sha2) { }
+  }
+}
+
+struct HKDF {
+	init(password: Array<UInt8>, salt: Array<UInt8>? = nil, info: Array<UInt8>? = nil, keyLength: Int? = nil, variant: Variant = .sha2) { }
+}
+
+final class Scrypt {
+	init(password: Array<UInt8>, salt: Array<UInt8>, dkLen: Int, N: Int, r: Int, p: Int) { }
+}
+
+// Helper functions
+func getConstantString() -> String {
+  "this string is constant"
+}
+
+func getConstantArray() -> Array<UInt8> {
+	[UInt8](getConstantString().utf8)
+}
+
+func getRandomArray() -> Array<UInt8> {
+	(0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+}
+
+// --- tests ---
+
+func test() {
+	let constantPassword: Array<UInt8> = [0x2a, 0x3a, 0x80, 0x05, 0xaf, 0x46, 0x58, 0x2d, 0x66, 0x52, 0x10, 0xae, 0x86, 0xd3, 0x8e, 0x8f]
+	let constantStringPassword = getConstantArray()
+	let randomPassword = getRandomArray()
+	let randomArray = getRandomArray()
+	let variant = Variant.sha2
+	let iterations = 120120
+	
+	// HKDF test cases
+	let hkdfb1 = HKDF(password: constantPassword, salt: randomArray, info: randomArray, keyLength: 0, variant: variant) // BAD
+	let hkdfb2 = HKDF(password: constantStringPassword, salt: randomArray, info: randomArray, keyLength: 0, variant: variant) // BAD [NOT DETECTED]
+	let hkdfg1 = HKDF(password: randomPassword, salt: randomArray, info: randomArray, keyLength: 0, variant: variant) // GOOD
+
+	// PBKDF1 test cases
+	let pbkdf1b1 = PKCS5.PBKDF1(password: constantPassword, salt: randomArray, iterations: iterations, keyLength: 0) // BAD
+	let pbkdf1b2 = PKCS5.PBKDF1(password: constantStringPassword, salt: randomArray, iterations: iterations, keyLength: 0) // BAD [NOT DETECTED]
+	let pbkdf1g1 = PKCS5.PBKDF1(password: randomPassword, salt: randomArray, iterations: iterations, keyLength: 0) // GOOD
+
+
+	// PBKDF2 test cases
+	let pbkdf2b1 = PKCS5.PBKDF2(password: constantPassword, salt: randomArray, iterations: iterations, keyLength: 0) // BAD
+	let pbkdf2b2 = PKCS5.PBKDF2(password: constantStringPassword, salt: randomArray, iterations: iterations, keyLength: 0) // BAD [NOT DETECTED]
+	let pbkdf2g1 = PKCS5.PBKDF2(password: randomPassword, salt: randomArray, iterations: iterations, keyLength: 0) // GOOD
+
+	// Scrypt test cases
+	let scryptb1 = Scrypt(password: constantPassword, salt: randomArray, dkLen: 64, N: 16384, r: 8, p: 1) // BAD
+	let scryptb2 = Scrypt(password: constantStringPassword, salt: randomArray, dkLen: 64, N: 16384, r: 8, p: 1) // BAD [NOT DETECTED]
+	let scryptg1 = Scrypt(password: randomPassword, salt: randomArray, dkLen: 64, N: 16384, r: 8, p: 1) // GOOD
+}


### PR DESCRIPTION
Deriving password-based encryption keys using hard-coded passwords is insecure, because the generated key may be easily discovered. Data hashed using constant salts are vulnerable to dictionary attacks, enabling attackers to recover the original input.

The rule currently supports all ciphers that the CryptoSwift API provides, but we can always extend it further if more APIs are added.

I'd appreciate a review of the query itself, the accompanying tests, and the associated documentation.