### PR TITLE
C++: Simplify dataflow taint test query

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
@@ -95,16 +95,7 @@ module IRTest {
     override predicate isSink(DataFlow::Node sink) {
       exists(FunctionCall call |
         call.getTarget().getName() = "sink" and
-        sink.asConvertedExpr() = call.getAnArgument()
-        or
-        call.getTarget().getName() = "sink" and
-        sink.asExpr() = call.getAnArgument() and
-        sink.asConvertedExpr() instanceof ReferenceDereferenceExpr
-      )
-      or
-      exists(ReadSideEffectInstruction read |
-        read.getSideEffectOperand() = sink.asOperand() and
-        read.getPrimaryInstruction().(CallInstruction).getStaticCallTarget().hasName("sink")
+        sink.asExpr() = call.getAnArgument()
       )
     }
 


### PR DESCRIPTION
The complexity seems a left-over from before these tests were turned into inline expectation tests, where the aim seems to have been to have exactly one sink node for each `sink` call. Multiple sink nodes for the same `sink` call are not made visible in the inline expecation tests, and I am not conviced this was very useful before, so remove the complexity.