### PR TITLE
QL: improve the dead-code query

### DIFF
--- a/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
+++ b/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
@@ -77,6 +77,18 @@ private AstNode alive() {
   or
   // recursive cases
   result = aliveStep(alive())
+  or
+  // cached predicates inside a cached module, because they can group cached predicate.
+  // this is deliberately not part of `aliveStep`, as it only means the predicate is live, but not if it's queryable.
+  exists(Module mod, ClasslessPredicate pred | pred = alive() |
+    not pred.isPrivate() and
+    not result.(ClasslessPredicate).isPrivate() and
+    pred.hasAnnotation("cached") and
+    result.hasAnnotation("cached") and
+    pred.getParent() = mod and
+    result.getParent() = mod and
+    mod.hasAnnotation("cached")
+  )
 }
 
 private AstNode aliveStep(AstNode prev) {
@@ -172,6 +184,8 @@ private AstNode aliveStep(AstNode prev) {
   or
   // the implements of a module
   result = prev.(Module).getImplements(_)
+  or
+  result = prev.(PredicateExpr).getQualifier()
 }
 
 private AstNode deprecated() {

--- a/ql/ql/test/queries/style/DeadCode/Foo.qll
+++ b/ql/ql/test/queries/style/DeadCode/Foo.qll
@@ -7,3 +7,26 @@ private module Mixed {
 }
 
 predicate usesAlive() { Mixed::alive1() }
+
+cached
+private module Cached {
+  cached
+  predicate isUsed() { any() }
+
+  cached
+  predicate isNotUsed() { any() }
+}
+
+module UseCache {
+  private import Cached
+
+  predicate usesCached() { isUsed() }
+}
+
+private module Foo {
+  signature predicate bar();
+}
+
+module ValidationMethod<Foo::bar/0 sig> {
+  predicate impl() { sig() }
+}


### PR DESCRIPTION
Fixes this FP https://github.com/github/codeql/security/code-scanning/77411 
And an FP that appeared [here](https://github.com/github/codeql/blob/main/java/ql/lib/semmle/code/java/security/PathSanitizer.qll#L15) when testing locally.  