### PR TITLE
JS/RB/PY: Recognize `passcode` as sensitive

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
+++ b/javascript/ql/lib/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
@@ -103,7 +103,7 @@ module HeuristicNames {
    */
   string notSensitiveRegexp() {
     result =
-      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)|certain|concert|secretar|accountant|accountab).*"
+      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|(?<!pass)code)|certain|concert|secretar|accountant|accountab).*"
   }
 
   /**

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -133,6 +133,9 @@ nodes
 | passwords.js:170:11:170:18 | password |
 | passwords.js:170:11:170:39 | passwor ... g, "*") |
 | passwords.js:170:11:170:39 | passwor ... g, "*") |
+| passwords.js:173:17:173:26 | myPassword |
+| passwords.js:173:17:173:26 | myPassword |
+| passwords.js:173:17:173:26 | myPassword |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -277,6 +280,7 @@ edges
 | passwords.js:170:11:170:18 | password | passwords.js:170:11:170:39 | passwor ... g, "*") |
 | passwords.js:170:11:170:18 | password | passwords.js:170:11:170:39 | passwor ... g, "*") |
 | passwords.js:170:11:170:18 | password | passwords.js:170:11:170:39 | passwor ... g, "*") |
+| passwords.js:173:17:173:26 | myPassword | passwords.js:173:17:173:26 | myPassword |
 | passwords_in_browser1.js:2:13:2:20 | password | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser2.js:2:13:2:20 | password | passwords_in_browser2.js:2:13:2:20 | password |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password |
@@ -322,6 +326,7 @@ edges
 | passwords.js:164:14:164:42 | passwor ... g, "*") | passwords.js:164:14:164:21 | password | passwords.js:164:14:164:42 | passwor ... g, "*") | This logs sensitive data returned by $@ as clear text. | passwords.js:164:14:164:21 | password | an access to password |
 | passwords.js:169:17:169:45 | passwor ... g, "*") | passwords.js:169:17:169:24 | password | passwords.js:169:17:169:45 | passwor ... g, "*") | This logs sensitive data returned by $@ as clear text. | passwords.js:169:17:169:24 | password | an access to password |
 | passwords.js:170:11:170:39 | passwor ... g, "*") | passwords.js:170:11:170:18 | password | passwords.js:170:11:170:39 | passwor ... g, "*") | This logs sensitive data returned by $@ as clear text. | passwords.js:170:11:170:18 | password | an access to password |
+| passwords.js:173:17:173:26 | myPassword | passwords.js:173:17:173:26 | myPassword | passwords.js:173:17:173:26 | myPassword | This logs sensitive data returned by $@ as clear text. | passwords.js:173:17:173:26 | myPassword | an access to myPassword |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | This logs sensitive data returned by $@ as clear text. | passwords_in_server_1.js:6:13:6:20 | password | an access to password |
 | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | This logs sensitive data returned by $@ as clear text. | passwords_in_server_2.js:3:13:3:20 | password | an access to password |
 | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | This logs sensitive data returned by $@ as clear text. | passwords_in_server_3.js:2:13:2:20 | password | an access to password |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -136,6 +136,9 @@ nodes
 | passwords.js:173:17:173:26 | myPassword |
 | passwords.js:173:17:173:26 | myPassword |
 | passwords.js:173:17:173:26 | myPassword |
+| passwords.js:176:17:176:26 | myPasscode |
+| passwords.js:176:17:176:26 | myPasscode |
+| passwords.js:176:17:176:26 | myPasscode |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -281,6 +284,7 @@ edges
 | passwords.js:170:11:170:18 | password | passwords.js:170:11:170:39 | passwor ... g, "*") |
 | passwords.js:170:11:170:18 | password | passwords.js:170:11:170:39 | passwor ... g, "*") |
 | passwords.js:173:17:173:26 | myPassword | passwords.js:173:17:173:26 | myPassword |
+| passwords.js:176:17:176:26 | myPasscode | passwords.js:176:17:176:26 | myPasscode |
 | passwords_in_browser1.js:2:13:2:20 | password | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser2.js:2:13:2:20 | password | passwords_in_browser2.js:2:13:2:20 | password |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password |
@@ -327,6 +331,7 @@ edges
 | passwords.js:169:17:169:45 | passwor ... g, "*") | passwords.js:169:17:169:24 | password | passwords.js:169:17:169:45 | passwor ... g, "*") | This logs sensitive data returned by $@ as clear text. | passwords.js:169:17:169:24 | password | an access to password |
 | passwords.js:170:11:170:39 | passwor ... g, "*") | passwords.js:170:11:170:18 | password | passwords.js:170:11:170:39 | passwor ... g, "*") | This logs sensitive data returned by $@ as clear text. | passwords.js:170:11:170:18 | password | an access to password |
 | passwords.js:173:17:173:26 | myPassword | passwords.js:173:17:173:26 | myPassword | passwords.js:173:17:173:26 | myPassword | This logs sensitive data returned by $@ as clear text. | passwords.js:173:17:173:26 | myPassword | an access to myPassword |
+| passwords.js:176:17:176:26 | myPasscode | passwords.js:176:17:176:26 | myPasscode | passwords.js:176:17:176:26 | myPasscode | This logs sensitive data returned by $@ as clear text. | passwords.js:176:17:176:26 | myPasscode | an access to myPasscode |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | This logs sensitive data returned by $@ as clear text. | passwords_in_server_1.js:6:13:6:20 | password | an access to password |
 | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | This logs sensitive data returned by $@ as clear text. | passwords_in_server_2.js:3:13:3:20 | password | an access to password |
 | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | This logs sensitive data returned by $@ as clear text. | passwords_in_server_3.js:2:13:2:20 | password | an access to password |

--- a/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
+++ b/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
@@ -168,4 +168,10 @@ const debug = require('debug')('test');
 (function () {
     console.log(password.replace(/foo/g, "*")); // NOT OK
     debug(password.replace(/foo/g, "*")); // NOT OK
+
+    const myPassword = foo();
+    console.log(myPassword); // NOT OK
+
+    const myPasscode = foo();
+    console.log(myPasscode); // NOT OK - but not flagged
 });

--- a/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
+++ b/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
@@ -173,5 +173,5 @@ const debug = require('debug')('test');
     console.log(myPassword); // NOT OK
 
     const myPasscode = foo();
-    console.log(myPasscode); // NOT OK - but not flagged
+    console.log(myPasscode); // NOT OK
 });

--- a/python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll
+++ b/python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll
@@ -103,7 +103,7 @@ module HeuristicNames {
    */
   string notSensitiveRegexp() {
     result =
-      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)|certain|concert|secretar|accountant|accountab).*"
+      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|(?<!pass)code)|certain|concert|secretar|accountant|accountab).*"
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/security/internal/SensitiveDataHeuristics.qll
+++ b/ruby/ql/lib/codeql/ruby/security/internal/SensitiveDataHeuristics.qll
@@ -103,7 +103,7 @@ module HeuristicNames {
    */
   string notSensitiveRegexp() {
     result =
-      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|code)|certain|concert|secretar|accountant|accountab).*"
+      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|(?<!pass)code)|certain|concert|secretar|accountant|accountab).*"
   }
 
   /**


### PR DESCRIPTION
Fixes #11148

Evaluations were uneventful: [Ruby](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11178-2-ruby/reports), [Python](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11178-1-python/reports), [JavaScript](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11178-0-javascript/reports)