### PR TITLE
Swift: Move the Unit class to its own file

### DIFF
--- a/swift/ql/lib/codeql/swift/Unit.qll
+++ b/swift/ql/lib/codeql/swift/Unit.qll
@@ -1,0 +1,10 @@
+/** Provides the `Unit` class. */
+
+/** The unit type. */
+private newtype TUnit = TMkUnit()
+
+/** The trivial type with a single element. */
+class Unit extends TUnit {
+  /** Gets a textual representation of this element. */
+  string toString() { result = "unit" }
+}

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplSpecific.qll
@@ -1,9 +1,15 @@
 /**
  * Provides Swift-specific definitions for use in the data flow library.
  */
+
+// we need to export `Unit` for the DataFlowImpl* files
+private import swift as Swift
+
 module Private {
   import DataFlowPrivate
   import DataFlowDispatch
+
+  class Unit = Swift::Unit;
 }
 
 module Public {

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -603,15 +603,6 @@ int accessPathLimit() { result = 5 }
  */
 predicate forceHighPrecision(Content c) { none() }
 
-/** The unit type. */
-private newtype TUnit = TMkUnit()
-
-/** The trivial type with a single element. */
-class Unit extends TUnit {
-  /** Gets a textual representation of this element. */
-  string toString() { result = "unit" }
-}
-
 /**
  * Holds if the node `n` is unreachable when the call context is `call`.
  */

--- a/swift/ql/lib/swift.qll
+++ b/swift/ql/lib/swift.qll
@@ -5,3 +5,4 @@ import codeql.swift.elements.expr.ArithmeticOperation
 import codeql.swift.elements.expr.LogicalOperation
 import codeql.swift.elements.decl.MethodDecl
 import codeql.swift.elements.decl.ClassOrStructDecl
+import codeql.swift.Unit


### PR DESCRIPTION
This removes the necessity of importing an internal dataflow file to be able to use the `Unit` class.