### PR TITLE
Kotlin: Extract missing arguments of enum constructor calls

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -1868,13 +1868,12 @@ open class KotlinFileExtractor(
             extractStaticTypeAccessQualifierUnchecked(overriddenCallTarget.parent, id, locId, enclosingCallable, enclosingStmt)
         }
 
-        extractDefaultsCallArguments(id, overriddenCallTarget, locId, enclosingCallable, enclosingStmt, valueArguments, dispatchReceiver, extensionReceiver)
+        extractDefaultsCallArguments(id, overriddenCallTarget, enclosingCallable, enclosingStmt, valueArguments, dispatchReceiver, extensionReceiver)
     }
 
     private fun extractDefaultsCallArguments(
         id: Label<out DbExprparent>,
         callTarget: IrFunction,
-        locId: Label<DbLocation>,
         enclosingCallable: Label<out DbCallable>,
         enclosingStmt: Label<out DbStmt>,
         valueArguments: List<IrExpression?>,
@@ -1901,7 +1900,7 @@ open class KotlinFileExtractor(
             IrConstImpl.defaultValueForType(0, 0, getDefaultsMethodLastArgType(callTarget))
         )
 
-        extractCallValueArguments(id, valueArgsWithDummies + extraArgs, callTarget, locId, enclosingStmt, enclosingCallable, nextIdx, extractVarargAsArray = true)
+        extractCallValueArguments(id, valueArgsWithDummies + extraArgs, enclosingStmt, enclosingCallable, nextIdx, extractVarargAsArray = true)
     }
 
     private fun getFunctionInvokeMethod(typeArgs: List<IrTypeArgument>): IrFunction? {
@@ -2023,7 +2022,7 @@ open class KotlinFileExtractor(
                 childIdx,
                 enclosingStmt,
                 valueArguments.size,
-                { argParent, idxOffset -> extractCallValueArguments(argParent, valueArguments, syntacticCallTarget, locId, enclosingStmt, enclosingCallable, idxOffset) },
+                { argParent, idxOffset -> extractCallValueArguments(argParent, valueArguments, enclosingStmt, enclosingCallable, idxOffset) },
                 dispatchReceiver?.type,
                 dispatchReceiver?.let { { callId -> extractExpressionExpr(dispatchReceiver, enclosingCallable, callId, -1, enclosingStmt) } },
                 extensionReceiver?.let { { argParent -> extractExpressionExpr(extensionReceiver, enclosingCallable, argParent, 0, enclosingStmt) } },
@@ -2117,10 +2116,10 @@ open class KotlinFileExtractor(
                 this is IrEnumEntry
 
 
-    private fun extractCallValueArguments(callId: Label<out DbExprparent>, call: IrFunctionAccessExpression, callTarget: IrFunction, fallbackLocation: Label<DbLocation>, enclosingStmt: Label<out DbStmt>, enclosingCallable: Label<out DbCallable>, idxOffset: Int) =
-        extractCallValueArguments(callId, (0 until call.valueArgumentsCount).map { call.getValueArgument(it) }, callTarget, fallbackLocation, enclosingStmt, enclosingCallable, idxOffset)
+    private fun extractCallValueArguments(callId: Label<out DbExprparent>, call: IrFunctionAccessExpression, enclosingStmt: Label<out DbStmt>, enclosingCallable: Label<out DbCallable>, idxOffset: Int) =
+        extractCallValueArguments(callId, (0 until call.valueArgumentsCount).map { call.getValueArgument(it) }, enclosingStmt, enclosingCallable, idxOffset)
 
-    private fun extractCallValueArguments(callId: Label<out DbExprparent>, valueArguments: List<IrExpression?>, callTarget: IrFunction, fallbackLocation: Label<DbLocation>, enclosingStmt: Label<out DbStmt>, enclosingCallable: Label<out DbCallable>, idxOffset: Int, extractVarargAsArray: Boolean = false) {
+    private fun extractCallValueArguments(callId: Label<out DbExprparent>, valueArguments: List<IrExpression?>, enclosingStmt: Label<out DbStmt>, enclosingCallable: Label<out DbCallable>, idxOffset: Int, extractVarargAsArray: Boolean = false) {
         var i = 0
         valueArguments.forEach { arg ->
             if (arg != null) {
@@ -2129,25 +2128,6 @@ open class KotlinFileExtractor(
                     i += arg.elements.size
                 } else {
                     extractExpressionExpr(arg, enclosingCallable, callId, (i++) + idxOffset, enclosingStmt)
-                }
-            } else {
-                val realCallTarget = callTarget.target.realOverrideTarget
-
-                // Generated constructor calls to kotlin.Enum have no arguments in IR, but the constructor takes two parameters.
-                if (realCallTarget is IrConstructor &&
-                    realCallTarget.parentClassOrNull?.fqNameWhenAvailable?.asString() == "kotlin.Enum" &&
-                    realCallTarget.valueParameters.size == 2 &&
-                    i < realCallTarget.valueParameters.size) {
-
-                    if (i == 0 && realCallTarget.valueParameters[i].type == pluginContext.irBuiltIns.stringType) {
-
-                        val id = extractNull(pluginContext.irBuiltIns.stringType, fallbackLocation, callId, (i++) + idxOffset, enclosingCallable, enclosingStmt)
-                        tw.writeCompiler_generated(id, CompilerGeneratedKinds.ENUM_CONSTRUCTOR_ARGUMENT.kind)
-                    } else if (i == 1 && realCallTarget.valueParameters[i].type == pluginContext.irBuiltIns.intType) {
-
-                        val id = extractConstantInteger(0, fallbackLocation, callId, (i++) + idxOffset, enclosingCallable, enclosingStmt)
-                        tw.writeCompiler_generated(id, CompilerGeneratedKinds.ENUM_CONSTRUCTOR_ARGUMENT.kind)
-                    }
                 }
             }
         }
@@ -3083,15 +3063,31 @@ open class KotlinFileExtractor(
         val isAnonymous = eType.isAnonymous
         val locId = tw.getLocation(e)
         val valueArgs = (0 until e.valueArgumentsCount).map { e.getValueArgument(it) }
-        // For now, don't try to use default methods for enum constructor calls,
-        // which have null arguments even though the parameters don't give default values.
+
         val id = if (e !is IrEnumConstructorCall && callUsesDefaultArguments(e.symbol.owner, valueArgs)) {
             extractNewExpr(getDefaultsMethodLabel(e.symbol.owner).cast(), type, locId, parent, idx, callable, enclosingStmt).also {
-                extractDefaultsCallArguments(it, e.symbol.owner, locId, callable, enclosingStmt, valueArgs, null, null)
+                extractDefaultsCallArguments(it, e.symbol.owner, callable, enclosingStmt, valueArgs, null, null)
             }
         } else {
             extractNewExpr(e.symbol.owner, eType.arguments, type, locId, parent, idx, callable, enclosingStmt).also {
-                extractCallValueArguments(it, e, e.symbol.owner, locId, enclosingStmt, callable, 0)
+
+                val realCallTarget = e.symbol.owner.realOverrideTarget
+                // Generated constructor calls to kotlin.Enum have no arguments in IR, but the constructor takes two parameters.
+                if (e is IrEnumConstructorCall &&
+                    realCallTarget is IrConstructor &&
+                    realCallTarget.parentClassOrNull?.fqNameWhenAvailable?.asString() == "kotlin.Enum" &&
+                    realCallTarget.valueParameters.size == 2 &&
+                    realCallTarget.valueParameters[0].type == pluginContext.irBuiltIns.stringType &&
+                    realCallTarget.valueParameters[1].type == pluginContext.irBuiltIns.intType) {
+
+                    val id0 = extractNull(pluginContext.irBuiltIns.stringType, locId, it, 0, callable, enclosingStmt)
+                    tw.writeCompiler_generated(id0, CompilerGeneratedKinds.ENUM_CONSTRUCTOR_ARGUMENT.kind)
+
+                    val id1 = extractConstantInteger(0, locId, it, 1, callable, enclosingStmt)
+                    tw.writeCompiler_generated(id1, CompilerGeneratedKinds.ENUM_CONSTRUCTOR_ARGUMENT.kind)
+                } else {
+                    extractCallValueArguments(it, e, enclosingStmt, callable, 0)
+                }
             }
         }
 
@@ -3464,7 +3460,7 @@ open class KotlinFileExtractor(
 
                     tw.writeHasLocation(id, locId)
                     tw.writeCallableBinding(id.cast<DbCaller>(), methodId)
-                    extractCallValueArguments(id, e, e.symbol.owner, locId, id, callable, 0)
+                    extractCallValueArguments(id, e, id, callable, 0)
                     val dr = e.dispatchReceiver
                     if (dr != null) {
                         extractExpressionExpr(dr, callable, id, -1, id)

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -2135,7 +2135,7 @@ open class KotlinFileExtractor(
 
                 // Generated constructor calls to kotlin.Enum have no arguments in IR, but the constructor takes two parameters.
                 if (realCallTarget is IrConstructor &&
-                    realCallTarget.parentClassOrNull?.symbol == pluginContext.irBuiltIns.enumClass &&
+                    realCallTarget.parentClassOrNull?.fqNameWhenAvailable?.asString() == "kotlin.Enum" &&
                     realCallTarget.valueParameters.size == 2 &&
                     i < realCallTarget.valueParameters.size) {
 

--- a/java/ql/consistency-queries/callArgs.ql
+++ b/java/ql/consistency-queries/callArgs.ql
@@ -1,0 +1,9 @@
+import java
+
+from Call call, Callable c
+where
+  count(call.getAnArgument()) != c.getNumberOfParameters() and
+  call.getCallee() = c and
+  not exists(Parameter p | c.getAParameter() = p and p.isVarargs()) and
+  call.getFile().isKotlinSourceFile()
+select call, c, count(call.getAnArgument()), c.getNumberOfParameters()

--- a/java/ql/lib/semmle/code/java/Element.qll
+++ b/java/ql/lib/semmle/code/java/Element.qll
@@ -69,6 +69,8 @@ class Element extends @element, Top {
       i = 10 and result = "Forwarder for Kotlin calls that need default arguments filling in"
       or
       i = 11 and result = "Forwarder for a Kotlin class inheriting an interface default method"
+      or
+      i = 12 and result = "Argument for enum constructor call"
     )
   }
 }

--- a/java/ql/test/kotlin/library-tests/classes/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/classes/PrintAst.expected
@@ -174,6 +174,8 @@ classes.kt:
 #   49|           0: [ClassInstanceExpr] new Enum(...)
 #   49|             -3: [TypeAccess] Enum<Direction>
 #   49|               0: [TypeAccess] Direction
+#   49|             0: [NullLiteral] null
+#   49|             1: [IntegerLiteral] 0
 #   49|         1: [BlockStmt] { ... }
 #   50|     5: [FieldDeclaration] Direction NORTH;
 #   50|       -1: [TypeAccess] Direction
@@ -209,6 +211,8 @@ classes.kt:
 #   53|           0: [ClassInstanceExpr] new Enum(...)
 #   53|             -3: [TypeAccess] Enum<Color>
 #   53|               0: [TypeAccess] Color
+#   53|             0: [NullLiteral] null
+#   53|             1: [IntegerLiteral] 0
 #   53|         1: [BlockStmt] { ... }
 #   53|           0: [ExprStmt] <Expr>;
 #   53|             0: [KtInitializerAssignExpr] ...=...

--- a/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
@@ -3358,6 +3358,8 @@ exprs.kt:
 #  174|           0: [ClassInstanceExpr] new Enum(...)
 #  174|             -3: [TypeAccess] Enum<Direction>
 #  174|               0: [TypeAccess] Direction
+#  174|             0: [NullLiteral] null
+#  174|             1: [IntegerLiteral] 0
 #  174|         1: [BlockStmt] { ... }
 #  175|     5: [FieldDeclaration] Direction NORTH;
 #  175|       -1: [TypeAccess] Direction
@@ -3393,6 +3395,8 @@ exprs.kt:
 #  178|           0: [ClassInstanceExpr] new Enum(...)
 #  178|             -3: [TypeAccess] Enum<Color>
 #  178|               0: [TypeAccess] Color
+#  178|             0: [NullLiteral] null
+#  178|             1: [IntegerLiteral] 0
 #  178|         1: [BlockStmt] { ... }
 #  178|           0: [ExprStmt] <Expr>;
 #  178|             0: [KtInitializerAssignExpr] ...=...

--- a/java/ql/test/kotlin/library-tests/exprs/exprs.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/exprs.expected
@@ -1470,9 +1470,11 @@
 | exprs.kt:170:9:170:17 | r2.height | exprs.kt:165:1:172:1 | foo | VarAccess |
 | exprs.kt:170:9:170:21 | ...=... | exprs.kt:165:1:172:1 | foo | AssignExpr |
 | exprs.kt:170:21:170:21 | 3 | exprs.kt:165:1:172:1 | foo | IntegerLiteral |
+| exprs.kt:174:1:176:1 | 0 | exprs.kt:174:6:176:1 | Direction | IntegerLiteral |
 | exprs.kt:174:1:176:1 | Direction | exprs.kt:174:6:176:1 | Direction | TypeAccess |
 | exprs.kt:174:1:176:1 | Enum<Direction> | exprs.kt:174:6:176:1 | Direction | TypeAccess |
 | exprs.kt:174:1:176:1 | new Enum(...) | exprs.kt:174:6:176:1 | Direction | ClassInstanceExpr |
+| exprs.kt:174:1:176:1 | null | exprs.kt:174:6:176:1 | Direction | NullLiteral |
 | exprs.kt:175:5:175:10 | ...=... | exprs.kt:0:0:0:0 | <clinit> | KtInitializerAssignExpr |
 | exprs.kt:175:5:175:10 | Direction | exprs.kt:0:0:0:0 | <clinit> | TypeAccess |
 | exprs.kt:175:5:175:10 | Direction | exprs.kt:0:0:0:0 | <clinit> | TypeAccess |
@@ -1497,9 +1499,11 @@
 | exprs.kt:175:25:175:28 | Direction | file://:0:0:0:0 | <none> | TypeAccess |
 | exprs.kt:175:25:175:28 | Direction.EAST | exprs.kt:0:0:0:0 | <clinit> | VarAccess |
 | exprs.kt:175:25:175:28 | new Direction(...) | exprs.kt:0:0:0:0 | <clinit> | ClassInstanceExpr |
+| exprs.kt:178:1:182:1 | 0 | exprs.kt:178:6:182:1 | Color | IntegerLiteral |
 | exprs.kt:178:1:182:1 | Color | exprs.kt:178:6:182:1 | Color | TypeAccess |
 | exprs.kt:178:1:182:1 | Enum<Color> | exprs.kt:178:6:182:1 | Color | TypeAccess |
 | exprs.kt:178:1:182:1 | new Enum(...) | exprs.kt:178:6:182:1 | Color | ClassInstanceExpr |
+| exprs.kt:178:1:182:1 | null | exprs.kt:178:6:182:1 | Color | NullLiteral |
 | exprs.kt:178:18:178:29 | ...=... | exprs.kt:178:6:182:1 | Color | KtInitializerAssignExpr |
 | exprs.kt:178:18:178:29 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | exprs.kt:178:18:178:29 | int | file://:0:0:0:0 | <none> | TypeAccess |

--- a/java/ql/test/kotlin/library-tests/exprs_typeaccess/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/exprs_typeaccess/PrintAst.expected
@@ -88,6 +88,8 @@ A.kt:
 #   23|             0: [ClassInstanceExpr] new Enum(...)
 #   23|               -3: [TypeAccess] Enum<Enu>
 #   23|                 0: [TypeAccess] Enu
+#   23|               0: [NullLiteral] null
+#   23|               1: [IntegerLiteral] 0
 #   23|           1: [BlockStmt] { ... }
 #   24|       5: [FieldDeclaration] Enu A;
 #   24|         -1: [TypeAccess] Enu

--- a/java/ql/test/kotlin/library-tests/methods/exprs.expected
+++ b/java/ql/test/kotlin/library-tests/methods/exprs.expected
@@ -231,9 +231,11 @@
 | enumClass.kt:0:0:0:0 | EnumWithFunctions[] | TypeAccess |
 | enumClass.kt:0:0:0:0 | String | TypeAccess |
 | enumClass.kt:0:0:0:0 | String | TypeAccess |
+| enumClass.kt:1:1:4:1 | 0 | IntegerLiteral |
 | enumClass.kt:1:1:4:1 | Enum<EnumClass> | TypeAccess |
 | enumClass.kt:1:1:4:1 | EnumClass | TypeAccess |
 | enumClass.kt:1:1:4:1 | new Enum(...) | ClassInstanceExpr |
+| enumClass.kt:1:1:4:1 | null | NullLiteral |
 | enumClass.kt:1:22:1:31 | ...=... | KtInitializerAssignExpr |
 | enumClass.kt:1:22:1:31 | int | TypeAccess |
 | enumClass.kt:1:22:1:31 | int | TypeAccess |
@@ -256,9 +258,11 @@
 | enumClass.kt:3:5:3:12 | EnumClass.enum2 | VarAccess |
 | enumClass.kt:3:5:3:12 | new EnumClass(...) | ClassInstanceExpr |
 | enumClass.kt:3:11:3:11 | 1 | IntegerLiteral |
+| enumClass.kt:6:1:16:1 | 0 | IntegerLiteral |
 | enumClass.kt:6:1:16:1 | Enum<EnumWithFunctions> | TypeAccess |
 | enumClass.kt:6:1:16:1 | EnumWithFunctions | TypeAccess |
 | enumClass.kt:6:1:16:1 | new Enum(...) | ClassInstanceExpr |
+| enumClass.kt:6:1:16:1 | null | NullLiteral |
 | enumClass.kt:8:3:11:4 | ...=... | KtInitializerAssignExpr |
 | enumClass.kt:8:3:11:4 | <implicit coercion to unit> | ImplicitCoercionToUnitExpr |
 | enumClass.kt:8:3:11:4 | EnumWithFunctions | TypeAccess |


### PR DESCRIPTION
Additionally a consistency check is also added to compare argument count of calls with the parameter count of the call targets.