### PR TITLE
C++: Recognize `basic_string::iterator` as an iterator

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdString.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdString.qll
@@ -16,6 +16,15 @@ private class StdBasicString extends ClassTemplateInstantiation {
 }
 
 /**
+ * The `std::basic_string::iterator` declaration.
+ */
+private class StdBasicStringIterator extends Iterator, Type {
+  StdBasicStringIterator() {
+    this.getEnclosingElement() instanceof StdBasicString and this.hasName("iterator")
+  }
+}
+
+/**
  * A `std::string` function for which taint should be propagated.
  */
 abstract private class StdStringTaintFunction extends TaintFunction {


### PR DESCRIPTION
Follow-up to https://github.com/github/codeql/pull/11212. I played around a bit in that PR with:
```codeql
int getAnIteratorParameterIndex() { this.getParameter(result).getType() instanceof Iterator }
```
and
```codeql
int getAnIteratorParameterIndex() { this.getParameter(result).getUnspecifiedType() instanceof Iterator }
```
I eventually went for the first, but never tested that on the use-use dataflow feature branch. Turns out that doesn't work, as the iterator is typedef'ed in `basic_string` in out taint tests. So, we either need `getUnspecifiedType` or make sure the typedef is recoginzed as an iterator. The latter seems safer, as the C++ standard does not guarantee that `basic_string::iterator` needs to be a typedef.