### PR TITLE
Swift: Add LocalFlowSource class and a few sources.

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/FlowSources.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/FlowSources.qll
@@ -5,11 +5,25 @@
 private import ExternalFlow
 private import internal.DataFlowPublic
 
-/** A data flow source of remote user input. */
-abstract class RemoteFlowSource extends Node {
-  /** Gets a string that describes the type of this remote flow source. */
+/**
+ * A data flow source of user input, whether local or remote.
+ */
+abstract class FlowSource extends Node {
+  /** Gets a string that describes the type of this flow source. */
   abstract string getSourceType();
 }
+
+/**
+ * A data flow source of local user input, that is, user input from the same
+ * device as the code is running on.
+ */
+abstract class LocalFlowSource extends FlowSource { }
+
+/**
+ * A data flow source of remote user input. In this context, 'remote' means
+ * either across a network or from another application that is not trusted.
+ */
+abstract class RemoteFlowSource extends FlowSource { }
 
 /**
  * A data flow source of remote user input that is defined through 'models as data'.

--- a/swift/ql/lib/codeql/swift/dataflow/FlowSources.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/FlowSources.qll
@@ -26,6 +26,15 @@ abstract class LocalFlowSource extends FlowSource { }
 abstract class RemoteFlowSource extends FlowSource { }
 
 /**
+ * A data flow source of local user input that is defined through 'models as data'.
+ */
+private class ExternalLocalFlowSource extends RemoteFlowSource {
+  ExternalLocalFlowSource() { sourceNode(this, "local") }
+
+  override string getSourceType() { result = "external" }
+}
+
+/**
  * A data flow source of remote user input that is defined through 'models as data'.
  */
 private class ExternalRemoteFlowSource extends RemoteFlowSource {

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -6,7 +6,13 @@ private class StringSource extends SourceModelCsv {
     row =
       [
         // String(contentsOf:) is a remote flow source
-        ";String;true;init(contentsOf:);(URL);;ReturnValue;remote"
+        ";String;true;init(contentsOf:);(URL);;ReturnValue;remote",
+        ";String;true;init(contentsOf:encoding:);(URL,String.Encoding);;ReturnValue;remote",
+        ";String;true;init(contentsOf:usedEncoding:);(URL,String.Encoding);;ReturnValue;remote",
+        // String(contentsOfFile:) is a local flow source
+        ";String;true;init(contentsOfFile:);(String);;ReturnValue;local",
+        ";String;true;init(contentsOfFile:encoding:);(String,String.Encoding);;ReturnValue;local",
+        ";String;true;init(contentsOfFile:usedEncoding:);(String,String.Encoding);;ReturnValue;local"
       ]
   }
 }

--- a/swift/ql/src/queries/Summary/FlowSources.ql
+++ b/swift/ql/src/queries/Summary/FlowSources.ql
@@ -12,5 +12,11 @@
 import swift
 import codeql.swift.dataflow.FlowSources
 
-from RemoteFlowSource s
-select s, "Flow source: " + s.getSourceType()
+string sourceType(FlowSource s) {
+  s instanceof LocalFlowSource and result = "LocalFlowSource"
+  or
+  s instanceof RemoteFlowSource and result = "RemoteFlowSource"
+}
+
+from FlowSource s
+select s, sourceType(s) + ": " + s.getSourceType()

--- a/swift/ql/src/queries/Summary/FlowSources.ql
+++ b/swift/ql/src/queries/Summary/FlowSources.ql
@@ -12,11 +12,11 @@
 import swift
 import codeql.swift.dataflow.FlowSources
 
-string sourceType(FlowSource s) {
+string sourceClass(FlowSource s) {
   s instanceof LocalFlowSource and result = "LocalFlowSource"
   or
   s instanceof RemoteFlowSource and result = "RemoteFlowSource"
 }
 
 from FlowSource s
-select s, sourceType(s) + ": " + s.getSourceType()
+select s, sourceClass(s) + ": " + s.getSourceType()

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -15,6 +15,8 @@ predicate statistic(string what, int value) {
   or
   what = "Expressions" and value = count(Expr e | not e.getFile() instanceof UnknownFile)
   or
+  what = "Local flow sources" and value = count(LocalFlowSource s)
+  or
   what = "Remote flow sources" and value = count(RemoteFlowSource s)
   or
   what = "Sensitive expressions" and value = count(SensitiveExpr e)

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -5,6 +5,16 @@
 | customurlschemes.swift:48:9:48:28 | ...[...] | Remote URL in UIApplicationDelegate.application.launchOptions |
 | string.swift:56:21:56:21 | call to init(contentsOf:) | external |
 | string.swift:56:21:56:44 | call to init(contentsOf:) | external |
+| string.swift:57:21:57:21 | call to init(contentsOf:encoding:) | external |
+| string.swift:57:21:57:77 | call to init(contentsOf:encoding:) | external |
+| string.swift:59:21:59:21 | call to init(contentsOf:usedEncoding:) | external |
+| string.swift:59:21:59:69 | call to init(contentsOf:usedEncoding:) | external |
+| string.swift:62:21:62:21 | call to init(contentsOfFile:) | external |
+| string.swift:62:21:62:48 | call to init(contentsOfFile:) | external |
+| string.swift:63:21:63:21 | call to init(contentsOfFile:encoding:) | external |
+| string.swift:63:21:63:81 | call to init(contentsOfFile:encoding:) | external |
+| string.swift:64:21:64:21 | call to init(contentsOfFile:usedEncoding:) | external |
+| string.swift:64:21:64:73 | call to init(contentsOfFile:usedEncoding:) | external |
 | url.swift:53:15:53:19 | .resourceBytes | external |
 | url.swift:60:15:60:19 | .lines | external |
 | url.swift:67:16:67:22 | .lines | external |

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -3,8 +3,8 @@
 | customurlschemes.swift:38:52:38:62 | url | external |
 | customurlschemes.swift:43:9:43:28 | ...[...] | Remote URL in UIApplicationDelegate.application.launchOptions |
 | customurlschemes.swift:48:9:48:28 | ...[...] | Remote URL in UIApplicationDelegate.application.launchOptions |
-| string.swift:27:21:27:21 | call to init(contentsOf:) | external |
-| string.swift:27:21:27:44 | call to init(contentsOf:) | external |
+| string.swift:56:21:56:21 | call to init(contentsOf:) | external |
+| string.swift:56:21:56:44 | call to init(contentsOf:) | external |
 | url.swift:53:15:53:19 | .resourceBytes | external |
 | url.swift:60:15:60:19 | .lines | external |
 | url.swift:67:16:67:22 | .lines | external |

--- a/swift/ql/test/library-tests/dataflow/flowsources/string.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/string.swift
@@ -7,12 +7,40 @@ struct URL
 }
 
 extension String {
-	init(contentsOf: URL) throws {
+	struct Encoding {
+		var rawValue: UInt
+
+		init(rawValue: UInt) { self.rawValue = rawValue }
+
+		static let ascii = Encoding(rawValue: 1)
+	}
+
+	init(contentsOf url: URL) throws {
 		var data = ""
 
 		// ...
 
 		self.init(data)
+	}
+
+	init(contentsOf url: URL, encoding enc: String.Encoding) throws {
+		self.init("")
+	}
+
+	init(contentsOf url: URL, usedEncoding: inout String.Encoding) throws {
+		self.init("")
+	}
+
+	init(contentsOfFile path: String) throws {
+		self.init("")
+	}
+
+	init(contentsOfFile path: String, encoding enc: String.Encoding) throws {
+		self.init("")
+	}
+
+	init(contentsOfFile path: String, usedEncoding: inout String.Encoding) throws {
+		self.init("")
 	}
 }
 
@@ -23,8 +51,17 @@ func testStrings() {
 	{
 		let string1 = String()
 		let string2 = String(repeating: "abc", count: 10)
+
 		let url = URL(string: "http://example.com/")
 		let string3 = try String(contentsOf: url!) // SOURCE
+		let string4 = try String(contentsOf: url!, encoding: String.Encoding.ascii) // SOURCE [NOT DETECTED]
+		var encoding = String.Encoding.ascii
+		let string5 = try String(contentsOf: url!, usedEncoding: &encoding) // SOURCE [NOT DETECTED]
+
+		let path = "file.txt"
+		let string6 = try String(contentsOfFile: path) // SOURCE [NOT DETECTED]
+		let string7 = try String(contentsOfFile: path, encoding: String.Encoding.ascii) // SOURCE [NOT DETECTED]
+		let string8 = try String(contentsOfFile: path, usedEncoding: &encoding) // SOURCE [NOT DETECTED]
 	} catch {
 		// ...
 	}

--- a/swift/ql/test/library-tests/dataflow/flowsources/string.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/string.swift
@@ -54,14 +54,14 @@ func testStrings() {
 
 		let url = URL(string: "http://example.com/")
 		let string3 = try String(contentsOf: url!) // SOURCE
-		let string4 = try String(contentsOf: url!, encoding: String.Encoding.ascii) // SOURCE [NOT DETECTED]
+		let string4 = try String(contentsOf: url!, encoding: String.Encoding.ascii) // SOURCE
 		var encoding = String.Encoding.ascii
-		let string5 = try String(contentsOf: url!, usedEncoding: &encoding) // SOURCE [NOT DETECTED]
+		let string5 = try String(contentsOf: url!, usedEncoding: &encoding) // SOURCE
 
 		let path = "file.txt"
-		let string6 = try String(contentsOfFile: path) // SOURCE [NOT DETECTED]
-		let string7 = try String(contentsOfFile: path, encoding: String.Encoding.ascii) // SOURCE [NOT DETECTED]
-		let string8 = try String(contentsOfFile: path, usedEncoding: &encoding) // SOURCE [NOT DETECTED]
+		let string6 = try String(contentsOfFile: path) // SOURCE
+		let string7 = try String(contentsOfFile: path, encoding: String.Encoding.ascii) // SOURCE
+		let string8 = try String(contentsOfFile: path, usedEncoding: &encoding) // SOURCE
 	} catch {
 		// ...
 	}


### PR DESCRIPTION
Adds a `LocalFlowSource` class to complement `RemoteFlowSource` (both under a `FlowSource` parent class, as it is in CPP).

Adds a handful of local (and remote) flow sources for `String`s, demonstrating that this is all working correctly.  At some point we will want local flow sources for user input as well, but this requires a bit more research and is probably not a high priority.