### PR TITLE
Ruby: Avoid stage recomputation

### DIFF
--- a/ruby/ql/lib/codeql/ruby/regexp/internal/RegExpConfiguration.qll
+++ b/ruby/ql/lib/codeql/ruby/regexp/internal/RegExpConfiguration.qll
@@ -7,8 +7,7 @@ private import codeql.ruby.dataflow.internal.DataFlowImplForRegExp
 private import codeql.ruby.typetracking.TypeTracker
 private import codeql.ruby.ApiGraphs
 private import codeql.ruby.dataflow.internal.DataFlowPrivate as DataFlowPrivate
-private import codeql.ruby.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
-private import codeql.ruby.dataflow.FlowSummary as FlowSummary
+private import codeql.ruby.TaintTracking
 private import codeql.ruby.frameworks.core.String
 
 class RegExpConfiguration extends Configuration {
@@ -38,8 +37,8 @@ class RegExpConfiguration extends Configuration {
   }
 
   override predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    // include taint flow through `String` summaries,
-    FlowSummaryImpl::Private::Steps::summaryLocalStep(nodeFrom, nodeTo, false) and
+    // include taint flow through `String` summaries
+    TaintTracking::localTaintStep(nodeFrom, nodeTo) and
     nodeFrom.(DataFlowPrivate::SummaryNode).getSummarizedCallable() instanceof
       String::SummarizedCallable
     or


### PR DESCRIPTION
Thanks to DCA for [highlighting the fact](https://github.com/github/codeql-dca-main/tree/data/hvitved/PR-11087-4-ruby__3/reports#stage-timings) that we were recomputing the flow summary compilation.