### PR TITLE
Revert "Use 'gh codeql' with the nightly release for CI jobs"

### DIFF
--- a/.github/actions/fetch-codeql/action.yml
+++ b/.github/actions/fetch-codeql/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
         gh extension install github/gh-codeql
-        gh codeql set-channel nightly
+        gh codeql set-channel release
         gh codeql version
         gh codeql version --format=json | jq -r .unpackedLocation >> "${GITHUB_PATH}"
       env:


### PR DESCRIPTION
Reverts github/codeql#9936