### PR TITLE
Java: Improve sink model generation precision by excluding variable capture.

### DIFF
--- a/csharp/ql/src/utils/model-generator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/model-generator/internal/CaptureModels.qll
@@ -272,6 +272,8 @@ private class PropagateToSinkConfiguration extends TaintTracking::Configuration 
 
   override predicate isSink(DataFlow::Node sink) { ExternalFlow::sinkNode(sink, _) }
 
+  override predicate isSanitizer(DataFlow::Node node) { sinkModelSanitizer(node) }
+
   override DataFlow::FlowFeature getAFeature() {
     result instanceof DataFlow::FeatureHasSourceCallContext
   }

--- a/csharp/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
@@ -175,6 +175,8 @@ private predicate isRelevantMemberAccess(DataFlow::Node node) {
   )
 }
 
+predicate sinkModelSanitizer(DataFlow::Node node) { none() }
+
 /**
  * Holds if `source` is an api entrypoint relevant for creating sink models.
  */

--- a/java/ql/src/utils/model-generator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/model-generator/internal/CaptureModels.qll
@@ -272,6 +272,8 @@ private class PropagateToSinkConfiguration extends TaintTracking::Configuration 
 
   override predicate isSink(DataFlow::Node sink) { ExternalFlow::sinkNode(sink, _) }
 
+  override predicate isSanitizer(DataFlow::Node node) { sinkModelSanitizer(node) }
+
   override DataFlow::FlowFeature getAFeature() {
     result instanceof DataFlow::FeatureHasSourceCallContext
   }

--- a/java/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
@@ -7,6 +7,7 @@ private import semmle.code.java.dataflow.internal.DataFlowNodes
 private import semmle.code.java.dataflow.internal.DataFlowPrivate
 private import semmle.code.java.dataflow.internal.ContainerFlow as ContainerFlow
 private import semmle.code.java.dataflow.DataFlow as Df
+private import semmle.code.java.dataflow.SSA as Ssa
 private import semmle.code.java.dataflow.TaintTracking as Tt
 import semmle.code.java.dataflow.ExternalFlow as ExternalFlow
 import semmle.code.java.dataflow.internal.DataFlowImplCommon as DataFlowImplCommon
@@ -222,6 +223,14 @@ J::Callable returnNodeEnclosingCallable(DataFlowImplCommon::ReturnNodeExt ret) {
  */
 predicate isOwnInstanceAccessNode(ReturnNode node) {
   node.asExpr().(J::ThisAccess).isOwnInstanceAccess()
+}
+
+predicate sinkModelSanitizer(DataFlow::Node node) {
+  // exclude variable capture jump steps
+  exists(Ssa::SsaImplicitInit closure |
+    closure.captures(_) and
+    node.asExpr() = closure.getAFirstUse()
+  )
 }
 
 /**


### PR DESCRIPTION
Variable-capture-as-jump-steps discards the call context, which is crucial to sink model generation precision.