### PR TITLE
Kotlin: always populate the `files` table

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/ExternalDeclExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/ExternalDeclExtractor.kt
@@ -80,7 +80,7 @@ class ExternalDeclExtractor(val logger: FileLogger, val invocationTrapFile: Stri
                                     }
                                     // Now elevate to a SourceFileTrapWriter, and populate the
                                     // file information if needed:
-                                    val ftw = tw.makeFileTrapWriter(binaryPath, irDecl is IrClass)
+                                    val ftw = tw.makeFileTrapWriter(binaryPath, true)
 
                                     val fileExtractor = KotlinFileExtractor(logger, ftw, null, binaryPath, manager, this, primitiveTypeMapping, pluginContext, KotlinFileExtractor.DeclarationStack(), globalExtensionState)
 


### PR DESCRIPTION
Previously individual top-level file declarations relied on their corresponding file-class to declare their `File` instance, but this can be scuppered by a Java extractor replacing that file-class and identifying a different file location.