### PR TITLE
ATM: Fix CodeQL pack workspace references

### DIFF
--- a/codeql-workspace.yml
+++ b/codeql-workspace.yml
@@ -17,6 +17,7 @@ provide:
   # - "javascript/ql/experimental/adaptivethreatmodeling/model/qlpack.yml"
   - "javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml"
   - "javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml"
+  - "javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml"
   - "csharp/ql/campaigns/Solorigate/lib/qlpack.yml"
   - "csharp/ql/campaigns/Solorigate/src/qlpack.yml"
   - "csharp/ql/campaigns/Solorigate/test/qlpack.yml"

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
@@ -6,4 +6,4 @@ groups:
     - javascript
     - experimental
 dependencies:
-    codeql/javascript-all: "*"
+    codeql/javascript-all: ${workspace}

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml
@@ -5,5 +5,5 @@ groups:
     - javascript
     - experimental
 dependencies:
-    codeql/javascript-experimental-atm-lib: "*"
+    codeql/javascript-experimental-atm-lib: ${workspace}
     codeql/javascript-experimental-atm-model: "0.2.1-2022-09-06-08h55m54s.bubbly-basin-xpztl8fh.f3c3c9360a727959e428ecc6932257e6a546dc65d8a9baac525a49247123822d"

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
@@ -7,5 +7,5 @@ groups:
     - javascript
     - experimental
 dependencies:
-    codeql/javascript-experimental-atm-lib: "*"
+    codeql/javascript-experimental-atm-lib: ${workspace}
     codeql/javascript-experimental-atm-model: "0.2.1-2022-09-06-08h55m54s.bubbly-basin-xpztl8fh.f3c3c9360a727959e428ecc6932257e6a546dc65d8a9baac525a49247123822d"

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql/javascript-experimental-atm-tests
 extractor: javascript
 dependencies:
-    codeql/javascript-experimental-atm-model-building: "*"
+    codeql/javascript-experimental-atm-model-building: ${workspace}


### PR DESCRIPTION
This fixes the ATM PR checks, which [broke on main](https://github.com/github/codeql/actions/runs/3392995797/jobs/5639827326) as a result of the JavaScript pack being updated to use `${workspace}` in https://github.com/github/codeql/pull/11004.