### PR TITLE
Swift: detect the use of static initialization vectors

### DIFF
--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.qhelp
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.qhelp
@@ -3,7 +3,7 @@
 
 <overview>
   <p>When a cipher is used in certain modes (such as CBC or GCM), it requires an initialization vector (IV). Under the same secret key, IVs should be unique and ideally unpredictable. If the same IV is used with the same secret key, then the same plaintext results in the same ciphertext. This behavior may enable an attacker to learn if the same data pieces are transferred or stored, or help the attacker run a dictionary attack.</p>
-  <p>In particular, if the IV is hardcoded or constant, an attacker may just lookup potential keys in a dictionary, then concatenate those with the hardcoded or constant IV rather than trying to discover the entire encryption key.</p>
+  <p>In particular, if the IV is hardcoded or constant, an attacker may just look up potential keys in a dictionary, then concatenate those with the hardcoded or constant IV rather than trying to discover the entire encryption key.</p>
 </overview>
 
 <recommendation>

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.qhelp
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.qhelp
@@ -1,0 +1,22 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+  <p>When a cipher is used in certain modes (such as CBC or GCM), it requires an initialization vector (IV). Under the same secret key, IVs should be unique and ideally unpredictable. If the same IV is used with the same secret key, then the same plaintext results in the same ciphertext. This behavior may enable an attacker to learn if the same data pieces are transferred or stored, or help the attacker run a dictionary attack.</p>
+</overview>
+
+<recommendation>
+  <p>Use a randomly generated IV.</p>
+</recommendation>
+
+<example>
+    <p>The following example shows a few cases of instantiating a cipher with various encryption keys. In the 'BAD' cases, the IV is hardcoded or constant, making the encrypted data vulnerable to recovery.  In the 'GOOD' cases, the IV is randomly generated and not hardcoded, which protects the encrypted data against recovery.</p>
+    <sample src="StaticInitializationVector.swift" />
+  </example>
+
+<references>
+  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Initialization_vector">Initialization vector</a>.</li>
+  <li>National Institute of Standards and Technology: <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf">Recommendation for Block Cipher Modes of Operation</a>.</li>
+  <li>National Institute of Standards and Technology: <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-2.pdf">FIPS 140-2: Security Requirements for Cryptographic Modules</a>.</li>
+</references>
+</qhelp>

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.qhelp
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.qhelp
@@ -3,6 +3,7 @@
 
 <overview>
   <p>When a cipher is used in certain modes (such as CBC or GCM), it requires an initialization vector (IV). Under the same secret key, IVs should be unique and ideally unpredictable. If the same IV is used with the same secret key, then the same plaintext results in the same ciphertext. This behavior may enable an attacker to learn if the same data pieces are transferred or stored, or help the attacker run a dictionary attack.</p>
+  <p>In particular, if the IV is hardcoded or constant, an attacker may just lookup potential keys in a dictionary, then concatenate those with the hardcoded or constant IV rather than trying to discover the entire encryption key.</p>
 </overview>
 
 <recommendation>

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
@@ -1,6 +1,6 @@
 /**
  * @name Static initialization vector for encryption
- * @description Using a static initialization vector (IV) for encryption is not secure. To maximize encryption and prevent dictionary attacks, IVs should rather be unique and unpredictable.
+ * @description Using a static initialization vector (IV) for encryption is not secure. To maximize encryption and prevent dictionary attacks, IVs should be unique and unpredictable.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 7.5

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
@@ -41,7 +41,8 @@ class EncryptionInitializationSink extends Expr {
             ], fName) and
       fName.matches("%init(%iv:%") and
       arg = [0, 1] and
-      call.getArgument(arg).getExpr() = this
+      call.getStaticTarget().(MethodDecl).getParam(pragma[only_bind_into](arg)).getName() = "iv" and
+      call.getArgument(pragma[only_bind_into](arg)).getExpr() = this
     )
   }
 }

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
@@ -16,10 +16,6 @@ import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.TaintTracking
 import DataFlow::PathGraph
 
-// from DataFlow::PathNode source, DataFlow::PathNode sink, StaticInitializationVectorConfig conf
-// where conf.hasFlowPath(source, sink)
-// select sink.getNode(), source, sink, "A $@ should not be used for encryption.", source.getNode(),
-//   "static initialization vector"
 /**
  * A static IV is created through either a byte array or string literals.
  */

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
@@ -1,0 +1,76 @@
+/**
+ * @name Static initialization vector for encryption
+ * @description Using a static initialization vector (IV) for encryption is not secure. To maximize encryption and prevent dictionary attacks, IVs should rather be unique and unpredictable.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.5
+ * @precision high
+ * @id swift/static-initialization-vector
+ * @tags security
+ *       external/cwe/cwe-329
+ *       external/cwe/cwe-1204
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+// from DataFlow::PathNode source, DataFlow::PathNode sink, StaticInitializationVectorConfig conf
+// where conf.hasFlowPath(source, sink)
+// select sink.getNode(), source, sink, "A $@ should not be used for encryption.", source.getNode(),
+//   "static initialization vector"
+/**
+ * A static IV is created through either a byte array or string literals.
+ */
+class StaticInitializationVectorSource extends Expr {
+  StaticInitializationVectorSource() {
+    this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") or
+    this instanceof StringLiteralExpr
+  }
+}
+
+/**
+ * A class for all ways to set an IV.
+ */
+class EncryptionInitializationSink extends Expr {
+  EncryptionInitializationSink() {
+    // `iv` arg in `init` is a sink
+    exists(CallExpr call, string fName, int arg |
+      call.getStaticTarget()
+          .(MethodDecl)
+          .hasQualifiedName([
+              "AES", "ChaCha20", "Blowfish", "Rabbit", "CBC", "CFB", "GCM", "OCB", "OFB", "PCBC",
+              "CCM", "CTR"
+            ], fName) and
+      fName.matches("%init(%iv:%") and
+      arg = [0, 1] and
+      call.getArgument(arg).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A dataflow configuration from the source of a static IV to expressions that use
+ * it to initialize a cipher.
+ */
+class StaticInitializationVectorConfig extends TaintTracking::Configuration {
+  StaticInitializationVectorConfig() { this = "StaticInitializationVectorConfig" }
+
+  override predicate isSource(DataFlow::Node node) {
+    node.asExpr() instanceof StaticInitializationVectorSource
+  }
+
+  override predicate isSink(DataFlow::Node node) {
+    node.asExpr() instanceof EncryptionInitializationSink
+  }
+}
+
+// The query itself
+from
+  StaticInitializationVectorConfig config, DataFlow::PathNode sourceNode,
+  DataFlow::PathNode sinkNode
+where config.hasFlowPath(sourceNode, sinkNode)
+select sinkNode.getNode(), sourceNode, sinkNode,
+  "The static value '" + sourceNode.getNode().toString() +
+    "' is used as an initialization vector for encryption."

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.swift
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.swift
@@ -1,0 +1,20 @@
+
+func encrypt(padding : Padding) {
+	// ...
+
+	// BAD: Using static IVs for encryption
+	let iv: Array<UInt8> = [0x2a, 0x3a, 0x80, 0x05]
+	let ivString = "this is a constant string"
+	let key = getRandomKey()
+	_ = try AES(key: key, iv: ivString)
+	_ = try CBC(iv: iv)
+
+	// GOOD: Using randomly generated IVs for encryption
+	let iv = (0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+	let ivString = String(cString: iv)
+	let key = getRandomKey())
+	_ = try AES(key: key, iv: ivString)
+	_ = try CBC(iv: iv)
+
+	// ...
+}

--- a/swift/ql/test/query-tests/Security/CWE-1204/StaticInitializationVector.expected
+++ b/swift/ql/test/query-tests/Security/CWE-1204/StaticInitializationVector.expected
@@ -1,65 +1,65 @@
 edges
 | test.swift:85:3:85:3 | this string is constant :  | test.swift:101:17:101:35 | call to getConstantString() :  |
-| test.swift:99:25:99:120 | [...] :  | test.swift:129:33:129:33 | iv |
-| test.swift:99:25:99:120 | [...] :  | test.swift:136:22:136:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:128:33:128:33 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:135:22:135:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:139:22:139:22 | iv |
 | test.swift:99:25:99:120 | [...] :  | test.swift:140:22:140:22 | iv |
-| test.swift:99:25:99:120 | [...] :  | test.swift:141:22:141:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:145:22:145:22 | iv |
 | test.swift:99:25:99:120 | [...] :  | test.swift:146:22:146:22 | iv |
 | test.swift:99:25:99:120 | [...] :  | test.swift:147:22:147:22 | iv |
-| test.swift:99:25:99:120 | [...] :  | test.swift:148:22:148:22 | iv |
-| test.swift:99:25:99:120 | [...] :  | test.swift:154:22:154:22 | iv |
-| test.swift:99:25:99:120 | [...] :  | test.swift:158:24:158:24 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:153:22:153:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:157:24:157:24 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:161:22:161:22 | iv |
 | test.swift:99:25:99:120 | [...] :  | test.swift:162:22:162:22 | iv |
-| test.swift:99:25:99:120 | [...] :  | test.swift:163:22:163:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:167:22:167:22 | iv |
 | test.swift:99:25:99:120 | [...] :  | test.swift:168:22:168:22 | iv |
-| test.swift:99:25:99:120 | [...] :  | test.swift:169:22:169:22 | iv |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:112:36:112:36 | ivString |
 | test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:113:36:113:36 | ivString |
-| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:114:36:114:36 | ivString |
-| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:119:41:119:41 | ivString |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:118:41:118:41 | ivString |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:122:41:122:41 | ivString |
 | test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:123:41:123:41 | ivString |
-| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:124:41:124:41 | ivString |
-| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:131:39:131:39 | ivString |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:130:39:130:39 | ivString |
 nodes
 | test.swift:85:3:85:3 | this string is constant :  | semmle.label | this string is constant :  |
 | test.swift:99:25:99:120 | [...] :  | semmle.label | [...] :  |
 | test.swift:101:17:101:35 | call to getConstantString() :  | semmle.label | call to getConstantString() :  |
+| test.swift:112:36:112:36 | ivString | semmle.label | ivString |
 | test.swift:113:36:113:36 | ivString | semmle.label | ivString |
-| test.swift:114:36:114:36 | ivString | semmle.label | ivString |
-| test.swift:119:41:119:41 | ivString | semmle.label | ivString |
+| test.swift:118:41:118:41 | ivString | semmle.label | ivString |
+| test.swift:122:41:122:41 | ivString | semmle.label | ivString |
 | test.swift:123:41:123:41 | ivString | semmle.label | ivString |
-| test.swift:124:41:124:41 | ivString | semmle.label | ivString |
-| test.swift:129:33:129:33 | iv | semmle.label | iv |
-| test.swift:131:39:131:39 | ivString | semmle.label | ivString |
-| test.swift:136:22:136:22 | iv | semmle.label | iv |
+| test.swift:128:33:128:33 | iv | semmle.label | iv |
+| test.swift:130:39:130:39 | ivString | semmle.label | ivString |
+| test.swift:135:22:135:22 | iv | semmle.label | iv |
+| test.swift:139:22:139:22 | iv | semmle.label | iv |
 | test.swift:140:22:140:22 | iv | semmle.label | iv |
-| test.swift:141:22:141:22 | iv | semmle.label | iv |
+| test.swift:145:22:145:22 | iv | semmle.label | iv |
 | test.swift:146:22:146:22 | iv | semmle.label | iv |
 | test.swift:147:22:147:22 | iv | semmle.label | iv |
-| test.swift:148:22:148:22 | iv | semmle.label | iv |
-| test.swift:154:22:154:22 | iv | semmle.label | iv |
-| test.swift:158:24:158:24 | iv | semmle.label | iv |
+| test.swift:153:22:153:22 | iv | semmle.label | iv |
+| test.swift:157:24:157:24 | iv | semmle.label | iv |
+| test.swift:161:22:161:22 | iv | semmle.label | iv |
 | test.swift:162:22:162:22 | iv | semmle.label | iv |
-| test.swift:163:22:163:22 | iv | semmle.label | iv |
+| test.swift:167:22:167:22 | iv | semmle.label | iv |
 | test.swift:168:22:168:22 | iv | semmle.label | iv |
-| test.swift:169:22:169:22 | iv | semmle.label | iv |
 subpaths
 #select
+| test.swift:112:36:112:36 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:112:36:112:36 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
 | test.swift:113:36:113:36 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:113:36:113:36 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
-| test.swift:114:36:114:36 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:114:36:114:36 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
-| test.swift:119:41:119:41 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:119:41:119:41 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:118:41:118:41 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:118:41:118:41 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:122:41:122:41 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:122:41:122:41 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
 | test.swift:123:41:123:41 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:123:41:123:41 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
-| test.swift:124:41:124:41 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:124:41:124:41 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
-| test.swift:129:33:129:33 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:129:33:129:33 | iv | The static value '[...]' is used as an initialization vector for encryption. |
-| test.swift:131:39:131:39 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:131:39:131:39 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
-| test.swift:136:22:136:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:136:22:136:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:128:33:128:33 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:128:33:128:33 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:130:39:130:39 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:130:39:130:39 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:135:22:135:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:135:22:135:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:139:22:139:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:139:22:139:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
 | test.swift:140:22:140:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:140:22:140:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
-| test.swift:141:22:141:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:141:22:141:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:145:22:145:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:145:22:145:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
 | test.swift:146:22:146:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:146:22:146:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
 | test.swift:147:22:147:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:147:22:147:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
-| test.swift:148:22:148:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:148:22:148:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
-| test.swift:154:22:154:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:154:22:154:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
-| test.swift:158:24:158:24 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:158:24:158:24 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:153:22:153:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:153:22:153:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:157:24:157:24 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:157:24:157:24 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:161:22:161:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:161:22:161:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
 | test.swift:162:22:162:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:162:22:162:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
-| test.swift:163:22:163:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:163:22:163:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:167:22:167:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:167:22:167:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
 | test.swift:168:22:168:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:168:22:168:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
-| test.swift:169:22:169:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:169:22:169:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |

--- a/swift/ql/test/query-tests/Security/CWE-1204/StaticInitializationVector.expected
+++ b/swift/ql/test/query-tests/Security/CWE-1204/StaticInitializationVector.expected
@@ -1,0 +1,65 @@
+edges
+| test.swift:85:3:85:3 | this string is constant :  | test.swift:101:17:101:35 | call to getConstantString() :  |
+| test.swift:99:25:99:120 | [...] :  | test.swift:129:33:129:33 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:136:22:136:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:140:22:140:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:141:22:141:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:146:22:146:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:147:22:147:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:148:22:148:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:154:22:154:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:158:24:158:24 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:162:22:162:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:163:22:163:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:168:22:168:22 | iv |
+| test.swift:99:25:99:120 | [...] :  | test.swift:169:22:169:22 | iv |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:113:36:113:36 | ivString |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:114:36:114:36 | ivString |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:119:41:119:41 | ivString |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:123:41:123:41 | ivString |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:124:41:124:41 | ivString |
+| test.swift:101:17:101:35 | call to getConstantString() :  | test.swift:131:39:131:39 | ivString |
+nodes
+| test.swift:85:3:85:3 | this string is constant :  | semmle.label | this string is constant :  |
+| test.swift:99:25:99:120 | [...] :  | semmle.label | [...] :  |
+| test.swift:101:17:101:35 | call to getConstantString() :  | semmle.label | call to getConstantString() :  |
+| test.swift:113:36:113:36 | ivString | semmle.label | ivString |
+| test.swift:114:36:114:36 | ivString | semmle.label | ivString |
+| test.swift:119:41:119:41 | ivString | semmle.label | ivString |
+| test.swift:123:41:123:41 | ivString | semmle.label | ivString |
+| test.swift:124:41:124:41 | ivString | semmle.label | ivString |
+| test.swift:129:33:129:33 | iv | semmle.label | iv |
+| test.swift:131:39:131:39 | ivString | semmle.label | ivString |
+| test.swift:136:22:136:22 | iv | semmle.label | iv |
+| test.swift:140:22:140:22 | iv | semmle.label | iv |
+| test.swift:141:22:141:22 | iv | semmle.label | iv |
+| test.swift:146:22:146:22 | iv | semmle.label | iv |
+| test.swift:147:22:147:22 | iv | semmle.label | iv |
+| test.swift:148:22:148:22 | iv | semmle.label | iv |
+| test.swift:154:22:154:22 | iv | semmle.label | iv |
+| test.swift:158:24:158:24 | iv | semmle.label | iv |
+| test.swift:162:22:162:22 | iv | semmle.label | iv |
+| test.swift:163:22:163:22 | iv | semmle.label | iv |
+| test.swift:168:22:168:22 | iv | semmle.label | iv |
+| test.swift:169:22:169:22 | iv | semmle.label | iv |
+subpaths
+#select
+| test.swift:113:36:113:36 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:113:36:113:36 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:114:36:114:36 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:114:36:114:36 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:119:41:119:41 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:119:41:119:41 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:123:41:123:41 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:123:41:123:41 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:124:41:124:41 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:124:41:124:41 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:129:33:129:33 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:129:33:129:33 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:131:39:131:39 | ivString | test.swift:85:3:85:3 | this string is constant :  | test.swift:131:39:131:39 | ivString | The static value 'this string is constant' is used as an initialization vector for encryption. |
+| test.swift:136:22:136:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:136:22:136:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:140:22:140:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:140:22:140:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:141:22:141:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:141:22:141:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:146:22:146:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:146:22:146:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:147:22:147:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:147:22:147:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:148:22:148:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:148:22:148:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:154:22:154:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:154:22:154:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:158:24:158:24 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:158:24:158:24 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:162:22:162:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:162:22:162:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:163:22:163:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:163:22:163:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:168:22:168:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:168:22:168:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |
+| test.swift:169:22:169:22 | iv | test.swift:99:25:99:120 | [...] :  | test.swift:169:22:169:22 | iv | The static value '[...]' is used as an initialization vector for encryption. |

--- a/swift/ql/test/query-tests/Security/CWE-1204/StaticInitializationVector.qlref
+++ b/swift/ql/test/query-tests/Security/CWE-1204/StaticInitializationVector.qlref
@@ -1,0 +1,1 @@
+queries/Security/CWE-1204/StaticInitializationVector.ql

--- a/swift/ql/test/query-tests/Security/CWE-1204/test.swift
+++ b/swift/ql/test/query-tests/Security/CWE-1204/test.swift
@@ -104,7 +104,6 @@ func test() {
 	let randomIv = getRandomArray()
 	let randomIvString = String(cString: getRandomArray())
 
-	let blockMode = CBC(iv: randomIv)
 	let padding = Padding.noPadding
 	let key = getRandomArray()
 	let keyString = String(cString: key)

--- a/swift/ql/test/query-tests/Security/CWE-1204/test.swift
+++ b/swift/ql/test/query-tests/Security/CWE-1204/test.swift
@@ -1,0 +1,172 @@
+
+// --- stubs ---
+
+// These stubs roughly follows the same structure as classes from CryptoSwift
+class AES
+{
+	init(key: Array<UInt8>, blockMode: BlockMode, padding: Padding) { }
+	init(key: Array<UInt8>, blockMode: BlockMode) { }
+	init(key: String, iv: String) { }
+	init(key: String, iv: String, padding: Padding) { }
+}
+
+class Blowfish
+{
+	init(key: Array<UInt8>, blockMode: BlockMode, padding: Padding) { }
+	init(key: Array<UInt8>, blockMode: BlockMode) { }
+	init(key: String, iv: String) { }
+	init(key: String, iv: String, padding: Padding) { }
+}
+
+class ChaCha20
+{
+	init(key: Array<UInt8>, iv: Array<UInt8>) { }
+	init(key: String, iv: String) { }
+}
+
+class Rabbit
+{
+	init(key: Array<UInt8>) { }
+	init(key: String) { }
+	init(key: Array<UInt8>, iv: Array<UInt8>) { }
+	init(key: String, iv: String) { }
+}
+
+protocol BlockMode { }
+
+struct CBC: BlockMode { 
+	init(iv: Array<UInt8>) { }
+}
+
+struct CFB: BlockMode {
+	enum SegmentSize: Int {
+		case cfb8 = 1
+		case cfb128 = 16
+	}
+
+	init(iv: Array<UInt8>, segmentSize: SegmentSize = .cfb128) { }
+}
+
+final class GCM: BlockMode {
+	enum Mode { case combined, detached }
+	init(iv: Array<UInt8>, additionalAuthenticatedData: Array<UInt8>? = nil, tagLength: Int = 16, mode: Mode = .detached) { }
+	convenience init(iv: Array<UInt8>, authenticationTag: Array<UInt8>, additionalAuthenticatedData: Array<UInt8>? = nil, mode: Mode = .detached) { 
+		self.init(iv: iv, additionalAuthenticatedData: additionalAuthenticatedData, tagLength: authenticationTag.count, mode: mode)
+	}
+}
+
+struct OFB: BlockMode {
+	init(iv: Array<UInt8>) { }
+}
+
+struct PCBC: BlockMode {
+	init(iv: Array<UInt8>) { }
+}
+
+typealias StreamMode = BlockMode
+
+struct CCM: StreamMode {
+	init(iv: Array<UInt8>, tagLength: Int, messageLength: Int, additionalAuthenticatedData: Array<UInt8>? = nil) { }
+	init(iv: Array<UInt8>, tagLength: Int, messageLength: Int, authenticationTag: Array<UInt8>, additionalAuthenticatedData: Array<UInt8>? = nil) { }
+}
+
+struct CTR: StreamMode {
+	init(iv: Array<UInt8>, counter: Int = 0) { }
+}
+
+protocol PaddingProtocol { }
+
+enum Padding: PaddingProtocol {
+  case noPadding, zeroPadding, pkcs7, pkcs5, eme_pkcs1v15, emsa_pkcs1v15, iso78164, iso10126
+}
+
+// Helper functions
+func getConstantString() -> String {
+  "this string is constant"
+}
+
+func getConstantArray() -> Array<UInt8> {
+	[UInt8](getConstantString().utf8)
+}
+
+func getRandomArray() -> Array<UInt8> {
+	(0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
+}
+
+// --- tests ---
+
+func test() {
+	let iv: Array<UInt8> = [0x2a, 0x3a, 0x80, 0x05, 0xaf, 0x46, 0x58, 0x2d, 0x66, 0x52, 0x10, 0xae, 0x86, 0xd3, 0x8e, 0x8f]
+	let iv2 = getConstantArray()
+	let ivString = getConstantString()
+
+	let randomArray = getRandomArray()
+	let randomIv = getRandomArray()
+	let randomIvString = String(cString: getRandomArray())
+
+	let blockMode = CBC(iv: randomIv)
+	let padding = Padding.noPadding
+	let key = getRandomArray()
+	let keyString = String(cString: key)
+
+	// AES test cases
+	let ab1 = AES(key: keyString, iv: ivString) // BAD
+	let ab2 = AES(key: keyString, iv: ivString, padding: padding) // BAD
+	let ag1 = AES(key: keyString, iv: randomIvString) // GOOD
+	let ag2 = AES(key: keyString, iv: randomIvString, padding: padding) // GOOD
+
+	// ChaCha20 test cases
+	let cb1 = ChaCha20(key: keyString, iv: ivString) // BAD
+	let cg1 = ChaCha20(key: keyString, iv: randomIvString) // GOOD
+
+	// Blowfish test cases
+	let bb1 = Blowfish(key: keyString, iv: ivString) // BAD
+	let bb2 = Blowfish(key: keyString, iv: ivString, padding: padding) // BAD
+	let bg1 = Blowfish(key: keyString, iv: randomIvString) // GOOD
+	let bg2 = Blowfish(key: keyString, iv: randomIvString, padding: padding) // GOOD
+
+	// Rabbit
+	let rb1 = Rabbit(key: key, iv: iv) // BAD
+	let rb2 = Rabbit(key: key, iv: iv2) // BAD [NOT DETECTED]
+	let rb3 = Rabbit(key: keyString, iv: ivString) // BAD
+	let rg1 = Rabbit(key: key, iv: randomIv) // GOOD
+	let rg2 = Rabbit(key: keyString, iv: randomIvString) // GOOD
+
+	// CBC
+	let cbcb1 = CBC(iv: iv) // BAD
+	let cbcg1 = CBC(iv: randomIv) // GOOD
+
+	// CFB
+	let cfbb1 = CFB(iv: iv) // BAD
+	let cfbb2 = CFB(iv: iv, segmentSize: CFB.SegmentSize.cfb8) // BAD
+	let cfbg1 = CFB(iv: randomIv) // GOOD
+	let cfbg2 = CFB(iv: randomIv, segmentSize: CFB.SegmentSize.cfb8) // GOOD
+
+	// GCM
+	let cgmb1 = GCM(iv: iv) // BAD
+	let cgmb2 = GCM(iv: iv, additionalAuthenticatedData: randomArray, tagLength: 8, mode: GCM.Mode.combined) // BAD
+	let cgmb3 = GCM(iv: iv, authenticationTag: randomArray, additionalAuthenticatedData: randomArray, mode: GCM.Mode.combined) // BAD
+	let cgmg1 = GCM(iv: randomIv) // GOOD
+	let cgmg2 = GCM(iv: randomIv, additionalAuthenticatedData: randomArray, tagLength: 8, mode: GCM.Mode.combined) // GOOD
+	let cgmg3 = GCM(iv: randomIv, authenticationTag: randomArray, additionalAuthenticatedData: randomArray, mode: GCM.Mode.combined) // GOOD
+
+	// OFB
+	let ofbb1 = OFB(iv: iv) // BAD
+	let ofbg1 = OFB(iv: randomIv) // GOOD
+
+	// PCBC
+	let pcbcb1 = PCBC(iv: iv) // BAD
+	let pcbcg1 = PCBC(iv: randomIv) // GOOD
+
+	// CCM
+	let ccmb1 = CCM(iv: iv, tagLength: 0, messageLength: 0, additionalAuthenticatedData: randomArray) // BAD
+	let ccmb2 = CCM(iv: iv, tagLength: 0, messageLength: 0, authenticationTag: randomArray, additionalAuthenticatedData: randomArray) // BAD
+	let ccmg1 = CCM(iv: randomIv, tagLength: 0, messageLength: 0, additionalAuthenticatedData: randomArray) // GOOD
+	let ccmg2 = CCM(iv: randomIv, tagLength: 0, messageLength: 0, authenticationTag: randomArray, additionalAuthenticatedData: randomArray) // GOOD
+
+	// CTR
+	let ctrb1 = CTR(iv: iv) // BAD
+	let ctrb2 = CTR(iv: iv, counter: 0) // BAD
+	let ctrg1 = CTR(iv: randomIv) // GOOD
+	let ctrg2 = CTR(iv: randomIv, counter: 0) // GOOD
+}


### PR DESCRIPTION
Using a static initialization vector (IV) for encryption is not secure. To maximize encryption and prevent dictionary attacks, IVs should rather be unique and unpredictable (e.g., randomly generated).

The rule currently supports all ciphers that the CryptoSwift API provides, but we can always extend it further if more APIs are added.

I'd appreciate a review of the query itself, the accompanying tests, and the associated documentation.