### PR TITLE
C#: Telemetry query updates.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Type.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Type.qll
@@ -824,6 +824,8 @@ class RecordClass extends RecordType, Class {
  */
 class AnonymousClass extends Class {
   AnonymousClass() { anonymous_types(this) }
+
+  override string getAPrimaryQlClass() { result = "AnonymousClass" }
 }
 
 /**

--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -37,6 +37,7 @@ class ExternalApi extends DotNet::Callable {
   /**
    * Gets the unbound type, name and parameter types of this API.
    */
+  bindingset[this]
   private string getSignature() {
     result =
       this.getDeclaringType().getUnboundDeclaration() + "." + this.getName() + "(" +
@@ -46,11 +47,13 @@ class ExternalApi extends DotNet::Callable {
   /**
    * Gets the namespace of this API.
    */
+  bindingset[this]
   string getNamespace() { this.getDeclaringType().hasQualifiedName(result, _) }
 
   /**
    * Gets the namespace and signature of this API.
    */
+  bindingset[this]
   string getApiName() { result = this.getNamespace() + "#" + this.getSignature() }
 
   /** Gets a node that is an input to a call to this API. */

--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -42,22 +42,12 @@ class ExternalApi extends DotNet::Callable {
   /**
    * Gets the namespace of this API.
    */
-  private string getNamespace() { this.getDeclaringType().hasQualifiedName(result, _) }
+  string getNamespace() { this.getDeclaringType().hasQualifiedName(result, _) }
 
   /**
-   * Gets the assembly file name containing this API.
+   * Gets the namespace and signature of this API.
    */
-  private string getAssembly() { result = this.getFile().getBaseName() }
-
-  /**
-   * Gets the assembly file name and namespace of this API.
-   */
-  string getInfoPrefix() { result = this.getAssembly() + "#" + this.getNamespace() }
-
-  /**
-   * Gets the assembly file name, namespace and signature of this API.
-   */
-  string getInfo() { result = this.getInfoPrefix() + "#" + this.getSignature() }
+  string getApiName() { result = this.getNamespace() + "#" + this.getSignature() }
 
   /** Gets a call to this API callable. */
   DispatchCall getACall() {
@@ -125,30 +115,30 @@ signature predicate relevantApi(ExternalApi api);
  * for restricting the number or returned results based on a certain limit.
  */
 module Results<relevantApi/1 getRelevantUsages> {
-  private int getUsages(string apiInfo) {
+  private int getUsages(string apiName) {
     result =
       strictcount(DispatchCall c, ExternalApi api |
         c = api.getACall() and
-        apiInfo = api.getInfo() and
+        apiName = api.getApiName() and
         getRelevantUsages(api)
       )
   }
 
-  private int getOrder(string apiInfo) {
-    apiInfo =
-      rank[result](string info, int usages |
-        usages = getUsages(info)
+  private int getOrder(string apiName) {
+    apiName =
+      rank[result](string name, int usages |
+        usages = getUsages(name)
       |
-        info order by usages desc, info
+        name order by usages desc, name
       )
   }
 
   /**
-   * Holds if there exists an API with `apiInfo` that is being used `usages` times
+   * Holds if there exists an API with `apiName` that is being used `usages` times
    * and if it is in the top results (guarded by resultLimit).
    */
-  predicate restrict(string apiInfo, int usages) {
-    usages = getUsages(apiInfo) and
-    getOrder(apiInfo) <= resultLimit()
+  predicate restrict(string apiName, int usages) {
+    usages = getUsages(apiName) and
+    getOrder(apiName) <= resultLimit()
   }
 }

--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -28,7 +28,11 @@ class TestLibrary extends RefType {
  * An external API from either the C# Standard Library or a 3rd party library.
  */
 class ExternalApi extends DotNet::Callable {
-  ExternalApi() { this.isUnboundDeclaration() and this.fromLibrary() }
+  ExternalApi() {
+    this.isUnboundDeclaration() and
+    this.fromLibrary() and
+    this.(Modifiable).isEffectivelyPublic()
+  }
 
   /**
    * Gets the unbound type, name and parameter types of this API.

--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -12,8 +12,8 @@ private import ExternalApi
 
 private predicate getRelevantUsages(string namespace, int usages) {
   usages =
-    strictcount(DispatchCall c, ExternalApi api |
-      c = api.getACall() and
+    strictcount(Call c, ExternalApi api |
+      c.getTarget().getUnboundDeclaration() = api and
       api.getNamespace() = namespace and
       not api.isUninteresting()
     )

--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -1,6 +1,6 @@
 /**
  * @name External libraries
- * @description A list of external libraries used in the code
+ * @description A list of external libraries used in the code given by their namespace.
  * @kind metric
  * @tags summary telemetry
  * @id csharp/telemetry/external-libs
@@ -10,23 +10,23 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate getRelevantUsages(string info, int usages) {
+private predicate getRelevantUsages(string namespace, int usages) {
   usages =
     strictcount(DispatchCall c, ExternalApi api |
       c = api.getACall() and
-      api.getInfoPrefix() = info and
+      api.getNamespace() = namespace and
       not api.isUninteresting()
     )
 }
 
-private int getOrder(string info) {
-  info =
+private int getOrder(string namespace) {
+  namespace =
     rank[result](string i, int usages | getRelevantUsages(i, usages) | i order by usages desc, i)
 }
 
-from ExternalApi api, string info, int usages
+from ExternalApi api, string namespace, int usages
 where
-  info = api.getInfoPrefix() and
-  getRelevantUsages(info, usages) and
-  getOrder(info) <= resultLimit()
-select info, usages order by usages desc
+  namespace = api.getNamespace() and
+  getRelevantUsages(namespace, usages) and
+  getOrder(namespace) <= resultLimit()
+select namespace, usages order by usages desc

--- a/csharp/ql/src/meta/frameworks/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/meta/frameworks/UnsupportedExternalAPIs.ql
@@ -14,9 +14,9 @@ private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSumma
 private import semmle.code.csharp.dataflow.internal.NegativeSummary
 private import Telemetry.ExternalApi
 
-from DispatchCall c, ExternalApi api
+from Call c, ExternalApi api
 where
-  c = api.getACall() and
+  c.getTarget().getUnboundDeclaration() = api and
   not api.isUninteresting() and
   not api.isSupported() and
   not api instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.expected
@@ -1,2 +1,2 @@
-| System.Private.CoreLib.dll#System | 5 |
-| System.Private.CoreLib.dll#System.Collections.Generic | 2 |
+| System | 5 |
+| System.Collections.Generic | 2 |

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.expected
@@ -1,1 +1,1 @@
-| System.Private.CoreLib.dll#System.Collections.Generic#List<>.Add(T) | 2 |
+| System.Collections.Generic#List<>.Add(T) | 2 |

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.expected
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.expected
@@ -1,2 +1,2 @@
-| System.Web.cs#System.Web#HttpResponse.Write(System.Object) | 2 |
-| System.Web.cs#System.Web#HttpResponse.WriteFile(System.String) | 1 |
+| System.Web#HttpResponse.Write(System.Object) | 2 |
+| System.Web#HttpResponse.WriteFile(System.String) | 1 |

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/SupportedExternalSources.expected
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/SupportedExternalSources.expected
@@ -1,2 +1,2 @@
-| System.Console.dll#System#Console.ReadLine() | 2 |
-| System.Console.dll#System#Console.Read() | 1 |
+| System#Console.ReadLine() | 2 |
+| System#Console.Read() | 1 |


### PR DESCRIPTION
It turns out that the Telemetry we emit for API calls in C# needs to be changed.
- We have removed the (assembly) file name as the same method can be located in different assemblies across version, which clutters the picture of the usage.
- We have aligned the counting to only count *calls* and not the possible (runtime) dispatch targets.
- We now only consider callables that are effectively public.

This should align the implemetation a bit better with Java.

With respect to testing of the PR
- The unit tests behaves as expected (the coverage is not optimal, but still a good indication that everything works as expected).
- I have tried to run some of the queries locally against .NET Runtime and .NET EfCore and the results looks reasonable (ie. the results doesn't contain any "noise", but it would be a huge task to verify that the results are correct manually).
- The DCA results looks acceptable (ie. there are no performance regressions when running the full nightly query suite).

The only thing in this PR I am a bit uncertain about is, whether it is a good idea to tag some of the string generating predicates with the `bindingset` pragma.