### PR TITLE
Ruby: Fix SSA entry definitions for `self` in top-level

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -30,7 +30,8 @@ private module SsaInput implements SsaImplCommon::InputSig {
         i = 0
         or
         // ...or a class or module block.
-        bb.getNode(i).getNode() = scope.(ModuleBase).getAControlFlowEntryNode()
+        bb.getNode(i).getNode() = scope.(ModuleBase).getAControlFlowEntryNode() and
+        not scope instanceof Toplevel // handled by case above
       )
       or
       uninitializedWrite(bb, i, v)

--- a/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
@@ -1,6 +1,6 @@
 | local_dataflow.rb:1:1:7:3 | self (foo) | local_dataflow.rb:3:8:3:10 | self |
-| local_dataflow.rb:1:1:7:3 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:1:7:3 | self in foo | local_dataflow.rb:1:1:7:3 | self (foo) |
+| local_dataflow.rb:1:1:124:4 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:1:9:1:9 | a |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:2:7:2:7 | a |
 | local_dataflow.rb:2:3:2:7 | ... = ... | local_dataflow.rb:3:13:3:13 | b |

--- a/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
@@ -49,8 +49,8 @@
 | file://:0:0:0:0 | parameter self of activesupport;;Member[ActionView].Member[SafeBuffer].Instance.Method[concat,insert,prepend,to_s,to_param] | file://:0:0:0:0 | [summary] to write: return (return) in activesupport;;Member[ActionView].Member[SafeBuffer].Instance.Method[concat,insert,prepend,to_s,to_param] |
 | file://:0:0:0:0 | parameter self of each(0) | file://:0:0:0:0 | [summary] read: argument self.any element in each(0) |
 | local_dataflow.rb:1:1:7:3 | self (foo) | local_dataflow.rb:3:8:3:10 | self |
-| local_dataflow.rb:1:1:7:3 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:1:7:3 | self in foo | local_dataflow.rb:1:1:7:3 | self (foo) |
+| local_dataflow.rb:1:1:124:4 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:1:9:1:9 | a |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:2:7:2:7 | a |
 | local_dataflow.rb:2:3:2:7 | ... = ... | local_dataflow.rb:3:13:3:13 | b |

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -1,10 +1,10 @@
 track
 | type_tracker.rb:1:1:10:3 | self (Container) | type tracker without call steps | type_tracker.rb:1:1:10:3 | self (Container) |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:18:1:21:3 | self (positional) |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:18:1:21:3 | self in positional |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:25:1:28:3 | self (keyword) |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:25:1:28:3 | self in keyword |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type tracker without call steps | type_tracker.rb:1:1:10:3 | self (type_tracker.rb) |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:18:1:21:3 | self (positional) |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:18:1:21:3 | self in positional |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:25:1:28:3 | self (keyword) |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:25:1:28:3 | self in keyword |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker without call steps | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) |
 | type_tracker.rb:2:5:5:7 | &block | type tracker without call steps | type_tracker.rb:2:5:5:7 | &block |
 | type_tracker.rb:2:5:5:7 | field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | field= |
 | type_tracker.rb:2:5:5:7 | return return in field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | return return in field= |
@@ -358,19 +358,19 @@ track
 | type_tracker.rb:52:5:52:13 | ...[...] | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
 trackEnd
 | type_tracker.rb:1:1:10:3 | self (Container) | type_tracker.rb:1:1:10:3 | self (Container) |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:1:1:10:3 | self (type_tracker.rb) |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:18:1:21:3 | self (positional) |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:18:1:21:3 | self in positional |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:19:5:19:11 | self |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:20:5:20:11 | self |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:23:1:23:16 | self |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:25:1:28:3 | self (keyword) |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:25:1:28:3 | self in keyword |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:26:5:26:11 | self |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:27:5:27:11 | self |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:30:1:30:21 | self |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:31:1:31:21 | self |
-| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:32:1:32:27 | self |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:18:1:21:3 | self (positional) |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:18:1:21:3 | self in positional |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:19:5:19:11 | self |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:20:5:20:11 | self |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:23:1:23:16 | self |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:25:1:28:3 | self (keyword) |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:25:1:28:3 | self in keyword |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:26:5:26:11 | self |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:27:5:27:11 | self |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:30:1:30:21 | self |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:31:1:31:21 | self |
+| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:32:1:32:27 | self |
 | type_tracker.rb:2:5:5:7 | &block | type_tracker.rb:2:5:5:7 | &block |
 | type_tracker.rb:2:5:5:7 | field= | type_tracker.rb:2:5:5:7 | field= |
 | type_tracker.rb:2:5:5:7 | return return in field= | type_tracker.rb:2:5:5:7 | return return in field= |

--- a/ruby/ql/test/library-tests/variables/ssa.expected
+++ b/ruby/ql/test/library-tests/variables/ssa.expected
@@ -1,5 +1,5 @@
 definition
-| class_variables.rb:1:1:1:3 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self |
+| class_variables.rb:1:1:29:4 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self |
 | class_variables.rb:5:1:7:3 | self (print) | class_variables.rb:5:1:7:3 | self |
 | class_variables.rb:9:1:16:3 | self (X) | class_variables.rb:9:1:16:3 | self |
 | class_variables.rb:10:3:12:5 | self (b) | class_variables.rb:10:3:12:5 | self |
@@ -7,7 +7,6 @@ definition
 | class_variables.rb:18:1:20:3 | self (Y) | class_variables.rb:18:1:20:3 | self |
 | class_variables.rb:22:1:24:3 | self (M) | class_variables.rb:22:1:24:3 | self |
 | class_variables.rb:26:1:29:3 | self (N) | class_variables.rb:26:1:29:3 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self |
 | instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self |
 | instance_variables.rb:3:1:5:3 | self (foo) | instance_variables.rb:3:1:5:3 | self |
 | instance_variables.rb:7:1:9:3 | self (print_foo) | instance_variables.rb:7:1:9:3 | self |
@@ -42,7 +41,7 @@ definition
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self |
 | nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a |
 | nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d |
-| parameters.rb:1:1:1:1 | self (parameters.rb) | parameters.rb:1:1:62:1 | self |
+| parameters.rb:1:1:62:1 | self (parameters.rb) | parameters.rb:1:1:62:1 | self |
 | parameters.rb:1:9:5:3 | <captured> self | parameters.rb:1:1:62:1 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x |
 | parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y |
@@ -87,7 +86,7 @@ definition
 | parameters.rb:59:20:59:20 | a | parameters.rb:59:20:59:20 | a |
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c |
-| scopes.rb:1:1:1:15 | self (scopes.rb) | scopes.rb:1:1:49:4 | self |
+| scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self |
 | scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self |
 | scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a |
 | scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a |
@@ -166,17 +165,17 @@ definition
 | ssa.rb:84:10:86:8 | <captured> captured | ssa.rb:82:3:82:10 | captured |
 | ssa.rb:84:10:86:8 | <captured> self | ssa.rb:81:1:88:3 | self |
 read
-| class_variables.rb:1:1:1:3 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
+| class_variables.rb:1:1:29:4 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
 | class_variables.rb:5:1:7:3 | self (print) | class_variables.rb:5:1:7:3 | self | class_variables.rb:6:2:6:6 | self |
 | class_variables.rb:9:1:16:3 | self (X) | class_variables.rb:9:1:16:3 | self | class_variables.rb:13:7:13:10 | self |
 | class_variables.rb:10:3:12:5 | self (b) | class_variables.rb:10:3:12:5 | self | class_variables.rb:11:5:11:9 | self |
 | class_variables.rb:13:3:15:5 | self (s) | class_variables.rb:13:3:15:5 | self | class_variables.rb:14:4:14:8 | self |
 | class_variables.rb:26:1:29:3 | self (N) | class_variables.rb:26:1:29:3 | self | class_variables.rb:27:3:27:11 | self |
 | class_variables.rb:26:1:29:3 | self (N) | class_variables.rb:26:1:29:3 | self | class_variables.rb:28:3:28:7 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:1:11:9 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:6:11:9 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:27:1:29:1 | self |
 | instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:1:1:1:4 | self |
+| instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:1:11:9 | self |
+| instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:6:11:9 | self |
+| instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:27:1:29:1 | self |
 | instance_variables.rb:3:1:5:3 | self (foo) | instance_variables.rb:3:1:5:3 | self | instance_variables.rb:4:3:4:6 | self |
 | instance_variables.rb:7:1:9:3 | self (print_foo) | instance_variables.rb:7:1:9:3 | self | instance_variables.rb:8:3:8:11 | self |
 | instance_variables.rb:7:1:9:3 | self (print_foo) | instance_variables.rb:7:1:9:3 | self | instance_variables.rb:8:8:8:11 | self |
@@ -259,7 +258,7 @@ read
 | parameters.rb:59:20:59:20 | a | parameters.rb:59:20:59:20 | a | parameters.rb:60:11:60:11 | a |
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b | parameters.rb:60:16:60:16 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
-| scopes.rb:1:1:1:15 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
+| scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
 | scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self |
 | scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:9:3:9 | self |
 | scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:5:4:5:9 | self |
@@ -349,13 +348,12 @@ read
 | ssa.rb:84:10:86:8 | <captured> captured | ssa.rb:82:3:82:10 | captured | ssa.rb:85:15:85:22 | captured |
 | ssa.rb:84:10:86:8 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
 firstRead
-| class_variables.rb:1:1:1:3 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
+| class_variables.rb:1:1:29:4 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
 | class_variables.rb:5:1:7:3 | self (print) | class_variables.rb:5:1:7:3 | self | class_variables.rb:6:2:6:6 | self |
 | class_variables.rb:9:1:16:3 | self (X) | class_variables.rb:9:1:16:3 | self | class_variables.rb:13:7:13:10 | self |
 | class_variables.rb:10:3:12:5 | self (b) | class_variables.rb:10:3:12:5 | self | class_variables.rb:11:5:11:9 | self |
 | class_variables.rb:13:3:15:5 | self (s) | class_variables.rb:13:3:15:5 | self | class_variables.rb:14:4:14:8 | self |
 | class_variables.rb:26:1:29:3 | self (N) | class_variables.rb:26:1:29:3 | self | class_variables.rb:27:3:27:11 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:1:11:9 | self |
 | instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:1:1:1:4 | self |
 | instance_variables.rb:3:1:5:3 | self (foo) | instance_variables.rb:3:1:5:3 | self | instance_variables.rb:4:3:4:6 | self |
 | instance_variables.rb:7:1:9:3 | self (print_foo) | instance_variables.rb:7:1:9:3 | self | instance_variables.rb:8:3:8:11 | self |
@@ -428,7 +426,7 @@ firstRead
 | parameters.rb:59:20:59:20 | a | parameters.rb:59:20:59:20 | a | parameters.rb:60:11:60:11 | a |
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b | parameters.rb:60:16:60:16 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
-| scopes.rb:1:1:1:15 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
+| scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
 | scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self |
 | scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
 | scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
@@ -488,15 +486,13 @@ firstRead
 | ssa.rb:84:10:86:8 | <captured> captured | ssa.rb:82:3:82:10 | captured | ssa.rb:85:15:85:22 | captured |
 | ssa.rb:84:10:86:8 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
 lastRead
-| class_variables.rb:1:1:1:3 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
+| class_variables.rb:1:1:29:4 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
 | class_variables.rb:5:1:7:3 | self (print) | class_variables.rb:5:1:7:3 | self | class_variables.rb:6:2:6:6 | self |
 | class_variables.rb:9:1:16:3 | self (X) | class_variables.rb:9:1:16:3 | self | class_variables.rb:13:7:13:10 | self |
 | class_variables.rb:10:3:12:5 | self (b) | class_variables.rb:10:3:12:5 | self | class_variables.rb:11:5:11:9 | self |
 | class_variables.rb:13:3:15:5 | self (s) | class_variables.rb:13:3:15:5 | self | class_variables.rb:14:4:14:8 | self |
 | class_variables.rb:26:1:29:3 | self (N) | class_variables.rb:26:1:29:3 | self | class_variables.rb:28:3:28:7 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:1:1:1:4 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:27:1:29:1 | self |
-| instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:1:1:1:4 | self |
+| instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:27:1:29:1 | self |
 | instance_variables.rb:3:1:5:3 | self (foo) | instance_variables.rb:3:1:5:3 | self | instance_variables.rb:4:3:4:6 | self |
 | instance_variables.rb:7:1:9:3 | self (print_foo) | instance_variables.rb:7:1:9:3 | self | instance_variables.rb:8:8:8:11 | self |
 | instance_variables.rb:13:1:18:3 | self (X) | instance_variables.rb:13:1:18:3 | self | instance_variables.rb:14:3:14:4 | self |
@@ -568,7 +564,7 @@ lastRead
 | parameters.rb:59:20:59:20 | a | parameters.rb:59:20:59:20 | a | parameters.rb:60:11:60:11 | a |
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b | parameters.rb:60:16:60:16 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
-| scopes.rb:1:1:1:15 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
+| scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
 | scopes.rb:2:9:6:3 | <captured> self | scopes.rb:1:1:49:4 | self | scopes.rb:5:4:5:9 | self |
 | scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
 | scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
@@ -630,9 +626,9 @@ lastRead
 | ssa.rb:84:10:86:8 | <captured> self | ssa.rb:81:1:88:3 | self | ssa.rb:85:10:85:22 | self |
 adjacentReads
 | class_variables.rb:26:1:29:3 | self (N) | class_variables.rb:26:1:29:3 | self | class_variables.rb:27:3:27:11 | self | class_variables.rb:28:3:28:7 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:1:1:1:4 | self | instance_variables.rb:11:1:11:9 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:1:11:9 | self | instance_variables.rb:11:6:11:9 | self |
-| instance_variables.rb:1:1:1:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:6:11:9 | self | instance_variables.rb:27:1:29:1 | self |
+| instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:1:1:1:4 | self | instance_variables.rb:11:1:11:9 | self |
+| instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:1:11:9 | self | instance_variables.rb:11:6:11:9 | self |
+| instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:11:6:11:9 | self | instance_variables.rb:27:1:29:1 | self |
 | instance_variables.rb:7:1:9:3 | self (print_foo) | instance_variables.rb:7:1:9:3 | self | instance_variables.rb:8:3:8:11 | self | instance_variables.rb:8:8:8:11 | self |
 | instance_variables.rb:37:3:43:5 | self (x) | instance_variables.rb:37:3:43:5 | self | instance_variables.rb:41:4:41:4 | self | instance_variables.rb:42:4:42:7 | self |
 | instance_variables.rb:37:3:43:5 | self (x) | instance_variables.rb:37:3:43:5 | self | instance_variables.rb:42:4:42:7 | self | instance_variables.rb:42:6:42:7 | self |


### PR DESCRIPTION
We were incorrectly generating two write definitions (at index 0 and 1 in the entry basic block); now we only generate one (at index 0).