### PR TITLE
Ruby: add a couple of missing links to a new article

### DIFF
--- a/docs/codeql/writing-codeql-queries/about-data-flow-analysis.rst
+++ b/docs/codeql/writing-codeql-queries/about-data-flow-analysis.rst
@@ -21,6 +21,7 @@ See the following tutorials for more information about analyzing data flow in sp
 - ":ref:`Analyzing data flow in Java <analyzing-data-flow-in-java>`"
 - ":ref:`Analyzing data flow in JavaScript/TypeScript <analyzing-data-flow-in-javascript-and-typescript>`"
 - ":ref:`Analyzing data flow in Python <analyzing-data-flow-in-python>`"
+- ":ref:`Analyzing data flow in Ruby <analyzing-data-flow-in-ruby>`"
 
 .. pull-quote::
 

--- a/docs/codeql/writing-codeql-queries/creating-path-queries.rst
+++ b/docs/codeql/writing-codeql-queries/creating-path-queries.rst
@@ -29,6 +29,7 @@ For more language-specific information on analyzing data flow, see:
 - ":ref:`Analyzing data flow in Java <analyzing-data-flow-in-java>`"
 - ":ref:`Analyzing data flow in JavaScript/TypeScript <analyzing-data-flow-in-javascript-and-typescript>`"
 - ":ref:`Analyzing data flow in Python <analyzing-data-flow-in-python>`"
+- ":ref:`Analyzing data flow in Ruby <analyzing-data-flow-in-ruby>`"
 
 
 Path query examples


### PR DESCRIPTION
When looking at the preview of the new Ruby articles, I realized that we were missing a couple of links in general articles.

This PR adds those links.

@aibaars - this is targeted at the 2.11.3 branch as I don't think this is urgent and the docs updates can wait until the next release of the CLI.