### PR TITLE
CI: use `find` in the format check to fix it

### DIFF
--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           channel: 'release'
       - name: check formatting
-        run: codeql query format */ql/**/*.{qll,ql} --check-only
+        run: find */ql -type f \( -name "*.qll" -o -name "*.ql" \) -print0 | xargs -0 codeql query format --check-only
       - name: compile queries - check-only
         # run with --check-only if running in a PR (github.sha != main)
         if : ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
The previous approach worked on my local machine, but apparently that didn't translate to the cloud.  
So now I'm using the `find` command instead, which checks formatting on all files.  

For some reason the previous approach skipped a lot of files, and I'm not sure why. 