### PR TITLE
C++: Fix the use-use dataflow configuration in `dataflow/dataflow-tests`

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/clang.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/clang.cpp
@@ -19,7 +19,7 @@ void following_pointers(
 
   sink(sourceArray1[0]); // no flow
   sink(*sourceArray1); // no flow
-  sink(&sourceArray1); // $ ast // [should probably be taint only]
+  sink(&sourceArray1); // $ ast,ir // [should probably be taint only]
 
   sink(sourceStruct1.m1); // no flow
   sink(sourceStruct1_ptr->m1); // no flow
@@ -48,5 +48,5 @@ void following_pointers(
 
   int stackArray[2] = { source(), source() };
   stackArray[0] = source();
-  sink(stackArray); // $ ast MISSING: ir
+  sink(stackArray); // $ ast,ir
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/ref.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/ref.cpp
@@ -53,16 +53,16 @@ namespace withoutFields {
     int x1, x2, x3, x4;
 
     assignWrapper(x1, source());
-    sink(x1); // $ ast=55:23 ir SPURIOUS: ast=53:9
+    sink(x1); // $ ast,ir=55:23 SPURIOUS: ast,ir=53:9
 
     notAssign(x2, source());
-    sink(x2); // $ SPURIOUS: ast,ir
+    sink(x2); // $ SPURIOUS: ast ir=53:13 ir=58:19
 
     sourceToParamWrapper(x3);
-    sink(x3); // $ ast=29:11 ir SPURIOUS: ast=53:17
+    sink(x3); // $ ast,ir=29:11 SPURIOUS: ast,ir=53:17
 
     notSource(x4);
-    sink(x4); // $ SPURIOUS: ast,ir
+    sink(x4); // $ SPURIOUS: ast ir=44:11 ir=53:21
   }
 }
 

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -71,9 +71,9 @@ void identityOperations(int* source1) {
   sink(x4);  // $ ast,ir
 }
 
-void trackUninitialized() { // NOTE: uninitialized tracking for IR dataflow is deprecated
+void trackUninitialized() {
   int u1;
-  sink(u1); // $ ast
+  sink(u1); // $ ast,ir
   u1 = 2;
   sink(u1); // clean
 
@@ -81,9 +81,9 @@ void trackUninitialized() { // NOTE: uninitialized tracking for IR dataflow is d
   sink(i1); // clean
 
   int u2;
-  sink(i1 ? u2 : 1); // $ ast
+  sink(i1 ? u2 : 1); // $ ast,ir
   i1 = u2;
-  sink(i1); // $ ast
+  sink(i1); // $ ast,ir
 }
 
 void local_references(int &source1, int clean1) {
@@ -346,7 +346,7 @@ namespace FlowThroughGlobals {
   void taintAndCall() {
     globalVar = source();
     calledAfterTaint();
-    sink(globalVar); // $ ast ir=333:17 ir=347:17
+    sink(globalVar); // $ ast ir ir=333:17 ir=347:17
   }
 }
 
@@ -398,14 +398,14 @@ void flowThroughMemcpy_blockvar_with_local_flow(int source1, int b) {
 void cleanedByMemcpy_ssa(int clean1) { // currently modeled with BlockVar, not SSA
   int tmp;
   memcpy(&tmp, &clean1, sizeof tmp);
-  sink(tmp); // $ SPURIOUS: ast
+  sink(tmp); // $ SPURIOUS: ast,ir
 }
 
 void cleanedByMemcpy_blockvar(int clean1) {
   int tmp;
   int *capture = &tmp;
   memcpy(&tmp, &clean1, sizeof tmp);
-  sink(tmp); // $ SPURIOUS: ast
+  sink(tmp); // $ SPURIOUS: ast,ir
 }
 
 void intRefSource(int &ref_source);
@@ -415,33 +415,33 @@ void intArraySource(int ref_source[], size_t len);
 void intRefSourceCaller() {
   int local;
   intRefSource(local);
-  sink(local); // $ ast=416:7 ast=417:16 MISSING: ir
+  sink(local); // $ ast,ir=416:7 ast,ir=417:16
 }
 
 void intPointerSourceCaller() {
   int local;
   intPointerSource(&local);
-  sink(local); // $ ast=422:7 ast=423:20 MISSING: ir
+  sink(local); // $ ast,ir=422:7 ast,ir=423:20
 }
 
 void intPointerSourceCaller2() {
   int local[1];
   intPointerSource(local);
-  sink(local); // $ ast=428:7 ast=429:20 MISSING: ir
-  sink(*local); // $ ast=428:7 ast=429:20 MISSING: ir
+  sink(local); // $ ast,ir=428:7 ast,ir=429:20
+  sink(*local); // $ ast,ir=428:7 ast,ir=429:20
 }
 
 void intArraySourceCaller() {
   int local;
   intArraySource(&local, 1);
-  sink(local); // $ ast=435:7 ast=436:18 MISSING: ir
+  sink(local); // $ ast,ir=435:7 ast,ir=436:18
 }
 
 void intArraySourceCaller2() {
   int local[2];
   intArraySource(local, 2);
-  sink(local); // $ ast=441:7 ast=442:18 MISSING: ir
-  sink(*local); // $ ast=441:7 ast=442:18 MISSING: ir
+  sink(local); // $ ast,ir=441:7 ast,ir=442:18
+  sink(*local); // $ ast,ir=441:7 ast,ir=442:18
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.ql
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.ql
@@ -24,17 +24,24 @@ module IRTest {
       source.asExpr().(FunctionCall).getTarget().getName() = "source"
       or
       source.asParameter().getName().matches("source%")
+      or
+      source.(DataFlow::DefinitionByReferenceNode).getParameter().getName().matches("ref_source%")
+      or
+      exists(source.asUninitialized())
     }
 
     override predicate isSink(DataFlow::Node sink) {
       exists(FunctionCall call |
         call.getTarget().getName() = "sink" and
-        sink.asExpr() = call.getAnArgument()
+        call.getAnArgument() in [sink.asExpr(), sink.asIndirectExpr()]
       )
     }
 
     override predicate isBarrier(DataFlow::Node barrier) {
-      barrier.asExpr().(VariableAccess).getTarget().hasName("barrier") or
+      exists(Expr barrierExpr | barrierExpr in [barrier.asExpr(), barrier.asIndirectExpr()] |
+        barrierExpr.(VariableAccess).getTarget().hasName("barrier")
+      )
+      or
       barrier = DataFlow::InstructionBarrierGuard<testBarrierGuard/3>::getABarrierNode()
     }
   }


### PR DESCRIPTION
Remaining cases where IR use-use dataflow seems to perform worse than AST dataflow:
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/ref.cpp#L59
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/ref.cpp#L65
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp#L92
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/true_upon_entry.cpp#L13
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/true_upon_entry.cpp#L66

Inconsistent behaviour for flow through global variables:
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp#L349

Broken barrier guard:
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp#L7
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp#L17
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp#L23
* https://github.com/github/codeql/blob/89c5e3df1f5453c7fe3c6e70c6243ef4c4b0f4a1/cpp/ql/test/library-tests/dataflow/dataflow-tests/BarrierGuard.cpp#L41