### PR TITLE
Java: Add test for multiply-bounded wildcards

### DIFF
--- a/java/ql/test/library-tests/multiply-bounded-wildcards/Test.java
+++ b/java/ql/test/library-tests/multiply-bounded-wildcards/Test.java
@@ -1,0 +1,19 @@
+public class Test {
+
+  static class BoundedGeneric<T extends CharSequence> {
+    public T getter(int unused) { return null; }
+    public void setter(T t) { }
+  }
+
+  public static BoundedGeneric<?> getUnbounded() { return null; }
+
+  public static BoundedGeneric<? super String> getLowerBounded() { return null; }
+
+  public static void test() {
+    CharSequence cs = getUnbounded().getter(0);
+    Object o = getLowerBounded().getter(0);
+    getUnbounded().setter(null);
+    getLowerBounded().setter(null);
+  }
+
+}

--- a/java/ql/test/library-tests/multiply-bounded-wildcards/test.expected
+++ b/java/ql/test/library-tests/multiply-bounded-wildcards/test.expected
@@ -1,0 +1,4 @@
+| Test$BoundedGeneric.class:0:0:0:0 | getter | Test$BoundedGeneric.class:0:0:0:0 | BoundedGeneric<? super String> | CharSequence | int |
+| Test$BoundedGeneric.class:0:0:0:0 | getter | Test$BoundedGeneric.class:0:0:0:0 | BoundedGeneric<?> | CharSequence | int |
+| Test$BoundedGeneric.class:0:0:0:0 | setter | Test$BoundedGeneric.class:0:0:0:0 | BoundedGeneric<? super String> | void | String |
+| Test$BoundedGeneric.class:0:0:0:0 | setter | Test$BoundedGeneric.class:0:0:0:0 | BoundedGeneric<?> | void | <nulltype> |

--- a/java/ql/test/library-tests/multiply-bounded-wildcards/test.ql
+++ b/java/ql/test/library-tests/multiply-bounded-wildcards/test.ql
@@ -1,0 +1,5 @@
+import java
+
+from MethodAccess ma
+select ma.getCallee(), ma.getCallee().getDeclaringType(), ma.getCallee().getReturnType().toString(),
+  ma.getCallee().getAParamType().toString()

--- a/java/ql/test/library-tests/wildcards-and-captured-types/Test.java
+++ b/java/ql/test/library-tests/wildcards-and-captured-types/Test.java
@@ -1,0 +1,13 @@
+import java.util.Collection;
+
+public class Test {
+
+  public Collection<? extends CharSequence> getCollection() {
+    return null;
+  }
+
+  public void test() {
+    this.getCollection().isEmpty();
+  }
+
+}

--- a/java/ql/test/library-tests/wildcards-and-captured-types/test.ql
+++ b/java/ql/test/library-tests/wildcards-and-captured-types/test.ql
@@ -1,0 +1,5 @@
+import java
+
+from Method m, Type t
+where m.getAParamType() = t and t.toString().matches("%? super ? extends%")
+select m, t


### PR DESCRIPTION
This exercises several cases of variables bounded both by a wildcard and by a bound on the type parameter, checking that the extractor strips the wildcards and captures to decide on a concrete type for the parameters and return values.