### PR TITLE
C++: Re-introduce the `ast` annotations in the taint tests and related test infrastructure

### DIFF
--- a/cpp/ql/test/TestUtilities/dataflow/FlowTestCommon.qll
+++ b/cpp/ql/test/TestUtilities/dataflow/FlowTestCommon.qll
@@ -13,6 +13,7 @@
 
 import cpp
 private import semmle.code.cpp.ir.dataflow.DataFlow::DataFlow as IRDataFlow
+private import semmle.code.cpp.dataflow.old.DataFlow::DataFlow as AstDataFlow
 import TestUtilities.InlineExpectationsTest
 
 class IRFlowTest extends InlineExpectationsTest {
@@ -40,3 +41,34 @@ class IRFlowTest extends InlineExpectationsTest {
     )
   }
 }
+
+class AstFlowTest extends InlineExpectationsTest {
+  AstFlowTest() { this = "ASTFlowTest" }
+
+  override string getARelevantTag() { result = "ast" }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(
+      AstDataFlow::Node source, AstDataFlow::Node sink, AstDataFlow::Configuration conf, int n
+    |
+      tag = "ast" and
+      conf.hasFlow(source, sink) and
+      n = strictcount(AstDataFlow::Node otherSource | conf.hasFlow(otherSource, sink)) and
+      (
+        n = 1 and value = ""
+        or
+        // If there is more than one source for this sink
+        // we specify the source location explicitly.
+        n > 1 and
+        value =
+          source.getLocation().getStartLine().toString() + ":" +
+            source.getLocation().getStartColumn()
+      ) and
+      location = sink.getLocation() and
+      element = sink.toString()
+    )
+  }
+}
+
+/** DEPRECATED: Alias for AstFlowTest */
+deprecated class ASTFlowTest = AstFlowTest;

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.ql
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.ql
@@ -1,5 +1,49 @@
 import TestUtilities.dataflow.FlowTestCommon
 
+module AstTest {
+  private import semmle.code.cpp.dataflow.old.DataFlow
+  private import semmle.code.cpp.controlflow.Guards
+
+  /**
+   * A `BarrierGuard` that stops flow to all occurrences of `x` within statement
+   * S in `if (guarded(x)) S`.
+   */
+  // This is tested in `BarrierGuard.cpp`.
+  predicate testBarrierGuard(GuardCondition g, Expr checked, boolean isTrue) {
+    g.(FunctionCall).getTarget().getName() = "guarded" and
+    checked = g.(FunctionCall).getArgument(0) and
+    isTrue = true
+  }
+
+  /** Common data flow configuration to be used by tests. */
+  class AstTestAllocationConfig extends DataFlow::Configuration {
+    AstTestAllocationConfig() { this = "ASTTestAllocationConfig" }
+
+    override predicate isSource(DataFlow::Node source) {
+      source.asExpr().(FunctionCall).getTarget().getName() = "source"
+      or
+      source.asParameter().getName().matches("source%")
+      or
+      source.(DataFlow::DefinitionByReferenceNode).getParameter().getName().matches("ref_source%")
+      or
+      // Track uninitialized variables
+      exists(source.asUninitialized())
+    }
+
+    override predicate isSink(DataFlow::Node sink) {
+      exists(FunctionCall call |
+        call.getTarget().getName() = "sink" and
+        sink.asExpr() = call.getAnArgument()
+      )
+    }
+
+    override predicate isBarrier(DataFlow::Node barrier) {
+      barrier.asExpr().(VariableAccess).getTarget().hasName("barrier") or
+      barrier = DataFlow::BarrierGuard<testBarrierGuard/3>::getABarrierNode()
+    }
+  }
+}
+
 module IRTest {
   private import semmle.code.cpp.ir.dataflow.DataFlow
   private import semmle.code.cpp.ir.IR

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/arrayassignment.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/arrayassignment.cpp
@@ -13,10 +13,10 @@ void test_pointer_deref_assignment()
 
 	*p_x = source();
 
-	sink(x); // $ MISSING: ir
-	sink(*p_x); // $ ir
-	sink(*p2_x); // $ MISSING: ir
-	sink(r_x); // $ MISSING: ir
+	sink(x); // $ MISSING: ast,ir
+	sink(*p_x); // $ ast,ir
+	sink(*p2_x); // $ MISSING: ast,ir
+	sink(r_x); // $ MISSING: ast,ir
 }
 
 void test_reference_deref_assignment()
@@ -28,10 +28,10 @@ void test_reference_deref_assignment()
 
 	r_x = source();
 
-	sink(x); // $ MISSING: ir
-	sink(*p_x); // $ MISSING: ir
-	sink(r_x); // $ ir
-	sink(r2_x); // $ MISSING: ir
+	sink(x); // $ MISSING: ast,ir
+	sink(*p_x); // $ MISSING: ast,ir
+	sink(r_x); // $ ast,ir
+	sink(r2_x); // $ MISSING: ast,ir
 }
 
 class MyInt
@@ -53,8 +53,8 @@ void test_myint_member_assignment()
 
 	mi.i = source();
 
-	sink(mi); // $ MISSING: ir
-	sink(mi.get()); // $ ir
+	sink(mi); // $ MISSING: ast,ir
+	sink(mi.get()); // $ ast,ir
 }
 
 void test_myint_method_assignment()
@@ -63,8 +63,8 @@ void test_myint_method_assignment()
 
 	mi.get() = source();
 
-	sink(mi); // $ MISSING: ir
-	sink(mi.get()); // $ MISSING: ir
+	sink(mi); // $ MISSING: ast,ir
+	sink(mi.get()); // $ ast MISSING: ir
 }
 
 void test_myint_overloaded_assignment()
@@ -74,10 +74,10 @@ void test_myint_overloaded_assignment()
 	mi = source();
 	mi2 = mi;
 
-	sink(mi); // $ MISSING: ir
-	sink(mi.get()); // $ MISSING: ir
-	sink(mi2); // $ MISSING: ir
-	sink(mi2.get()); // $ MISSING: ir
+	sink(mi); // $ MISSING: ast,ir
+	sink(mi.get()); // $ MISSING: ast,ir
+	sink(mi2); // $ MISSING: ast,ir
+	sink(mi2.get()); // $ MISSING: ast,ir
 }
 
 class MyArray
@@ -98,7 +98,7 @@ void test_myarray_member_assignment()
 
 	ma.values[0] = source();
 
-	sink(ma.values[0]); // $ ir
+	sink(ma.values[0]); // $ ast,ir
 }
 
 void test_myarray_method_assignment()
@@ -107,7 +107,7 @@ void test_myarray_method_assignment()
 
 	ma.get(0) = source();
 
-	sink(ma.get(0)); // $ MISSING: ir
+	sink(ma.get(0)); // $ MISSING: ast,ir
 }
 
 void test_myarray_overloaded_assignment()
@@ -117,8 +117,8 @@ void test_myarray_overloaded_assignment()
 	ma[0] = source();
 	ma2 = ma;
 
-	sink(ma[0]); // $ MISSING: ir
-	sink(ma2[0]); // $ MISSING: ir
+	sink(ma[0]); // $ MISSING: ast,ir
+	sink(ma2[0]); // $ MISSING: ast,ir
 }
 
 void sink(int *);
@@ -132,16 +132,16 @@ void test_array_reference_assignment()
 	int *ptr2, *ptr3;
 
 	ref1 = source();
-	sink(ref1); // $ ir
-	sink(arr1[5]); // $ MISSING: ir
+	sink(ref1); // $ ast,ir
+	sink(arr1[5]); // $ MISSING: ast,ir
 
 	ptr2 = &(arr2[5]);
 	*ptr2 = source();
-	sink(*ptr2); // $ ir
-	sink(arr2[5]); // $ MISSING: ir
+	sink(*ptr2); // $ ast,ir
+	sink(arr2[5]); // $ MISSING: ast,ir
 
 	ptr3 = arr3;
 	ptr3[5] = source();
-	sink(ptr3[5]); // $ ir
-	sink(arr3[5]); // $ MISSING: ir
+	sink(ptr3[5]); // $ ast,ir
+	sink(arr3[5]); // $ MISSING: ast,ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/bsd.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/bsd.cpp
@@ -19,6 +19,6 @@ void test_accept() {
   int size = sizeof(sockaddr);
   int a = accept(s, &addr, &size);
 
-  sink(a); // $ ir
-  sink(addr); // $ MISSING: ir
+  sink(a); // $ ast=17:11 ir SPURIOUS: ast=18:12
+  sink(addr); // $ ast MISSING: ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/constructor_delegation.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/constructor_delegation.cpp
@@ -34,14 +34,14 @@ void test_inits()
 	MyDerivedValue v11(true, source());
 
 	sink(v1.x);
-	sink(v2.x); // $ ir
+	sink(v2.x); // $ ast,ir
 	sink(v3.x);
-	sink(v4.x); // $ ir
+	sink(v4.x); // $ ir MISSING: ast
 	sink(v5.x);
-	sink(v6.x); // $ ir
-	sink(v7.x); // $ ir
+	sink(v6.x); // $ ir MISSING: ast
+	sink(v7.x); // $ ir MISSING: ast
 	sink(v8.x);
 	sink(v9.x);
 	sink(v10.x);
-	sink(v11.x); // $ ir
+	sink(v11.x); // $ ir MISSING: ast
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/copyableclass.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/copyableclass.cpp
@@ -37,10 +37,10 @@ void test_copyableclass()
 		MyCopyableClass s4;
 		s4 = source();
 
-		sink(s1); // $ ir
-		sink(s2); // $ ir
-		sink(s3); // $ ir
-		sink(s4); // $ ir
+		sink(s1); // $ ast,ir
+		sink(s2); // $ ast,ir
+		sink(s3); // $ ast,ir
+		sink(s4); // $ ast,ir
 	}
 
 	{
@@ -62,8 +62,8 @@ void test_copyableclass()
 		MyCopyableClass s3;
 		s2 = MyCopyableClass(source());
 
-		sink(s1); // $ ir
-		sink(s2); // $ ir
-		sink(s3 = source()); // $ ir
+		sink(s1); // $ ast,ir
+		sink(s2); // $ ast,ir
+		sink(s3 = source()); // $ ast,ir
 	}
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/copyableclass_declonly.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/copyableclass_declonly.cpp
@@ -37,10 +37,10 @@ void test_copyableclass_declonly()
 		MyCopyableClassDeclOnly s4;
 		s4 = source();
 
-		sink(s1); // $ ir
-		sink(s2); // $ ir
-		sink(s3); // $ ir
-		sink(s4); // $ ir
+		sink(s1); // $ ast,ir
+		sink(s2); // $ ast,ir
+		sink(s3); // $ ast,ir
+		sink(s4); // $ ast,ir
 	}
 
 	{
@@ -62,8 +62,8 @@ void test_copyableclass_declonly()
 		MyCopyableClassDeclOnly s3;
 		s2 = MyCopyableClassDeclOnly(source());
 
-		sink(s1); // $ ir
-		sink(s2); // $ ir
-		sink(s3 = source()); // $ ir
+		sink(s1); // $ ast,ir
+		sink(s2); // $ ast,ir
+		sink(s3 = source()); // $ ast,ir
 	}
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/format.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/format.cpp
@@ -54,22 +54,22 @@ void test1()
 	{
 		char buffer[256] = {0};
 		sink(snprintf(buffer, 256, "%s", string::source()));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 	{
 		char buffer[256] = {0};
 		sink(snprintf(buffer, 256, string::source(), "Hello."));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 	{
 		char buffer[256] = {0};
 		sink(snprintf(buffer, 256, "%s %s %s", "a", "b", string::source()));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 	{
 		char buffer[256] = {0};
 		sink(snprintf(buffer, 256, "%.*s", 10, string::source()));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 
 	{
@@ -80,39 +80,39 @@ void test1()
 	{
 		char buffer[256] = {0};
 		sink(snprintf(buffer, 256, "%i", source()));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 	{
 		char buffer[256] = {0};
 		sink(snprintf(buffer, 256, "%.*s", source(), "Hello."));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 
 	{
 		char buffer[256] = {0};
 		sink(snprintf(buffer, 256, "%p", string::source()));
-		sink(buffer); // $ MISSING: ir // tainted (debatable)
+		sink(buffer); // $ ast MISSING: ir // tainted (debatable)
 	}
 
 	{
 		char buffer[256] = {0};
 		sink(sprintf(buffer, "%s", string::source()));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 	{
 		char buffer[256] = {0};
 		sink(sprintf(buffer, "%ls", wstring::source()));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 	{
 		wchar_t wbuffer[256] = {0};
 		sink(swprintf(wbuffer, 256, L"%s", wstring::source()));
-		sink(wbuffer); // $ MISSING: ir
+		sink(wbuffer); // $ ast MISSING: ir
 	}
 	{
 		char buffer[256] = {0};
 		sink(mysprintf(buffer, 256, "%s", string::source()));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 
 	{
@@ -123,7 +123,7 @@ void test1()
 	{
 		int i = 0;
 		sink(sscanf(string::source(), "%i", &i));
-		sink(i); // $ ir
+		sink(i); // $ ast,ir
 	}
 	{
 		char buffer[256] = {0};
@@ -133,7 +133,7 @@ void test1()
 	{
 		char buffer[256] = {0};
 		sink(sscanf(string::source(), "%s", &buffer));
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 }
 
@@ -154,6 +154,6 @@ void test2()
 	i = strlen(s) + 1;
 	sink(i);
 
-	sink(s[strlen(s) - 1]); // $ ir
-	sink(ws + (wcslen(ws) / 2)); // $ ir
+	sink(s[strlen(s) - 1]); // $ ast,ir
+	sink(ws + (wcslen(ws) / 2)); // $ ast,ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/map.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/map.cpp
@@ -26,14 +26,14 @@ void test_pair()
 	sink(a);
 
 	b.first = source();
-	sink(b.first); // $ ir
+	sink(b.first); // $ ast,ir
 	sink(b.second);
-	sink(b); // $ MISSING: ir
+	sink(b); // $ MISSING: ast,ir
 
 	c.second = source();
 	sink(c.first);
-	sink(c.second); // $ ir
-	sink(c); // $ MISSING: ir
+	sink(c.second); // $ ast,ir
+	sink(c); // $ MISSING: ast,ir
 
 	std::pair<char *, char *> d("123", "456");
 	sink(d.first);
@@ -41,25 +41,25 @@ void test_pair()
 	sink(d);
 
 	std::pair<char *, char *> e(source(), "456");
-	sink(e.first); // $ ir
+	sink(e.first); // $ ast,ir
 	sink(e.second);
-	sink(e); // $ MISSING: ir
+	sink(e); // $ MISSING: ast,ir
 
 	std::pair<char *, char *> f("123", source());
 	sink(f.first);
-	sink(f.second); // $ ir
-	sink(f); // $ ir
+	sink(f.second); // $ ast,ir
+	sink(f); // $ ast,ir
 
 	std::pair<char *, char *> g(f);
 	sink(g.first);
-	sink(g.second); // $ ir
-	sink(g); // $ ir
+	sink(g.second); // $ ast,ir
+	sink(g); // $ ast,ir
 
 	std::pair<char *, char *> h;
 	h = f;
 	sink(h.first);
-	sink(h.second); // $ ir
-	sink(h); // $ ir
+	sink(h.second); // $ ast,ir
+	sink(h); // $ ast,ir
 
 	std::pair<char *, char *> i("123", "456");
 	std::pair<char *, char *> j("123", source());
@@ -68,34 +68,34 @@ void test_pair()
  	i.swap(j);
 	k.swap(l);
 	sink(i.first);
-	sink(i.second); // $ MISSING: ir
-	sink(i); // $ ir
+	sink(i.second); // $ MISSING: ast,ir
+	sink(i); // $ ast,ir
 	sink(j.first);
-	sink(j.second); // $ SPURIOUS: ir
-	sink(j); // $ SPURIOUS: ir
+	sink(j.second); // $ SPURIOUS: ast,ir
+	sink(j); // $ SPURIOUS: ast,ir
 	sink(k.first);
-	sink(k.second); // $ SPURIOUS: ir
-	sink(k); // $ SPURIOUS: ir
+	sink(k.second); // $ SPURIOUS: ast,ir
+	sink(k); // $ SPURIOUS: ast,ir
 	sink(l.first);
-	sink(l.second); // $ MISSING: ir
-	sink(l); // $ ir
+	sink(l.second); // $ MISSING: ast,ir
+	sink(l); // $ ast,ir
 
 	sink(make_pair("123", "456"));
 	sink(make_pair("123", "456").first);
 	sink(make_pair("123", "456").second);
-	sink(make_pair(source(), "456")); // $ MISSING: ir
-	sink(make_pair(source(), "456").first); // $ ir
+	sink(make_pair(source(), "456")); // $ MISSING: ast,ir
+	sink(make_pair(source(), "456").first); // $ ast,ir
 	sink(make_pair(source(), "456").second);
-	sink(make_pair("123", source())); // $ ir
+	sink(make_pair("123", source())); // $ ast,ir
 	sink(make_pair("123", source()).first);
-	sink(make_pair("123", source()).second); // $ ir
+	sink(make_pair("123", source()).second); // $ ast,ir
 
 	std::pair<std::pair<char *, char *>, char *> m;
 	m = make_pair(make_pair("123", source()), "789");
-	sink(m); // $ MISSING: ir
-	sink(m.first); // $ MISSING: ir
+	sink(m); // $ MISSING: ast,ir
+	sink(m.first); // $ MISSING: ast,ir
 	sink(m.first.first);
-	sink(m.first.second); // $ MISSING: ir
+	sink(m.first.second); // $ MISSING: ast,ir
 	sink(m.second);
 }
 
@@ -106,40 +106,40 @@ void test_map()
 
 	sink(m1.insert(std::make_pair("abc", "def")).first);
 	sink(m2.insert(std::make_pair("abc", source())).first);
-	sink(m3.insert(std::make_pair(source(), "def")).first); // $ MISSING: ir
-	sink(m4.insert(m4.begin(), std::pair<char *, char *>("abc", source()))); // $ ir
+	sink(m3.insert(std::make_pair(source(), "def")).first); // $ MISSING: ast,ir
+	sink(m4.insert(m4.begin(), std::pair<char *, char *>("abc", source()))); // $ ast,ir
 	sink(m5.insert_or_assign("abc", source()).first);
-	sink(m6.insert_or_assign(m6.begin(), "abc", source())); // $ ir
+	sink(m6.insert_or_assign(m6.begin(), "abc", source())); // $ ast,ir
 	sink(m1);
-	sink(m2); // $ ir
-	sink(m3); // $ MISSING: ir
-	sink(m4); // $ ir
-	sink(m5); // $ ir
-	sink(m6); // $ ir
+	sink(m2); // $ ast,ir
+	sink(m3); // $ MISSING: ast,ir
+	sink(m4); // $ ast,ir
+	sink(m5); // $ ast,ir
+	sink(m6); // $ ast,ir
 	sink(m1.find("abc"));
-	sink(m2.find("abc")); // $ ir
+	sink(m2.find("abc")); // $ ast,ir
 	sink(m3.find("abc"));
-	sink(m4.find("abc")); // $ ir
-	sink(m5.find("abc")); // $ ir
-	sink(m6.find("abc")); // $ ir
+	sink(m4.find("abc")); // $ ast,ir
+	sink(m5.find("abc")); // $ ast,ir
+	sink(m6.find("abc")); // $ ast,ir
 	sink(m1.find("def"));
-	sink(m2.find("def")); // $ SPURIOUS: ir
+	sink(m2.find("def")); // $ SPURIOUS: ast,ir
 	sink(m3.find("def"));
-	sink(m4.find("def")); // $ SPURIOUS: ir
-	sink(m5.find("def")); // $ SPURIOUS: ir
-	sink(m6.find("def")); // $ SPURIOUS: ir
+	sink(m4.find("def")); // $ SPURIOUS: ast,ir
+	sink(m5.find("def")); // $ SPURIOUS: ast,ir
+	sink(m6.find("def")); // $ SPURIOUS: ast,ir
 
 	// copy constructors and assignment
 	std::map<char *, char *> m7(m2);
 	std::map<char *, char *> m8 = m2;
 	std::map<char *, char *> m9;
 	m9 = m2;
-	sink(m7); // $ ir
-	sink(m8); // $ ir
-	sink(m9); // $ ir
-	sink(m7.find("abc")); // $ ir
-	sink(m8.find("abc")); // $ ir
-	sink(m9.find("abc")); // $ ir
+	sink(m7); // $ ast,ir
+	sink(m8); // $ ast,ir
+	sink(m9); // $ ast,ir
+	sink(m7.find("abc")); // $ ast,ir
+	sink(m8.find("abc")); // $ ast,ir
+	sink(m9.find("abc")); // $ ast,ir
 
 	// iterators
 	std::map<char *, char *>::iterator i1, i2, i3;
@@ -151,27 +151,27 @@ void test_map()
 	}
 	for (i2 = m2.begin(); i2 != m2.end(); i2++)
 	{
-		sink(*i2); // $ ir
+		sink(*i2); // $ ast,ir
 		sink(i2->first); // clean
-		sink(i2->second); // $ MISSING: ir
+		sink(i2->second); // $ MISSING: ast,ir
 	}
 	for (i3 = m3.begin(); i3 != m3.end(); i3++)
 	{
-		sink(*i3); // $ MISSING: ir
-		sink(i3->first);  // $ MISSING: ir
+		sink(*i3); // $ MISSING: ast,ir
+		sink(i3->first);  // $ MISSING: ast,ir
 		sink(i3->second); // clean
 	}
 
 	// array-like access
 	std::map<char *, char *> m10, m11, m12, m13;
 	sink(m10["abc"] = "def");
-	sink(m11["abc"] = source()); // $ ir
+	sink(m11["abc"] = source()); // $ ast,ir
 	sink(m12.at("abc") = "def");
-	sink(m13.at("abc") = source()); // $ ir
+	sink(m13.at("abc") = source()); // $ ast,ir
 	sink(m10["abc"]);
-	sink(m11["abc"]); // $ ir
+	sink(m11["abc"]); // $ ast,ir
 	sink(m12["abc"]);
-	sink(m13["abc"]); // $ ir
+	sink(m13["abc"]); // $ ast,ir
 
 	// ranges
 	std::map<char *, char *> m14;
@@ -179,27 +179,27 @@ void test_map()
 	m14.insert(std::make_pair("b", source()));
 	m14.insert(std::make_pair("c", source()));
 	m14.insert(std::make_pair("d", "d"));
-	sink(m14.lower_bound("b")); // $ ir=179:33 ir=180:33
-	sink(m14.upper_bound("b")); // $ ir=179:33 ir=180:33
-	sink(m14.equal_range("b").first); // $ MISSING: ir
-	sink(m14.equal_range("b").second); // $ MISSING: ir
-	sink(m14.upper_bound("c")); // $ SPURIOUS: ir=179:33 ir=180:33
+	sink(m14.lower_bound("b")); // $ ast,ir=179:33 ast,ir=180:33
+	sink(m14.upper_bound("b")); // $ ast,ir=179:33 ast,ir=180:33
+	sink(m14.equal_range("b").first); // $ MISSING: ast,ir
+	sink(m14.equal_range("b").second); // $ MISSING: ast,ir
+	sink(m14.upper_bound("c")); // $ SPURIOUS: ast,ir=179:33 ast,ir=180:33
 	sink(m14.equal_range("c").second);
 
 	// swap
 	std::map<char *, char *> m15, m16, m17, m18;
 	m15.insert(std::pair<char *, char *>(source(), source()));
 	m18.insert(std::pair<char *, char *>(source(), source()));
-	sink(m15); // $ ir
+	sink(m15); // $ ast,ir
 	sink(m16);
 	sink(m17);
-	sink(m18); // $ ir
+	sink(m18); // $ ast,ir
 	m15.swap(m16);
 	m17.swap(m18);
-	sink(m15); // $ SPURIOUS: ir
-	sink(m16); // $ ir
-	sink(m17); // $ ir
-	sink(m18); // $ SPURIOUS: ir
+	sink(m15); // $ SPURIOUS: ast,ir
+	sink(m16); // $ ast,ir
+	sink(m17); // $ ast,ir
+	sink(m18); // $ SPURIOUS: ast,ir
 
 	// merge
 	std::map<char *, char *> m19, m20, m21, m22;
@@ -207,48 +207,48 @@ void test_map()
 	m20.insert(std::pair<char *, char *>("abc", "def"));
 	m21.insert(std::pair<char *, char *>("abc", "def"));
 	m22.insert(std::pair<char *, char *>(source(), source()));
-	sink(m19); // $ ir
+	sink(m19); // $ ast,ir
 	sink(m20);
 	sink(m21);
-	sink(m22); // $ ir
+	sink(m22); // $ ast,ir
 	m19.merge(m20);
 	m21.merge(m22);
-	sink(m19); // $ ir
+	sink(m19); // $ ast,ir
 	sink(m20);
-	sink(m21); // $ ir
-	sink(m22); // $ ir
+	sink(m21); // $ ast,ir
+	sink(m22); // $ ast,ir
 
 	// erase, clear
 	std::map<char *, char *> m23;
 	m23.insert(std::pair<char *, char *>(source(), source()));
 	m23.insert(std::pair<char *, char *>(source(), source()));
-	sink(m23); // $ ir=223:49 ir=224:49
-	sink(m23.erase(m23.begin())); // $ ir=223:49 ir=224:49
-	sink(m23); // $ ir=223:49 ir=224:49
+	sink(m23); // $ ast,ir=223:49 ast,ir=224:49
+	sink(m23.erase(m23.begin())); // $ ast,ir=223:49 ast,ir=224:49
+	sink(m23); // $ ast,ir=223:49 ast,ir=224:49
 	m23.clear();
-	sink(m23); // $ SPURIOUS: ir=223:49 ir=224:49
+	sink(m23); // $ SPURIOUS: ast,ir=223:49 ast,ir=224:49
 
 	// emplace, emplace_hint
 	std::map<char *, char *> m24, m25;
 	sink(m24.emplace("abc", "def").first);
 	sink(m24);
 	sink(m24.emplace("abc", source()).first);
-	sink(m24); // $ ir
+	sink(m24); // $ ast,ir
 	sink(m25.emplace_hint(m25.begin(), "abc", "def"));
 	sink(m25);
-	sink(m25.emplace_hint(m25.begin(), "abc", source())); // $ ir
-	sink(m25); // $ ir
+	sink(m25.emplace_hint(m25.begin(), "abc", source())); // $ ast,ir
+	sink(m25); // $ ast,ir
 	
 	// try_emplace
 	std::map<char *, char *> m26, m27;
 	sink(m26.try_emplace("abc", "def").first);
 	sink(m26);
 	sink(m26.try_emplace("abc", source()).first);
-	sink(m26); // $ ir
+	sink(m26); // $ ast,ir
 	sink(m27.try_emplace(m27.begin(), "abc", "def"));
 	sink(m27);
-	sink(m27.try_emplace(m27.begin(), "abc", source())); // $ ir
-	sink(m27); // $ ir
+	sink(m27.try_emplace(m27.begin(), "abc", source())); // $ ast,ir
+	sink(m27); // $ ast,ir
 }
 
 void test_unordered_map()
@@ -258,40 +258,40 @@ void test_unordered_map()
 
 	sink(m1.insert(std::make_pair("abc", "def")).first);
 	sink(m2.insert(std::make_pair("abc", source())).first);
-	sink(m3.insert(std::make_pair(source(), "def")).first); // $ MISSING: ir
-	sink(m4.insert(m4.begin(), std::pair<char *, char *>("abc", source()))); // $ ir
+	sink(m3.insert(std::make_pair(source(), "def")).first); // $ MISSING: ast,ir
+	sink(m4.insert(m4.begin(), std::pair<char *, char *>("abc", source()))); // $ ast,ir
 	sink(m5.insert_or_assign("abc", source()).first);
-	sink(m6.insert_or_assign(m6.begin(), "abc", source())); // $ ir
+	sink(m6.insert_or_assign(m6.begin(), "abc", source())); // $ ast,ir
 	sink(m1);
-	sink(m2); // $ ir
-	sink(m3); // $ MISSING: ir
-	sink(m4); // $ ir
-	sink(m5); // $ ir
-	sink(m6); // $ ir
+	sink(m2); // $ ast,ir
+	sink(m3); // $ MISSING: ast,ir
+	sink(m4); // $ ast,ir
+	sink(m5); // $ ast,ir
+	sink(m6); // $ ast,ir
 	sink(m1.find("abc"));
-	sink(m2.find("abc")); // $ ir
+	sink(m2.find("abc")); // $ ast,ir
 	sink(m3.find("abc"));
-	sink(m4.find("abc")); // $ ir
-	sink(m5.find("abc")); // $ ir
-	sink(m6.find("abc")); // $ ir
+	sink(m4.find("abc")); // $ ast,ir
+	sink(m5.find("abc")); // $ ast,ir
+	sink(m6.find("abc")); // $ ast,ir
 	sink(m1.find("def"));
-	sink(m2.find("def")); // $ SPURIOUS: ir
+	sink(m2.find("def")); // $ SPURIOUS: ast,ir
 	sink(m3.find("def"));
-	sink(m4.find("def")); // $ SPURIOUS: ir
-	sink(m5.find("def")); // $ SPURIOUS: ir
-	sink(m6.find("def")); // $ SPURIOUS: ir
+	sink(m4.find("def")); // $ SPURIOUS: ast,ir
+	sink(m5.find("def")); // $ SPURIOUS: ast,ir
+	sink(m6.find("def")); // $ SPURIOUS: ast,ir
 
 	// copy constructors and assignment
 	std::unordered_map<char *, char *> m7(m2);
 	std::unordered_map<char *, char *> m8 = m2;
 	std::unordered_map<char *, char *> m9;
 	m9 = m2;
-	sink(m7); // $ ir
-	sink(m8); // $ ir
-	sink(m9); // $ ir
-	sink(m7.find("abc")); // $ ir
-	sink(m8.find("abc")); // $ ir
-	sink(m9.find("abc")); // $ ir
+	sink(m7); // $ ast,ir
+	sink(m8); // $ ast,ir
+	sink(m9); // $ ast,ir
+	sink(m7.find("abc")); // $ ast,ir
+	sink(m8.find("abc")); // $ ast,ir
+	sink(m9.find("abc")); // $ ast,ir
 
 	// iterators
 	std::unordered_map<char *, char *>::iterator i1, i2, i3;
@@ -303,27 +303,27 @@ void test_unordered_map()
 	}
 	for (i2 = m2.begin(); i2 != m2.end(); i2++)
 	{
-		sink(*i2); // $ ir
+		sink(*i2); // $ ast,ir
 		sink(i2->first); // clean
-		sink(i2->second); // $ MISSING: ir
+		sink(i2->second); // $ MISSING: ast,ir
 	}
 	for (i3 = m3.begin(); i3 != m3.end(); i3++)
 	{
-		sink(*i3); // $ MISSING: ir
-		sink(i3->first); // $ MISSING: ir
+		sink(*i3); // $ MISSING: ast,ir
+		sink(i3->first); // $ MISSING: ast,ir
 		sink(i3->second); // clean
 	}
 
 	// array-like access
 	std::unordered_map<char *, char *> m10, m11, m12, m13;
 	sink(m10["abc"] = "def");
-	sink(m11["abc"] = source()); // $ ir
+	sink(m11["abc"] = source()); // $ ast,ir
 	sink(m12.at("abc") = "def");
-	sink(m13.at("abc") = source()); // $ ir
+	sink(m13.at("abc") = source()); // $ ast,ir
 	sink(m10["abc"]);
-	sink(m11["abc"]); // $ ir
+	sink(m11["abc"]); // $ ast,ir
 	sink(m12["abc"]);
-	sink(m13["abc"]); // $ ir
+	sink(m13["abc"]); // $ ast,ir
 
 	// ranges
 	std::unordered_map<char *, char *> m14;
@@ -332,23 +332,23 @@ void test_unordered_map()
 	m14.insert(std::make_pair("c", source()));
 	m14.insert(std::make_pair("d", "d"));
 	sink(m14.equal_range("b").first);
-	sink(m14.equal_range("b").second); // $ MISSING: ir
+	sink(m14.equal_range("b").second); // $ MISSING: ast,ir
 	sink(m14.equal_range("c").second);
 
 	// swap
 	std::unordered_map<char *, char *> m15, m16, m17, m18;
 	m15.insert(std::pair<char *, char *>(source(), source()));
 	m18.insert(std::pair<char *, char *>(source(), source()));
-	sink(m15); // $ ir
+	sink(m15); // $ ast,ir
 	sink(m16);
 	sink(m17);
-	sink(m18); // $ ir
+	sink(m18); // $ ast,ir
 	m15.swap(m16);
 	m17.swap(m18);
-	sink(m15); // $ SPURIOUS: ir
-	sink(m16); // $ ir
-	sink(m17); // $ ir
-	sink(m18); // $ SPURIOUS: ir
+	sink(m15); // $ SPURIOUS: ast,ir
+	sink(m16); // $ ast,ir
+	sink(m17); // $ ast,ir
+	sink(m18); // $ SPURIOUS: ast,ir
 
 	// merge
 	std::unordered_map<char *, char *> m19, m20, m21, m22;
@@ -356,37 +356,37 @@ void test_unordered_map()
 	m20.insert(std::pair<char *, char *>("abc", "def"));
 	m21.insert(std::pair<char *, char *>("abc", "def"));
 	m22.insert(std::pair<char *, char *>(source(), source()));
-	sink(m19); // $ ir
+	sink(m19); // $ ast,ir
 	sink(m20);
 	sink(m21);
-	sink(m22); // $ ir
+	sink(m22); // $ ast,ir
 	m19.merge(m20);
 	m21.merge(m22);
-	sink(m19); // $ ir
+	sink(m19); // $ ast,ir
 	sink(m20);
-	sink(m21); // $ ir
-	sink(m22); // $ ir
+	sink(m21); // $ ast,ir
+	sink(m22); // $ ast,ir
 
 	// erase, clear
 	std::unordered_map<char *, char *> m23;
 	m23.insert(std::pair<char *, char *>(source(), source()));
 	m23.insert(std::pair<char *, char *>(source(), source()));
-	sink(m23); // $ ir=372:49 ir=373:49
-	sink(m23.erase(m23.begin())); // $ ir=372:49 ir=373:49
-	sink(m23); // $ ir=372:49 ir=373:49
+	sink(m23); // $ ast,ir=372:49 ast,ir=373:49
+	sink(m23.erase(m23.begin())); // $ ast,ir=372:49 ast,ir=373:49
+	sink(m23); // $ ast,ir=372:49 ast,ir=373:49
 	m23.clear();
-	sink(m23); // $ SPURIOUS: ir=372:49 ir=373:49
+	sink(m23); // $ SPURIOUS: ast,ir=372:49 ast,ir=373:49
 
 	// emplace, emplace_hint
 	std::unordered_map<char *, char *> m24, m25;
 	sink(m24.emplace("abc", "def").first);
 	sink(m24);
 	sink(m24.emplace("abc", source()).first);
-	sink(m24); // $ ir
+	sink(m24); // $ ast,ir
 	sink(m25.emplace_hint(m25.begin(), "abc", "def"));
 	sink(m25);
-	sink(m25.emplace_hint(m25.begin(), "abc", source())); // $ ir
-	sink(m25); // $ ir
+	sink(m25.emplace_hint(m25.begin(), "abc", source())); // $ ast,ir
+	sink(m25); // $ ast,ir
 
 	// try_emplace
 	std::unordered_map<char *, char *> m26, m27, m28;
@@ -394,45 +394,45 @@ void test_unordered_map()
 	sink(m26.try_emplace("abc", "def").second);
 	sink(m26);
 	sink(m26.try_emplace("abc", source()).first);
-	sink(m26.try_emplace("abc", source()).second); // $ MISSING: ir=396:30
-	sink(m26); // $ ir=396:30 SPURIOUS: ir=397:30
+	sink(m26.try_emplace("abc", source()).second); // $ MISSING: ast,ir=396:30
+	sink(m26); // $ ast,ir=396:30 SPURIOUS: ast,ir=397:30
 	sink(m27.try_emplace(m27.begin(), "abc", "def"));
 	sink(m27);
-	sink(m27.try_emplace(m27.begin(), "abc", source())); // $ ir
-	sink(m27); // $ ir
+	sink(m27.try_emplace(m27.begin(), "abc", source())); // $ ast,ir
+	sink(m27); // $ ast,ir
 	sink(m28.try_emplace(m28.begin(), "abc", "def"));
 	sink(m28);
-	sink(m28.try_emplace(m28.begin(), source(), "def")); // $ MISSING: ir
-	sink(m28); // $ MISSING: ir
+	sink(m28.try_emplace(m28.begin(), source(), "def")); // $ MISSING: ast,ir
+	sink(m28); // $ MISSING: ast,ir
 
 	// additional try_emplace test cases
 	std::unordered_map<char *, std::pair<int, int>> m29, m30, m31, m32;
 	sink(m29.try_emplace("abc", 1, 2));
 	sink(m29);
 	sink(m29["abc"]);
-	sink(m30.try_emplace(source(), 1, 2)); // $ MISSING: ir
-	sink(m30); // $ MISSING: ir
+	sink(m30.try_emplace(source(), 1, 2)); // $ MISSING: ast,ir
+	sink(m30); // $ MISSING: ast,ir
 	sink(m30["abc"]);
-	sink(m31.try_emplace("abc", source(), 2)); // $ ir
-	sink(m31); // $ ir
-	sink(m31["abc"]); // $ ir
-	sink(m32.try_emplace("abc", 1, source())); // $ ir
-	sink(m32); // $ ir
-	sink(m32["abc"]); // $ ir
+	sink(m31.try_emplace("abc", source(), 2)); // $ ast,ir
+	sink(m31); // $ ast,ir
+	sink(m31["abc"]); // $ ast,ir
+	sink(m32.try_emplace("abc", 1, source())); // $ ast,ir
+	sink(m32); // $ ast,ir
+	sink(m32["abc"]); // $ ast,ir
 
 	// additional emplace test cases
 	std::unordered_map<char *, char *> m33;
-	sink(m33.emplace(source(), "def").first); // $ MISSING: ir
-	sink(m33); // $ MISSING: ir
+	sink(m33.emplace(source(), "def").first); // $ MISSING: ast,ir
+	sink(m33); // $ MISSING: ast,ir
 
 	std::unordered_map<char *, char *> m34, m35;
 	sink(m34.emplace(std::pair<char *, char *>("abc", "def")).first);
 	sink(m34);
 	sink(m34.emplace(std::pair<char *, char *>("abc", source())).first);
-	sink(m34); // $ ir
-	sink(m34.emplace_hint(m34.begin(), "abc", "def")); // $ ir
+	sink(m34); // $ ast,ir
+	sink(m34.emplace_hint(m34.begin(), "abc", "def")); // $ ast,ir
 	sink(m35.emplace().first);
 	sink(m35);
-	sink(m35.emplace(std::pair<char *, char *>(source(), "def")).first); // $ MISSING: ir
-	sink(m35); // $ MISSING: ir
+	sink(m35.emplace(std::pair<char *, char *>(source(), "def")).first); // $ MISSING: ast,ir
+	sink(m35); // $ MISSING: ast,ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/movableclass.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/movableclass.cpp
@@ -41,9 +41,9 @@ void test_movableclass()
 		MyMovableClass s3;
 		s3 = source();
 
-		sink(s1); // $ ir
-		sink(s2); // $ ir
-		sink(s3); // $ ir
+		sink(s1); // $ ast,ir
+		sink(s2); // $ ast,ir
+		sink(s3); // $ ast,ir
 	}
 
 	{
@@ -51,8 +51,8 @@ void test_movableclass()
 		MyMovableClass s2;
 		s2 = MyMovableClass(source());
 
-		sink(s1); // $ ir
-		sink(s2); // $ ir
+		sink(s1); // $ ast,ir
+		sink(s2); // $ ast,ir
 	}
 
 	{
@@ -61,7 +61,7 @@ void test_movableclass()
 		MyMovableClass s3;
 
 		sink(s1);
-		sink(s2); // $ ir
-		sink(s3 = source()); // $ ir
+		sink(s2); // $ ast,ir
+		sink(s3 = source()); // $ ast,ir
 	}
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/set.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/set.cpp
@@ -17,23 +17,23 @@ void test_set()
 	std::set<char *> s1, s2, s3, s4, s5, s6;
 
 	sink(s1.insert("abc").first);
-	sink(s2.insert(source()).first); // $ MISSING: ir
+	sink(s2.insert(source()).first); // $ MISSING: ast,ir
 	sink(s3.insert(s3.begin(), "abc"));
-	sink(s4.insert(s4.begin(), source())); // $ ir
+	sink(s4.insert(s4.begin(), source())); // $ ast,ir
 	s5.insert(s1.begin(), s1.end());
 	s6.insert(s2.begin(), s2.end());
 	sink(s1);
-	sink(s2); // $ ir
+	sink(s2); // $ ast,ir
 	sink(s3);
-	sink(s4); // $ ir
+	sink(s4); // $ ast,ir
 	sink(s5);
-	sink(s6); // $ ir
+	sink(s6); // $ ast,ir
 	sink(s1.find("abc"));
-	sink(s2.find("abc")); // $ ir
+	sink(s2.find("abc")); // $ ast,ir
 	sink(s3.find("abc"));
-	sink(s4.find("abc")); // $ ir
+	sink(s4.find("abc")); // $ ast,ir
 	sink(s5.find("abc"));
-	sink(s6.find("abc")); // $ ir
+	sink(s6.find("abc")); // $ ast,ir
 
 	// copy constructors and assignment
 	std::set<char *> s7(s2);
@@ -41,14 +41,14 @@ void test_set()
 	std::set<char *> s9(s2.begin(), s2.end());
 	std::set<char *> s10;
 	s10 = s2;
-	sink(s7); // $ ir
-	sink(s8); // $ ir
-	sink(s9); // $ ir
-	sink(s10); // $ ir
-	sink(s7.find("abc")); // $ ir
-	sink(s8.find("abc")); // $ ir
-	sink(s9.find("abc")); // $ ir
-	sink(s10.find("abc")); // $ ir
+	sink(s7); // $ ast,ir
+	sink(s8); // $ ast,ir
+	sink(s9); // $ ast,ir
+	sink(s10); // $ ast,ir
+	sink(s7.find("abc")); // $ ast,ir
+	sink(s8.find("abc")); // $ ast,ir
+	sink(s9.find("abc")); // $ ast,ir
+	sink(s10.find("abc")); // $ ast,ir
 
 	// iterators
 	std::set<char *>::iterator i1, i2;
@@ -58,7 +58,7 @@ void test_set()
 	}
 	for (i2 = s2.begin(); i2 != s2.end(); i2++)
 	{
-		sink(*i2); // $ ir
+		sink(*i2); // $ ast,ir
 	}
 
 	// ranges
@@ -66,25 +66,25 @@ void test_set()
 	s11.insert("a");
 	s11.insert(source());
 	s11.insert("c");
-	sink(s11.lower_bound("b")); // $ ir
-	sink(s11.upper_bound("b")); // $ ir
-	sink(s11.equal_range("b").first); // $ MISSING: ir
-	sink(s11.equal_range("b").second); // $ MISSING: ir
+	sink(s11.lower_bound("b")); // $ ast,ir
+	sink(s11.upper_bound("b")); // $ ast,ir
+	sink(s11.equal_range("b").first); // $ MISSING: ast,ir
+	sink(s11.equal_range("b").second); // $ MISSING: ast,ir
 
 	// swap
 	std::set<char *> s12, s13, s14, s15;
 	s12.insert(source());
 	s15.insert(source());
-	sink(s12); // $ ir
+	sink(s12); // $ ast,ir
 	sink(s13);
 	sink(s14);
-	sink(s15); // $ ir
+	sink(s15); // $ ast,ir
 	s12.swap(s13);
 	s14.swap(s15);
-	sink(s12); // $ SPURIOUS: ir
-	sink(s13); // $ ir
-	sink(s14); // $ ir
-	sink(s15); // $ SPURIOUS: ir
+	sink(s12); // $ SPURIOUS: ast,ir
+	sink(s13); // $ ast,ir
+	sink(s14); // $ ast,ir
+	sink(s15); // $ SPURIOUS: ast,ir
 
 	// merge
 	std::set<char *> s16, s17, s18, s19;
@@ -92,37 +92,37 @@ void test_set()
 	s17.insert("abc");
 	s18.insert("def");
 	s19.insert(source());
-	sink(s16); // $ ir
+	sink(s16); // $ ast,ir
 	sink(s17);
 	sink(s18);
-	sink(s19); // $ ir
+	sink(s19); // $ ast,ir
 	s16.merge(s17);
 	s18.merge(s19);
-	sink(s16); // $ ir
+	sink(s16); // $ ast,ir
 	sink(s17);
-	sink(s18); // $ ir
-	sink(s19); // $ ir
+	sink(s18); // $ ast,ir
+	sink(s19); // $ ast,ir
 
 	// erase, clear
 	std::set<char *> s20;
 	s20.insert(source());
 	s20.insert(source());
-	sink(s20); // $ ir=108:13 ir=109:13
-	sink(s20.erase(s20.begin())); // $ ir=108:13 ir=109:13
-	sink(s20); // $ ir=108:13 ir=109:13
+	sink(s20); // $ ast,ir=108:13 ast,ir=109:13
+	sink(s20.erase(s20.begin())); // $ ast,ir=108:13 ast,ir=109:13
+	sink(s20); // $ ast,ir=108:13 ast,ir=109:13
 	s20.clear();
-	sink(s20); // $ SPURIOUS: ir=108:13 ir=109:13
+	sink(s20); // $ SPURIOUS: ast,ir=108:13 ast,ir=109:13
 
 	// emplace, emplace_hint
 	std::set<char *> s21, s22;
 	sink(s21.emplace("abc").first);
 	sink(s21);
-	sink(s21.emplace(source()).first); // $ MISSING: ir
-	sink(s21); // $ ir
+	sink(s21.emplace(source()).first); // $ MISSING: ast,ir
+	sink(s21); // $ ast,ir
 	sink(s22.emplace_hint(s22.begin(), "abc"));
 	sink(s22);
-	sink(s22.emplace_hint(s22.begin(), source())); // $ ir
-	sink(s22); // $ ir
+	sink(s22.emplace_hint(s22.begin(), source())); // $ ast,ir
+	sink(s22); // $ ast,ir
 }
 
 void test_unordered_set()
@@ -131,23 +131,23 @@ void test_unordered_set()
 	std::unordered_set<char *> s1, s2, s3, s4, s5, s6;
 
 	sink(s1.insert("abc").first);
-	sink(s2.insert(source()).first); // $ MISSING: ir
+	sink(s2.insert(source()).first); // $ MISSING: ast,ir
 	sink(s3.insert(s3.begin(), "abc"));
-	sink(s4.insert(s4.begin(), source())); // $ ir
+	sink(s4.insert(s4.begin(), source())); // $ ast,ir
 	s5.insert(s1.begin(), s1.end());
 	s6.insert(s2.begin(), s2.end());
 	sink(s1);
-	sink(s2); // $ ir
+	sink(s2); // $ ast,ir
 	sink(s3);
-	sink(s4); // $ ir
+	sink(s4); // $ ast,ir
 	sink(s5);
-	sink(s6); // $ ir
+	sink(s6); // $ ast,ir
 	sink(s1.find("abc"));
-	sink(s2.find("abc")); // $ ir
+	sink(s2.find("abc")); // $ ast,ir
 	sink(s3.find("abc"));
-	sink(s4.find("abc")); // $ ir
+	sink(s4.find("abc")); // $ ast,ir
 	sink(s5.find("abc"));
-	sink(s6.find("abc")); // $ ir
+	sink(s6.find("abc")); // $ ast,ir
 
 	// copy constructors and assignment
 	std::unordered_set<char *> s7(s2);
@@ -155,14 +155,14 @@ void test_unordered_set()
 	std::unordered_set<char *> s9(s2.begin(), s2.end());
 	std::unordered_set<char *> s10;
 	s10 = s2;
-	sink(s7); // $ ir
-	sink(s8); // $ ir
-	sink(s9); // $ ir
-	sink(s10); // $ ir
-	sink(s7.find("abc")); // $ ir
-	sink(s8.find("abc")); // $ ir
-	sink(s9.find("abc")); // $ ir
-	sink(s10.find("abc")); // $ ir
+	sink(s7); // $ ast,ir
+	sink(s8); // $ ast,ir
+	sink(s9); // $ ast,ir
+	sink(s10); // $ ast,ir
+	sink(s7.find("abc")); // $ ast,ir
+	sink(s8.find("abc")); // $ ast,ir
+	sink(s9.find("abc")); // $ ast,ir
+	sink(s10.find("abc")); // $ ast,ir
 
 	// iterators
 	std::unordered_set<char *>::iterator i1, i2;
@@ -172,7 +172,7 @@ void test_unordered_set()
 	}
 	for (i2 = s2.begin(); i2 != s2.end(); i2++)
 	{
-		sink(*i2); // $ ir
+		sink(*i2); // $ ast,ir
 	}
 
 	// ranges
@@ -180,23 +180,23 @@ void test_unordered_set()
 	s11.insert("a");
 	s11.insert(source());
 	s11.insert("c");
-	sink(s11.equal_range("b").first); // $ MISSING: ir
-	sink(s11.equal_range("b").second); // $ MISSING: ir
+	sink(s11.equal_range("b").first); // $ MISSING: ast,ir
+	sink(s11.equal_range("b").second); // $ MISSING: ast,ir
 
 	// swap
 	std::unordered_set<char *> s12, s13, s14, s15;
 	s12.insert(source());
 	s15.insert(source());
-	sink(s12); // $ ir
+	sink(s12); // $ ast,ir
 	sink(s13);
 	sink(s14);
-	sink(s15); // $ ir
+	sink(s15); // $ ast,ir
 	s12.swap(s13);
 	s14.swap(s15);
-	sink(s12); // $ SPURIOUS: ir
-	sink(s13); // $ ir
-	sink(s14); // $ ir
-	sink(s15); // $ SPURIOUS: ir
+	sink(s12); // $ SPURIOUS: ast,ir
+	sink(s13); // $ ast,ir
+	sink(s14); // $ ast,ir
+	sink(s15); // $ SPURIOUS: ast,ir
 
 	// merge
 	std::unordered_set<char *> s16, s17, s18, s19;
@@ -204,35 +204,35 @@ void test_unordered_set()
 	s17.insert("abc");
 	s18.insert("def");
 	s19.insert(source());
-	sink(s16); // $ ir
+	sink(s16); // $ ast,ir
 	sink(s17);
 	sink(s18);
-	sink(s19); // $ ir
+	sink(s19); // $ ast,ir
 	s16.merge(s17);
 	s18.merge(s19);
-	sink(s16); // $ ir
+	sink(s16); // $ ast,ir
 	sink(s17);
-	sink(s18); // $ ir
-	sink(s19); // $ ir
+	sink(s18); // $ ast,ir
+	sink(s19); // $ ast,ir
 
 	// erase, clear
 	std::unordered_set<char *> s20;
 	s20.insert(source());
 	s20.insert(source());
-	sink(s20); // $ ir=220:13 ir=221:13
-	sink(s20.erase(s20.begin())); // $ ir=220:13 ir=221:13
-	sink(s20); // $ ir=220:13 ir=221:13
+	sink(s20); // $ ast,ir=220:13 ast,ir=221:13
+	sink(s20.erase(s20.begin())); // $ ast,ir=220:13 ast,ir=221:13
+	sink(s20); // $ ast,ir=220:13 ast,ir=221:13
 	s20.clear();
-	sink(s20); // $ SPURIOUS: ir=220:13 ir=221:13
+	sink(s20); // $ SPURIOUS: ast,ir=220:13 ast,ir=221:13
 
 	// emplace, emplace_hint
 	std::unordered_set<char *> s21, s22;
 	sink(s21.emplace("abc").first);
 	sink(s21);
-	sink(s21.emplace(source()).first); // $ MISSING: ir
-	sink(s21); // $ ir
+	sink(s21.emplace(source()).first); // $ MISSING: ast,ir
+	sink(s21); // $ ast,ir
 	sink(s22.emplace_hint(s22.begin(), "abc"));
 	sink(s22);
-	sink(s22.emplace_hint(s22.begin(), source())); // $ ir
-	sink(s22); // $ ir
+	sink(s22.emplace_hint(s22.begin(), source())); // $ ast,ir
+	sink(s22); // $ ast,ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
@@ -9,8 +9,8 @@ template<typename T> void sink(std::unique_ptr<T>&);
 
 void test_make_shared() {
     std::shared_ptr<int> p = std::make_shared<int>(source());
-    sink(*p); // $ ir
-    sink(p); // $ MISSING: ir
+    sink(*p); // $ ast,ir
+    sink(p); // $ ast MISSING: ir
 }
 
 void test_make_shared_array() {
@@ -21,8 +21,8 @@ void test_make_shared_array() {
 
 void test_make_unique() {
     std::unique_ptr<int> p = std::make_unique<int>(source());
-    sink(*p); // $ ir
-    sink(p); // $ MISSING: ir
+    sink(*p); // $ ast,ir
+    sink(p); // $ ast MISSING: ir
 }
 
 void test_make_unique_array() {
@@ -35,26 +35,26 @@ void test_reverse_taint_shared() {
     std::shared_ptr<int> p = std::make_shared<int>();
 
     *p = source();
-    sink(p); // $ MISSING: ir
-    sink(*p); // $ MISSING: ir
+    sink(p); // $ ast MISSING: ir
+    sink(*p); // $ ast MISSING: ir
 }
 
 void test_reverse_taint_unique() {
     std::unique_ptr<int> p = std::unique_ptr<int>();
 
     *p = source();
-    sink(p); // $ MISSING: ir
-    sink(*p); // $ MISSING: ir
+    sink(p); // $ ast MISSING: ir
+    sink(*p); // $ ast MISSING: ir
 }
 
 void test_shared_get() {
     std::shared_ptr<int> p = std::make_shared<int>(source());
-    sink(p.get()); // $ ir
+    sink(p.get()); // $ ast,ir
 }
 
 void test_unique_get() {
     std::unique_ptr<int> p = std::make_unique<int>(source());
-    sink(p.get()); // $ ir
+    sink(p.get()); // $ ast,ir
 }
 
 struct A {
@@ -63,7 +63,7 @@ struct A {
 
 void test_shared_field_member() {
     std::unique_ptr<A> p = std::make_unique<A>(source(), 0);
-    sink(p->x); // $ MISSING: ir
+    sink(p->x); // $ MISSING: ast,ir
     sink(p->y); // not tainted
 }
 
@@ -74,7 +74,7 @@ void getNumber(std::shared_ptr<int> ptr) {
 int test_from_issue_5190() {
   std::shared_ptr<int> p(new int);
   getNumber(p);
-  sink(*p); // $ MISSING: ir
+  sink(*p); // $ ast MISSING: ir
 }
 
 struct B {
@@ -85,11 +85,11 @@ struct B {
 
 void test_operator_arrow(std::unique_ptr<A> p, std::unique_ptr<B> q) {
   p->x = source();
-  sink(p->x); // $ MISSING: ir
+  sink(p->x); // $ ast MISSING: ir
   sink(p->y);
 
   q->a1.x = source();
-  sink(q->a1.x); // $ MISSING: ir
+  sink(q->a1.x); // $ ast MISSING: ir
   sink(q->a1.y);
   sink(q->a2.x);
 }
@@ -101,7 +101,7 @@ void taint_x(A* pa) {
 void reverse_taint_smart_pointer() {
   std::unique_ptr<A> p = std::unique_ptr<A>(new A);
   taint_x(p.get());
-  sink(p->x); // $ MISSING: ir
+  sink(p->x); // $ ast MISSING: ir
 }
 
 struct C {
@@ -123,16 +123,16 @@ void getNumberCRef(const std::shared_ptr<int>& ptr) {
 
 int nested_shared_ptr_taint(std::shared_ptr<C> p1, std::unique_ptr<std::shared_ptr<int>> p2) {
   taint_x_shared(p1->q);
-  sink(p1->q->x); // $ MISSING: ir
+  sink(p1->q->x); // $ ast MISSING: ir
 
   getNumber(*p2);
-  sink(**p2); // $ MISSING: ir
+  sink(**p2); // $ ast MISSING: ir
 }
 
 int nested_shared_ptr_taint_cref(std::shared_ptr<C> p1, std::unique_ptr<std::shared_ptr<int>> p2) {
   taint_x_shared_cref(p1->q);
-  sink(p1->q->x); // $ MISSING: ir
+  sink(p1->q->x); // $ ast MISSING: ir
 
   getNumberCRef(*p2);
-  sink(**p2); // $ MISSING: ir
+  sink(**p2); // $ ast MISSING: ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/standalone_iterators.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/standalone_iterators.cpp
@@ -37,15 +37,15 @@ public:
 };
 
 void test_typedefs(int_iterator_by_typedefs source1) {
-    sink(*source1); // $ ir
-    sink(*(source1++)); // $ ir
-    sink(*(++source1)); // $ ir
+    sink(*source1); // $ ast,ir
+    sink(*(source1++)); // $ ast,ir
+    sink(*(++source1)); // $ ast,ir
 }
 
 void test_trait(int_iterator_by_trait source1) {
-    sink(*source1); // $ ir
-    sink(*(source1++)); // $ ir
-    sink(*(++source1)); // $ ir
+    sink(*source1); // $ ast,ir
+    sink(*(source1++)); // $ ast,ir
+    sink(*(++source1)); // $ ast,ir
 }
 
 void test_non_iterator(non_iterator source1) {
@@ -84,7 +84,7 @@ void test_insert_iterator() {
 
     insert_iterator_by_trait i1 = c1.begin();
     *i1-- = source();
-    sink(c1); // $ MISSING: ir
+    sink(c1); // $ ast MISSING: ir
 
     insert_iterator_by_trait i2 = c2.begin();
     *i2-- = 0;
@@ -101,12 +101,12 @@ void test_assign_through_iterator() {
 	a = c1.begin();
 	b = c1.begin();
 	*a = source();
-	sink(a); // $ MISSING: ir
+	sink(a); // $ ast MISSING: ir
 
 	c = c1.begin();
-	sink(b); // MISSING: ir
-	sink(c); // $ MISSING: ir
-	sink(c1); // $ MISSING: ir
+	sink(b); // MISSING: ast,ir
+	sink(c); // $ ast MISSING: ir
+	sink(c1); // $ ast MISSING: ir
 }
 
 void test_nonmember_iterator() {
@@ -118,6 +118,6 @@ void test_nonmember_iterator() {
 	it += 1;
 	sink(it);
 	it += source();
-	sink(it); // $ ir
+	sink(it); // $ ast,ir
 	sink(c1);
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
@@ -26,24 +26,24 @@ void test_string()
 	std::string b("123");
 	std::string c(source());
 
-	sink(a); // $ ir
+	sink(a); // $ ast,ir
 	sink(b);
-	sink(c); // $ MISSING: ir
+	sink(c); // $ ast MISSING: ir
 	sink(b.c_str());
-	sink(c.c_str()); // $ ir
+	sink(c.c_str()); // $ ast,ir
 }
 
 void test_strings2()
 {
 	string path1 = user_input();
-	sink(path1.c_str(), "r"); // $ ir
+	sink(path1.c_str(), "r"); // $ ast,ir
 
 	string path2;
 	path2 = user_input();
-	sink(path2.c_str(), "r"); // $ ir
+	sink(path2.c_str(), "r"); // $ ast,ir
 
 	string path3(user_input());
-	sink(path3.c_str(), "r"); // $ ir
+	sink(path3.c_str(), "r"); // $ ast,ir
 }
 
 void test_string3()
@@ -53,8 +53,8 @@ void test_string3()
 	// convert char * -> std::string
 	std::string ss(cs);
 
-	sink(cs); // $ ir
-	sink(ss); // $ MISSING: ir
+	sink(cs); // $ ast,ir
+	sink(ss); // $ ast MISSING: ir
 }
 
 void test_string4()
@@ -67,8 +67,8 @@ void test_string4()
 	// convert back std::string -> char *
 	cs = ss.c_str();
 
-	sink(cs); // $ ir
-	sink(ss); // $ MISSING: ir
+	sink(cs); // $ ast,ir
+	sink(ss); // $ ast MISSING: ir
 }
 
 void test_string_constructors_assignments()
@@ -90,9 +90,9 @@ void test_string_constructors_assignments()
 		std::string s3;
 		s3 = source();
 
-		sink(s1); // $ MISSING: ir
-		sink(s2); // $ MISSING: ir
-		sink(s3); // $ MISSING: ir
+		sink(s1); // $ ast MISSING: ir
+		sink(s2); // $ ast MISSING: ir
+		sink(s3); // $ ast MISSING: ir
 	}
 
 	{
@@ -111,28 +111,28 @@ void test_string_constructors_assignments()
 		std::string s2;
 		s2 = std::string(source());
 
-		sink(s1); // $ MISSING: ir
-		sink(s2); // $ MISSING: ir
+		sink(s1); // $ ast MISSING: ir
+		sink(s2); // $ ast MISSING: ir
 	}
 }
 
 void test_range_based_for_loop_string() {
 	std::string s(source());
 	for(char c : s) {
-		sink(c); // $ ir
+		sink(c); // $ ast,ir
 	}
 
 	for(std::string::iterator it = s.begin(); it != s.end(); ++it) {
-		sink(*it); // $ ir
+		sink(*it); // $ ast,ir
 	}
 
 	for(char& c : s) {
-		sink(c); // $ ir
+		sink(c); // $ ast,ir
 	}
 
 	const std::string const_s(source());
 	for(const char& c : const_s) {
-		sink(c); // $ ir
+		sink(c); // $ ast,ir
 	}
 }
 
@@ -142,12 +142,12 @@ void test_string_append() {
 		std::string s2(source());
 
 		sink(s1 + s1);
-		sink(s1 + s2); // $ ir
-		sink(s2 + s1); // $ ir
-		sink(s2 + s2); // $ ir
+		sink(s1 + s2); // $ ast,ir
+		sink(s2 + s1); // $ ast,ir
+		sink(s2 + s2); // $ ast,ir
 	
 		sink(s1 + " world");
-		sink(s1 + source()); // $ ir
+		sink(s1 + source()); // $ ast,ir
 	}
 
 	{
@@ -156,25 +156,25 @@ void test_string_append() {
 		std::string s5, s6, s7, s8, s9;
 
 		s5 = s3 + s4;
-		sink(s5); // $ MISSING: ir
+		sink(s5); // $ ast MISSING: ir
 
 		s6 = s3;
-		sink(s6 += s4); // $ MISSING: ir
-		sink(s6); // $ MISSING: ir
+		sink(s6 += s4); // $ ast MISSING: ir
+		sink(s6); // $ ast MISSING: ir
 
 		s7 = s3;
-		sink(s7 += source()); // $ ir
-		sink(s7 += " "); // $ MISSING: ir
-		sink(s7); // $ MISSING: ir
+		sink(s7 += source()); // $ ast,ir
+		sink(s7 += " "); // $ ast MISSING: ir
+		sink(s7); // $ ast MISSING: ir
 
 		s8 = s3;
 		s8.append(s4);
-		sink(s8); // $ MISSING: ir
+		sink(s8); // $ ast MISSING: ir
 
 		s9 = s3;
 		s9.append(source());
 		s9.append(" ");
-		sink(s9); // $ MISSING: ir
+		sink(s9); // $ ast MISSING: ir
 	}
 
 	{
@@ -182,7 +182,7 @@ void test_string_append() {
 		char c = ns_char::source();
 
 		s10.append(1, c);
-		sink(s10); // $ MISSING: ir
+		sink(s10); // $ ast MISSING: ir
 	}
 }
 
@@ -196,14 +196,14 @@ void test_string_assign() {
 	sink(s3.assign(s1));
 	sink(s3);
 
-	sink(s4.assign(s2)); // $ MISSING: ir
-	sink(s4); // $ MISSING: ir
+	sink(s4.assign(s2)); // $ ast MISSING: ir
+	sink(s4); // $ ast MISSING: ir
 
-	sink(s5.assign(10, c)); // $ MISSING: ir
-	sink(s5); // $ MISSING: ir
+	sink(s5.assign(10, c)); // $ ast MISSING: ir
+	sink(s5); // $ ast MISSING: ir
 
 	sink(s6.assign(s1));
-	sink(s6); //
+	sink(s6); // $ SPURIOUS: ast
 }
 
 void test_string_insert() {
@@ -217,16 +217,16 @@ void test_string_insert() {
 	sink(s3);
 
 	s4 = s2;
-	sink(s4.insert(0, s1)); // $ MISSING: ir
-	sink(s4); // $ MISSING: ir
+	sink(s4.insert(0, s1)); // $ ast MISSING: ir
+	sink(s4); // $ ast MISSING: ir
 
 	s5 = s1;
-	sink(s5.insert(0, s2)); // $ MISSING: ir
-	sink(s5); // $ MISSING: ir
+	sink(s5.insert(0, s2)); // $ ast MISSING: ir
+	sink(s5); // $ ast MISSING: ir
 
 	s6 = s1;
-	sink(s6.insert(0, 10, c)); // $ MISSING: ir
-	sink(s6); // $ MISSING: ir
+	sink(s6.insert(0, 10, c)); // $ ast MISSING: ir
+	sink(s6); // $ ast MISSING: ir
 }
 
 void test_string_replace() {
@@ -240,16 +240,16 @@ void test_string_replace() {
 	sink(s3);
 
 	s4 = s2;
-	sink(s4.replace(1, 2, s1)); // $ MISSING: ir
-	sink(s4); // $ MISSING: ir
+	sink(s4.replace(1, 2, s1)); // $ ast MISSING: ir
+	sink(s4); // $ ast MISSING: ir
 
 	s5 = s1;
-	sink(s5.replace(1, 2, s2)); // $ MISSING: ir
-	sink(s5); // $ MISSING: ir
+	sink(s5.replace(1, 2, s2)); // $ ast MISSING: ir
+	sink(s5); // $ ast MISSING: ir
 
 	s6 = s1;
-	sink(s6.replace(1, 2, 10, c)); // $ MISSING: ir
-	sink(s6); // $ MISSING: ir
+	sink(s6.replace(1, 2, 10, c)); // $ ast MISSING: ir
+	sink(s6); // $ ast MISSING: ir
 }
 
 void test_string_copy() {
@@ -262,7 +262,7 @@ void test_string_copy() {
 	sink(b1);
 
 	s2.copy(b2, s1.length(), 0);
-	sink(b2); // $ MISSING: ir
+	sink(b2); // $ ast MISSING: ir
 }
 
 void test_string_swap() {
@@ -272,17 +272,17 @@ void test_string_swap() {
 	std::string s4(source());
 
 	sink(s1);
-	sink(s2); // $ MISSING: ir
+	sink(s2); // $ ast MISSING: ir
 	sink(s3);
-	sink(s4); // $ MISSING: ir
+	sink(s4); // $ ast MISSING: ir
 
 	s1.swap(s2);
 	s4.swap(s3);
 
-	sink(s1); // $ MISSING: ir
-	sink(s2);
-	sink(s3); // $ MISSING: ir
-	sink(s4);
+	sink(s1); // $ ast MISSING: ir
+	sink(s2); // $ SPURIOUS: ast
+	sink(s3); // $ ast MISSING: ir
+	sink(s4); // $ SPURIOUS: ast
 }
 
 void test_string_clear() {
@@ -290,17 +290,17 @@ void test_string_clear() {
 	std::string s2(source());
 	std::string s3(source());
 
-	sink(s1); // $ MISSING: ir
-	sink(s2); // $ MISSING: ir
-	sink(s3); // $ MISSING: ir
+	sink(s1); // $ ast MISSING: ir
+	sink(s2); // $ ast MISSING: ir
+	sink(s3); // $ ast MISSING: ir
 
 	s1.clear();
 	s2 = "";
 	s3 = s3;
 
-	sink(s1);
+	sink(s1); // $ SPURIOUS: ast
 	sink(s2);
-	sink(s3); // $ MISSING: ir
+	sink(s3); // $ ast MISSING: ir
 }
 
 void test_string_data()
@@ -309,7 +309,7 @@ void test_string_data()
 	std::string b(source());
 
 	sink(a.data());
-	sink(b.data()); // $ MISSING: ir
+	sink(b.data()); // $ ast MISSING: ir
 	sink(a.length());
 	sink(b.length());
 }
@@ -320,7 +320,7 @@ void test_string_substr()
 	std::string b(source());
 
 	sink(a.substr(0, a.length()));
-	sink(b.substr(0, b.length())); // $ ir
+	sink(b.substr(0, b.length())); // $ ast,ir
 }
 
 void test_string_at()
@@ -337,9 +337,9 @@ void test_string_at()
 	b.at(0) = ns_char::source();
 	c[0] = a[0];
 
-	sink(a); // $ MISSING: ir
-	sink(b); // $ MISSING: ir
-	sink(c); // $ MISSING: ir
+	sink(a); // $ ast MISSING: ir
+	sink(b); // $ ast MISSING: ir
+	sink(c); // $ ast MISSING: ir
 }
 
 void test_string_data_more()
@@ -347,8 +347,8 @@ void test_string_data_more()
 	std::string str("123");
 
 	str.data()[1] = ns_char::source();
-	sink(str); // $ MISSING: ir
-	sink(str.data()); // $ MISSING: ir
+	sink(str); // $ ast MISSING: ir
+	sink(str.data()); // $ ast MISSING: ir
 }
 
 void test_string_iterators() {
@@ -360,8 +360,8 @@ void test_string_iterators() {
 		std::string s4("world");
 
 		sink(s1);
-		sink(s1.append(s2.begin(), s2.end())); // $ MISSING: ir
-		sink(s1); // $ MISSING: ir
+		sink(s1.append(s2.begin(), s2.end())); // $ ast MISSING: ir
+		sink(s1); // $ ast MISSING: ir
 
 		sink(s3);
 		sink(s3.append(s4.begin(), s4.end()));
@@ -379,8 +379,8 @@ void test_string_iterators() {
 		sink(iter1[1]);
 		string::iterator iter2 = s2.begin();
 
-		sink(*iter2); // $ ir
-		sink(iter2[1]); // $ ir
+		sink(*iter2); // $ ast,ir
+		sink(iter2[1]); // $ ast,ir
 	}
 
 	// arithmetic operators
@@ -393,33 +393,33 @@ void test_string_iterators() {
 		string::iterator i2 = s2.begin();
 		string::iterator i3, i4, i5, i6, i7, i8, i9, i10, i11;
 
-		sink(*(i2+1)); // $ ir
-		sink(*(i2-1)); // $ ir
+		sink(*(i2+1)); // $ ast,ir
+		sink(*(i2-1)); // $ ast,ir
 		i3 = i2;
-		sink(*(++i3)); // $ ir
+		sink(*(++i3)); // $ ast,ir
 		i4 = i2;
-		sink(*(--i4)); // $ ir
+		sink(*(--i4)); // $ ast,ir
 		i5 = i2;
 		i5++;
-		sink(*i5); // $ ir
+		sink(*i5); // $ ast,ir
 		i6 = i2;
 		i6--;
-		sink(*i6); // $ ir
+		sink(*i6); // $ ast,ir
 		i7 = i2;
-		sink(*(i7+=1)); // $ ir
+		sink(*(i7+=1)); // $ ast,ir
 		i8 = i2;
-		sink(*(i8-=1)); // $ ir
+		sink(*(i8-=1)); // $ ast,ir
 
 		i9 = s2.end();
 		--i9;
-		sink(*i9); // $ ir
+		sink(*i9); // $ ast,ir
 
 		i10 = i2;
-		sink(*(i10++)); // $ ir
-		sink(i10); // $ ir
+		sink(*(i10++)); // $ ast,ir
+		sink(i10); // $ ast,ir
 		i11 = i2;
-		sink(*(i11--)); // $ ir
-		sink(i11); // $ ir
+		sink(*(i11--)); // $ ast,ir
+		sink(i11); // $ ast,ir
 	}
 }
 
@@ -433,8 +433,8 @@ void test_string_insert_more()
 	sink(s1.insert(0, cs1));
 	sink(s1);
 
-	sink(s2.insert(0, cs2)); // $ MISSING: ir
-	sink(s2); // $ MISSING: ir
+	sink(s2.insert(0, cs2)); // $ ast MISSING: ir
+	sink(s2); // $ ast MISSING: ir
 }
 
 void test_string_iterator_methods()
@@ -446,8 +446,8 @@ void test_string_iterator_methods()
 		sink(a.insert(a.begin(), 10, 'x'));
 		sink(a);
 
-		sink(b.insert(b.begin(), 10, ns_char::source())); // $ MISSING: ir
-		sink(b); // $ MISSING: ir
+		sink(b.insert(b.begin(), 10, ns_char::source())); // $ ast MISSING: ir
+		sink(b); // $ ast MISSING: ir
 	}
 
 	{
@@ -459,11 +459,11 @@ void test_string_iterator_methods()
 		sink(c.insert(c.end(), s1.begin(), s1.end()));
 		sink(c);
 
-		sink(d.insert(d.end(), s2.begin(), s2.end())); // $ MISSING: ir
-		sink(d); // $ MISSING: ir
+		sink(d.insert(d.end(), s2.begin(), s2.end())); // $ ast MISSING: ir
+		sink(d); // $ ast MISSING: ir
 
-		sink(s2.insert(s2.end(), s1.begin(), s1.end())); // $ MISSING: ir
-		sink(s2); // $ MISSING: ir
+		sink(s2.insert(s2.end(), s1.begin(), s1.end())); // $ ast MISSING: ir
+		sink(s2); // $ ast MISSING: ir
 	}
 
 	{
@@ -475,11 +475,11 @@ void test_string_iterator_methods()
 		sink(e.append(s3.begin(), s3.end()));
 		sink(e);
 
-		sink(f.append(s4.begin(), s4.end())); // $ MISSING: ir
-		sink(f); // $ MISSING: ir
+		sink(f.append(s4.begin(), s4.end())); // $ ast MISSING: ir
+		sink(f); // $ ast MISSING: ir
 
-		sink(s4.append(s3.begin(), s3.end())); // $ MISSING: ir
-		sink(s4); // $ MISSING: ir
+		sink(s4.append(s3.begin(), s3.end())); // $ ast MISSING: ir
+		sink(s4); // $ ast MISSING: ir
 	}
 
 	{
@@ -491,11 +491,11 @@ void test_string_iterator_methods()
 		sink(g.assign(s5.cbegin(), s5.cend()));
 		sink(g);
 
-		sink(h.assign(s6.cbegin(), s6.cend())); // $ MISSING: ir
-		sink(h); // $ MISSING: ir
+		sink(h.assign(s6.cbegin(), s6.cend())); // $ ast MISSING: ir
+		sink(h); // $ ast MISSING: ir
 
 		sink(s6.assign(s5.cbegin(), s5.cend()));
-		sink(s6);
+		sink(s6); // $ SPURIOUS: ast
 	}
 }
 
@@ -508,9 +508,9 @@ void test_string_constructors_more() {
 	std::string s4(s2.begin(), s2.end());
 
 	sink(s1);
-	sink(s2); // $ MISSING: ir
+	sink(s2); // $ ast MISSING: ir
 	sink(s3);
-	sink(s4); // $ MISSING: ir
+	sink(s4); // $ ast MISSING: ir
 }
 
 void test_string_front_back() {
@@ -519,8 +519,8 @@ void test_string_front_back() {
 	sink(a.front());
 	sink(a.back());
 	a.push_back(ns_char::source());
-	sink(a.front()); // $ SPURIOUS: ir
-	sink(a.back()); // $ ir
+	sink(a.front()); // $ SPURIOUS: ast,ir
+	sink(a.back()); // $ ast,ir
 }
 
 void test_string_return_assign() {
@@ -533,15 +533,15 @@ void test_string_return_assign() {
 		std::string f("ff");
 
 		sink( a += (b += "bb") );
-		sink( c += (d += source()) ); // $ MISSING: ir
-		sink( (e += "ee") += source() ); // $ ir
-		sink( (f += source()) += "ff" ); // $ MISSING: ir
+		sink( c += (d += source()) ); // $ ast MISSING: ir
+		sink( (e += "ee") += source() ); // $ ast,ir
+		sink( (f += source()) += "ff" ); // $ ast MISSING: ir
 		sink(a);
 		sink(b);
-		sink(c); // $ MISSING: ir
-		sink(d); // $ MISSING: ir
-		sink(e); // $ MISSING: ir
-		sink(f); // $ MISSING: ir
+		sink(c); // $ ast MISSING: ir
+		sink(d); // $ ast MISSING: ir
+		sink(e); // $ ast MISSING: ir
+		sink(f); // $ ast MISSING: ir
 	}
 
 	{
@@ -553,14 +553,14 @@ void test_string_return_assign() {
 		std::string f("ff");
 
 		sink( a.assign(b.assign("bb")) );
-		sink( c.assign(d.assign(source())) ); // $ MISSING: ir
-		sink( e.assign("ee").assign(source()) ); // $ MISSING: ir
+		sink( c.assign(d.assign(source())) ); // $ ast MISSING: ir
+		sink( e.assign("ee").assign(source()) ); // $ ast MISSING: ir
 		sink( f.assign(source()).assign("ff") );
 		sink(a);
 		sink(b);
-		sink(c); // $ MISSING: ir
-		sink(d); // $ MISSING: ir
-		sink(e); // $ MISSING: ir
-		sink(f);
+		sink(c); // $ ast MISSING: ir
+		sink(d); // $ ast MISSING: ir
+		sink(e); // $ ast MISSING: ir
+		sink(f); // $ SPURIOUS: ast
 	}
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stringstream.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stringstream.cpp
@@ -29,42 +29,42 @@ void test_stringstream_string(int amount)
 	std::string t(source());
 
 	sink(ss1 << "1234");
-	sink(ss2 << source()); // $ ir
-	sink(ss3 << "123" << source()); // $ ir
-	sink(ss4 << source() << "456"); // $ ir
-	sink(ss5 << t); // $ ir
+	sink(ss2 << source()); // $ ast,ir
+	sink(ss3 << "123" << source()); // $ ast,ir
+	sink(ss4 << source() << "456"); // $ ast,ir
+	sink(ss5 << t); // $ ast,ir
 
 	sink(ss1);
-	sink(ss2); // $ MISSING: ir
-	sink(ss3); // $ MISSING: ir
-	sink(ss4); // $ MISSING: ir
-	sink(ss5); // $ MISSING: ir
+	sink(ss2); // $ ast MISSING: ir
+	sink(ss3); // $ ast MISSING: ir
+	sink(ss4); // $ ast MISSING: ir
+	sink(ss5); // $ ast MISSING: ir
 	sink(ss1.str());
-	sink(ss2.str()); // $ ir
-	sink(ss3.str()); // $ ir
-	sink(ss4.str()); // $ ir
-	sink(ss5.str()); // $ ir
+	sink(ss2.str()); // $ ast,ir
+	sink(ss3.str()); // $ ast,ir
+	sink(ss4.str()); // $ ast,ir
+	sink(ss5.str()); // $ ast,ir
 
 	ss6.str("abc");
 	ss6.str(source()); // (overwrites)
 	ss7.str(source());
 	ss7.str("abc"); // (overwrites)
-	sink(ss6); // $ MISSING: ir
-	sink(ss7);
+	sink(ss6); // $ ast MISSING: ir
+	sink(ss7); // $ SPURIOUS: ast
 
 	sink(ss8.put('a'));
-	sink(ss9.put(ns_char::source())); // $ MISSING: ir
-	sink(ss10.put('a').put(ns_char::source()).put('z')); // $ ir
+	sink(ss9.put(ns_char::source())); // $ ast MISSING: ir
+	sink(ss10.put('a').put(ns_char::source()).put('z')); // $ ast,ir
 	sink(ss8);
-	sink(ss9); // $ MISSING: ir
-	sink(ss10); // $ MISSING: ir
+	sink(ss9); // $ ast MISSING: ir
+	sink(ss10); // $ ast MISSING: ir
 
 	sink(ss11.write("begin", 5));
-	sink(ss12.write(source(), 5)); // $ MISSING: ir
-	sink(ss13.write("begin", 5).write(source(), amount).write("end", 3)); // $ ir
+	sink(ss12.write(source(), 5)); // $ ast MISSING: ir
+	sink(ss13.write("begin", 5).write(source(), amount).write("end", 3)); // $ ast,ir
 	sink(ss11);
-	sink(ss12); // $ MISSING: ir
-	sink(ss13); // $ MISSING: ir
+	sink(ss12); // $ ast MISSING: ir
+	sink(ss13); // $ ast MISSING: ir
 }
 
 void test_stringstream_int(int source)
@@ -73,16 +73,16 @@ void test_stringstream_int(int source)
 	int v1 = 0, v2 = 0;
 
 	sink(ss1 << 1234);
-	sink(ss2 << source); // $ MISSING: ir
+	sink(ss2 << source); // $ ast MISSING: ir
 	sink(ss1 >> v1);
-	sink(ss2 >> v2); // $ ir
+	sink(ss2 >> v2); // $ ast,ir
 
 	sink(ss1);
-	sink(ss2); // $ MISSING: ir
+	sink(ss2); // $ ast MISSING: ir
 	sink(ss1.str());
-	sink(ss2.str()); // $ ir
+	sink(ss2.str()); // $ ast,ir
 	sink(v1);
-	sink(v2); // $ ir
+	sink(v2); // $ ast,ir
 }
 
 void test_stringstream_constructors()
@@ -97,14 +97,14 @@ void test_stringstream_constructors()
 	std::stringstream ss6;
 
 	sink(ss5 = std::stringstream("abc"));
-	sink(ss6 = std::stringstream(source())); // $ MISSING: ir
+	sink(ss6 = std::stringstream(source())); // $ ast MISSING: ir
 
 	sink(ss1);
-	sink(ss2); // $ MISSING: ir
+	sink(ss2); // $ ast MISSING: ir
 	sink(ss3);
-	sink(ss4); // $ MISSING: ir
+	sink(ss4); // $ ast MISSING: ir
 	sink(ss5);
-	sink(ss6); // $ MISSING: ir
+	sink(ss6); // $ ast MISSING: ir
 }
 
 void test_stringstream_swap()
@@ -117,10 +117,10 @@ void test_stringstream_swap()
 	ss1.swap(ss2);
 	ss4.swap(ss3);
 
-	sink(ss1); // $ MISSING: ir
-	sink(ss2);
-	sink(ss3); // $ MISSING: ir
-	sink(ss4);
+	sink(ss1); // $ ast MISSING: ir
+	sink(ss2); // $ SPURIOUS: ast
+	sink(ss3); // $ ast MISSING: ir
+	sink(ss4); // $ SPURIOUS: ast
 }
 
 void test_stringstream_in()
@@ -140,49 +140,49 @@ void test_stringstream_in()
 	char c1 = 0, c2 = 0, c3 = 0, c4 = 0, c5 = 0, c6 = 0;
 
 	sink(ss1 << "abc");
-	sink(ss2 << source()); // $ ir
+	sink(ss2 << source()); // $ ast,ir
 
 	sink(ss1 >> s1);
-	sink(ss2 >> s2); // $ ir
-	sink(ss2 >> s3 >> s4); // $ ir
+	sink(ss2 >> s2); // $ ast,ir
+	sink(ss2 >> s3 >> s4); // $ ast,ir
 	sink(s1);
-	sink(s2); // $ MISSING: ir
-	sink(s3); // $ MISSING: ir
-	sink(s4); // $ MISSING: ir
+	sink(s2); // $ ast MISSING: ir
+	sink(s3); // $ ast MISSING: ir
+	sink(s4); // $ ast MISSING: ir
 
 	sink(ss1 >> b1);
-	sink(ss2 >> b2); // $ ir
-	sink(ss2 >> b3 >> b4); // $ ir
+	sink(ss2 >> b2); // $ ast,ir
+	sink(ss2 >> b3 >> b4); // $ ast,ir
 	sink(b1);
-	sink(b2); // $ ir
-	sink(b3); // $ ir
-	sink(b4); // $ ir
+	sink(b2); // $ ast,ir
+	sink(b3); // $ ast,ir
+	sink(b4); // $ ast,ir
 
 	sink(ss1.read(b5, 100));
-	sink(ss2.read(b6, 100)); // $ ir
+	sink(ss2.read(b6, 100)); // $ ast,ir
 	sink(ss1.readsome(b7, 100));
 	sink(ss2.readsome(b8, 100)); // (returns a length, not significantly tainted)
 	sink(ss1.get(b9, 100));
-	sink(ss2.get(b10, 100)); // $ ir
+	sink(ss2.get(b10, 100)); // $ ast,ir
 	sink(b5);
-	sink(b6); // $ ir
+	sink(b6); // $ ast,ir
 	sink(b7);
-	sink(b8); // $ ir
+	sink(b8); // $ ast,ir
 	sink(b9);
-	sink(b10); // $ ir
+	sink(b10); // $ ast,ir
 
 	sink(c1 = ss1.get());
-	sink(c2 = ss2.get()); // $ ir
+	sink(c2 = ss2.get()); // $ ast,ir
 	sink(c3 = ss1.peek());
-	sink(c4 = ss2.peek()); // $ ir
+	sink(c4 = ss2.peek()); // $ ast,ir
 	sink(ss1.get(c5));
-	sink(ss2.get(c6)); // $ ir
+	sink(ss2.get(c6)); // $ ast,ir
 	sink(c1);
-	sink(c2); // $ ir
+	sink(c2); // $ ast,ir
 	sink(c3);
-	sink(c4); // $ ir
+	sink(c4); // $ ast,ir
 	sink(c5);
-	sink(c6); // $ ir
+	sink(c6); // $ ast,ir
 }
 
 void test_stringstream_putback()
@@ -193,8 +193,8 @@ void test_stringstream_putback()
 	sink(ss.get());
 	sink(ss.putback('b'));
 	sink(ss.get());
-	sink(ss.putback(ns_char::source())); // $ MISSING: ir
-	sink(ss.get()); // $ ir
+	sink(ss.putback(ns_char::source())); // $ ast MISSING: ir
+	sink(ss.get()); // $ ast,ir
 }
 
 void test_getline()
@@ -212,44 +212,44 @@ void test_getline()
 	std::string s1, s2, s3, s4, s5, s6, s7, s8;
 
 	sink(ss1.getline(b1, 1000));
-	sink(ss2.getline(b2, 1000)); // $ ir
-	sink(ss2.getline(b3, 1000)); // $ ir
+	sink(ss2.getline(b2, 1000)); // $ ast,ir
+	sink(ss2.getline(b3, 1000)); // $ ast,ir
 	sink(ss1.getline(b3, 1000));
 	sink(b1);
-	sink(b2); // $ ir
-	sink(b3); // $ SPURIOUS: ir
+	sink(b2); // $ ast,ir
+	sink(b3); // $ SPURIOUS: ast,ir
 
 	sink(ss1.getline(b4, 1000, ' '));
-	sink(ss2.getline(b5, 1000, ' ')); // $ ir
-	sink(ss2.getline(b6, 1000, ' ')); // $ ir
+	sink(ss2.getline(b5, 1000, ' ')); // $ ast,ir
+	sink(ss2.getline(b6, 1000, ' ')); // $ ast,ir
 	sink(ss1.getline(b6, 1000, ' '));
 	sink(b4);
-	sink(b5); // $ ir
-	sink(b6); // $ SPURIOUS: ir
+	sink(b5); // $ ast,ir
+	sink(b6); // $ SPURIOUS: ast,ir
 
-	sink(ss2.getline(b7, 1000).getline(b8, 1000)); // $ ir
-	sink(b7); // $ ir
-	sink(b8); // $ ir
+	sink(ss2.getline(b7, 1000).getline(b8, 1000)); // $ ast,ir
+	sink(b7); // $ ast,ir
+	sink(b8); // $ ast,ir
 
 	sink(getline(ss1, s1));
-	sink(getline(ss2, s2)); // $ ir
-	sink(getline(ss2, s3)); // $ ir
+	sink(getline(ss2, s2)); // $ ast,ir
+	sink(getline(ss2, s3)); // $ ast,ir
 	sink(getline(ss1, s3));
 	sink(s1);
-	sink(s2); // $ MISSING: ir
-	sink(s3);
+	sink(s2); // $ ast MISSING: ir
+	sink(s3); // $ SPURIOUS: ast
 
 	sink(getline(ss1, s4, ' '));
-	sink(getline(ss2, s5, ' ')); // $ ir
-	sink(getline(ss2, s6, ' ')); // $ ir
+	sink(getline(ss2, s5, ' ')); // $ ast,ir
+	sink(getline(ss2, s6, ' ')); // $ ast,ir
 	sink(getline(ss1, s6, ' '));
 	sink(s4);
-	sink(s5); // $ MISSING: ir
-	sink(s6);
+	sink(s5); // $ ast MISSING: ir
+	sink(s6); // $ SPURIOUS: ast
 
-	sink(getline(getline(ss2, s7), s8)); // $ ir
-	sink(s7); // $ MISSING: ir
-	sink(s8); // $ MISSING: ir
+	sink(getline(getline(ss2, s7), s8)); // $ ast,ir
+	sink(s7); // $ ast MISSING: ir
+	sink(s8); // $ ast MISSING: ir
 }
 
 void test_chaining()
@@ -259,10 +259,10 @@ void test_chaining()
 	char b1[1000] = {0};
 	char b2[1000] = {0};
 
-	sink(ss1.get(b1, 100).unget().get(b2, 100)); // $ ir
-	sink(b1); // $ ir
-	sink(b2); // $ ir
+	sink(ss1.get(b1, 100).unget().get(b2, 100)); // $ ast,ir
+	sink(b1); // $ ast,ir
+	sink(b2); // $ ast,ir
 
-	sink(ss2.write("abc", 3).flush().write(source(), 3).flush().write("xyz", 3)); // $ ir
-	sink(ss2); // $ MISSING: ir
+	sink(ss2.write("abc", 3).flush().write(source(), 3).flush().write("xyz", 3)); // $ ast,ir
+	sink(ss2); // $ ast MISSING: ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/structlikeclass.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/structlikeclass.cpp
@@ -32,10 +32,10 @@ void test_structlikeclass()
 		StructLikeClass s4;
 		s4 = source();
 
-		sink(s1); // $ ir
-		sink(s2); // $ ir
-		sink(s3); // $ ir
-		sink(s4); // $ ir
+		sink(s1); // $ ast,ir
+		sink(s2); // $ ast,ir
+		sink(s3); // $ ast,ir
+		sink(s4); // $ ast,ir
 	}
 
 	{
@@ -57,8 +57,8 @@ void test_structlikeclass()
 		StructLikeClass s3;
 		s2 = StructLikeClass(source());
 
-		sink(s1); // $ ir
-		sink(s2); // $ ir
-		sink(s3 = source()); // $ ir
+		sink(s1); // $ ast,ir
+		sink(s2); // $ ast,ir
+		sink(s3 = source()); // $ ast,ir
 	}
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/swap1.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/swap1.cpp
@@ -70,22 +70,22 @@ void test_copy_assignment_operator()
     IntWrapper::Class y;
     x.data1 = source();
 
-    sink(x.data1); // $ ir
+    sink(x.data1); // $ ast,ir
     sink(y.data1); // clean
 
     y = x;
 
-    sink(y.data1); // $ ir
-    sink(x.data1); // $ ir
+    sink(y.data1); // $ ir ast=71:15 SPURIOUS: ast=69:23
+    sink(x.data1); // $ ast,ir
 
     IntWrapper::Class z1, z2;
     z1.data1 = source();
-    sink(z1.data1); // $ ir
+    sink(z1.data1); // $ ast,ir
 
     swap(z1, z2);
 
-    sink(z2.data1); // $ ir
-    sink(z1.data1); // $ SPURIOUS: ir
+    sink(z2.data1); // $ ast,ir
+    sink(z1.data1); // $ SPURIOUS: ir ast=81:27 ast=82:16
 }
 
 void test_move_assignment_operator()
@@ -94,13 +94,13 @@ void test_move_assignment_operator()
     IntWrapper::Class y;
     x.data1 = source();
 
-    sink(x.data1); // $ ir
+    sink(x.data1); // $ ast,ir
     sink(y.data1); // clean
 
     y = std::move(x);
 
-    sink(y.data1); // $ ir
-    sink(x.data1); // $ ir
+    sink(y.data1); // $ ir ast=95:15 SPURIOUS: ast=93:23
+    sink(x.data1); // $ ast,ir
 }
 
 void test_move_constructor()
@@ -108,11 +108,11 @@ void test_move_constructor()
     IntWrapper::Class move_from;
     move_from.data1 = source();
 
-    sink(move_from.data1); // $ ir
+    sink(move_from.data1); // $ ast,ir
 
     IntWrapper::Class move_to(std::move(move_from));
 
-    sink(move_to.data1); // $ ir
+    sink(move_to.data1); // $ ir ast=109:23 SPURIOUS: ast=108:23
 }
 
 void test_copy_assignment_method()
@@ -121,13 +121,13 @@ void test_copy_assignment_method()
     IntWrapper::Class y;
     x.data1 = source();
 
-    sink(x.data1); // $ ir
+    sink(x.data1); // $ ast,ir
     sink(y.data1); // clean
 
     y.copy_assign(x);
 
-    sink(y.data1); // $ ir
-    sink(x.data1); // $ ir
+    sink(y.data1); // $ ir ast=122:15 SPURIOUS: ast=120:23
+    sink(x.data1); // $ ast,ir
 }
 
 void test_move_assignment_method()
@@ -136,13 +136,13 @@ void test_move_assignment_method()
     IntWrapper::Class y;
     x.data1 = source();
 
-    sink(x.data1); // $ ir
+    sink(x.data1); // $ ast,ir
     sink(y.data1); // clean
 
     y.move_assign(std::move(x));
 
-    sink(y.data1); // $ ir
-    sink(x.data1); // $ ir
+    sink(y.data1); // $ ir ast=137:15 SPURIOUS: ast=135:23
+    sink(x.data1); // $ ast,ir
 }
 
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/swap2.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/swap2.cpp
@@ -70,22 +70,22 @@ void test_copy_assignment_operator()
     IntWrapper::Class y;
     x.data1 = source();
 
-    sink(x.data1); // $ ir
+    sink(x.data1); // $ ast,ir
     sink(y.data1); // clean
 
     y = x;
 
-    sink(y.data1); // $ ir
-    sink(x.data1); // $ ir
+    sink(y.data1); // $ ir ast=71:15 SPURIOUS: ast=69:23
+    sink(x.data1); // $ ast,ir
 
     IntWrapper::Class z1, z2;
     z1.data1 = source();
-    sink(z1.data1); // $ ir
+    sink(z1.data1); // $ ast,ir
 
     swap(z1, z2);
 
-    sink(z2.data1); // $ ir
-    sink(z1.data1); // $ SPURIOUS: ir
+    sink(z2.data1); // $ ir MISSING: ast
+    sink(z1.data1); // $ SPURIOUS: ir ast=81:27 ast=82:16
 }
 
 void test_move_assignment_operator()
@@ -94,13 +94,13 @@ void test_move_assignment_operator()
     IntWrapper::Class y;
     x.data1 = source();
 
-    sink(x.data1); // $ ir
+    sink(x.data1); // $ ast,ir
     sink(y.data1); // clean
 
     y = std::move(x);
 
-    sink(y.data1); // $ ir
-    sink(x.data1); // $ ir
+    sink(y.data1); // $ ir ast=95:15 SPURIOUS: ast=93:23
+    sink(x.data1); // $ ast,ir
 }
 
 void test_move_constructor()
@@ -108,11 +108,11 @@ void test_move_constructor()
     IntWrapper::Class move_from;
     move_from.data1 = source();
 
-    sink(move_from.data1); // $ ir
+    sink(move_from.data1); // $ ast,ir
 
     IntWrapper::Class move_to(std::move(move_from));
 
-    sink(move_to.data1); // $ ir
+    sink(move_to.data1); // $ ir ast=109:23 SPURIOUS: ast=108:23
 }
 
 void test_copy_assignment_method()
@@ -121,13 +121,13 @@ void test_copy_assignment_method()
     IntWrapper::Class y;
     x.data1 = source();
 
-    sink(x.data1); // $ ir
+    sink(x.data1); // $ ast,ir
     sink(y.data1); // clean
 
     y.copy_assign(x);
 
-    sink(y.data1); // $ ir
-    sink(x.data1); // $ ir
+    sink(y.data1); // $ ir ast=122:15 SPURIOUS: ast=120:23
+    sink(x.data1); // $ ast,ir
 }
 
 void test_move_assignment_method()
@@ -136,13 +136,13 @@ void test_move_assignment_method()
     IntWrapper::Class y;
     x.data1 = source();
 
-    sink(x.data1); // $ ir
+    sink(x.data1); // $ ast,ir
     sink(y.data1); // clean
 
     y.move_assign(std::move(x));
 
-    sink(y.data1); // $ ir
-    sink(x.data1); // $ ir
+    sink(y.data1); // $ ir ast=137:15 SPURIOUS: ast=135:23
+    sink(x.data1); // $ ast,ir
 }
 
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -5,7 +5,7 @@ void arithAssignments(int source1, int clean1) {
   sink(clean1); // clean
   clean1 += source1;
   clean1 += 1;
-  sink(clean1); // $ ir
+  sink(clean1); // $ ast,ir
 
   clean1 = source1 = 1;
   sink(clean1); // clean
@@ -13,8 +13,8 @@ void arithAssignments(int source1, int clean1) {
   source1++;
   ++source1;
   source1 += 1;
-  sink(source1); // $ ir
-  sink(++source1); // $ ir
+  sink(source1); // $ ast,ir
+  sink(++source1); // $ ast,ir
 }
 
 // --- globals ---
@@ -38,23 +38,23 @@ void do_source()
 	global10 = zero(source());
 
 	sink(global6);
-	sink(global7); // $ ir
-	sink(global8); // $ ir
-	sink(global9); // $ ir
+	sink(global7); // $ ast,ir
+	sink(global8); // $ ast,ir
+	sink(global9); // $ ast,ir
 	sink(global10);
 }
 
 void do_sink()
 {
 	sink(global1);
-	sink(global2); // $ ir 
-	sink(global3); // $ ir 
-	sink(global4); // $ ir 
+	sink(global2); // $ ir MISSING: ast
+	sink(global3); // $ ir MISSING: ast
+	sink(global4); // $ ir MISSING: ast
 	sink(global5);
 	sink(global6);
-	sink(global7); // $ ir 
-	sink(global8); // $ ir 
-	sink(global9); // $ ir 
+	sink(global7); // $ ir MISSING: ast
+	sink(global8); // $ ir MISSING: ast
+	sink(global9); // $ ir MISSING: ast
 	sink(global10);
 }
 
@@ -86,12 +86,12 @@ void class_field_test() {
 	mc1.myMethod();
 
 	sink(mc1.a);
-	sink(mc1.b); // $ ir
-	sink(mc1.c); // $ ir
-	sink(mc1.d); // $ ir
+	sink(mc1.b); // $ ast,ir
+	sink(mc1.c); // $ ast,ir
+	sink(mc1.d); // $ ast,ir
 	sink(mc2.a);
-	sink(mc2.b); // $ ir
-	sink(mc2.c); // $ ir
+	sink(mc2.b); // $ ast,ir
+	sink(mc2.c); // $ ast,ir
 	sink(mc2.d);
 }
 
@@ -106,10 +106,10 @@ void array_test(int i) {
 	arr2[i] = source();
 	arr3[5] = 0;
 
-	sink(arr1[5]); // $ ir
-	sink(arr1[i]); // $ ir
-	sink(arr2[5]); // $ ir
-	sink(arr2[i]); // $ ir
+	sink(arr1[5]); // $ ast,ir
+	sink(arr1[i]); // $ ast,ir
+	sink(arr2[5]); // $ ast,ir
+	sink(arr2[i]); // $ ast,ir
 	sink(arr3[5]);
 	sink(arr3[i]);
 }
@@ -126,15 +126,15 @@ void pointer_test() {
 
 	*p2 = source();
 
-	sink(*p1); // $ ir
-	sink(*p2); // $ ir
+	sink(*p1); // $ ast,ir
+	sink(*p2); // $ ast,ir
 	sink(*p3);
 
 	p3 = &t1;
-	sink(*p3); // $ ir
+	sink(*p3); // $ ast,ir
 
 	*p3 = 0;
-	sink(*p3); // $ SPURIOUS: ir
+	sink(*p3); // $ SPURIOUS: ast,ir
 }
 
 // --- return values ---
@@ -148,7 +148,7 @@ int select(int i, int a, int b) {
 }
 
 void fn_test(int i) {
-	sink(select(i, 1, source())); // $ ir
+	sink(select(i, 1, source())); // $ ast,ir
 }
 
 // --- strings ---
@@ -164,13 +164,13 @@ namespace strings
 		char *tainted = source();
 		char buffer[1024] = {0};
 
-		sink(source()); // $ ir
-		sink(tainted); // $ ir
+		sink(source()); // $ ast,ir
+		sink(tainted); // $ ast,ir
 
 		strcpy(buffer, "Hello, ");
 		sink(buffer);
 		strcat(buffer, tainted);
-		sink(buffer); // $ MISSING: ir
+		sink(buffer); // $ ast MISSING: ir
 	}
 }
 
@@ -178,7 +178,7 @@ namespace strings
 
 namespace refs {
 	void callee(int *p) {
-		sink(*p); // $ ir
+		sink(*p); // $ ast,ir
 	}
 
 	void caller() {
@@ -192,7 +192,7 @@ void *memcpy(void *dest, void *src, int len);
 void test_memcpy(int *source) {
 	int x;
 	memcpy(&x, source, sizeof(int));
-	sink(x); // $ ir
+	sink(x); // $ ast=192:23 ir SPURIOUS: ast=193:6
 }
 
 // --- std::swap ---
@@ -207,13 +207,13 @@ void test_swap() {
 	x = source();
 	y = 0;
 
-	sink(x); // $ ir
+	sink(x); // $ ast,ir
 	sink(y); // clean
 
 	std::swap(x, y);
 
-	sink(x); // $ SPURIOUS: ir
-	sink(y); // $ ir
+	sink(x); // $ SPURIOUS: ast,ir
+	sink(y); // $ ast,ir
 }
 
 // --- lambdas ---
@@ -226,39 +226,39 @@ void test_lambdas()
 	int w = 0;
 
 	auto a = [t, u]() -> int {
-		sink(t); // $ ir
+		sink(t); // $ ast,ir
 		sink(u); // clean
 		return t;
 	};
-	sink(a()); // $ ir
+	sink(a()); // $ ast,ir
 
 	auto b = [&] {
-		sink(t); // $ ir
+		sink(t); // $ ast,ir
 		sink(u); // clean
 		v = source(); // (v is reference captured)
 	};
 	b();
-	sink(v); // $ MISSING: ir
+	sink(v); // $ MISSING: ast,ir
 
 	auto c = [=] {
-		sink(t); // $ ir
+		sink(t); // $ ast,ir
 		sink(u); // clean
 	};
 	c();
 
 	auto d = [](int a, int b) {
-		sink(a); // $ ir
+		sink(a); // $ ast,ir
 		sink(b); // clean
 	};
 	d(t, u);
 
 	auto e = [](int &a, int &b, int &c) {
-		sink(a); // $ ir
+		sink(a); // $ ast,ir
 		sink(b); // clean
 		c = source();
 	};
 	e(t, u, w);
-	sink(w); // $ ir
+	sink(w); // $ ast,ir
 }
 
 // --- taint through return value ---
@@ -277,7 +277,7 @@ void test_return()
 	y = 0;
 	z = 0;
 
-	sink(t); // $ ir
+	sink(t); // $ ast,ir
 	sink(x);
 	sink(y);
 	sink(z);
@@ -286,9 +286,9 @@ void test_return()
 	y = id(id(t));
 	z = id(z);
 
-	sink(t); // $ ir
-	sink(x); // $ ir
-	sink(y); // $ ir
+	sink(t); // $ ast,ir
+	sink(x); // $ ast,ir
+	sink(y); // $ ast,ir
 	sink(z);
 }
 
@@ -334,7 +334,7 @@ void test_outparams()
 	d = 0;
 	e = 0;
 
-	sink(t); // $ ir
+	sink(t); // $ ast,ir
 	sink(a);
 	sink(b);
 	sink(c);
@@ -347,11 +347,11 @@ void test_outparams()
 	myAssign4(&d, t);
 	myNotAssign(e, t);
 
-	sink(t); // $ ir
-	sink(a); // $ ir
-	sink(b); // $ ir
-	sink(c); // $ ir
-	sink(d); // $ ir
+	sink(t); // $ ast,ir
+	sink(a); // $ ast,ir
+	sink(b); // $ ast,ir
+	sink(c); // $ ast,ir
+	sink(d); // $ ast,ir
 	sink(e);
 }
 
@@ -371,9 +371,9 @@ void test_strdup(char *source)
 	a = strdup(source);
 	b = strdup("hello, world");
 	c = strndup(source, 100);
-	sink(a); // $ ir
+	sink(a); // $ ast,ir
 	sink(b);
-	sink(c); // $ ir
+	sink(c); // $ ast,ir
 }
 
 void test_strndup(int source)
@@ -381,7 +381,7 @@ void test_strndup(int source)
 	char *a;
 
 	a = strndup("hello, world", source);
-	sink(a); // $ ir
+	sink(a); // $ ast,ir
 }
 
 void test_wcsdup(wchar_t *source)
@@ -390,7 +390,7 @@ void test_wcsdup(wchar_t *source)
 
 	a = wcsdup(source);
 	b = wcsdup(L"hello, world");
-	sink(a); // $ ir
+	sink(a); // $ ast,ir
 	sink(b);
 }
 
@@ -401,9 +401,9 @@ void test_strdupa(char *source)
 	a = strdupa(source);
 	b = strdupa("hello, world");
 	c = strndupa(source, 100);
-	sink(a); // $ ir
+	sink(a); // $ ast,ir
 	sink(b);
-	sink(c); // $ ir
+	sink(c); // $ ast,ir
 }
 
 void test_strndupa(int source)
@@ -411,7 +411,7 @@ void test_strndupa(int source)
 	char *a;
 
 	a = strndupa("hello, world", source);
-	sink(a); // $ ir
+	sink(a); // $ ast,ir
 }
 
 // --- qualifiers ---
@@ -442,31 +442,31 @@ void test_qualifiers()
 	sink(a);
 	sink(a.getMember());
 	a.setMember(source());
-	sink(a); // $ ir
-	sink(a.getMember()); // $ ir
+	sink(a); // $ ast,ir
+	sink(a.getMember()); // $ ast,ir
 
 	sink(b);
 	sink(b.getMember());
 	b.member = source();
-	sink(b); // $ MISSING: ir
-	sink(b.member); // $ ir
-	sink(b.getMember()); // $ MISSING: ir
+	sink(b); // $ MISSING: ast,ir
+	sink(b.member); // $ ast,ir
+	sink(b.getMember()); // $ MISSING: ast,ir
 
 	c = new MyClass2(0);
 
 	sink(c);
 	sink(c->getMember());
 	c->setMember(source());
-	sink(c); // $ ir
-	sink(c->getMember()); // $ ir
+	sink(c); // $ ast,ir
+	sink(c->getMember()); // $ ast,ir
 
 	delete c;
 
 	sink(d);
 	sink(d.getString());
 	d.setString(strings::source());
-	sink(d); // $ ir
-	sink(d.getString()); // $ ir
+	sink(d); // $ ast,ir
+	sink(d.getString()); // $ ast,ir
 }
 
 // --- non-standard swap ---
@@ -484,13 +484,13 @@ void test_swop() {
 	x = source();
 	y = 0;
 
-	sink(x); // $ ir
+	sink(x); // $ ast,ir
 	sink(y); // clean
 
 	swop(x, y);
 
-	sink(x); // $ SPURIOUS: ir
-	sink(y); // $ ir
+	sink(x); // $ SPURIOUS: ast,ir
+	sink(y); // $ ast,ir
 }
 
 // --- getdelim ---
@@ -504,7 +504,7 @@ void test_getdelim(FILE* source1) {
 	size_t n;
 	getdelim(&line, &n, '\n', source1);
 
-	sink(line); // $ ir
+	sink(line); // $ ir,ast
 }
 
 // --- strtok ---
@@ -514,7 +514,7 @@ char *strtok(char *str, const char *delim);
 void test_strtok(char *source) {
 	const char* delim = ",.-;:_";
 	char* tokenized = strtok(source, delim);
-	sink(tokenized); // $ ir
+	sink(tokenized); // $ ast,ir
 	sink(delim);
 }
 
@@ -524,13 +524,13 @@ char *_strset(char *str, int c);
 
 void test_strset_1(char* ptr, char source) {
 	_strset(ptr, source);
-	sink(ptr); // $ SPURIOUS: ir
-	sink(*ptr); // $ ir
+	sink(ptr); // $ SPURIOUS: ast,ir
+	sink(*ptr); // $ ast,ir
 }
 
 void test_strset_2(char* source) {
 	_strset(source, 0);
-	sink(source); // $ ir
+	sink(source); // $ ast,ir
 }
 
 // --- mempcpy ---
@@ -540,7 +540,7 @@ void *mempcpy(void *dest, const void *src, size_t n);
 void test_mempcpy(int *source) {
 	int x;
 	mempcpy(&x, source, sizeof(int));
-	sink(x); // $ ir
+	sink(x); // $ ast=540:24 ir SPURIOUS: ast=541:6
 }
 
 // --- memccpy ---
@@ -550,7 +550,7 @@ void *memccpy(void *dest, const void *src, int c, size_t n);
 void test_memccpy(int *source) {
 	int dest[16];
 	memccpy(dest, source, 42, sizeof(dest));
-	sink(dest); // $ MISSING: ir
+	sink(dest); // $ ast=550:24  MISSING: ir SPURIOUS: ast=551:6
 }
 
 // --- strcat and related functions ---
@@ -559,7 +559,7 @@ char* strcat (char*, const char*);
 
 void test_strcat(char* dest1, char* dest2, char* clean, char* source) {
 	strcat(dest1, source);
-	sink(dest1); // $ ir
+	sink(dest1); // $ ast,ir
 
 	strcat(dest2, clean);
 	sink(dest2);
@@ -572,8 +572,8 @@ unsigned char *_mbsncat_l(unsigned char *, const unsigned char *, int, _locale_t
 void test__mbsncat_l(unsigned char* dest1, unsigned const char* ptr, unsigned char* dest3,
                      _locale_t clean, _locale_t source, int n) {
 	unsigned char* dest2 = _mbsncat_l(dest1, ptr, n, source);
-	sink(dest1); // $ SPURIOUS: ir
-	sink(*dest1); // $ ir
+	sink(dest1); // $ SPURIOUS: ast,ir
+	sink(*dest1); // $ ast,ir
 	sink(dest2); // $ SPURIOUS: ast,ir
 	sink(*dest2); // $ ast,ir
 
@@ -592,8 +592,8 @@ void test_strsep(char *source) {
   const char* delim = ",.-;:_";
   char* tokenized;
   while(tokenized = strsep(&source, delim)) {
-    sink(tokenized); // $ ir
-    sink(*tokenized); // $ ir
+    sink(tokenized); // $ ast,ir
+    sink(*tokenized); // $ ast,ir
   }
 }
 
@@ -605,8 +605,8 @@ unsigned char *_strdec(const unsigned char*, const unsigned char*);
 
 void test__strinc(char* source, char* clean, char* dest1, char* dest2, _locale_t locale) {
 	dest1 = _strinc(source, locale);
-	sink(dest1); // $ ir
-	sink(*dest1); // $ ir
+	sink(dest1); // $ ast,ir
+	sink(*dest1); // $ ast,ir
 
 	dest2 = _strinc(clean, locale);
 	sink(dest2);
@@ -615,29 +615,29 @@ void test__strinc(char* source, char* clean, char* dest1, char* dest2, _locale_t
 
 void test__mbsinc(unsigned char* source_unsigned, char* source, unsigned char* dest_unsigned, char* dest) {
 	dest_unsigned = _mbsinc(source_unsigned);
-	sink(dest_unsigned); // $ ir
-	sink(*dest_unsigned); // $ ir
+	sink(dest_unsigned); // $ ast,ir
+	sink(*dest_unsigned); // $ ast,ir
 
 	dest = (char*)_mbsinc((unsigned char*)source);
-	sink(dest); // $ ir
-	sink(*dest); // $ ir
+	sink(dest); // $ ast,ir
+	sink(*dest); // $ ast,ir
 }
 
 void test__strdec(const unsigned char* source, unsigned char* clean, unsigned char* dest1, unsigned char* dest2, unsigned char* dest3) {
 	dest1 = _strdec(source + 12, source);
-	sink(dest1); // $ ir
-	sink(*dest1); // $ ir
+	sink(dest1); // $ ast,ir
+	sink(*dest1); // $ ast,ir
 
 	// If `clean` does not precede `source` this technically breaks the precondition of _strdec.
 	// We would still like to have taint, though.
 	dest2 = _strdec(clean, source);
-	sink(dest2); // $ ir
-	sink(*dest2); // $ ir
+	sink(dest2); // $ ast,ir
+	sink(*dest2); // $ ast,ir
 
 	// Also breaks the precondition on _strdec.
 	dest3 = _strdec(source, clean);
-	sink(dest3); // $ ir
-	sink(*dest3); // $ ir
+	sink(dest3); // $ ast,ir
+	sink(*dest3); // $ ast,ir
 }
 
 // --- strnextc ---
@@ -648,7 +648,7 @@ void test__strnextc(const char* source) {
 	unsigned c = 0;
 	do {
 		c = _strnextc(source++);
-		sink(c); // $ ir
+		sink(c); // $ ast,ir
 	} while(c != '\0');
 	c = _strnextc("");
 	sink(c);
@@ -665,7 +665,7 @@ public:
 void test_no_const_member(char* source) {
   C_no_const_member_function c;
   memcpy(c.data(), source, 16);
-  sink(c.data()); // $ ir
+  sink(c.data()); // $ ast,ir
 }
 
 class C_const_member_function {
@@ -677,7 +677,7 @@ public:
 void test_with_const_member(char* source) {
   C_const_member_function c;
   memcpy(c.data(), source, 16);
-  sink(c.data()); // $ MISSING: ir
+  sink(c.data()); // $ ast MISSING: ir
 }
 
 void argument_source(void*);
@@ -690,7 +690,7 @@ void test_argument_source_field_to_obj() {
 	two_members s;
 	argument_source(s.x);
 
-	sink(s);
-	sink(s.x); // $ ir
+	sink(s); // $ SPURIOUS: ast
+	sink(s.x); // $ ast,ir
 	sink(s.y); // clean
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
@@ -38,6 +38,41 @@ module TaintModels {
   }
 }
 
+module AstTest {
+  private import semmle.code.cpp.dataflow.old.TaintTracking
+  private import semmle.code.cpp.models.interfaces.Taint
+
+  /** Common data flow configuration to be used by tests. */
+  class AstTestAllocationConfig extends TaintTracking::Configuration {
+    AstTestAllocationConfig() { this = "ASTTestAllocationConfig" }
+
+    override predicate isSource(DataFlow::Node source) {
+      source.asExpr().(FunctionCall).getTarget().getName() = "source"
+      or
+      source.asParameter().getName().matches("source%")
+      or
+      // Track uninitialized variables
+      exists(source.asUninitialized())
+      or
+      exists(FunctionCall fc |
+        fc.getAnArgument() = source.asDefiningArgument() and
+        fc.getTarget().hasName("argument_source")
+      )
+    }
+
+    override predicate isSink(DataFlow::Node sink) {
+      exists(FunctionCall call |
+        call.getTarget().getName() = "sink" and
+        sink.asExpr() = call.getAnArgument()
+      )
+    }
+
+    override predicate isSanitizer(DataFlow::Node barrier) {
+      barrier.asExpr().(VariableAccess).getTarget().hasName("sanitizer")
+    }
+  }
+}
+
 module IRTest {
   private import semmle.code.cpp.ir.IR
   private import semmle.code.cpp.ir.dataflow.TaintTracking

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -17,20 +17,20 @@ void test_range_based_for_loop_vector(int source1) {
 	std::vector<int> v(100, source1);
 
 	for(int x : v) {
-		sink(x); // $ ir
+		sink(x); // $ ast,ir
 	}
 
 	for(std::vector<int>::iterator it = v.begin(); it != v.end(); ++it) {
-		sink(*it); // $ ir
+		sink(*it); // $ ast,ir
 	}
 
 	for(int& x : v) {
-		sink(x); // $ ir
+		sink(x); // $ ast,ir
 	}
 
 	const std::vector<int> const_v(100, source1);
 	for(const int& x : const_v) {
-		sink(x); // $ ir
+		sink(x); // $ ast,ir
 	}
 }
 
@@ -49,55 +49,55 @@ void test_element_taint(int x) {
 	sink(v1.back());
 
 	v2[0] = source();
-	sink(v2); // $ MISSING: ir
-	sink(v2[0]); // $ ir
-	sink(v2[1]); // $ SPURIOUS: ir
-	sink(v2[x]); // $ ir
+	sink(v2); // $ ast MISSING: ir
+	sink(v2[0]); // $ ast,ir
+	sink(v2[1]); // $ SPURIOUS: ast,ir
+	sink(v2[x]); // $ ast,ir
 
 	v3 = v2;
-	sink(v3); // $ MISSING: ir
-	sink(v3[0]); // $ ir
-	sink(v3[1]); // $ SPURIOUS: ir
-	sink(v3[x]); // $ ir
+	sink(v3); // $ ast MISSING: ir
+	sink(v3[0]); // $ ast,ir
+	sink(v3[1]); // $ SPURIOUS: ast,ir
+	sink(v3[x]); // $ ast,ir
 
 	v4[x] = source();
-	sink(v4); // $ MISSING: ir
-	sink(v4[0]); // $ ir
-	sink(v4[1]); // $ ir
-	sink(v4[x]); // $ ir
+	sink(v4); // $ ast MISSING: ir
+	sink(v4[0]); // $ ast,ir
+	sink(v4[1]); // $ ast,ir
+	sink(v4[x]); // $ ast,ir
 
 	v5.push_back(source());
-	sink(v5); // $ MISSING: ir
-	sink(v5.front()); // $ SPURIOUS: ir
-	sink(v5.back()); // $ ir
+	sink(v5); // $ ast MISSING: ir
+	sink(v5.front()); // $ SPURIOUS: ast,ir
+	sink(v5.back()); // $ ast,ir
 
 	v6.data()[2] = source();
-	sink(v6); // $ MISSING: ir
-	sink(v6.data()[2]); // $ ir
+	sink(v6); // $ ast MISSING: ir
+	sink(v6.data()[2]); // $ ast,ir
 
 
 	{
 		std::vector<int>::const_iterator it = v7.begin();
 		v7.insert(it, source());
 	}
-	sink(v7); // $ MISSING: ir
-	sink(v7.front()); // $ ir
-	sink(v7.back()); // $ SPURIOUS: ir
+	sink(v7); // $ ast MISSING: ir
+	sink(v7.front()); // $ ast,ir
+	sink(v7.back()); // $ SPURIOUS: ast,ir
 
 	{
 		const std::vector<int> &v8c = v8;
 		std::vector<int>::const_iterator it = v8c.begin();
 		v8.insert(it, 10, ns_int::source());
 	}
-	sink(v8); // $ MISSING: ir
-	sink(v8.front()); // $ MISSING: ir
-	sink(v8.back()); // $ MISSING: ir
+	sink(v8); // $ MISSING: ast,ir
+	sink(v8.front()); // $ MISSING: ast,ir
+	sink(v8.back()); // $ MISSING: ast,ir
 
 	v9.at(x) = source();
-	sink(v9); // $ MISSING: ir
-	sink(v9.at(0)); // $ ir
-	sink(v9.at(1)); // $ ir
-	sink(v9.at(x)); // $ ir
+	sink(v9); // $ ast MISSING: ir
+	sink(v9.at(0)); // $ ast,ir
+	sink(v9.at(1)); // $ ast,ir
+	sink(v9.at(x)); // $ ast,ir
 }
 
 void test_vector_swap() {
@@ -106,18 +106,18 @@ void test_vector_swap() {
 	v1.push_back(source());
 	v4.push_back(source());
 
-	sink(v1); // $ MISSING: ir
+	sink(v1); // $ ast MISSING: ir
 	sink(v2);
 	sink(v3);
-	sink(v4); // $ MISSING: ir
+	sink(v4); // $ ast MISSING: ir
 
 	v1.swap(v2);
 	v3.swap(v4);
 
-	sink(v1);
-	sink(v2); // $ MISSING: ir
-	sink(v3); // $ MISSING: ir
-	sink(v4);
+	sink(v1); // $ SPURIOUS: ast
+	sink(v2); // $ ast MISSING: ir
+	sink(v3); // $ ast MISSING: ir
+	sink(v4); // $ SPURIOUS: ast
 }
 
 void test_vector_clear() {
@@ -127,18 +127,18 @@ void test_vector_clear() {
 	v2.push_back(source());
 	v3.push_back(source());
 
-	sink(v1); // $ MISSING: ir
-	sink(v2); // $ MISSING: ir
-	sink(v3); // $ MISSING: ir
+	sink(v1); // $ ast MISSING: ir
+	sink(v2); // $ ast MISSING: ir
+	sink(v3); // $ ast MISSING: ir
 	sink(v4);
 
 	v1.clear();
 	v2 = v2;
 	v3 = v4;
 
-	sink(v1);
-	sink(v2); // $ MISSING: ir
-	sink(v3); // $ MISSING: ir
+	sink(v1); // $ SPURIOUS: ast
+	sink(v2); // $ ast MISSING: ir
+	sink(v3); // $ ast MISSING: ir
 	sink(v4);
 }
 
@@ -159,7 +159,7 @@ void test_nested_vectors()
 
 		sink(aa[0][0]);
 		aa[0][0] = source();
-		sink(aa[0][0]); // $ ir
+		sink(aa[0][0]); // $ ast,ir
 	}
 
 	{
@@ -168,7 +168,7 @@ void test_nested_vectors()
 		bb[0].push_back(0);
 		sink(bb[0][0]);
 		bb[0][0] = source();
-		sink(bb[0][0]); // $ ir
+		sink(bb[0][0]); // $ ast,ir
 	}
 
 	{
@@ -177,7 +177,7 @@ void test_nested_vectors()
 		cc[0].push_back(0);
 		sink(cc[0][0]);
 		cc[0][0] = source();
-		sink(cc[0][0]); // $ ir
+		sink(cc[0][0]); // $ ast,ir
 	}
 
 	{
@@ -188,7 +188,7 @@ void test_nested_vectors()
 		sink(dd[0].a);
 		sink(dd[0].b);
 		dd[0].a = source();
-		sink(dd[0].a); // $ MISSING: ir
+		sink(dd[0].a); // $ MISSING: ast,ir
 		sink(dd[0].b);
 	}
 
@@ -198,7 +198,7 @@ void test_nested_vectors()
 		ee.vs.push_back(0);
 		sink(ee.vs[0]);
 		ee.vs[0] = source();
-		sink(ee.vs[0]); // $ ir
+		sink(ee.vs[0]); // $ ast,ir
 	}
 
 	{
@@ -209,7 +209,7 @@ void test_nested_vectors()
 		ff.push_back(mvc);
 		sink(ff[0].vs[0]);
 		ff[0].vs[0] = source();
-		sink(ff[0].vs[0]); // $ MISSING: ir
+		sink(ff[0].vs[0]); // $ MISSING: ast,ir
 	}
 }
 
@@ -239,8 +239,8 @@ void test_vector_assign() {
 	v3.push_back(source());
 
 	sink(v1);
-	sink(v2); // $ MISSING: ir
-	sink(v3); // $ MISSING: ir
+	sink(v2); // $ ast MISSING: ir
+	sink(v3); // $ ast MISSING: ir
 
 	{
 		std::vector<int> v4, v5, v6;
@@ -255,10 +255,10 @@ void test_vector_assign() {
 		v6.assign(i1, i2);
 
 		sink(v4);
-		sink(v5); // $ MISSING: ir
-		sink(i1); // $ MISSING: ir
-		sink(i2); // $ MISSING: ir
-		sink(v6); // $ MISSING: ir
+		sink(v5); // $ ast MISSING: ir
+		sink(i1); // $ ast MISSING: ir
+		sink(i2); // $ ast MISSING: ir
+		sink(v6); // $ ast MISSING: ir
 	}
 
 	{
@@ -270,9 +270,9 @@ void test_vector_assign() {
 		v8.assign(100, ns_myFloat::source());
 		v9.assign(100, ns_ci_ptr::source());
 
-		sink(v7); // $ MISSING: ir
-		sink(v8); // $ MISSING: ir
-		sink(v9); // $ MISSING: ir
+		sink(v7); // $ ast MISSING: ir
+		sink(v8); // $ ast MISSING: ir
+		sink(v9); // $ ast MISSING: ir
 	}
 }
 
@@ -282,14 +282,14 @@ void test_data_more() {
 	std::vector<int> v1, v2;
 
 	v1.push_back(source());
-	sink(v1); // $ MISSING: ir
-	sink(v1.data()); // $ ir
-	sink(v1.data()[2]); // $ ir
+	sink(v1); // $ ast MISSING: ir
+	sink(v1.data()); // $ ast,ir
+	sink(v1.data()[2]); // $ ast,ir
 
 	*(v2.data()) = ns_int::source();
-	sink(v2); // $ MISSING: ir
-	sink(v2.data()); // $ ir
-	sink(v2.data()[2]); // $ ir
+	sink(v2); // $ ast MISSING: ir
+	sink(v2.data()); // $ ast,ir
+	sink(v2.data()[2]); // $ ast,ir
 }
 
 void sink(std::vector<int>::iterator);
@@ -305,11 +305,11 @@ void test_vector_insert() {
 	sink(a.insert(a.end(), b.begin(), b.end()));
 	sink(a);
 
-	sink(c.insert(c.end(), d.begin(), d.end())); // $ ir
-	sink(c); // $ MISSING: ir
+	sink(c.insert(c.end(), d.begin(), d.end())); // $ ast,ir
+	sink(c); // $ ast MISSING: ir
 
-	sink(d.insert(d.end(), a.begin(), a.end())); // $ ir
-	sink(d); // $ MISSING: ir
+	sink(d.insert(d.end(), a.begin(), a.end())); // $ ast,ir
+	sink(d); // $ ast MISSING: ir
 }
 
 void test_vector_constructors_more() {
@@ -321,9 +321,9 @@ void test_vector_constructors_more() {
 	std::vector<int> v4(v2.begin(), v2.end());
 
 	sink(v1);
-	sink(v2); // $ MISSING: ir
+	sink(v2); // $ ast MISSING: ir
 	sink(v3);
-	sink(v4); // $ MISSING: ir
+	sink(v4); // $ ast MISSING: ir
 }
 
 void taint_vector_output_iterator(std::vector<int>::iterator iter) {
@@ -339,57 +339,57 @@ void test_vector_output_iterator(int b) {
 
 	std::vector<int>::iterator i1 = v1.begin();
 	*i1 = source();
-	sink(v1); // $ MISSING: ir
+	sink(v1); // $ ast MISSING: ir
 
 	for(std::vector<int>::iterator it = v2.begin(); it != v2.end(); ++it) {
 		*it = source();
 	}
-	sink(v2); // $ MISSING: ir
+	sink(v2); // $ ast MISSING: ir
 
 	for(int& x : v3) {
 		x = source();
 	}
-	sink(v3); // $ MISSING: ir
+	sink(v3); // $ MISSING: ast,ir
 
 	for(std::vector<int>::iterator it = v4.begin(); it != v4.end(); ++it) {
 		taint_vector_output_iterator(it);
 	}
-	sink(v4); // $ MISSING: ir
+	sink(v4); // $ ast MISSING: ir
 	
 	std::vector<int>::iterator i5 = v5.begin();
 	*i5 = source();
-	sink(v5); // $ MISSING: ir
+	sink(v5); // $ ast MISSING: ir
 	*i5 = 1;
-	sink(v5); // $ MISSING: ir
+	sink(v5); // $ ast MISSING: ir
 
 	std::vector<int>::iterator i6 = v6.begin();
 	*i6 = source();
-	sink(v6); // $ MISSING: ir
+	sink(v6); // $ ast MISSING: ir
 	v6 = std::vector<int>(10);
-	sink(v6);
+	sink(v6); // $ SPURIOUS: ast
 
 	std::vector<int>::iterator i7 = v7.begin();
 	if(b) {
 		*i7 = source();
-		sink(v7); // $ MISSING: ir
+		sink(v7); // $ ast MISSING: ir
 	} else {
 		*i7 = 1;
 		sink(v7);
 	}
-	sink(v7); // $ MISSING: ir
+	sink(v7); // $ ast MISSING: ir
 
 	std::vector<int>::iterator i8 = v8.begin();
 	*i8 = source();
-	sink(v8); // $ MISSING: ir
+	sink(v8); // $ ast MISSING: ir
 	*i8 = 1;
-	sink(v8);
+	sink(v8); // $ SPURIOUS: ast
 
 	std::vector<int>::iterator i9 = v9.begin();
 
 	*i9 = source();
 	taint_vector_output_iterator(i9);
 
-	sink(v9); // $ MISSING: ir
+	sink(v9); // $ ast=330:10 SPURIOUS: ast=389:8 MISSING: ir
 
 	std::vector<int>::iterator i10 = v10.begin();
 	vector_iterator_assign_wrapper(i10, 10);
@@ -397,21 +397,21 @@ void test_vector_output_iterator(int b) {
 
 	std::vector<int>::iterator i11 = v11.begin();
 	vector_iterator_assign_wrapper(i11, source());
-	sink(v11); // $ MISSING: ir
+	sink(v11); // $ ast MISSING: ir
 
 	std::vector<int>::iterator i12 = v12.begin();
 	*i12++ = 0;
 	*i12 = source();
-	sink(v12); // $ MISSING: ir
+	sink(v12); // $ ast MISSING: ir
 
 	std::vector<int>::iterator i13 = v13.begin();
 	*i13++ = source();
-	sink(v13); // $ MISSING: ir
+	sink(v13); // $ ast MISSING: ir
 
 	std::vector<int>::iterator i14 = v14.begin();
 	i14++;
 	*i14++ = source();
-	sink(v14); // $ MISSING: ir
+	sink(v14); // $ ast MISSING: ir
 }
 
 void test_vector_inserter(char *source_string) {
@@ -419,35 +419,35 @@ void test_vector_inserter(char *source_string) {
 		std::vector<std::string> out;
 		auto it = out.end();
 		*it++ = std::string(source_string);
-		sink(out); // $ MISSING: ir
+		sink(out); // $ ast MISSING: ir
 	}
 
 	{
 		std::vector<std::string> out;
 		auto it = std::back_inserter(out);
 		*it++ = std::string(source_string);
-		sink(out); // $ MISSING: ir
+		sink(out); // $ ast MISSING: ir
 	}
 
 	{
 		std::vector<int> out;
 		auto it = std::back_inserter(out);
 		*it++ = source();
-		sink(out); // $ MISSING: ir
+		sink(out); // $ ast MISSING: ir
 	}
 
 	{
 		std::vector<std::string> out;
 		auto it = std::back_inserter(out);
 		*++it = std::string(source_string);
-		sink(out); // $ MISSING: ir
+		sink(out); // $ ast MISSING: ir
 	}
 
 	{
 		std::vector<int> out;
 		auto it = std::back_inserter(out);
 		*++it = source();
-		sink(out); // $ MISSING: ir
+		sink(out); // $ ast MISSING: ir
 	}
 }
 
@@ -470,7 +470,7 @@ void test_vector_memcpy()
 
 		sink(v);
 		memcpy(&v[i], &s, sizeof(int));
-		sink(v); // $ MISSING: ir
+		sink(v); // $ ast MISSING: ir
 	}
 
 	{
@@ -479,11 +479,11 @@ void test_vector_memcpy()
 		const size_t offs = 10;
 		const size_t len = src.length();
 
-		sink(src); // $ MISSING: ir
+		sink(src); // $ ast MISSING: ir
 		sink(cs);
 		memcpy(&cs[offs + 1], src.c_str(), len);
-		sink(src); // $ MISSING: ir
-		sink(cs); // $ MISSING: ir
+		sink(src); // $ ast MISSING: ir
+		sink(cs); // $ ast MISSING: ir
 	}
 }
 
@@ -491,10 +491,10 @@ void test_vector_emplace() {
 	std::vector<int> v1(10), v2(10);
 
 	v1.emplace_back(source());
-	sink(v1); // $ MISSING: ir
+	sink(v1); // $ ast MISSING: ir
 
 	v2.emplace(v2.begin(), source());
-	sink(v2); // $ MISSING: ir
+	sink(v2); // $ ast MISSING: ir
 }
 
 void test_vector_iterator() {
@@ -504,14 +504,14 @@ void test_vector_iterator() {
 		short *ptr;
 
 		sink(as[1]);
-		sink(as[source()]); // $ ir
+		sink(as[source()]); // $ ast,ir
 
 		ptr = as;
 		sink(*ptr);
 		ptr += 1;
 		sink(*ptr);
 		ptr += source();
-		sink(*ptr); // $ ir
+		sink(*ptr); // $ ast,ir
 		sink(as[1]);
 	}
 
@@ -521,14 +521,14 @@ void test_vector_iterator() {
 		std::vector<short>::iterator it;
 
 		sink(vs[1]);
-		sink(vs[source()]); // $ MISSING: ir
+		sink(vs[source()]); // $ MISSING: ast,ir
 
 		it = vs.begin();
 		sink(*it);
 		it += 1;
 		sink(*it);
 		it += source();
-		sink(*it); // $ ir
+		sink(*it); // $ ast,ir
 		sink(vs[1]);
 	}
 }


### PR DESCRIPTION
This makes it easier to fix the library tests for me, and we should probably keep these around anyway until we remove the AST-based dataflow library.