### PR TITLE
add workflow that checks compilation of all queries with the latest stable release

### DIFF
--- a/.github/actions/fetch-codeql/action.yml
+++ b/.github/actions/fetch-codeql/action.yml
@@ -1,14 +1,22 @@
 name: Fetch CodeQL
 description: Fetches the latest version of CodeQL
+
+inputs:
+  channel:
+    description: 'The CodeQL channel to use'
+    required: false
+    default: 'nightly'
+
 runs:
   using: composite
   steps:
     - name: Fetch CodeQL
       shell: bash
-      run: |
-        gh extension install github/gh-codeql
-        gh codeql set-channel nightly
-        gh codeql version
-        gh codeql version --format=json | jq -r .unpackedLocation >> "${GITHUB_PATH}"
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        CHANNEL: ${{ inputs.channel }}
+      run: |
+        gh extension install github/gh-codeql
+        gh codeql set-channel $CHANNEL
+        gh codeql version
+        gh codeql version --format=json | jq -r .unpackedLocation >> "${GITHUB_PATH}"

--- a/.github/actions/fetch-codeql/action.yml
+++ b/.github/actions/fetch-codeql/action.yml
@@ -17,6 +17,6 @@ runs:
         CHANNEL: ${{ inputs.channel }}
       run: |
         gh extension install github/gh-codeql
-        gh codeql set-channel $CHANNEL
+        gh codeql set-channel "$CHANNEL"
         gh codeql version
         gh codeql version --format=json | jq -r .unpackedLocation >> "${GITHUB_PATH}"

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -33,25 +33,19 @@ jobs:
           restore-keys: |
             codeql-stable-compile-${{ env.merge-base }}
             codeql-stable-compile-
-      - name: install codeql
-        run: gh extension install github/gh-codeql
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup CodeQL
+        uses: ./.github/actions/fetch-codeql
+        with:
+          channel: 'release'
       - name: check formatting
-        run: gh codeql query format */ql/{src,lib,test}/**/*.{qll,ql} --check-only
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: codeql query format */ql/{src,lib,test}/**/*.{qll,ql} --check-only
       - name: compile queries - check-only
         # run with --check-only if running in a PR (github.sha != main)
         if : ${{ github.sha != steps.merge-base.outputs.merge-base }}
         shell: bash
-        run: gh codeql query compile -j0 */ql/src --keep-going --warnings=error --check-only
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: codeql query compile -j0 */ql/src --keep-going --warnings=error --check-only
       - name: compile queries - full
         # do full compile if running on main - this populates the cache
         if : ${{ github.sha == steps.merge-base.outputs.merge-base }}
         shell: bash
-        run: gh codeql query compile -j0 */ql/src --keep-going --warnings=error
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: codeql query compile -j0 */ql/src --keep-going --warnings=error

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -1,0 +1,57 @@
+name: "Compile all queries using the latest stable CodeQL CLI"
+
+on:
+  push:
+    branches: [main] # makes sure the cache gets populated
+  pull_request:
+    branches:
+      - main
+      - "rc/*"
+
+jobs:
+  compile-queries:
+    runs-on: ubuntu-latest-xl
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # calculate the merge-base with main, in a way that works both on PRs and pushes to main. 
+      - name: Calculate merge-base
+        id: merge-base
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: |
+          MERGE_BASE=$(git merge-base --fork-point origin/$BASE_BRANCH)
+          echo "merge-base=$MERGE_BASE" >> $GITHUB_ENV
+      - name: Cache CodeQL query compilation
+        uses: actions/cache@v3
+        with:
+          path: '*/ql/src/.cache'
+          # current GH HEAD first, merge-base second, generic third
+          key: codeql-stable-compile-${{ github.sha }}
+          restore-keys: |
+            codeql-stable-compile-${{ env.merge-base }}
+            codeql-stable-compile-
+      - name: install codeql
+        run: gh extension install github/gh-codeql
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check formatting
+        run: gh codeql query format */ql/{src,lib,test}/**/*.{qll,ql} --check-only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: compile queries - check-only
+        # run with --check-only if running in a PR (github.sha != main)
+        if : ${{ github.sha != steps.merge-base.outputs.merge-base }}
+        shell: bash
+        run: gh codeql query compile -j0 */ql/src --keep-going --warnings=error --check-only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: compile queries - full
+        # do full compile if running on main - this populates the cache
+        if : ${{ github.sha == steps.merge-base.outputs.merge-base }}
+        shell: bash
+        run: gh codeql query compile -j0 */ql/src --keep-going --warnings=error
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go/ql/src/Metrics/FLinesOfCode.ql
+++ b/go/ql/src/Metrics/FLinesOfCode.ql
@@ -6,7 +6,6 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg sum max
- * @precision very-high
  * @id go/lines-of-code-in-files
  * @tags maintainability
  */

--- a/go/ql/src/Metrics/FLinesOfComment.ql
+++ b/go/ql/src/Metrics/FLinesOfComment.ql
@@ -6,7 +6,6 @@
  * @treemap.warnOn lowValues
  * @metricType file
  * @metricAggregate avg sum max
- * @precision very-high
  * @id go/lines-of-comments-in-files
  * @tags documentation
  */

--- a/go/ql/src/experimental/CWE-400/DatabaseCallInLoop.ql
+++ b/go/ql/src/experimental/CWE-400/DatabaseCallInLoop.ql
@@ -66,4 +66,5 @@ query predicate edges(CallGraphNode pred, CallGraphNode succ) {
 
 from LoopStmt loop, DatabaseAccess dbAccess
 where edges*(loop, dbAccess.asExpr())
-select dbAccess, loop, dbAccess, "This calls " + dbAccess.toString() + " in a $@.", loop, "loop"
+select dbAccess, loop, dbAccess.asExpr(), "This calls " + dbAccess.toString() + " in a $@.", loop,
+  "loop"

--- a/go/ql/src/experimental/InconsistentCode/DeferInLoop.ql
+++ b/go/ql/src/experimental/InconsistentCode/DeferInLoop.ql
@@ -4,6 +4,8 @@
  *              This can lead to unintentionally holding resources open like file handles or database transactions.
  * @id go/examples/deferinloop
  * @kind problem
+ * @problem.severity warning
+ * @precision high
  * @tags defer
  *       nesting
  */

--- a/swift/ql/lib/codeql/swift/controlflow/internal/Completion.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/Completion.qll
@@ -70,7 +70,8 @@ abstract class Completion extends TCompletion {
   predicate isValidFor(ControlFlowElement n) {
     this.isValidForSpecific(n)
     or
-    mayHaveThrowCompletion(n, this)
+    this instanceof ThrowCompletion and
+    mayHaveThrowCompletion(n)
     or
     not any(Completion c).isValidForSpecific(n) and
     this = TSimpleCompletion()
@@ -320,7 +321,7 @@ private predicate mustHaveThrowCompletion(ThrowStmt throw, ThrowCompletion c) { 
 
 private predicate isThrowingType(AnyFunctionType type) { type.isThrowing() }
 
-private predicate mayHaveThrowCompletion(ControlFlowElement n, ThrowCompletion c) {
+private predicate mayHaveThrowCompletion(ControlFlowElement n) {
   // An AST expression that may throw.
   isThrowingType(n.asAstNode().(ApplyExpr).getFunction().getType())
   or


### PR DESCRIPTION
This new workflow uses the latest stable release of CodeQL to check the formatting of all `*/ql/{src,lib,test}/**/*.{qll,ql}` files, and check that all `*/ql/src/**/*.ql` files compile without without warnings.  

And I've drive-by fixed some compiler warnings such that the new CI workflow passes. 

I investigated whether I wanted to use the `--check-only` flag while checking compilation.  
Not using `--check-only` populates the cache, which makes subsequent much faster, but using `--check-only` is faster when there is no cache.  

I ended up going for an approach where I get the best of both worlds. 
When this workflow runs in a PR it uses `--check-only`, but when the code is merged to main it populates the cache from there.  
So the average PR will get a cache hit on all queries that aren't changed compared to `main`.   
I'm hoping this will keep the average runtime under 5 minutes.  
But even when there is no cache hit the runtime is only ~20 minutes.  

I'm not too sure if the caching works - I'll try to do some followup work if it turns out that the cache doesn't work.  

---- 

Some numbers (from my local machine).  
 - Checking all queries with a cold cache: 15 minutes. 
 - Compiling all queries with a warm cache: 1 minute 30 seconds. 
 - Full compilation after fixing swift (with otherwise warm cache): 2 minutes. 