### PR TITLE
CI: compile-queries: use cache when running on main, and support more base-branches

### DIFF
--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -31,8 +31,8 @@ jobs:
           path: '*/ql/src/.cache'
           key: codeql-compile-pr-${{ github.sha }} # deliberately not using the `compile-compile-main` keys here.
           restore-keys: |
-            codeql-compile-${{ github.base_ref }}-${{ env.merge-base }}
-            codeql-compile-${{ github.base_ref }}-
+            codeql-compile-refs/heads/${{ github.base_ref }}-${{ env.merge-base }}
+            codeql-compile-refs/heads/${{ github.base_ref }}-
       - name: Fill CodeQL query compilation cache - main
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache@v3

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -38,9 +38,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '*/ql/src/.cache'
-          key: codeql-compile-main-${{ github.sha }} # just fill on main
+          key: codeql-compile-${{ github.ref }}-${{ github.sha }} # just fill on main
           restore-keys: | # restore from another random commit, to speed up compilation.
-            codeql-compile-main- 
+            codeql-compile-${{ github.ref }}- 
       - name: Setup CodeQL
         uses: ./.github/actions/fetch-codeql
         with:

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -31,8 +31,8 @@ jobs:
           path: '*/ql/src/.cache'
           key: codeql-compile-pr-${{ github.sha }} # deliberately not using the `compile-compile-main` keys here.
           restore-keys: |
-            codeql-compile-main-${{ env.merge-base }}
-            codeql-compile-main-
+            codeql-compile-${{ github.base_ref }}-${{ env.merge-base }}
+            codeql-compile-${{ github.base_ref }}-
       - name: Fill CodeQL query compilation cache - main
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache@v3

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -41,6 +41,7 @@ jobs:
           key: codeql-compile-${{ github.ref }}-${{ github.sha }} # just fill on main
           restore-keys: | # restore from another random commit, to speed up compilation.
             codeql-compile-${{ github.ref }}- 
+            codeql-compile-refs/heads/main-
       - name: Setup CodeQL
         uses: ./.github/actions/fetch-codeql
         with:

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -31,6 +31,7 @@ jobs:
           restore-keys: |
             codeql-compile-${{ github.base_ref }}-${{ env.merge-base }}
             codeql-compile-${{ github.base_ref }}-
+            codeql-compile-main-
       - name: Fill CodeQL query compilation cache - main
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache@v3

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -2,11 +2,10 @@ name: "Compile all queries using the latest stable CodeQL CLI"
 
 on:
   push:
-    branches: [main] # makes sure the cache gets populated
-  pull_request:
-    branches:
+    branches:  # makes sure the cache gets populated - running on the branches people tend to merge into.
       - main
       - "rc/*"
+      - "codeql-cli-*"
 
 jobs:
   compile-queries:

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -14,15 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       # calculate the merge-base with main, in a way that works both on PRs and pushes to main. 
       - name: Calculate merge-base
         if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_BRANCH: ${{ github.base_ref }}
         run: |
-          MERGE_BASE=$(git merge-base --fork-point origin/$BASE_BRANCH)
+          MERGE_BASE=$(git cat-file commit $GITHUB_SHA | grep '^parent ' | head -1 | cut -f 2 -d " ")
           echo "merge-base=$MERGE_BASE" >> $GITHUB_ENV
       - name: Read CodeQL query compilation - PR
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -29,17 +29,17 @@ jobs:
           path: '*/ql/src/.cache'
           key: codeql-compile-pr-${{ github.sha }} # deliberately not using the `compile-compile-main` keys here.
           restore-keys: |
-            codeql-compile-refs/heads/${{ github.base_ref }}-${{ env.merge-base }}
-            codeql-compile-refs/heads/${{ github.base_ref }}-
+            codeql-compile-${{ github.base_ref }}-${{ env.merge-base }}
+            codeql-compile-${{ github.base_ref }}-
       - name: Fill CodeQL query compilation cache - main
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache@v3
         with:
           path: '*/ql/src/.cache'
-          key: codeql-compile-${{ github.ref }}-${{ github.sha }} # just fill on main
+          key: codeql-compile-${{ github.ref_name }}-${{ github.sha }} # just fill on main
           restore-keys: | # restore from another random commit, to speed up compilation.
-            codeql-compile-${{ github.ref }}- 
-            codeql-compile-refs/heads/main-
+            codeql-compile-${{ github.ref_name }}- 
+            codeql-compile-main-
       - name: Setup CodeQL
         uses: ./.github/actions/fetch-codeql
         with:

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           path: '*/ql/src/.cache'
           key: codeql-compile-main-${{ github.sha }} # just fill on main
+          restore-keys: | # restore from another random commit, to speed up compilation.
+            codeql-compile-main- 
       - name: Setup CodeQL
         uses: ./.github/actions/fetch-codeql
         with:

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -6,6 +6,7 @@ on:
       - main
       - "rc/*"
       - "codeql-cli-*"
+  pull_request:
 
 jobs:
   compile-queries:


### PR DESCRIPTION
Followup to https://github.com/github/codeql/pull/11162