### PR TITLE
Docs: Add note about old/unsupported VS versions

### DIFF
--- a/docs/codeql/support/reusables/versions-compilers.rst
+++ b/docs/codeql/support/reusables/versions-compilers.rst
@@ -8,33 +8,34 @@
 
    GNU extensions (up to GCC 11.1),
 
-   Microsoft extensions (up to VS 2019),
+   Microsoft extensions (supported versions [3]_ up to VS 2019),
 
-   Arm Compiler 5 [3]_","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
+   Arm Compiler 5 [4]_","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
    C#,C# up to 10.0,"Microsoft Visual Studio up to 2019 with .NET up to 4.8,
 
    .NET Core up to 3.1
 
    .NET 5, .NET 6","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
    Go (aka Golang), "Go up to 1.18", "Go 1.11 or more recent", ``.go``
-   Java,"Java 7 to 18 [4]_","javac (OpenJDK and Oracle JDK),
+   Java,"Java 7 to 18 [5]_","javac (OpenJDK and Oracle JDK),
 
-   Eclipse compiler for Java (ECJ) [5]_",``.java``
-   Kotlin [6]_,"Kotlin 1.5.0 to 1.7.21","kotlinc",``.kt``
-   JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_"
-   Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10",Not applicable,``.py``
-   Ruby [9]_,"up to 3.1",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
-   TypeScript [10]_,"2.6-4.8",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
+   Eclipse compiler for Java (ECJ) [6]_",``.java``
+   Kotlin [7]_,"Kotlin 1.5.0 to 1.7.21","kotlinc",``.kt``
+   JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [8]_"
+   Python [9]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10",Not applicable,``.py``
+   Ruby [10]_,"up to 3.1",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
+   TypeScript [11]_,"2.6-4.8",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
 
 .. container:: footnote-group
 
     .. [1] C++20 support is currently in beta. Supported for GCC on Linux only. Modules are *not* supported.
     .. [2] Support for the clang-cl compiler is preliminary.
-    .. [3] Support for the Arm Compiler (armcc) is preliminary.
-    .. [4] Builds that execute on Java 7 to 19 can be analyzed. The analysis understands Java 19 standard language features.
-    .. [5] ECJ is supported when the build invokes it via the Maven Compiler plugin or the Takari Lifecycle plugin.
-    .. [6] Kotlin support is currently in beta.
-    .. [7] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files.
-    .. [8] The extractor requires Python 3 to run. To analyze Python 2.7 you should install both versions of Python.
-    .. [9] Requires glibc 2.17.
-    .. [10] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.
+    .. [3] See the `Visual Studio Product Lifecycle <https://learn.microsoft.com/en-us/visualstudio/productinfo/vs-servicing#older-versions-of-visual-studio>`__.
+    .. [4] Support for the Arm Compiler (armcc) is preliminary.
+    .. [5] Builds that execute on Java 7 to 19 can be analyzed. The analysis understands Java 19 standard language features.
+    .. [6] ECJ is supported when the build invokes it via the Maven Compiler plugin or the Takari Lifecycle plugin.
+    .. [7] Kotlin support is currently in beta.
+    .. [8] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files.
+    .. [9] The extractor requires Python 3 to run. To analyze Python 2.7 you should install both versions of Python.
+    .. [10] Requires glibc 2.17.
+    .. [11] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.


### PR DESCRIPTION
We previously didn't claim a minimum supported version for Visual Studio and its C/C++ compiler. We now reference the Visual Studio Product Lifecycle, which gives an EOL date of 10 years after release.

cc @turbo 