### PR TITLE
Kotlin: Add total number of diagnostics to telemetry

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/utils/Logger.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/Logger.kt
@@ -138,6 +138,10 @@ open class LoggerBase(val logCounter: LogCounter) {
         fullMsgBuilder.append(suffix)
 
         val fullMsg = fullMsgBuilder.toString()
+        emitDiagnostic(tw, severity, diagnosticLocStr, msg, fullMsg, locationString, mkLocationId)
+    }
+
+    fun emitDiagnostic(tw: TrapWriter, severity: Severity, diagnosticLocStr: String, msg: String, fullMsg: String, locationString: String? = null, mkLocationId: () -> Label<DbLocation> = { tw.unknownLocation }) {
         val locStr = if (locationString == null) "" else "At " + locationString + ": "
         val kind = if (severity <= Severity.WarnHigh) "WARN" else "ERROR"
         val logMessage = LogMessage(kind, "Diagnostic($diagnosticLocStr): $locStr$fullMsg")
@@ -190,9 +194,10 @@ open class LoggerBase(val logCounter: LogCounter) {
                 // We don't know if this location relates to an error
                 // or a warning, so we just declare hitting the limit
                 // to be an error regardless.
-                val logMessage = LogMessage("ERROR", "Total of $count diagnostics from $caller.")
-                tw.writeComment(logMessage.toText())
-                logStream.write(logMessage.toJsonLine())
+                val message = "Total of $count diagnostics (reached limit of ${logCounter.diagnosticLimit}) from $caller."
+                if (verbosity >= 1) {
+                    emitDiagnostic(tw, Severity.Error, "Limit", message, message)
+                }
             }
         }
     }

--- a/java/kotlin-extractor/src/main/kotlin/utils/Logger.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/Logger.kt
@@ -141,7 +141,7 @@ open class LoggerBase(val logCounter: LogCounter) {
         emitDiagnostic(tw, severity, diagnosticLocStr, msg, fullMsg, locationString, mkLocationId)
     }
 
-    fun emitDiagnostic(tw: TrapWriter, severity: Severity, diagnosticLocStr: String, msg: String, fullMsg: String, locationString: String? = null, mkLocationId: () -> Label<DbLocation> = { tw.unknownLocation }) {
+    private fun emitDiagnostic(tw: TrapWriter, severity: Severity, diagnosticLocStr: String, msg: String, fullMsg: String, locationString: String? = null, mkLocationId: () -> Label<DbLocation> = { tw.unknownLocation }) {
         val locStr = if (locationString == null) "" else "At " + locationString + ": "
         val kind = if (severity <= Severity.WarnHigh) "WARN" else "ERROR"
         val logMessage = LogMessage(kind, "Diagnostic($diagnosticLocStr): $locStr$fullMsg")

--- a/java/ql/src/Telemetry/ExtractorInformation.ql
+++ b/java/ql/src/Telemetry/ExtractorInformation.ql
@@ -62,21 +62,16 @@ predicate extractorDiagnostics(string key, int value) {
  */
 
 predicate extractorTotalDiagnostics(string key, int value) {
-  exists(string extractor |
+  exists(string extractor, string limitRegex |
+    limitRegex = "Total of ([0-9]+) diagnostics \\(reached limit of ([0-9]+)\\).*" and
     key = "Total number of diagnostics from " + extractor and
     value =
       strictcount(Diagnostic d | d.getGeneratedBy() = extractor) +
         sum(Diagnostic d |
           d.getGeneratedBy() = extractor
         |
-          d.getMessage()
-                  .regexpCapture("Total of ([0-9]+) diagnostics \\(reached limit of ([0-9]+)\\).*",
-                    1)
-                  .toInt() -
-              d.getMessage()
-                  .regexpCapture("Total of ([0-9]+) diagnostics \\(reached limit of ([0-9]+)\\).*",
-                    2)
-                  .toInt() - 1
+          d.getMessage().regexpCapture(limitRegex, 1).toInt() -
+              d.getMessage().regexpCapture(limitRegex, 2).toInt() - 1
         )
   )
 }


### PR DESCRIPTION
This isn't as simple as counting them, as `CODEQL_EXTRACTOR_KOTLIN_DIAGNOSTIC_LIMIT` means that they don't all get written. Also discovered that we weren't writing the message about having hit the limit to the database, so that's now done too.