### PR TITLE
Go: Use `any()` to stub getCallbackParameter/ReturnType

### DIFF
--- a/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -74,13 +74,13 @@ DataFlowType getReturnType(SummarizedCallable c, ReturnKind rk) {
  * Gets the type of the `i`th parameter in a synthesized call that targets a
  * callback of type `t`.
  */
-DataFlowType getCallbackParameterType(DataFlowType t, int i) { none() }
+DataFlowType getCallbackParameterType(DataFlowType t, int i) { any() }
 
 /**
  * Gets the return type of kind `rk` in a synthesized call that targets a
  * callback of type `t`.
  */
-DataFlowType getCallbackReturnType(DataFlowType t, ReturnKind rk) { none() }
+DataFlowType getCallbackReturnType(DataFlowType t, ReturnKind rk) { any() }
 
 /**
  * Holds if an external flow summary exists for `c` with input specification


### PR DESCRIPTION
This is used in all other languages not currently using dataflow type pruning.