### PR TITLE
Non-sink endpoint characteristics

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/ATMConfig.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/ATMConfig.qll
@@ -50,7 +50,8 @@ abstract class AtmConfig extends string {
     // known sink for the class.
     exists(EndpointCharacteristic characteristic |
       characteristic.getEndpoints(sink) and
-      characteristic.getImplications(this.getASinkEndpointType(), true, 1.0)
+      characteristic
+          .getImplications(this.getASinkEndpointType(), true, characteristic.maximalConfidence())
     )
   }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
@@ -44,6 +44,14 @@ abstract class EndpointCharacteristic extends string {
   abstract predicate getImplications(
     EndpointType endpointClass, boolean isPositiveIndicator, float confidence
   );
+
+  // The following are some confidence values that are used in practice by the subclasses. They are defined as named
+  // constants here to make it easier to change them in the future.
+  final float maximalConfidence() { result = 1.0 }
+
+  final float highConfidence() { result = 0.9 }
+
+  final float mediumConfidence() { result = 0.6 }
 }
 
 /*
@@ -63,7 +71,9 @@ private class DomBasedXssSinkCharacteristic extends EndpointCharacteristic {
   override predicate getImplications(
     EndpointType endpointClass, boolean isPositiveIndicator, float confidence
   ) {
-    endpointClass instanceof XssSinkType and isPositiveIndicator = true and confidence = 1.0
+    endpointClass instanceof XssSinkType and
+    isPositiveIndicator = true and
+    confidence = maximalConfidence()
   }
 }
 
@@ -79,7 +89,9 @@ private class TaintedPathSinkCharacteristic extends EndpointCharacteristic {
   override predicate getImplications(
     EndpointType endpointClass, boolean isPositiveIndicator, float confidence
   ) {
-    endpointClass instanceof TaintedPathSinkType and isPositiveIndicator = true and confidence = 1.0
+    endpointClass instanceof TaintedPathSinkType and
+    isPositiveIndicator = true and
+    confidence = maximalConfidence()
   }
 }
 
@@ -97,7 +109,7 @@ private class SqlInjectionSinkCharacteristic extends EndpointCharacteristic {
   ) {
     endpointClass instanceof SqlInjectionSinkType and
     isPositiveIndicator = true and
-    confidence = 1.0
+    confidence = maximalConfidence()
   }
 }
 
@@ -115,7 +127,7 @@ private class NosqlInjectionSinkCharacteristic extends EndpointCharacteristic {
   ) {
     endpointClass instanceof NosqlInjectionSinkType and
     isPositiveIndicator = true and
-    confidence = 1.0
+    confidence = maximalConfidence()
   }
 }
 
@@ -151,7 +163,9 @@ abstract private class NotASinkCharacteristic extends OtherModeledArgumentCharac
   override predicate getImplications(
     EndpointType endpointClass, boolean isPositiveIndicator, float confidence
   ) {
-    endpointClass instanceof NegativeType and isPositiveIndicator = true and confidence = 0.9
+    endpointClass instanceof NegativeType and
+    isPositiveIndicator = true and
+    confidence = highConfidence()
   }
 }
 
@@ -168,7 +182,9 @@ abstract class LikelyNotASinkCharacteristic extends OtherModeledArgumentCharacte
   override predicate getImplications(
     EndpointType endpointClass, boolean isPositiveIndicator, float confidence
   ) {
-    endpointClass instanceof NegativeType and isPositiveIndicator = true and confidence = 0.6
+    endpointClass instanceof NegativeType and
+    isPositiveIndicator = true and
+    confidence = mediumConfidence()
   }
 }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
@@ -45,6 +45,12 @@ abstract class EndpointCharacteristic extends string {
   );
 }
 
+/*
+ * Characteristics that are indicative of a sink.
+ * NOTE: Initially each sink type has only one characteristic, which is that it's a sink of this type in the standard
+ * JavaScript libraries.
+ */
+
 /**
  * Endpoints identified as "DomBasedXssSink" by the standard JavaScript libraries are XSS sinks with maximal confidence.
  */
@@ -109,5 +115,319 @@ private class NosqlInjectionSinkCharacteristic extends EndpointCharacteristic {
     endpointClass instanceof NosqlInjectionSinkType and
     isPositiveIndicator = true and
     confidence = 1.0
+  }
+}
+
+/*
+ * Characteristics that are indicative of not being a sink of any type.
+ */
+
+/**
+ * A characteristic that is an indicator of not being a sink of any type, because it's an argument that has a manual
+ * model.
+ */
+abstract private class OtherModeledArgumentCharacteristic extends EndpointCharacteristic {
+  bindingset[this]
+  OtherModeledArgumentCharacteristic() { any() }
+}
+
+/**
+ * A characteristic that is an indicator of not being a sink of any type, because it's an argument to a function of a
+ * builtin object.
+ */
+abstract private class ArgumentToBuiltinFunctionCharacteristic extends OtherModeledArgumentCharacteristic {
+  bindingset[this]
+  ArgumentToBuiltinFunctionCharacteristic() { any() }
+}
+
+/**
+ * A high-confidence characteristic that indicates that an endpoint is not a sink of any type.
+ */
+abstract private class NotASinkCharacteristic extends OtherModeledArgumentCharacteristic {
+  bindingset[this]
+  NotASinkCharacteristic() { any() }
+
+  override predicate getImplications(
+    EndpointType endpointClass, boolean isPositiveIndicator, float confidence
+  ) {
+    endpointClass instanceof NegativeType and isPositiveIndicator = true and confidence = 0.9
+  }
+}
+
+/**
+ * A medium-confidence characteristic that indicates that an endpoint is not a sink of any type.
+ *
+ * TODO: This class is currently not private, because the current extraction logic explicitly avoids including these
+ * endpoints in the training data. We might want to change this in the future.
+ */
+abstract class LikelyNotASinkCharacteristic extends OtherModeledArgumentCharacteristic {
+  bindingset[this]
+  LikelyNotASinkCharacteristic() { any() }
+
+  override predicate getImplications(
+    EndpointType endpointClass, boolean isPositiveIndicator, float confidence
+  ) {
+    endpointClass instanceof NegativeType and isPositiveIndicator = true and confidence = 0.6
+  }
+}
+
+private class LodashUnderscore extends NotASinkCharacteristic {
+  LodashUnderscore() { this = "LodashUnderscoreArgument" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    any(LodashUnderscore::Member m).getACall().getAnArgument() = n
+  }
+}
+
+private class JQueryArgumentCharacteristic extends NotASinkCharacteristic {
+  JQueryArgumentCharacteristic() { this = "JQueryArgument" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    any(JQuery::MethodCall m).getAnArgument() = n
+  }
+}
+
+private class ClientRequestCharacteristic extends NotASinkCharacteristic {
+  ClientRequestCharacteristic() { this = "ClientRequest" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(ClientRequest r |
+      r.getAnArgument() = n or n = r.getUrl() or n = r.getHost() or n = r.getADataNode()
+    )
+  }
+}
+
+private class PromiseDefinitionCharacteristic extends NotASinkCharacteristic {
+  PromiseDefinitionCharacteristic() { this = "PromiseDefinition" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(PromiseDefinition p |
+      n = [p.getResolveParameter(), p.getRejectParameter()].getACall().getAnArgument()
+    )
+  }
+}
+
+private class CryptographicKeyCharacteristic extends NotASinkCharacteristic {
+  CryptographicKeyCharacteristic() { this = "CryptographicKey" }
+
+  override predicate getEndpoints(DataFlow::Node n) { n instanceof CryptographicKey }
+}
+
+private class CryptographicOperationFlowCharacteristic extends NotASinkCharacteristic {
+  CryptographicOperationFlowCharacteristic() { this = "CryptographicOperationFlow" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    any(CryptographicOperation op).getInput() = n
+  }
+}
+
+private class LoggerMethodCharacteristic extends NotASinkCharacteristic {
+  LoggerMethodCharacteristic() { this = "LoggerMethod" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      call.getCalleeName() = getAStandardLoggerMethodName()
+    )
+  }
+}
+
+private class TimeoutCharacteristic extends NotASinkCharacteristic {
+  TimeoutCharacteristic() { this = "Timeout" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      call.getCalleeName() = ["setTimeout", "clearTimeout"]
+    )
+  }
+}
+
+private class ReceiverStorageCharacteristic extends NotASinkCharacteristic {
+  ReceiverStorageCharacteristic() { this = "ReceiverStorage" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      call.getReceiver() = DataFlow::globalVarRef(["localStorage", "sessionStorage"])
+    )
+  }
+}
+
+private class StringStartsWithCharacteristic extends NotASinkCharacteristic {
+  StringStartsWithCharacteristic() { this = "StringStartsWith" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      call instanceof StringOps::StartsWith
+    )
+  }
+}
+
+private class StringEndsWithCharacteristic extends NotASinkCharacteristic {
+  StringEndsWithCharacteristic() { this = "StringEndsWith" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() | call instanceof StringOps::EndsWith)
+  }
+}
+
+private class StringRegExpTestCharacteristic extends NotASinkCharacteristic {
+  StringRegExpTestCharacteristic() { this = "StringRegExpTest" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      call instanceof StringOps::RegExpTest
+    )
+  }
+}
+
+private class EventRegistrationCharacteristic extends NotASinkCharacteristic {
+  EventRegistrationCharacteristic() { this = "EventRegistration" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() | call instanceof EventRegistration)
+  }
+}
+
+private class EventDispatchCharacteristic extends NotASinkCharacteristic {
+  EventDispatchCharacteristic() { this = "EventDispatch" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() | call instanceof EventDispatch)
+  }
+}
+
+private class MembershipCandidateTestCharacteristic extends NotASinkCharacteristic {
+  MembershipCandidateTestCharacteristic() { this = "MembershipCandidateTest" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      call = any(MembershipCandidate c).getTest()
+    )
+  }
+}
+
+private class FileSystemAccessCharacteristic extends NotASinkCharacteristic {
+  FileSystemAccessCharacteristic() { this = "FileSystemAccess" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() | call instanceof FileSystemAccess)
+  }
+}
+
+private class DatabaseAccessCharacteristic extends NotASinkCharacteristic {
+  DatabaseAccessCharacteristic() { this = "DatabaseAccess" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    // TODO database accesses are less well defined than database query sinks, so this may cover unmodeled sinks on
+    // existing database models
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      [
+        call, call.getAMethodCall()
+      /* command pattern where the query is built, and then exec'ed later */ ] instanceof
+        DatabaseAccess
+    )
+  }
+}
+
+private class DomCharacteristic extends NotASinkCharacteristic {
+  DomCharacteristic() { this = "DOM" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() | call = DOM::domValueRef())
+  }
+}
+
+private class NextFunctionCallCharacteristic extends NotASinkCharacteristic {
+  NextFunctionCallCharacteristic() { this = "NextFunctionCall" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      call.getCalleeName() = "next" and
+      exists(DataFlow::FunctionNode f | call = f.getLastParameter().getACall())
+    )
+  }
+}
+
+private class DojoRequireCharacteristic extends NotASinkCharacteristic {
+  DojoRequireCharacteristic() { this = "DojoRequire" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call | n = call.getAnArgument() |
+      call = DataFlow::globalVarRef("dojo").getAPropertyRead("require").getACall()
+    )
+  }
+}
+
+private class Base64ManipulationCharacteristic extends NotASinkCharacteristic {
+  Base64ManipulationCharacteristic() { this = "Base64Manipulation" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(Base64::Decode d | n = d.getInput()) or
+    exists(Base64::Encode d | n = d.getInput())
+  }
+}
+
+private class ArgumentToArrayCharacteristic extends ArgumentToBuiltinFunctionCharacteristic,
+  LikelyNotASinkCharacteristic {
+  ArgumentToArrayCharacteristic() { this = "ArgumentToArray" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::SourceNode builtin, DataFlow::SourceNode receiver, DataFlow::InvokeNode invk |
+      builtin instanceof DataFlow::ArrayCreationNode
+    |
+      receiver = [builtin.getAnInvocation(), builtin] and
+      invk = [receiver, receiver.getAPropertyRead()].getAnInvocation() and
+      invk.getAnArgument() = n
+    )
+  }
+}
+
+private class ArgumentToBuiltinGlobalVarRefCharacteristic extends ArgumentToBuiltinFunctionCharacteristic,
+  LikelyNotASinkCharacteristic {
+  ArgumentToBuiltinGlobalVarRefCharacteristic() { this = "ArgumentToBuiltinGlobalVarRef" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::SourceNode builtin, DataFlow::SourceNode receiver, DataFlow::InvokeNode invk |
+      builtin =
+        DataFlow::globalVarRef([
+            "Map", "Set", "WeakMap", "WeakSet", "Number", "Object", "String", "Array", "Error",
+            "Math", "Boolean"
+          ])
+    |
+      receiver = [builtin.getAnInvocation(), builtin] and
+      invk = [receiver, receiver.getAPropertyRead()].getAnInvocation() and
+      invk.getAnArgument() = n
+    )
+  }
+}
+
+private class ConstantReceiverCharacteristic extends ArgumentToBuiltinFunctionCharacteristic,
+  NotASinkCharacteristic {
+  ConstantReceiverCharacteristic() { this = "ConstantReceiver" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(Expr primitive, MethodCallExpr c |
+      primitive instanceof ConstantString or
+      primitive instanceof NumberLiteral or
+      primitive instanceof BooleanLiteral
+    |
+      c.calls(primitive, _) and
+      c.getAnArgument() = n.asExpr()
+    )
+  }
+}
+
+private class BuiltinCallNameCharacteristic extends ArgumentToBuiltinFunctionCharacteristic,
+  NotASinkCharacteristic {
+  BuiltinCallNameCharacteristic() { this = "BuiltinCallName" }
+
+  override predicate getEndpoints(DataFlow::Node n) {
+    exists(DataFlow::CallNode call |
+      call.getAnArgument() = n and
+      call.getCalleeName() =
+        [
+          "indexOf", "hasOwnProperty", "substring", "isDecimal", "decode", "encode", "keys",
+          "shift", "values", "forEach", "toString", "slice", "splice", "push", "isArray", "sort"
+        ]
+    )
   }
 }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
@@ -31,8 +31,9 @@ abstract class EndpointCharacteristic extends string {
    * This predicate describes what the characteristic tells us about an endpoint.
    *
    * Params:
-   * endpointClass: Class 0 is the negative class, containing non-sink endpoints. Each positive int corresponds to a
-   * single sink type.
+   * endpointClass: The sink type. Each EndpointType has a predicate getEncoding, which specifies the classifier
+   * class for this sink type. Class 0 is the negative class (non-sink). Each positive int corresponds to a single
+   * sink type.
    * isPositiveIndicator: If true, this characteristic indicates that this endpoint _is_ a member of the class; if
    * false, it indicates that it _isn't_ a member of the class.
    * confidence: A float in [0, 1], which tells us how strong an indicator this characteristic is for the endpoint

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
@@ -36,9 +36,9 @@ abstract class EndpointCharacteristic extends string {
    * isPositiveIndicator: If true, this characteristic indicates that this endpoint _is_ a member of the class; if
    * false, it indicates that it _isn't_ a member of the class.
    * confidence: A float in [0, 1], which tells us how strong an indicator this characteristic is for the endpoint
-   * belonging / not belonging to the given class. A confidence near zero means this characterestic is a very weak
+   * belonging / not belonging to the given class. A confidence near zero means this characteristic is a very weak
    * indicator of whether or not the endpoint belongs to the class. A confidence of 1 means that all endpoints with
-   * this characteristic difinitively do/don't belong to the class.
+   * this characteristic definitively do/don't belong to the class.
    */
   abstract predicate getImplications(
     EndpointType endpointClass, boolean isPositiveIndicator, float confidence

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointCharacteristics.qll
@@ -30,12 +30,15 @@ abstract class EndpointCharacteristic extends string {
   /**
    * This predicate describes what the characteristic tells us about an endpoint.
    *
-   *  Params:
-   *  endpointClass: Class 0 is the negative class. Each positive int corresponds to a single sink type.
-   *  isPositiveIndicator: Does this characteristic indicate this endpoint _is_ a member of the class, or that it
-   *  _isn't_ a member of the class?
-   *  confidence: A number in [0, 1], which tells us how strong an indicator this characteristic is for the endpoint
-   *  belonging / not belonging to the given class.
+   * Params:
+   * endpointClass: Class 0 is the negative class, containing non-sink endpoints. Each positive int corresponds to a
+   * single sink type.
+   * isPositiveIndicator: If true, this characteristic indicates that this endpoint _is_ a member of the class; if
+   * false, it indicates that it _isn't_ a member of the class.
+   * confidence: A float in [0, 1], which tells us how strong an indicator this characteristic is for the endpoint
+   * belonging / not belonging to the given class. A confidence near zero means this characterestic is a very weak
+   * indicator of whether or not the endpoint belongs to the class. A confidence of 1 means that all endpoints with
+   * this characteristic difinitively do/don't belong to the class.
    */
   abstract predicate getImplications(
     EndpointType endpointClass, boolean isPositiveIndicator, float confidence

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointTypes.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointTypes.qll
@@ -16,6 +16,11 @@ newtype TEndpointType =
 abstract class EndpointType extends TEndpointType {
   abstract string getDescription();
 
+  /**
+   * The integer representation of this endpoint type. This integer representation specifies the class number used
+   * by the endpoint scoring model (the classifier) to represent this endpoint type. Class 0 is the negative class
+   * (non-sink). Each positive int corresponds to a single sink type.
+   */
   abstract int getEncoding();
 
   string toString() { result = getDescription() }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointTypes.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointTypes.qll
@@ -17,9 +17,9 @@ abstract class EndpointType extends TEndpointType {
   abstract string getDescription();
 
   /**
-   * The integer representation of this endpoint type. This integer representation specifies the class number used
-   * by the endpoint scoring model (the classifier) to represent this endpoint type. Class 0 is the negative class
-   * (non-sink). Each positive int corresponds to a single sink type.
+   * Gets the integer representation of this endpoint type. This integer representation specifies the class number
+   * used by the endpoint scoring model (the classifier) to represent this endpoint type. Class 0 is the negative
+   * class (non-sink). Each positive int corresponds to a single sink type.
    */
   abstract int getEncoding();
 


### PR DESCRIPTION
This PR simply follows the chain of logic that determines that an endpoint is not a sink [here](https://github.com/github/codeql/blob/387e57546bf7352f7c1cfe781daa1a3799b7063e/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointData.qll#L75), and converts all the reasoning into `EndpointCharacteristic`s. These new characteristics will get used in [the next PR](https://github.com/github/ml-ql-adaptive-threat-modeling/issues/2098) to select endpoints as negative training samples.

Timing checks:
- ✅ KPI timing experiment: https://github.com/github/codeql-dca-main/issues/8438
- ✅ The local runtime of `endpoint_large_scale/ExtractEndpointData` and `endpoint_large_scale/ExtractEndpointDataTraining` are not impacted

closes https://github.com/github/ml-ql-adaptive-threat-modeling/issues/2097