### PR TITLE
C++: Do not use the old dataflow library in `additional-flow-to-parameter`

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/additional-flow-to-parameter/standardFlow.ql
+++ b/cpp/ql/test/library-tests/dataflow/additional-flow-to-parameter/standardFlow.ql
@@ -1,5 +1,5 @@
 import cpp
-import semmle.code.cpp.dataflow.old.DataFlow
+import semmle.code.cpp.dataflow.DataFlow
 
 class TestConfig extends DataFlow::Configuration {
   TestConfig() { this = "TestConfig" }


### PR DESCRIPTION
Either both queries here should use the old library or neither should. The expectation is that the expected results between the queries differ depending on the additional flow step in one of them.