### PR TITLE
Swift: add `String` taint steps

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -1,5 +1,7 @@
 import swift
+private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.ExternalFlow
+private import codeql.swift.dataflow.FlowSteps
 
 private class StringSource extends SourceModelCsv {
   override predicate row(string row) {
@@ -14,5 +16,17 @@ private class StringSource extends SourceModelCsv {
         ";String;true;init(contentsOfFile:encoding:);(String,String.Encoding);;ReturnValue;local",
         ";String;true;init(contentsOfFile:usedEncoding:);(String,String.Encoding);;ReturnValue;local"
       ]
+  }
+}
+
+/**
+ * A content implying that, if a `String` is tainted, then all its fields are tainted.
+ */
+private class StringFieldsInheritTaint extends TaintInheritingContent,
+  DataFlow::Content::FieldContent {
+  StringFieldsInheritTaint() {
+    this.getField().getEnclosingDecl().(ClassOrStructDecl).getFullName() = "String" or
+    this.getField().getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getFullName() =
+      "String"
   }
 }

--- a/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
@@ -600,6 +600,8 @@
 | nsmutabledata.swift:49:15:49:15 | nsMutableDataTainted6 | nsmutabledata.swift:49:15:49:37 | .mutableBytes |
 | string.swift:5:7:5:7 | SSA def(x) | string.swift:7:16:7:16 | x |
 | string.swift:5:11:5:18 | call to source() | string.swift:5:7:5:7 | SSA def(x) |
+| data.swift:20:23:20:23 | 123456 | data.swift:20:23:20:32 | .utf8 |
+| data.swift:21:25:21:32 | call to source() | data.swift:21:25:21:34 | .utf8 |
 | string.swift:7:13:7:13 |  | string.swift:7:13:7:13 | [post]  |
 | string.swift:7:13:7:13 |  | string.swift:7:14:7:14 | [post] &... |
 | string.swift:7:13:7:13 | SSA def($interpolation) | string.swift:7:14:7:14 | SSA phi($interpolation) |
@@ -932,6 +934,13 @@
 | subscript.swift:3:9:3:9 | self | subscript.swift:3:9:3:9 | SSA def(self) |
 | subscript.swift:4:9:4:9 | SSA def(self) | subscript.swift:4:9:4:24 | self[return] |
 | subscript.swift:4:9:4:9 | self | subscript.swift:4:9:4:9 | SSA def(self) |
+| string.swift:84:13:84:13 | clean | string.swift:84:13:84:19 | .description |
+| string.swift:85:13:85:13 | tainted | string.swift:85:13:85:21 | .description |
+| string.swift:87:13:87:13 | clean | string.swift:87:13:87:19 | .debugDescription |
+| string.swift:88:13:88:13 | tainted | string.swift:88:13:88:21 | .debugDescription |
+| string.swift:97:17:97:25 | call to source2() | string.swift:97:17:97:27 | .utf8 |
+| string.swift:98:24:98:32 | call to source2() | string.swift:98:24:98:34 | .utf8CString |
+| string.swift:99:31:99:39 | call to source2() | string.swift:99:31:99:41 | .unicodeScalars |
 | subscript.swift:13:15:13:22 | call to source() | subscript.swift:13:15:13:25 | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] |
 | try.swift:8:17:8:23 | call to clean() | try.swift:8:13:8:23 | try ... |

--- a/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
@@ -120,11 +120,13 @@
 | data.swift:80:6:80:6 | SSA def(dataClean) | data.swift:84:12:84:12 | dataClean |
 | data.swift:80:18:80:18 | Data.Type | data.swift:80:18:80:18 | call to init(_:) |
 | data.swift:80:18:80:36 | call to init(_:) | data.swift:80:6:80:6 | SSA def(dataClean) |
+| data.swift:80:23:80:23 | 123456 | data.swift:80:23:80:32 | .utf8 |
 | data.swift:80:23:80:32 | .utf8 | data.swift:80:18:80:36 | call to init(_:) |
 | data.swift:81:6:81:6 | SSA def(dataTainted) | data.swift:82:26:82:26 | dataTainted |
 | data.swift:81:20:81:20 | Data.Type | data.swift:81:20:81:20 | call to init(_:) |
 | data.swift:81:20:81:51 | call to init(_:) | data.swift:81:6:81:6 | SSA def(dataTainted) |
 | data.swift:81:25:81:47 | .utf8 | data.swift:81:20:81:51 | call to init(_:) |
+| data.swift:81:26:81:33 | call to source() | data.swift:81:25:81:47 | .utf8 |
 | data.swift:82:6:82:6 | SSA def(dataTainted2) | data.swift:86:12:86:12 | dataTainted2 |
 | data.swift:82:21:82:21 | Data.Type | data.swift:82:21:82:21 | call to init(_:) |
 | data.swift:82:21:82:37 | call to init(_:) | data.swift:82:6:82:6 | SSA def(dataTainted2) |
@@ -600,8 +602,6 @@
 | nsmutabledata.swift:49:15:49:15 | nsMutableDataTainted6 | nsmutabledata.swift:49:15:49:37 | .mutableBytes |
 | string.swift:5:7:5:7 | SSA def(x) | string.swift:7:16:7:16 | x |
 | string.swift:5:11:5:18 | call to source() | string.swift:5:7:5:7 | SSA def(x) |
-| data.swift:20:23:20:23 | 123456 | data.swift:20:23:20:32 | .utf8 |
-| data.swift:21:25:21:32 | call to source() | data.swift:21:25:21:34 | .utf8 |
 | string.swift:7:13:7:13 |  | string.swift:7:13:7:13 | [post]  |
 | string.swift:7:13:7:13 |  | string.swift:7:14:7:14 | [post] &... |
 | string.swift:7:13:7:13 | SSA def($interpolation) | string.swift:7:14:7:14 | SSA phi($interpolation) |
@@ -900,9 +900,13 @@
 | string.swift:81:31:81:31 | clean | string.swift:84:13:84:13 | clean |
 | string.swift:82:31:82:31 | tainted | string.swift:85:13:85:13 | tainted |
 | string.swift:84:13:84:13 | [post] clean | string.swift:87:13:87:13 | clean |
+| string.swift:84:13:84:13 | clean | string.swift:84:13:84:19 | .description |
 | string.swift:84:13:84:13 | clean | string.swift:87:13:87:13 | clean |
 | string.swift:85:13:85:13 | [post] tainted | string.swift:88:13:88:13 | tainted |
+| string.swift:85:13:85:13 | tainted | string.swift:85:13:85:21 | .description |
 | string.swift:85:13:85:13 | tainted | string.swift:88:13:88:13 | tainted |
+| string.swift:87:13:87:13 | clean | string.swift:87:13:87:19 | .debugDescription |
+| string.swift:88:13:88:13 | tainted | string.swift:88:13:88:21 | .debugDescription |
 | string.swift:91:7:91:7 | SSA def(self) | string.swift:91:7:91:7 | self[return] |
 | string.swift:91:7:91:7 | self | string.swift:91:7:91:7 | SSA def(self) |
 | string.swift:93:5:93:5 | SSA def(self) | string.swift:93:5:93:29 | self[return] |
@@ -925,6 +929,17 @@
 | string.swift:109:23:109:77 | call to init(data:encoding:) | string.swift:109:7:109:7 | SSA def(stringTainted) |
 | string.swift:111:12:111:12 | stringClean | string.swift:111:12:111:23 | ...! |
 | string.swift:112:12:112:12 | stringTainted | string.swift:112:12:112:25 | ...! |
+| string.swift:120:7:120:7 | SSA def(clean) | string.swift:125:13:125:13 | clean |
+| string.swift:120:15:120:15 |  | string.swift:120:7:120:7 | SSA def(clean) |
+| string.swift:121:7:121:7 | SSA def(tainted) | string.swift:126:13:126:13 | tainted |
+| string.swift:121:17:121:25 | call to source2() | string.swift:121:17:121:27 | .utf8 |
+| string.swift:121:17:121:27 | .utf8 | string.swift:121:7:121:7 | SSA def(tainted) |
+| string.swift:122:7:122:7 | SSA def(taintedCString) | string.swift:127:13:127:13 | taintedCString |
+| string.swift:122:24:122:32 | call to source2() | string.swift:122:24:122:34 | .utf8CString |
+| string.swift:122:24:122:34 | .utf8CString | string.swift:122:7:122:7 | SSA def(taintedCString) |
+| string.swift:123:7:123:7 | SSA def(taintedUnicodeScalars) | string.swift:128:13:128:13 | taintedUnicodeScalars |
+| string.swift:123:31:123:39 | call to source2() | string.swift:123:31:123:41 | .unicodeScalars |
+| string.swift:123:31:123:41 | .unicodeScalars | string.swift:123:7:123:7 | SSA def(taintedUnicodeScalars) |
 | subscript.swift:1:7:1:7 | SSA def(self) | subscript.swift:1:7:1:7 | self[return] |
 | subscript.swift:1:7:1:7 | SSA def(self) | subscript.swift:1:7:1:7 | self[return] |
 | subscript.swift:1:7:1:7 | self | subscript.swift:1:7:1:7 | SSA def(self) |
@@ -934,13 +949,6 @@
 | subscript.swift:3:9:3:9 | self | subscript.swift:3:9:3:9 | SSA def(self) |
 | subscript.swift:4:9:4:9 | SSA def(self) | subscript.swift:4:9:4:24 | self[return] |
 | subscript.swift:4:9:4:9 | self | subscript.swift:4:9:4:9 | SSA def(self) |
-| string.swift:84:13:84:13 | clean | string.swift:84:13:84:19 | .description |
-| string.swift:85:13:85:13 | tainted | string.swift:85:13:85:21 | .description |
-| string.swift:87:13:87:13 | clean | string.swift:87:13:87:19 | .debugDescription |
-| string.swift:88:13:88:13 | tainted | string.swift:88:13:88:21 | .debugDescription |
-| string.swift:97:17:97:25 | call to source2() | string.swift:97:17:97:27 | .utf8 |
-| string.swift:98:24:98:32 | call to source2() | string.swift:98:24:98:34 | .utf8CString |
-| string.swift:99:31:99:39 | call to source2() | string.swift:99:31:99:41 | .unicodeScalars |
 | subscript.swift:13:15:13:22 | call to source() | subscript.swift:13:15:13:25 | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] |
 | try.swift:8:17:8:23 | call to clean() | try.swift:8:13:8:23 | try ... |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -1,4 +1,5 @@
 edges
+| data.swift:24:5:24:29 | [summary param] 0 in init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(_:) :  |
 | data.swift:25:2:25:66 | [summary param] 0 in init(base64Encoded:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  |
 | data.swift:26:2:26:61 | [summary param] 0 in init(buffer:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(buffer:) :  |
 | data.swift:27:2:27:62 | [summary param] 0 in init(buffer:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(buffer:) :  |
@@ -34,6 +35,14 @@ edges
 | data.swift:62:2:62:58 | [summary param] this in shuffled(using:) :  | file://:0:0:0:0 | [summary] to write: return (return) in shuffled(using:) :  |
 | data.swift:63:2:63:123 | [summary param] this in trimmingPrefix(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in trimmingPrefix(_:) :  |
 | data.swift:64:2:64:72 | [summary param] this in trimmingPrefix(while:) :  | file://:0:0:0:0 | [summary] to write: return (return) in trimmingPrefix(while:) :  |
+| data.swift:81:20:81:51 | call to init(_:) :  | data.swift:82:26:82:26 | dataTainted :  |
+| data.swift:81:20:81:51 | call to init(_:) :  | data.swift:85:12:85:12 | dataTainted |
+| data.swift:81:25:81:47 | .utf8 :  | data.swift:24:5:24:29 | [summary param] 0 in init(_:) :  |
+| data.swift:81:25:81:47 | .utf8 :  | data.swift:81:20:81:51 | call to init(_:) :  |
+| data.swift:81:26:81:33 | call to source() :  | data.swift:81:25:81:47 | .utf8 :  |
+| data.swift:82:21:82:37 | call to init(_:) :  | data.swift:86:12:86:12 | dataTainted2 |
+| data.swift:82:26:82:26 | dataTainted :  | data.swift:24:5:24:29 | [summary param] 0 in init(_:) :  |
+| data.swift:82:26:82:26 | dataTainted :  | data.swift:82:21:82:37 | call to init(_:) :  |
 | data.swift:89:21:89:71 | call to init(base64Encoded:options:) :  | data.swift:90:12:90:12 | dataTainted3 |
 | data.swift:89:41:89:48 | call to source() :  | data.swift:25:2:25:66 | [summary param] 0 in init(base64Encoded:options:) :  |
 | data.swift:89:41:89:48 | call to source() :  | data.swift:89:21:89:71 | call to init(base64Encoded:options:) :  |
@@ -303,9 +312,9 @@ edges
 | string.swift:28:17:28:25 | call to source2() :  | string.swift:39:13:39:29 | ... .+(_:_:) ... |
 | string.swift:74:17:74:25 | call to source2() :  | string.swift:85:13:85:21 | .description |
 | string.swift:74:17:74:25 | call to source2() :  | string.swift:88:13:88:21 | .debugDescription |
-| string.swift:97:17:97:25 | call to source2() :  | string.swift:102:13:102:13 | tainted |
-| string.swift:98:24:98:32 | call to source2() :  | string.swift:103:13:103:13 | taintedCString |
-| string.swift:99:31:99:39 | call to source2() :  | string.swift:104:13:104:13 | taintedUnicodeScalars |
+| string.swift:121:17:121:25 | call to source2() :  | string.swift:126:13:126:13 | tainted |
+| string.swift:122:24:122:32 | call to source2() :  | string.swift:127:13:127:13 | taintedCString |
+| string.swift:123:31:123:39 | call to source2() :  | string.swift:128:13:128:13 | taintedUnicodeScalars |
 | subscript.swift:13:15:13:22 | call to source() :  | subscript.swift:13:15:13:25 | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() :  | subscript.swift:14:15:14:26 | ...[...] |
 | try.swift:9:17:9:24 | call to source() :  | try.swift:9:13:9:24 | try ... |
@@ -546,6 +555,7 @@ edges
 | webview.swift:137:34:137:41 | call to source() :  | webview.swift:66:5:66:126 | [summary param] 0 in init(source:injectionTime:forMainFrameOnly:in:) :  |
 | webview.swift:137:34:137:41 | call to source() :  | webview.swift:137:13:137:113 | call to init(source:injectionTime:forMainFrameOnly:in:) :  |
 nodes
+| data.swift:24:5:24:29 | [summary param] 0 in init(_:) :  | semmle.label | [summary param] 0 in init(_:) :  |
 | data.swift:25:2:25:66 | [summary param] 0 in init(base64Encoded:options:) :  | semmle.label | [summary param] 0 in init(base64Encoded:options:) :  |
 | data.swift:26:2:26:61 | [summary param] 0 in init(buffer:) :  | semmle.label | [summary param] 0 in init(buffer:) :  |
 | data.swift:27:2:27:62 | [summary param] 0 in init(buffer:) :  | semmle.label | [summary param] 0 in init(buffer:) :  |
@@ -581,6 +591,13 @@ nodes
 | data.swift:62:2:62:58 | [summary param] this in shuffled(using:) :  | semmle.label | [summary param] this in shuffled(using:) :  |
 | data.swift:63:2:63:123 | [summary param] this in trimmingPrefix(_:) :  | semmle.label | [summary param] this in trimmingPrefix(_:) :  |
 | data.swift:64:2:64:72 | [summary param] this in trimmingPrefix(while:) :  | semmle.label | [summary param] this in trimmingPrefix(while:) :  |
+| data.swift:81:20:81:51 | call to init(_:) :  | semmle.label | call to init(_:) :  |
+| data.swift:81:25:81:47 | .utf8 :  | semmle.label | .utf8 :  |
+| data.swift:81:26:81:33 | call to source() :  | semmle.label | call to source() :  |
+| data.swift:82:21:82:37 | call to init(_:) :  | semmle.label | call to init(_:) :  |
+| data.swift:82:26:82:26 | dataTainted :  | semmle.label | dataTainted :  |
+| data.swift:85:12:85:12 | dataTainted | semmle.label | dataTainted |
+| data.swift:86:12:86:12 | dataTainted2 | semmle.label | dataTainted2 |
 | data.swift:89:21:89:71 | call to init(base64Encoded:options:) :  | semmle.label | call to init(base64Encoded:options:) :  |
 | data.swift:89:41:89:48 | call to source() :  | semmle.label | call to source() :  |
 | data.swift:90:12:90:12 | dataTainted3 | semmle.label | dataTainted3 |
@@ -739,6 +756,7 @@ nodes
 | file://:0:0:0:0 | [summary] to write: return (return) in flatMap(_:) :  | semmle.label | [summary] to write: return (return) in flatMap(_:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in flatMap(_:) :  | semmle.label | [summary] to write: return (return) in flatMap(_:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  | semmle.label | [summary] to write: return (return) in forProperty(_:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(_:) :  | semmle.label | [summary] to write: return (return) in init(_:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  | semmle.label | [summary] to write: return (return) in init(base64Encoded:options:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  | semmle.label | [summary] to write: return (return) in init(base64Encoded:options:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  | semmle.label | [summary] to write: return (return) in init(base64Encoded:options:) :  |
@@ -948,12 +966,12 @@ nodes
 | string.swift:74:17:74:25 | call to source2() :  | semmle.label | call to source2() :  |
 | string.swift:85:13:85:21 | .description | semmle.label | .description |
 | string.swift:88:13:88:21 | .debugDescription | semmle.label | .debugDescription |
-| string.swift:97:17:97:25 | call to source2() :  | semmle.label | call to source2() :  |
-| string.swift:98:24:98:32 | call to source2() :  | semmle.label | call to source2() :  |
-| string.swift:99:31:99:39 | call to source2() :  | semmle.label | call to source2() :  |
-| string.swift:102:13:102:13 | tainted | semmle.label | tainted |
-| string.swift:103:13:103:13 | taintedCString | semmle.label | taintedCString |
-| string.swift:104:13:104:13 | taintedUnicodeScalars | semmle.label | taintedUnicodeScalars |
+| string.swift:121:17:121:25 | call to source2() :  | semmle.label | call to source2() :  |
+| string.swift:122:24:122:32 | call to source2() :  | semmle.label | call to source2() :  |
+| string.swift:123:31:123:39 | call to source2() :  | semmle.label | call to source2() :  |
+| string.swift:126:13:126:13 | tainted | semmle.label | tainted |
+| string.swift:127:13:127:13 | taintedCString | semmle.label | taintedCString |
+| string.swift:128:13:128:13 | taintedUnicodeScalars | semmle.label | taintedUnicodeScalars |
 | subscript.swift:13:15:13:22 | call to source() :  | semmle.label | call to source() :  |
 | subscript.swift:13:15:13:25 | ...[...] | semmle.label | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() :  | semmle.label | call to source2() :  |
@@ -1153,6 +1171,8 @@ nodes
 | webview.swift:138:10:138:10 | c | semmle.label | c |
 | webview.swift:139:10:139:12 | .source | semmle.label | .source |
 subpaths
+| data.swift:81:25:81:47 | .utf8 :  | data.swift:24:5:24:29 | [summary param] 0 in init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(_:) :  | data.swift:81:20:81:51 | call to init(_:) :  |
+| data.swift:82:26:82:26 | dataTainted :  | data.swift:24:5:24:29 | [summary param] 0 in init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(_:) :  | data.swift:82:21:82:37 | call to init(_:) :  |
 | data.swift:89:41:89:48 | call to source() :  | data.swift:25:2:25:66 | [summary param] 0 in init(base64Encoded:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  | data.swift:89:21:89:71 | call to init(base64Encoded:options:) :  |
 | data.swift:93:34:93:41 | call to source() :  | data.swift:26:2:26:61 | [summary param] 0 in init(buffer:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(buffer:) :  | data.swift:93:21:93:73 | call to init(buffer:) :  |
 | data.swift:95:34:95:41 | call to source() :  | data.swift:27:2:27:62 | [summary param] 0 in init(buffer:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(buffer:) :  | data.swift:95:21:95:74 | call to init(buffer:) :  |
@@ -1274,6 +1294,8 @@ subpaths
 | webview.swift:132:34:132:41 | call to source() :  | webview.swift:65:5:65:93 | [summary param] 0 in init(source:injectionTime:forMainFrameOnly:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(source:injectionTime:forMainFrameOnly:) :  | webview.swift:132:13:132:102 | call to init(source:injectionTime:forMainFrameOnly:) :  |
 | webview.swift:137:34:137:41 | call to source() :  | webview.swift:66:5:66:126 | [summary param] 0 in init(source:injectionTime:forMainFrameOnly:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(source:injectionTime:forMainFrameOnly:in:) :  | webview.swift:137:13:137:113 | call to init(source:injectionTime:forMainFrameOnly:in:) :  |
 #select
+| data.swift:85:12:85:12 | dataTainted | data.swift:81:26:81:33 | call to source() :  | data.swift:85:12:85:12 | dataTainted | result |
+| data.swift:86:12:86:12 | dataTainted2 | data.swift:81:26:81:33 | call to source() :  | data.swift:86:12:86:12 | dataTainted2 | result |
 | data.swift:90:12:90:12 | dataTainted3 | data.swift:89:41:89:48 | call to source() :  | data.swift:90:12:90:12 | dataTainted3 | result |
 | data.swift:94:12:94:12 | dataTainted4 | data.swift:93:34:93:41 | call to source() :  | data.swift:94:12:94:12 | dataTainted4 | result |
 | data.swift:96:12:96:12 | dataTainted5 | data.swift:95:34:95:41 | call to source() :  | data.swift:96:12:96:12 | dataTainted5 | result |
@@ -1356,9 +1378,9 @@ subpaths
 | string.swift:39:13:39:29 | ... .+(_:_:) ... | string.swift:28:17:28:25 | call to source2() :  | string.swift:39:13:39:29 | ... .+(_:_:) ... | result |
 | string.swift:85:13:85:21 | .description | string.swift:74:17:74:25 | call to source2() :  | string.swift:85:13:85:21 | .description | result |
 | string.swift:88:13:88:21 | .debugDescription | string.swift:74:17:74:25 | call to source2() :  | string.swift:88:13:88:21 | .debugDescription | result |
-| string.swift:102:13:102:13 | tainted | string.swift:97:17:97:25 | call to source2() :  | string.swift:102:13:102:13 | tainted | result |
-| string.swift:103:13:103:13 | taintedCString | string.swift:98:24:98:32 | call to source2() :  | string.swift:103:13:103:13 | taintedCString | result |
-| string.swift:104:13:104:13 | taintedUnicodeScalars | string.swift:99:31:99:39 | call to source2() :  | string.swift:104:13:104:13 | taintedUnicodeScalars | result |
+| string.swift:126:13:126:13 | tainted | string.swift:121:17:121:25 | call to source2() :  | string.swift:126:13:126:13 | tainted | result |
+| string.swift:127:13:127:13 | taintedCString | string.swift:122:24:122:32 | call to source2() :  | string.swift:127:13:127:13 | taintedCString | result |
+| string.swift:128:13:128:13 | taintedUnicodeScalars | string.swift:123:31:123:39 | call to source2() :  | string.swift:128:13:128:13 | taintedUnicodeScalars | result |
 | subscript.swift:13:15:13:25 | ...[...] | subscript.swift:13:15:13:22 | call to source() :  | subscript.swift:13:15:13:25 | ...[...] | result |
 | subscript.swift:14:15:14:26 | ...[...] | subscript.swift:14:15:14:23 | call to source2() :  | subscript.swift:14:15:14:26 | ...[...] | result |
 | try.swift:9:13:9:24 | try ... | try.swift:9:17:9:24 | call to source() :  | try.swift:9:13:9:24 | try ... | result |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -301,6 +301,11 @@ edges
 | string.swift:28:17:28:25 | call to source2() :  | string.swift:35:13:35:23 | ... .+(_:_:) ... |
 | string.swift:28:17:28:25 | call to source2() :  | string.swift:36:13:36:23 | ... .+(_:_:) ... |
 | string.swift:28:17:28:25 | call to source2() :  | string.swift:39:13:39:29 | ... .+(_:_:) ... |
+| string.swift:74:17:74:25 | call to source2() :  | string.swift:85:13:85:21 | .description |
+| string.swift:74:17:74:25 | call to source2() :  | string.swift:88:13:88:21 | .debugDescription |
+| string.swift:97:17:97:25 | call to source2() :  | string.swift:102:13:102:13 | tainted |
+| string.swift:98:24:98:32 | call to source2() :  | string.swift:103:13:103:13 | taintedCString |
+| string.swift:99:31:99:39 | call to source2() :  | string.swift:104:13:104:13 | taintedUnicodeScalars |
 | subscript.swift:13:15:13:22 | call to source() :  | subscript.swift:13:15:13:25 | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() :  | subscript.swift:14:15:14:26 | ...[...] |
 | try.swift:9:17:9:24 | call to source() :  | try.swift:9:13:9:24 | try ... |
@@ -940,6 +945,15 @@ nodes
 | string.swift:35:13:35:23 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | string.swift:36:13:36:23 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | string.swift:39:13:39:29 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
+| string.swift:74:17:74:25 | call to source2() :  | semmle.label | call to source2() :  |
+| string.swift:85:13:85:21 | .description | semmle.label | .description |
+| string.swift:88:13:88:21 | .debugDescription | semmle.label | .debugDescription |
+| string.swift:97:17:97:25 | call to source2() :  | semmle.label | call to source2() :  |
+| string.swift:98:24:98:32 | call to source2() :  | semmle.label | call to source2() :  |
+| string.swift:99:31:99:39 | call to source2() :  | semmle.label | call to source2() :  |
+| string.swift:102:13:102:13 | tainted | semmle.label | tainted |
+| string.swift:103:13:103:13 | taintedCString | semmle.label | taintedCString |
+| string.swift:104:13:104:13 | taintedUnicodeScalars | semmle.label | taintedUnicodeScalars |
 | subscript.swift:13:15:13:22 | call to source() :  | semmle.label | call to source() :  |
 | subscript.swift:13:15:13:25 | ...[...] | semmle.label | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() :  | semmle.label | call to source2() :  |
@@ -1340,6 +1354,11 @@ subpaths
 | string.swift:35:13:35:23 | ... .+(_:_:) ... | string.swift:28:17:28:25 | call to source2() :  | string.swift:35:13:35:23 | ... .+(_:_:) ... | result |
 | string.swift:36:13:36:23 | ... .+(_:_:) ... | string.swift:28:17:28:25 | call to source2() :  | string.swift:36:13:36:23 | ... .+(_:_:) ... | result |
 | string.swift:39:13:39:29 | ... .+(_:_:) ... | string.swift:28:17:28:25 | call to source2() :  | string.swift:39:13:39:29 | ... .+(_:_:) ... | result |
+| string.swift:85:13:85:21 | .description | string.swift:74:17:74:25 | call to source2() :  | string.swift:85:13:85:21 | .description | result |
+| string.swift:88:13:88:21 | .debugDescription | string.swift:74:17:74:25 | call to source2() :  | string.swift:88:13:88:21 | .debugDescription | result |
+| string.swift:102:13:102:13 | tainted | string.swift:97:17:97:25 | call to source2() :  | string.swift:102:13:102:13 | tainted | result |
+| string.swift:103:13:103:13 | taintedCString | string.swift:98:24:98:32 | call to source2() :  | string.swift:103:13:103:13 | taintedCString | result |
+| string.swift:104:13:104:13 | taintedUnicodeScalars | string.swift:99:31:99:39 | call to source2() :  | string.swift:104:13:104:13 | taintedUnicodeScalars | result |
 | subscript.swift:13:15:13:25 | ...[...] | subscript.swift:13:15:13:22 | call to source() :  | subscript.swift:13:15:13:25 | ...[...] | result |
 | subscript.swift:14:15:14:26 | ...[...] | subscript.swift:14:15:14:23 | call to source2() :  | subscript.swift:14:15:14:26 | ...[...] | result |
 | try.swift:9:13:9:24 | try ... | try.swift:9:17:9:24 | call to source() :  | try.swift:9:13:9:24 | try ... | result |

--- a/swift/ql/test/library-tests/dataflow/taint/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/TaintInline.expected
@@ -1,0 +1,2 @@
+| data.swift:85:12:85:12 | dataTainted | Fixed missing result:tainted=81 |
+| data.swift:86:12:86:12 | dataTainted2 | Fixed missing result:tainted=81 |

--- a/swift/ql/test/library-tests/dataflow/taint/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/string.swift
@@ -113,11 +113,14 @@ func taintThroughData() {
 }
 
 func sink(arg: String.UTF8View) {}
+func sink(arg: ContiguousArray<CChar>) {}
 
 func taintThroughStringFields() {
   let clean = ""
   let tainted = source2().utf8
+  let taintedCString = source2().utf8CString
 
   sink(arg: clean)
-  sink(arg: tainted) // $ tainted=95
+  sink(arg: tainted) // $ tainted=120
+  sink(arg: taintedCString) // $ tainted=121
 }

--- a/swift/ql/test/library-tests/dataflow/taint/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/string.swift
@@ -82,10 +82,10 @@ func taintThroughStringOperations() {
   sink(arg: String(repeating: tainted, count: 2)) // $ MISSING: tainted=74
 
   sink(arg: clean.description)
-  sink(arg: tainted.description) // $ MISSING: tainted=74
+  sink(arg: tainted.description) // $ tainted=74
 
   sink(arg: clean.debugDescription)
-  sink(arg: tainted.debugDescription) // $ MISSING: tainted=74
+  sink(arg: tainted.debugDescription) // $ tainted=74
 }
 
 class Data
@@ -110,4 +110,14 @@ func taintThroughData() {
 
 	sink(arg: stringClean!)
 	sink(arg: stringTainted!) // $ MISSING: tainted=100
+}
+
+func sink(arg: String.UTF8View) {}
+
+func taintThroughStringFields() {
+  let clean = ""
+  let tainted = source2().utf8
+
+  sink(arg: clean)
+  sink(arg: tainted) // $ tainted=95
 }

--- a/swift/ql/test/library-tests/dataflow/taint/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/string.swift
@@ -114,13 +114,16 @@ func taintThroughData() {
 
 func sink(arg: String.UTF8View) {}
 func sink(arg: ContiguousArray<CChar>) {}
+func sink(arg: String.UnicodeScalarView) {}
 
 func taintThroughStringFields() {
   let clean = ""
   let tainted = source2().utf8
   let taintedCString = source2().utf8CString
+  let taintedUnicodeScalars = source2().unicodeScalars
 
   sink(arg: clean)
-  sink(arg: tainted) // $ tainted=120
-  sink(arg: taintedCString) // $ tainted=121
+  sink(arg: tainted) // $ tainted=121
+  sink(arg: taintedCString) // $ tainted=122
+  sink(arg: taintedUnicodeScalars) // $ tainted=123
 }

--- a/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.expected
+++ b/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.expected
@@ -1,6 +1,7 @@
 edges
 | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  |
 | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  |
+| UnsafeWebViewFetch.swift:43:5:43:29 | [summary param] 0 in init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(_:) :  |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | UnsafeWebViewFetch.swift:120:25:120:39 | call to getRemoteData() |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  |
@@ -18,6 +19,7 @@ edges
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:137:25:137:25 | remoteString |
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:139:25:139:25 | remoteString |
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:141:25:141:25 | remoteString |
+| UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:150:24:150:37 | .utf8 :  |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:138:47:138:56 | ...! |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:139:48:139:57 | ...! |
@@ -29,6 +31,10 @@ edges
 | UnsafeWebViewFetch.swift:132:19:132:61 | call to init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:141:48:141:58 | ...! |
 | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  |
 | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  | UnsafeWebViewFetch.swift:132:19:132:61 | call to init(string:relativeTo:) :  |
+| UnsafeWebViewFetch.swift:150:19:150:41 | call to init(_:) :  | UnsafeWebViewFetch.swift:152:15:152:15 | remoteData |
+| UnsafeWebViewFetch.swift:150:19:150:41 | call to init(_:) :  | UnsafeWebViewFetch.swift:154:15:154:15 | remoteData |
+| UnsafeWebViewFetch.swift:150:24:150:37 | .utf8 :  | UnsafeWebViewFetch.swift:43:5:43:29 | [summary param] 0 in init(_:) :  |
+| UnsafeWebViewFetch.swift:150:24:150:37 | .utf8 :  | UnsafeWebViewFetch.swift:150:19:150:41 | call to init(_:) :  |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:168:25:168:25 | remoteString |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:171:25:171:51 | ... .+(_:_:) ... |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:174:25:174:25 | "..." |
@@ -37,6 +43,7 @@ edges
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:184:25:184:25 | remoteString |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:186:25:186:25 | remoteString |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:188:25:188:25 | remoteString |
+| UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:197:24:197:37 | .utf8 :  |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:185:47:185:56 | ...! |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  | UnsafeWebViewFetch.swift:186:48:186:57 | ...! |
@@ -48,11 +55,16 @@ edges
 | UnsafeWebViewFetch.swift:179:19:179:61 | call to init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:188:48:188:58 | ...! |
 | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  |
 | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  | UnsafeWebViewFetch.swift:179:19:179:61 | call to init(string:relativeTo:) :  |
+| UnsafeWebViewFetch.swift:197:19:197:41 | call to init(_:) :  | UnsafeWebViewFetch.swift:199:15:199:15 | remoteData |
+| UnsafeWebViewFetch.swift:197:19:197:41 | call to init(_:) :  | UnsafeWebViewFetch.swift:201:15:201:15 | remoteData |
+| UnsafeWebViewFetch.swift:197:24:197:37 | .utf8 :  | UnsafeWebViewFetch.swift:43:5:43:29 | [summary param] 0 in init(_:) :  |
+| UnsafeWebViewFetch.swift:197:24:197:37 | .utf8 :  | UnsafeWebViewFetch.swift:197:19:197:41 | call to init(_:) :  |
 | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:210:25:210:25 | htmlData |
 | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() :  | UnsafeWebViewFetch.swift:211:25:211:25 | htmlData |
 nodes
 | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  | semmle.label | [summary param] 0 in init(string:) :  |
 | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  | semmle.label | [summary param] 1 in init(string:relativeTo:) :  |
+| UnsafeWebViewFetch.swift:43:5:43:29 | [summary param] 0 in init(_:) :  | semmle.label | [summary param] 0 in init(_:) :  |
 | UnsafeWebViewFetch.swift:94:10:94:37 | try ... :  | semmle.label | try ... :  |
 | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | semmle.label | call to init(contentsOf:) :  |
 | UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | semmle.label | try! ... |
@@ -78,7 +90,11 @@ nodes
 | UnsafeWebViewFetch.swift:140:47:140:57 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:141:25:141:25 | remoteString | semmle.label | remoteString |
 | UnsafeWebViewFetch.swift:141:48:141:58 | ...! | semmle.label | ...! |
+| UnsafeWebViewFetch.swift:150:19:150:41 | call to init(_:) :  | semmle.label | call to init(_:) :  |
+| UnsafeWebViewFetch.swift:150:24:150:37 | .utf8 :  | semmle.label | .utf8 :  |
+| UnsafeWebViewFetch.swift:152:15:152:15 | remoteData | semmle.label | remoteData |
 | UnsafeWebViewFetch.swift:153:85:153:94 | ...! | semmle.label | ...! |
+| UnsafeWebViewFetch.swift:154:15:154:15 | remoteData | semmle.label | remoteData |
 | UnsafeWebViewFetch.swift:154:86:154:95 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() :  | semmle.label | call to getRemoteData() :  |
 | UnsafeWebViewFetch.swift:167:25:167:39 | call to getRemoteData() | semmle.label | call to getRemoteData() |
@@ -97,18 +113,25 @@ nodes
 | UnsafeWebViewFetch.swift:187:47:187:57 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:188:25:188:25 | remoteString | semmle.label | remoteString |
 | UnsafeWebViewFetch.swift:188:48:188:58 | ...! | semmle.label | ...! |
+| UnsafeWebViewFetch.swift:197:19:197:41 | call to init(_:) :  | semmle.label | call to init(_:) :  |
+| UnsafeWebViewFetch.swift:197:24:197:37 | .utf8 :  | semmle.label | .utf8 :  |
+| UnsafeWebViewFetch.swift:199:15:199:15 | remoteData | semmle.label | remoteData |
 | UnsafeWebViewFetch.swift:200:90:200:99 | ...! | semmle.label | ...! |
+| UnsafeWebViewFetch.swift:201:15:201:15 | remoteData | semmle.label | remoteData |
 | UnsafeWebViewFetch.swift:201:91:201:100 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() :  | semmle.label | call to getRemoteData() :  |
 | UnsafeWebViewFetch.swift:210:25:210:25 | htmlData | semmle.label | htmlData |
 | UnsafeWebViewFetch.swift:211:25:211:25 | htmlData | semmle.label | htmlData |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(_:) :  | semmle.label | [summary] to write: return (return) in init(_:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | semmle.label | [summary] to write: return (return) in init(string:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 subpaths
 | UnsafeWebViewFetch.swift:131:30:131:30 | remoteString :  | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | UnsafeWebViewFetch.swift:131:18:131:42 | call to init(string:) :  |
 | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:132:19:132:61 | call to init(string:relativeTo:) :  |
+| UnsafeWebViewFetch.swift:150:24:150:37 | .utf8 :  | UnsafeWebViewFetch.swift:43:5:43:29 | [summary param] 0 in init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(_:) :  | UnsafeWebViewFetch.swift:150:19:150:41 | call to init(_:) :  |
 | UnsafeWebViewFetch.swift:178:30:178:30 | remoteString :  | UnsafeWebViewFetch.swift:10:2:10:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | UnsafeWebViewFetch.swift:178:18:178:42 | call to init(string:) :  |
 | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL :  | UnsafeWebViewFetch.swift:11:2:11:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | UnsafeWebViewFetch.swift:179:19:179:61 | call to init(string:relativeTo:) :  |
+| UnsafeWebViewFetch.swift:197:24:197:37 | .utf8 :  | UnsafeWebViewFetch.swift:43:5:43:29 | [summary param] 0 in init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(_:) :  | UnsafeWebViewFetch.swift:197:19:197:41 | call to init(_:) :  |
 #select
 | UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | UnsafeWebViewFetch.swift:103:30:103:84 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:103:25:103:84 | try! ... | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:106:25:106:25 | data | UnsafeWebViewFetch.swift:105:18:105:72 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:106:25:106:25 | data | Tainted data is used in a WebView fetch without restricting the base URL. |
@@ -119,10 +142,12 @@ subpaths
 | UnsafeWebViewFetch.swift:127:25:127:25 | "..." | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:127:25:127:25 | "..." | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:139:25:139:25 | remoteString | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:139:25:139:25 | remoteString | Tainted data is used in a WebView fetch with a tainted base URL. |
 | UnsafeWebViewFetch.swift:141:25:141:25 | remoteString | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:141:25:141:25 | remoteString | Tainted data is used in a WebView fetch with a tainted base URL. |
+| UnsafeWebViewFetch.swift:154:15:154:15 | remoteData | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:154:15:154:15 | remoteData | Tainted data is used in a WebView fetch with a tainted base URL. |
 | UnsafeWebViewFetch.swift:167:25:167:39 | call to getRemoteData() | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:167:25:167:39 | call to getRemoteData() | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:168:25:168:25 | remoteString | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:168:25:168:25 | remoteString | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:171:25:171:51 | ... .+(_:_:) ... | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:171:25:171:51 | ... .+(_:_:) ... | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:174:25:174:25 | "..." | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:174:25:174:25 | "..." | Tainted data is used in a WebView fetch without restricting the base URL. |
 | UnsafeWebViewFetch.swift:186:25:186:25 | remoteString | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:186:25:186:25 | remoteString | Tainted data is used in a WebView fetch with a tainted base URL. |
 | UnsafeWebViewFetch.swift:188:25:188:25 | remoteString | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:188:25:188:25 | remoteString | Tainted data is used in a WebView fetch with a tainted base URL. |
+| UnsafeWebViewFetch.swift:201:15:201:15 | remoteData | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:201:15:201:15 | remoteData | Tainted data is used in a WebView fetch with a tainted base URL. |
 | UnsafeWebViewFetch.swift:210:25:210:25 | htmlData | UnsafeWebViewFetch.swift:94:14:94:37 | call to init(contentsOf:) :  | UnsafeWebViewFetch.swift:210:25:210:25 | htmlData | Tainted data is used in a WebView fetch without restricting the base URL. |

--- a/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.swift
+++ b/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.swift
@@ -151,7 +151,7 @@ func testUIWebView() {
 	webview.load(localData, mimeType: "text/html", textEncodingName: "utf-8", baseURL: localSafeURL!) // GOOD: the data is local
 	webview.load(remoteData, mimeType: "text/html", textEncodingName: "utf-8", baseURL: localSafeURL!) // GOOD: a safe baseURL is specified
 	webview.load(localData, mimeType: "text/html", textEncodingName: "utf-8", baseURL: remoteURL!) // GOOD: the HTML data is local
-	webview.load(remoteData, mimeType: "text/html", textEncodingName: "utf-8", baseURL: remoteURL!) // BAD [NOT DETECTED]
+	webview.load(remoteData, mimeType: "text/html", textEncodingName: "utf-8", baseURL: remoteURL!) // BAD
 }
 
 func testWKWebView() {
@@ -198,7 +198,7 @@ func testWKWebView() {
 	webview.load(localData, mimeType: "text/html", characterEncodingName: "utf-8", baseURL: localSafeURL!) // GOOD: the data is local
 	webview.load(remoteData, mimeType: "text/html", characterEncodingName: "utf-8", baseURL: localSafeURL!) // GOOD: a safe baseURL is specified
 	webview.load(localData, mimeType: "text/html", characterEncodingName: "utf-8", baseURL: remoteURL!) // GOOD: the HTML data is local
-	webview.load(remoteData, mimeType: "text/html", characterEncodingName: "utf-8", baseURL: remoteURL!) // BAD [NOT DETECTED]
+	webview.load(remoteData, mimeType: "text/html", characterEncodingName: "utf-8", baseURL: remoteURL!) // BAD
 }
 
 func testQHelpExamples() {


### PR DESCRIPTION
If a `String` is tainted, then all its fields should be tainted including computed properties such as `utf8`. This support follows a similar solution to what we do with [URLs](https://github.com/github/codeql/pull/10774) using `TaintInheritingContent`.