### PR TITLE
Summary metrics: Improve consistency of naming

### DIFF
--- a/csharp/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/csharp/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -1,6 +1,6 @@
 /**
  * @id cs/summary/lines-of-code
- * @name Total lines of code in the database
+ * @name Total lines of C# code in the database
  * @description The total number of lines of code across all files. This is a useful metric of the size of a database. For all files that were seen during the build, this query counts the lines of code, excluding whitespace or comments.
  * @kind metric
  * @tags summary

--- a/java/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -1,6 +1,6 @@
 /**
  * @id java/summary/lines-of-code
- * @name Total lines of code in the database
+ * @name Total lines of Java code in the database
  * @description The total number of lines of code across all files. This is a useful metric of the size of a database.
  *              For all files that were seen during the build, this query counts the lines of code, excluding whitespace
  *              or comments.

--- a/ql/ql/src/queries/summary/LinesOfUserCode.ql
+++ b/ql/ql/src/queries/summary/LinesOfUserCode.ql
@@ -1,6 +1,6 @@
 /**
  * @id ql/summary/lines-of-user-code
- * @name Total Lines of user written QL code in the database
+ * @name Total lines of user written QL code in the database
  * @description The total number of lines of QL code from the source code
  *   directory, excluding external library and auto-generated files. This
  *   query counts the lines of code, excluding whitespace or comments.

--- a/ql/ql/src/queries/summary/NumberOfFilesExtractedWithErrors.ql
+++ b/ql/ql/src/queries/summary/NumberOfFilesExtractedWithErrors.ql
@@ -1,6 +1,6 @@
 /**
  * @id ql/summary/number-of-files-extracted-with-errors
- * @name Total number of files that were extracted with errors
+ * @name Total number of QL files that were extracted with errors
  * @description The total number of QL code files that we extracted, but where
  *  at least one extraction error occurred in the process.
  * @kind metric

--- a/ql/ql/src/queries/summary/NumberOfSuccessfullyExtractedFiles.ql
+++ b/ql/ql/src/queries/summary/NumberOfSuccessfullyExtractedFiles.ql
@@ -1,6 +1,6 @@
 /**
  * @id ql/summary/number-of-successfully-extracted-files
- * @name Total number of files that were extracted without error
+ * @name Total number of QL files that were extracted without error
  * @description The total number of QL code files that we extracted without
  *   encountering any extraction errors
  * @kind metric

--- a/ruby/ql/src/queries/summary/LinesOfUserCode.ql
+++ b/ruby/ql/src/queries/summary/LinesOfUserCode.ql
@@ -1,6 +1,6 @@
 /**
  * @id rb/summary/lines-of-user-code
- * @name Total Lines of user written Ruby code in the database
+ * @name Total lines of user written Ruby code in the database
  * @description The total number of lines of Ruby code from the source code
  *   directory, excluding external library and auto-generated files. This
  *   query counts the lines of code, excluding whitespace or comments.

--- a/ruby/ql/src/queries/summary/NumberOfFilesExtractedWithErrors.ql
+++ b/ruby/ql/src/queries/summary/NumberOfFilesExtractedWithErrors.ql
@@ -1,6 +1,6 @@
 /**
  * @id rb/summary/number-of-files-extracted-with-errors
- * @name Total number of files that were extracted with errors
+ * @name Total number of Ruby files that were extracted with errors
  * @description The total number of Ruby code files that we extracted, but where
  *  at least one extraction error occurred in the process.
  * @kind metric

--- a/ruby/ql/src/queries/summary/NumberOfSuccessfullyExtractedFiles.ql
+++ b/ruby/ql/src/queries/summary/NumberOfSuccessfullyExtractedFiles.ql
@@ -1,6 +1,6 @@
 /**
  * @id rb/summary/number-of-successfully-extracted-files
- * @name Total number of files that were extracted without error
+ * @name Total number of Ruby files that were extracted without error
  * @description The total number of Ruby code files that we extracted without
  *   encountering any extraction errors
  * @kind metric


### PR DESCRIPTION
The story of this PR is that I saw "lines" and "Lines" here and wanted to fix the inconsistency :)

```
|                         Metric                          | Value |
+---------------------------------------------------------+-------+
| Total lines of Ruby code in the database                |     9 |
| Total Lines of user written Ruby code in the database   |     9 |
| Total number of files that were extracted with errors   |     0 |
| Total number of files that were extracted without error |     2 |
```