### PR TITLE
C++: Reintroduce the AST testing configuration for the smart pointer test too

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/smart-pointers-taint/taint.ql
+++ b/cpp/ql/test/library-tests/dataflow/smart-pointers-taint/taint.ql
@@ -1,5 +1,24 @@
 import TestUtilities.dataflow.FlowTestCommon
 
+module AstTest {
+  private import semmle.code.cpp.dataflow.old.TaintTracking
+
+  class AstSmartPointerTaintConfig extends TaintTracking::Configuration {
+    AstSmartPointerTaintConfig() { this = "ASTSmartPointerTaintConfig" }
+
+    override predicate isSource(DataFlow::Node source) {
+      source.asExpr().(FunctionCall).getTarget().getName() = "source"
+    }
+
+    override predicate isSink(DataFlow::Node sink) {
+      exists(FunctionCall call |
+        call.getTarget().getName() = "sink" and
+        sink.asExpr() = call.getAnArgument()
+      )
+    }
+  }
+}
+
 module IRTest {
   private import semmle.code.cpp.ir.dataflow.TaintTracking
 

--- a/cpp/ql/test/library-tests/dataflow/smart-pointers-taint/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/smart-pointers-taint/test.cpp
@@ -7,8 +7,8 @@ void test_unique_ptr_int() {
 	std::unique_ptr<int> p1(new int(source()));
 	std::unique_ptr<int> p2 = std::make_unique<int>(source());
 	
-	sink(*p1); // $ ir
-	sink(*p2); // $ ir=8:50
+	sink(*p1); // $ ir MISSING: ast
+	sink(*p2); // $ ast ir=8:50
 }
 
 struct A {
@@ -21,9 +21,9 @@ void test_unique_ptr_struct() {
 	std::unique_ptr<A> p1(new A{source(), 0});
 	std::unique_ptr<A> p2 = std::make_unique<A>(source(), 0);
 	
-	sink(p1->x); // $ ir
+	sink(p1->x); // $ ir MISSING: ast
 	sink(p1->y);
-	sink(p2->x); // $ ir=22:46
+	sink(p2->x); // $ ir=22:46 MISSING: ast
 	sink(p2->y);
 }
 
@@ -31,16 +31,16 @@ void test_shared_ptr_int() {
 	std::shared_ptr<int> p1(new int(source()));
 	std::shared_ptr<int> p2 = std::make_shared<int>(source());
 	
-	sink(*p1); // $ ir
-	sink(*p2); // $ ir=32:50 
+	sink(*p1); // $ ast,ir
+	sink(*p2); // $ ast ir=32:50
 }
 
 void test_shared_ptr_struct() {
 	std::shared_ptr<A> p1(new A{source(), 0});
 	std::shared_ptr<A> p2 = std::make_shared<A>(source(), 0);
 	
-	sink(p1->x); // $ MISSING: ir
+	sink(p1->x); // $ MISSING: ast,ir
 	sink(p1->y);
-	sink(p2->x); // $ MISSING: ir
+	sink(p2->x); // $ MISSING: ast,ir
 	sink(p2->y);
 }


### PR DESCRIPTION
I had previously omitted this, as I had not looked at the smart pointer test yet.