### PR TITLE
Swift: print unextracted entities

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -51,12 +51,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./swift/actions/create-extractor-pack
       - uses: ./swift/actions/run-quick-tests
+      - uses: ./swift/actions/print-unextracted
   build-and-test-linux:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./swift/actions/create-extractor-pack
       - uses: ./swift/actions/run-quick-tests
+      - uses: ./swift/actions/print-unextracted
   qltests-linux:
     needs: build-and-test-linux
     runs-on: ubuntu-latest

--- a/swift/actions/print-unextracted/action.yml
+++ b/swift/actions/print-unextracted/action.yml
@@ -1,0 +1,9 @@
+name: Print unextracted entities
+description: Prints all AST and Type entities that we do not extract yet. Must be run after `setup-env`
+runs:
+  using: composite
+  steps:
+    - name: Print unextracted entities
+      shell: bash
+      run: |
+        bazel run //swift/extractor/print_unextracted

--- a/swift/extractor/print_unextracted/BUILD.bazel
+++ b/swift/extractor/print_unextracted/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//swift:rules.bzl", "swift_cc_binary")
+
+swift_cc_binary(
+    name = "print_unextracted",
+    srcs = glob(["*.cpp"]),
+    deps = ["//swift/extractor/translators"],
+)

--- a/swift/extractor/print_unextracted/main.cpp
+++ b/swift/extractor/print_unextracted/main.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+
+#include "swift/extractor/translators/DeclTranslator.h"
+#include "swift/extractor/translators/ExprTranslator.h"
+#include "swift/extractor/translators/StmtTranslator.h"
+#include "swift/extractor/translators/TypeTranslator.h"
+#include "swift/extractor/translators/PatternTranslator.h"
+
+using namespace codeql;
+
+#define CHECK_CLASS(KIND, CLASS, PARENT)                             \
+  if (!detail::HasTranslate##CLASS##KIND<KIND##Translator>::value && \
+      !detail::HasTranslate##PARENT<KIND##Translator>::value) {      \
+    std::cout << "  " #CLASS #KIND "\n";                             \
+  }
+
+int main() {
+  std::cout << "Unextracted Decls:\n";
+
+#define DECL(CLASS, PARENT) CHECK_CLASS(Decl, CLASS, PARENT)
+#include "swift/AST/DeclNodes.def"
+
+  std::cout << "\nUnextracted Stmts:\n";
+
+#define STMT(CLASS, PARENT) CHECK_CLASS(Stmt, CLASS, PARENT)
+#include "swift/AST/StmtNodes.def"
+
+  std::cout << "\nUnextracted Exprs:\n";
+
+#define EXPR(CLASS, PARENT) CHECK_CLASS(Expr, CLASS, PARENT)
+#include "swift/AST/ExprNodes.def"
+
+  std::cout << "\nUnextracted Patterns:\n";
+
+#define PATTERN(CLASS, PARENT) CHECK_CLASS(Pattern, CLASS, PARENT)
+#include "swift/AST/PatternNodes.def"
+
+  std::cout << "\nUnextracted Types:\n";
+
+#define TYPE(CLASS, PARENT) CHECK_CLASS(Type, CLASS, PARENT)
+#include "swift/AST/TypeNodes.def"
+
+  return 0;
+}


### PR DESCRIPTION
Currently unextracted entities can be printed with
```bash
bazel run //swift/extractor/print_unextracted
```

This is also run by the build jobs and printed in the action logs:
![image](https://user-images.githubusercontent.com/1718270/200595833-369434ba-f7c9-412f-a761-e69a779fb5d0.png)

Current unextracted entities:
```
Unextracted Decls:
  OpaqueTypeDecl
  PoundDiagnosticDecl
  MissingMemberDecl

Unextracted Stmts:
  FailStmt
  PoundAssertStmt

Unextracted Exprs:
  RegexLiteralExpr
  ObjectLiteralExpr
  OverloadedDeclRefExpr
  DynamicMemberRefExpr
  DynamicSubscriptExpr
  UnresolvedSpecializeExpr
  PropertyWrapperValuePlaceholderExpr
  AppliedPropertyWrapperExpr
  PostfixUnaryExpr
  ArrowExpr
  CodeCompletionExpr
  EditorPlaceholderExpr
  PackExpr

Unextracted Patterns:

Unextracted Types:
  ErrorType
  UnresolvedType
  PlaceholderType
  OpaqueTypeArchetypeType
  SequenceArchetypeType
  SILFunctionType
  SILBlockStoragType
  SILBoxType
  SILTokenType
  ParameterizedProtocolType
  PackType
  PackExpansionType
  TypeVariableType
 ```

This could be made into a smoke test failing on any unextracted entity when we do finish extracting everything.