### PR TITLE
QL4QL: Add DependencyPath.ql query

### DIFF
--- a/ql/ql/src/codeql_ql/dependency/DependencyPath.qll
+++ b/ql/ql/src/codeql_ql/dependency/DependencyPath.qll
@@ -1,0 +1,191 @@
+/**
+ * Defines a graph for reasoning about dependencies between different predicates,
+ * that is, whether one would force evaluation of another (unless magic).
+ */
+
+private import codeql_ql.ast.Ast
+
+newtype TPathNode =
+  MkAstNode(AstNode node) or
+  MkTypeNode(Type type) { not type instanceof DontCareType }
+
+class PathNode extends TPathNode {
+  AstNode asAstNode() { this = MkAstNode(result) }
+
+  Type asType() { this = MkTypeNode(result) }
+
+  private string getOverrideToString() {
+    exists(Predicate p | this.asAstNode() = p |
+      result = p.(ClassPredicate).getDeclaringType().getName() + "." + p.getName()
+      or
+      result = p.(ClasslessPredicate).getName()
+    )
+    or
+    result = this.asAstNode().(TopLevel).getFile().getRelativePath()
+  }
+
+  string toString() {
+    result = this.getOverrideToString()
+    or
+    not exists(this.getOverrideToString()) and
+    (
+      result = this.asAstNode().toString()
+      or
+      result = this.asType().toString()
+    )
+  }
+
+  /**
+   * Tries to provide a more helpful location, if possible.
+   */
+  private Location getOverrideLocation() {
+    result = this.asType().(ClassCharType).getDeclaration().getCharPred().getLocation()
+  }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.getOverrideLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    or
+    not exists(this.getOverrideLocation()) and
+    (
+      this.asType().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+      or
+      this.asAstNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    )
+  }
+}
+
+private Predicate getAnOverriddenPredicate(Predicate p) { predOverrides(p, result) }
+
+private predicate isRootDef(Predicate p) { not exists(getAnOverriddenPredicate(p)) }
+
+private Predicate getARootDef(Predicate p) {
+  result = getAnOverriddenPredicate*(p) and
+  isRootDef(result)
+}
+
+private TypeExpr getABaseType(Class cls, boolean abstractExtension) {
+  result = cls.getASuperType() and
+  if result.getResolvedType().(ClassType).getDeclaration().isAbstract()
+  then abstractExtension = true
+  else abstractExtension = false
+  or
+  result = cls.getAnInstanceofType() and
+  abstractExtension = false
+}
+
+pragma[nomagic]
+predicate rawEdge(PathNode pred, PathNode succ) {
+  exists(Predicate predicat | pred.asAstNode() = predicat |
+    succ.asAstNode().getEnclosingPredicate() = predicat
+    or
+    getAnOverriddenPredicate(succ.asAstNode()) = predicat
+    or
+    succ.asType() = predicat.(ClassPredicate).getDeclaringType()
+  )
+  or
+  exists(Call call |
+    pred.asAstNode() = call and
+    succ.asAstNode() = getARootDef(call.getTarget())
+  )
+  or
+  exists(TypeExpr t | pred.asAstNode() = t |
+    if t = getABaseType(_, true)
+    then
+      // When extending an abstract class, the typename in the 'extends' clause is considered to target
+      // only the ClassCharType. The ClassType represents the union of concrete subtypes.
+      succ.asType().(ClassCharType).getClassType() = t.getResolvedType()
+    else succ.asType() = t.getResolvedType()
+  )
+  or
+  exists(ClassType classType | pred.asType() = classType |
+    // Always add an edge from ClassType to ClassCharType. For abstract class this makes the path shorter
+    // and more obvious than going through an arbitrary subclass.
+    succ.asType().(ClassCharType).getClassType() = classType
+    or
+    classType.getDeclaration().isAbstract() and
+    succ.asType().(ClassType).getDeclaration().getASuperType().getResolvedType() = classType
+  )
+  or
+  exists(ClassCharType charType, Class cls |
+    pred.asType() = charType and
+    cls = charType.getClassType().getDeclaration()
+  |
+    succ.asAstNode() = cls.getCharPred()
+    or
+    succ.asAstNode() = cls.getAField().getVarDecl().getTypeExpr()
+    or
+    succ.asAstNode() = getABaseType(cls, _)
+  )
+  or
+  exists(UnionType t |
+    pred.asType() = t and
+    succ.asAstNode() = t.getDeclaration().getUnionMember()
+  )
+  or
+  exists(NewTypeType t |
+    pred.asType() = t and
+    succ.asType() = t.getABranch()
+  )
+  or
+  exists(NewTypeBranchType t |
+    pred.asType() = t and
+    succ.asAstNode() = t.getDeclaration() // map to the Predicate AST node
+  )
+  or
+  exists(TopLevel top |
+    pred.asAstNode() = top and
+    succ.asAstNode().getFile() = top.getFile()
+  )
+}
+
+private PathNode getAPredecessor(PathNode node) { rawEdge(result, node) }
+
+private PathNode getASuccessor(PathNode node) { rawEdge(node, result) }
+
+signature module DependencyConfig {
+  /**
+   * Holds if we should explore the transitive dependencies of `source`.
+   */
+  predicate isSource(PathNode source);
+
+  /**
+   * Holds if a transitive dependency from a source to `sink` should be reported.
+   */
+  predicate isSink(PathNode sink);
+}
+
+module PathGraph<DependencyConfig C> {
+  private PathNode reachableFromSource() {
+    C::isSource(result)
+    or
+    result = getASuccessor(reachableFromSource())
+  }
+
+  private PathNode reachableSink() {
+    C::isSink(result) and
+    result = reachableFromSource()
+  }
+
+  private PathNode relevantNode() {
+    result = reachableSink()
+    or
+    result = getAPredecessor(relevantNode()) and
+    result = reachableFromSource()
+  }
+
+  query predicate edges(PathNode pred, PathNode succ) {
+    pred = relevantNode() and
+    succ = relevantNode() and
+    rawEdge(pred, succ)
+  }
+
+  query predicate nodes(PathNode node) { node = relevantNode() }
+
+  predicate hasFlowPath(PathNode source, PathNode sink) {
+    C::isSource(source) and
+    C::isSink(sink) and
+    edges+(source, sink)
+  }
+}

--- a/ql/ql/src/queries/explore/DependencyPath.ql
+++ b/ql/ql/src/queries/explore/DependencyPath.ql
@@ -29,6 +29,16 @@ module Config implements DependencyConfig {
    * Holds if a transitive dependency from a source to `sink` should be reported.
    */
   predicate isSink(PathNode sink) { sink.asAstNode().(Predicate).getName() = "isLocalSourceNode" }
+
+  /**
+   * Holds if the `cached` members of a `cached` module or class should be unified.
+   *
+   * Whether to set this depends on your use-case:
+   * - If you wish to know why one predicate causes another predicate to be evaluated, this should be `any()`.
+   * - If you wish to investigate recursion patterns or understand why the value of one predicate
+   *   is influenced by another predicate, it should be `none()`.
+   */
+  predicate followCacheDependencies() { any() }
 }
 
 import PathGraph<Config>

--- a/ql/ql/src/queries/explore/DependencyPath.ql
+++ b/ql/ql/src/queries/explore/DependencyPath.ql
@@ -1,0 +1,38 @@
+/**
+ * @name Dependency path
+ * @kind path-problem
+ * @description Reports known dependency paths between different predicates or classes.
+ * @precision medium
+ * @severity info
+ * @tags exploration
+ * @id ql/explore/dependency-path
+ */
+
+//
+// This query is for exploration purposes can be edited by hand according to your use-case.
+// Note that dependencies introduced by 'magic' are not recognized by this query.
+//
+import codeql_ql.ast.Ast
+import codeql_ql.dependency.DependencyPath
+
+module Config implements DependencyConfig {
+  /**
+   * Holds if we should explore the transitive dependencies of `source`.
+   */
+  predicate isSource(PathNode source) {
+    // A top-level is considered to depend on everything in the file, which can be useful for generating
+    // quick overview of which files depend on a given sink.
+    source.asAstNode() instanceof TopLevel
+  }
+
+  /**
+   * Holds if a transitive dependency from a source to `sink` should be reported.
+   */
+  predicate isSink(PathNode sink) { sink.asAstNode().(Predicate).getName() = "isLocalSourceNode" }
+}
+
+import PathGraph<Config>
+
+from PathNode source, PathNode sink
+where hasFlowPath(source, sink)
+select source, source, sink, "$@ depends on $@.", source, source.toString(), sink, sink.toString()


### PR DESCRIPTION
Adds an explorative query for visualising how a given predicate/class/file depends on a given predicate or class.

By "explorative" I mean it's not intended to run in CI. It's a query you have to adapt to your needs and run locally.

Dependencies introduced by magic are not known to the query.

To use the query:
- Build the QL4QL extractor and extract a database for the relevant CodeQL library
- Modify `ql/src/queries/explore/DependencyPath.ql` and run it

---

For example, here I ran it to answer how `RE::RegExpTerm` depends on `isLocalSource`:

![dependency-path-sloww](https://user-images.githubusercontent.com/316427/199490093-a2ae85c5-0117-49b2-a852-51021dcc40d9.gif)

