### PR TITLE
C++: Improve `Buffer.qll` performance

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/commons/Buffer.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Buffer.qll
@@ -73,20 +73,13 @@ private int isSource(Expr bufferExpr, Element why) {
   )
 }
 
-private predicate localFlowToExprStep(DataFlow::Node n1, DataFlow::Node n2) {
-  not exists(n2.asExpr()) and
-  DataFlow::localFlowStep(n1, n2)
-}
-
-/** Holds if `n2 + delta` may be equal to `n1`. */
+/**
+ * Holds if data flow steps from `e1` to `e2` without stepping through any
+ * other intermediate expressions.
+ */
 private predicate localFlowStepToExpr(Expr e1, Expr e2) {
   getBufferSizeCand0(e1) and
-  exists(DataFlow::Node n1, DataFlow::Node mid, DataFlow::Node n2 |
-    n1.asExpr() = e1 and
-    localFlowToExprStep*(n1, mid) and
-    DataFlow::localFlowStep(mid, n2) and
-    n2.asExpr() = e2
-  )
+  DataFlow::localExprFlowStep(e1, e2)
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1333,7 +1333,7 @@ private predicate localStepFromNonExpr(Node n1, Node n2) {
 
 /**
  * Holds if `n1.asExpr()` doesn't have a result, `n2.asExpr() = e2` and
- * `n2` is the first node reachable from `n2` such that `n2.asExpr()` exists.
+ * `n2` is the first node reachable from `n1` such that `n2.asExpr()` exists.
  */
 pragma[nomagic]
 private predicate localStepsToExpr(Node n1, Node n2, Expr e2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1320,7 +1320,36 @@ predicate localInstructionFlow(Instruction e1, Instruction e2) {
  * local (intra-procedural) steps.
  */
 pragma[inline]
-predicate localExprFlow(Expr e1, Expr e2) { localFlow(exprNode(e1), exprNode(e2)) }
+predicate localExprFlow(Expr e1, Expr e2) { localExprFlowStep*(e1, e2) }
+
+/**
+ * Holds if `n1.asExpr()` doesn't have a result and `n1` flows to `n2` in a single
+ * dataflow step.
+ */
+private predicate localStepFromNonExpr(Node n1, Node n2) {
+  not exists(n1.asExpr()) and
+  localFlowStep(n1, n2)
+}
+
+/**
+ * Holds if `n1.asExpr()` doesn't have a result, `n2.asExpr() = e2` and
+ * `n2` is the first node reachable from `n2` such that `n2.asExpr()` exists.
+ */
+pragma[nomagic]
+private predicate localStepsToExpr(Node n1, Node n2, Expr e2) {
+  localStepFromNonExpr*(n1, n2) and
+  e2 = n2.asExpr()
+}
+
+/** Holds if data can flow from `e1` to `e2` in one local (intra-procedural) step. */
+cached
+predicate localExprFlowStep(Expr e1, Expr e2) {
+  exists(Node mid, Node n1, Node n2 |
+    localFlowStep(n1, mid) and
+    localStepsToExpr(mid, n2, e2) and
+    e1 = n1.asExpr()
+  )
+}
 
 cached
 private newtype TContent =


### PR DESCRIPTION
Removes this large TC I saw on openjdk when evaluating `BadlyBoundedWrite.ql`:
```
[2022-11-03 20:23:46] (5s) Starting to evaluate predicate #Buffer#61e3d199::localFlowToExprStep#2Plus#ff/2@7c04651e = HOP fastTC(17471850)
[2022-11-03 20:24:09] (28s)  >>> Relation #Buffer#61e3d199::localFlowToExprStep#2Plus#ff: 312912206 rows using 611 MB
```
Instead we get this nice and fast cached predicate:
```
Tuple counts for DataFlowUtil#47741e1f::localExprFlowStep#2#ff/2@ebe6dafb after 3.4s:
  20455857 ~0%      {2} r1 = SCAN DataFlowUtil#47741e1f::simpleLocalFlowStep#2#ff OUTPUT In.1, In.0
  11981993 ~26%     {2} r2 = JOIN r1 WITH project#DataFlowUtil#47741e1f::localStepsToExpr#3#fff ON FIRST 1 OUTPUT Lhs.1, Rhs.1 'e2'
  2480227  ~45%     {2} r3 = JOIN r2 WITH DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1 'e1', Lhs.1 'e2'
  return r3
```