### PR TITLE
CI: remove langauge specific format checks

### DIFF
--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           channel: 'release'
       - name: check formatting
-        run: codeql query format */ql/{src,lib,test}/**/*.{qll,ql} --check-only
+        run: codeql query format */ql/**/*.{qll,ql} --check-only
       - name: compile queries - check-only
         # run with --check-only if running in a PR (github.sha != main)
         if : ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/js-ml-tests.yml
+++ b/.github/workflows/js-ml-tests.yml
@@ -23,19 +23,6 @@ defaults:
     working-directory: javascript/ql/experimental/adaptivethreatmodeling
 
 jobs:
-  qlformat:
-    name: Check QL formatting
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/actions/fetch-codeql
-
-      - name: Check QL formatting
-        run: |
-          find . "(" -name "*.ql" -or -name "*.qll" ")" -print0 | \
-            xargs -0 codeql query format --check-only
-
   qlcompile:
     name: Check QL compilation
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby-qltest.yml
+++ b/.github/workflows/ruby-qltest.yml
@@ -28,13 +28,6 @@ defaults:
     working-directory: ruby
 
 jobs:
-  qlformat:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/fetch-codeql
-      - name: Check QL formatting
-        run: find ql "(" -name "*.ql" -or -name "*.qll" ")" -print0 | xargs -0 codeql query format --check-only
   qlcompile:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -112,12 +112,3 @@ jobs:
         with:
           name: swift-generated-cpp-files
           path: swift/generated-cpp-files/**
-  qlformat:
-    runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.ql == 'true' }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/fetch-codeql
-      - name: Check QL formatting
-        run: find swift/ql "(" -name "*.ql" -or -name "*.qll" ")" -print0 | xargs -0 codeql query format --check-only


### PR DESCRIPTION
We now have [this format check](https://github.com/github/codeql/blob/main/.github/workflows/compile-queries.yml#L49) which checks all the languages all the time, so there's no need for language specific format checks. 