### PR TITLE
Swift: fix bad join order in WebView/JsExportedSource

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -118,7 +118,7 @@ private class JsExportedSource extends RemoteFlowSource {
       adopter.getEnclosingDecl() instanceof JsExportedType
     |
       this.(DataFlow::ParameterNode).getParameter().getDeclaringFunction() = adopter and
-      adopter.getName() = base.getName()
+      pragma[only_bind_out](adopter.getName()) = pragma[only_bind_out](base.getName())
     )
     or
     exists(FieldDecl adopter, FieldDecl base |


### PR DESCRIPTION
The `getName = getName` join was happening too early,
before the methods themselves have been enumerated.
