### PR TITLE
Java: Stub generator: Exclude invalid identifiers from generated stubs

### DIFF
--- a/java/ql/src/utils/stub-generator/Stubs.qll
+++ b/java/ql/src/utils/stub-generator/Stubs.qll
@@ -7,12 +7,17 @@
 
 import java
 
+/** Holds if `id` is a valid Java identifier. */
+bindingset[id]
+private predicate isValidIdentifier(string id) { id.regexpMatch("[\\w_$]+") }
+
 /** A type that should be in the generated code. */
 abstract private class GeneratedType extends ClassOrInterface {
   GeneratedType() {
     not this instanceof AnonymousClass and
     not this.isLocal() and
-    not this.getPackage() instanceof ExcludedPackage
+    not this.getPackage() instanceof ExcludedPackage and
+    isValidIdentifier(this.getName())
   }
 
   private string stubKeyword() {
@@ -108,7 +113,8 @@ abstract private class GeneratedType extends ClassOrInterface {
     not result.isPrivate() and
     not result.isPackageProtected() and
     not result instanceof StaticInitializer and
-    not result instanceof InstanceInitializer
+    not result instanceof InstanceInitializer and
+    isValidIdentifier(result.getName())
   }
 
   final Type getAGeneratedType() {


### PR DESCRIPTION
It appears that compiled `.class` files are able to contain identifiers that are not valid in Java source code. 
For instance, when stubing `okhttp`, I ran into several identifiers beginning with `-deprecated_`.
This PR excludes these identifiers from being stubbed. 