### PR TITLE
Swift: avoid wrongly using `doc` instead of `desc` for properties

### DIFF
--- a/swift/codegen/lib/schema/defs.py
+++ b/swift/codegen/lib/schema/defs.py
@@ -16,6 +16,8 @@ class _DocModifier(_schema.PropertyModifier):
     doc: str
 
     def modify(self, prop: _schema.Property):
+        if "\n" in self.doc or self.doc[-1] == ".":
+            raise _schema.Error("No newlines or trailing dots are allowed in doc, did you intend to use desc?")
         prop.doc = self.doc
 
 

--- a/swift/codegen/test/test_schema.py
+++ b/swift/codegen/test/test_schema.py
@@ -559,6 +559,22 @@ def test_property_doc_override():
     }
 
 
+def test_property_doc_override_no_newlines():
+    with pytest.raises(schema.Error):
+        @schema.load
+        class data:
+            class A:
+                x: int | defs.doc("no multiple\nlines")
+
+
+def test_property_doc_override_no_trailing_dot():
+    with pytest.raises(schema.Error):
+        @schema.load
+        class data:
+            class A:
+                x: int | defs.doc("no dots please.")
+
+
 def test_class_default_doc_name():
     @schema.load
     class data:


### PR DESCRIPTION
This is to avoid problems like [this one](https://github.com/github/codeql/pull/11190#discussion_r1018122475).