### PR TITLE
JS: fix issue with zero-column yaml locations

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -41,7 +41,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2022-09-19";
+  public static final String EXTRACTOR_VERSION = "2022-11-08";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/ql/src/change-notes/2022-11-08-yaml-locations.md
+++ b/javascript/ql/src/change-notes/2022-11-08-yaml-locations.md
@@ -1,0 +1,5 @@
+---
+category: fix
+---
+* Fixed an issue with multi-line strings in YAML files being associated with an invalid location,
+  causing alerts related to such strings to appear at the top of the YAML file.

--- a/javascript/ql/test/query-tests/Security/CWE-094/ExpressionInjection/.github/workflows/comment_issue.yml
+++ b/javascript/ql/test/query-tests/Security/CWE-094/ExpressionInjection/.github/workflows/comment_issue.yml
@@ -6,3 +6,9 @@ jobs:
     steps:
     - run: |
         echo '${{ github.event.comment.body }}'
+
+  echo-chamber2:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo '${{ github.event.comment.body }}'

--- a/javascript/ql/test/query-tests/Security/CWE-094/ExpressionInjection/.github/workflows/comment_issue_newline.yml
+++ b/javascript/ql/test/query-tests/Security/CWE-094/ExpressionInjection/.github/workflows/comment_issue_newline.yml
@@ -1,0 +1,10 @@
+on: issue_comment
+
+# same as comment_issue but this file ends with a line break
+
+jobs:
+  echo-chamber:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo '${{ github.event.comment.body }}'

--- a/javascript/ql/test/query-tests/Security/CWE-094/ExpressionInjection/ExpressionInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/ExpressionInjection/ExpressionInjection.expected
@@ -1,1 +1,3 @@
-| .github/workflows/comment_issue.yml:7:12:8:47 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |
+| .github/workflows/comment_issue.yml:7:12:10:0 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |
+| .github/workflows/comment_issue.yml:13:12:14:47 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |
+| .github/workflows/comment_issue_newline.yml:9:12:11:0 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |

--- a/javascript/ql/test/query-tests/Security/CWE-094/ExpressionInjection/ExpressionInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/ExpressionInjection/ExpressionInjection.expected
@@ -1,3 +1,3 @@
-| .github/workflows/comment_issue.yml:7:12:10:0 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |
+| .github/workflows/comment_issue.yml:7:12:8:48 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |
 | .github/workflows/comment_issue.yml:13:12:14:47 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |
-| .github/workflows/comment_issue_newline.yml:9:12:11:0 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |
+| .github/workflows/comment_issue_newline.yml:9:14:10:50 | \| | Potential injection from the github.event.comment.body context, which may be controlled by an external user. |


### PR DESCRIPTION
The alert renderer does not allow non-empty locations to end at the start of a line, but SnakeYaml emits such locations for multiline strings.

When the YAML extractor is about to emit a non-empty location that ends at column zero, it will instead move the end position backwards until it sees a non-line break character.