### PR TITLE
Ruby: handle knownOrUnkown in default taint step

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -105,7 +105,7 @@ private module Cached {
     exists(DataFlow::ContentSet c | readStep(nodeFrom, c, nodeTo) |
       c.isSingleton(any(DataFlow::Content::ElementContent ec))
       or
-      c.isKnownOrUnknownElement(any(DataFlow::Content::ElementContent ec))
+      c.isKnownOrUnknownElement(_)
       or
       c.isAnyElement()
     )

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -105,6 +105,8 @@ private module Cached {
     exists(DataFlow::ContentSet c | readStep(nodeFrom, c, nodeTo) |
       c.isSingleton(any(DataFlow::Content::ElementContent ec))
       or
+      c.isKnownOrUnknownElement(any(DataFlow::Content::ElementContent ec))
+      or
       c.isAnyElement()
     )
   }

--- a/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
@@ -1,3 +1,4 @@
+| file://:0:0:0:0 | [summary] read: argument position 0.any element in Hash[] | file://:0:0:0:0 | [summary] read: argument position 0.any element.element 1 or unknown in Hash[] |
 | file://:0:0:0:0 | parameter any of ;Pathname;Method[join] | file://:0:0:0:0 | [summary] to write: return (return) in ;Pathname;Method[join] |
 | file://:0:0:0:0 | parameter position 0 of & | file://:0:0:0:0 | [summary] read: argument position 0.any element in & |
 | file://:0:0:0:0 | parameter position 0 of + | file://:0:0:0:0 | [summary] read: argument position 0.any element in + |


### PR DESCRIPTION
Fixes a bug in the default taint steps, which caused us to miss some taint steps out of collections.

[Evaluation](https://github.com/github/codeql-dca-main/issues/8429) shows 538 new tainted nodes and 5 new alerts. 1 of the new alerts seem plausible and the other 4 are due to a missed sanitizer which will most likely be fixed by https://github.com/github/codeql/pull/11114.