### PR TITLE
RB: add join(" ") calls as a sink for rb/shell-command-constructed-from-input

### DIFF
--- a/ruby/ql/test/query-tests/security/cwe-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
@@ -9,6 +9,8 @@ edges
 | impl/unsafeShell.rb:33:12:33:17 | target :  | impl/unsafeShell.rb:34:19:34:27 | #{...} |
 | impl/unsafeShell.rb:37:10:37:10 | x :  | impl/unsafeShell.rb:38:19:38:22 | #{...} |
 | impl/unsafeShell.rb:47:16:47:21 | target :  | impl/unsafeShell.rb:48:19:48:27 | #{...} |
+| impl/unsafeShell.rb:51:17:51:17 | x :  | impl/unsafeShell.rb:52:14:52:14 | x |
+| impl/unsafeShell.rb:51:17:51:17 | x :  | impl/unsafeShell.rb:54:29:54:29 | x |
 nodes
 | impl/sub/notImported.rb:2:12:2:17 | target :  | semmle.label | target :  |
 | impl/sub/notImported.rb:3:19:3:27 | #{...} | semmle.label | #{...} |
@@ -30,6 +32,9 @@ nodes
 | impl/unsafeShell.rb:38:19:38:22 | #{...} | semmle.label | #{...} |
 | impl/unsafeShell.rb:47:16:47:21 | target :  | semmle.label | target :  |
 | impl/unsafeShell.rb:48:19:48:27 | #{...} | semmle.label | #{...} |
+| impl/unsafeShell.rb:51:17:51:17 | x :  | semmle.label | x :  |
+| impl/unsafeShell.rb:52:14:52:14 | x | semmle.label | x |
+| impl/unsafeShell.rb:54:29:54:29 | x | semmle.label | x |
 subpaths
 #select
 | impl/sub/notImported.rb:3:14:3:28 | "cat #{...}" | impl/sub/notImported.rb:2:12:2:17 | target :  | impl/sub/notImported.rb:3:19:3:27 | #{...} | This string construction which depends on $@ is later used in a $@. | impl/sub/notImported.rb:2:12:2:17 | target | library input | impl/sub/notImported.rb:3:5:3:34 | call to popen | shell command |
@@ -42,3 +47,5 @@ subpaths
 | impl/unsafeShell.rb:34:14:34:28 | "cat #{...}" | impl/unsafeShell.rb:33:12:33:17 | target :  | impl/unsafeShell.rb:34:19:34:27 | #{...} | This string construction which depends on $@ is later used in a $@. | impl/unsafeShell.rb:33:12:33:17 | target | library input | impl/unsafeShell.rb:34:5:34:34 | call to popen | shell command |
 | impl/unsafeShell.rb:38:14:38:23 | "cat #{...}" | impl/unsafeShell.rb:37:10:37:10 | x :  | impl/unsafeShell.rb:38:19:38:22 | #{...} | This string construction which depends on $@ is later used in a $@. | impl/unsafeShell.rb:37:10:37:10 | x | library input | impl/unsafeShell.rb:38:5:38:29 | call to popen | shell command |
 | impl/unsafeShell.rb:48:14:48:28 | "cat #{...}" | impl/unsafeShell.rb:47:16:47:21 | target :  | impl/unsafeShell.rb:48:19:48:27 | #{...} | This string construction which depends on $@ is later used in a $@. | impl/unsafeShell.rb:47:16:47:21 | target | library input | impl/unsafeShell.rb:48:5:48:34 | call to popen | shell command |
+| impl/unsafeShell.rb:52:14:52:24 | call to join | impl/unsafeShell.rb:51:17:51:17 | x :  | impl/unsafeShell.rb:52:14:52:14 | x | This array which depends on $@ is later used in a $@. | impl/unsafeShell.rb:51:17:51:17 | x | library input | impl/unsafeShell.rb:52:5:52:30 | call to popen | shell command |
+| impl/unsafeShell.rb:54:14:54:40 | call to join | impl/unsafeShell.rb:51:17:51:17 | x :  | impl/unsafeShell.rb:54:29:54:29 | x | This array which depends on $@ is later used in a $@. | impl/unsafeShell.rb:51:17:51:17 | x | library input | impl/unsafeShell.rb:54:5:54:46 | call to popen | shell command |

--- a/ruby/ql/test/query-tests/security/cwe-078/UnsafeShellCommandConstruction/impl/unsafeShell.rb
+++ b/ruby/ql/test/query-tests/security/cwe-078/UnsafeShellCommandConstruction/impl/unsafeShell.rb
@@ -47,4 +47,10 @@ class Foobar2
   def self.foo(target)
     IO.popen("cat #{target}", "w") # NOT OK
   end
+
+  def arrayJoin(x)
+    IO.popen(x.join(' '), "w") # NOT OK
+
+    IO.popen(["foo", "bar", x].join(' '), "w") # NOT OK
+  end
 end


### PR DESCRIPTION
Inspired by CVE-2021-33473 (recognizes a sink there). 

[Evaluation looks OK](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11191-0-ruby__2/reports).  
There is one new result, which looks benign (and there was already an alert on the line below). 