### PR TITLE
Fix AV Rule 76

### DIFF
--- a/cpp/ql/src/change-notes/2022-11-03-av-rule-76.md
+++ b/cpp/ql/src/change-notes/2022-11-03-av-rule-76.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed a bug in `cpp/jsf/av-rule-76` that caused the query to miss results when an implicitly-defined copy constructor or copy assignment operator was generated.

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 76.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 76.ql
@@ -38,9 +38,9 @@ predicate hasNontrivialDestructor(Class c) {
 from Class c
 where
   (hasPointerMember(c) or hasNontrivialDestructor(c)) and
-  not (
-    c.getAMemberFunction() instanceof CopyConstructor and
-    c.getAMemberFunction() instanceof CopyAssignmentOperator
+  (
+    c.hasImplicitCopyAssignmentOperator() or
+    c.hasImplicitCopyConstructor()
   ) and
   not c instanceof Struct
 select c,

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 76/AV Rule 76.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 76/AV Rule 76.expected
@@ -1,0 +1,3 @@
+| test.cpp:5:7:5:12 | Class2 | AV Rule 76: A copy constructor and an assignment operator shall be declared for classes that contain pointers to data items or nontrivial destructors. |
+| test.cpp:16:7:16:12 | Class3 | AV Rule 76: A copy constructor and an assignment operator shall be declared for classes that contain pointers to data items or nontrivial destructors. |
+| test.cpp:33:7:33:12 | Class4 | AV Rule 76: A copy constructor and an assignment operator shall be declared for classes that contain pointers to data items or nontrivial destructors. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 76/AV Rule 76.qlref
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 76/AV Rule 76.qlref
@@ -1,0 +1,1 @@
+jsf/4.10 Classes/AV Rule 76.ql

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 76/test.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 76/test.cpp
@@ -1,0 +1,96 @@
+class Class1 // good: no pointer members, default assignment operator and copy constructor
+{
+};
+
+class Class2 // bad: pointer members, default assignment operator and copy constructor
+{
+private:
+    int* _a;
+
+public:
+    Class2(int* a):_a(a)
+    {
+    }
+};
+
+class Class3 // bad: pointer members, custom assignment operator and default copy constructor
+{
+private:
+    int* _a;
+
+public:
+    Class3(int* a) :_a(a)
+    {
+    }
+
+    Class3& operator=(const Class3& rhs)
+    {
+        this->_a = rhs._a;
+        return *this;
+    }
+};
+
+class Class4 // bad: pointer members, default assignment operator and custom copy constructor
+{
+private:
+    int* _a;
+
+public:
+    Class4(int* a) :_a(a)
+    {
+    }
+
+    Class4(const Class4& rhs):_a(rhs._a)
+    {
+    }
+};
+
+class Class5  // good: pointer members, custom assignment operator and copy constructor
+{
+private:
+    int* _a;
+
+public:
+    Class5(int* a) :_a(a)
+    {
+    }
+
+    Class5(const Class5& rhs) :_a(rhs._a)
+    {
+    }
+
+    Class5& operator=(const Class5& rhs)
+    {
+        this->_a = rhs._a;
+        return *this;
+    }
+};
+
+class Class6 // good: pointer members, deleted assignment operator and copy constructor
+{
+private:
+    int* _a;
+
+public:
+    Class6(int* a) :_a(a)
+    {
+    }
+
+    Class6& operator=(const Class6& rhs) = delete;
+    Class6(const Class6& rhs) = delete;
+};
+
+class Class7 // good: pointer members, disallowed assignment operator and copy constructor
+{
+private:
+    int* _a;
+
+public:
+    Class7(int* a) :_a(a)
+    {
+    }
+
+private:
+    Class7& operator=(const Class7& rhs); // no implementation to get linker error!
+    Class7(const Class7& rhs); // no implementation to get linker error!
+};


### PR DESCRIPTION
The rule wasn't finding anything. The problem was that
```ql
    c.getAMemberFunction() instanceof CopyConstructor and
    c.getAMemberFunction() instanceof CopyAssignmentOperator
```
was returning compiler generated implicit assignment operators and copy constructors too.