### PR TITLE
CI: clean up the cache when compiling on main

### DIFF
--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -60,14 +60,10 @@ jobs:
           # Move all the existing cache into another folder, so we only preserve the cache for the current queries.
           mkdir -p ${COMBINED_CACHE_DIR}
           rm */ql/src/.cache/{lock,size}
-          # replicate the folder structure from the .cache folders into the combined cache folder. (because cp doesn't have a "create missing folders" option)
-          find */ql/src/.cache -type d | cut -d "/" -f 6,7 | sort | uniq > folders.txt
-          cat folders.txt | xargs -I {} mkdir -p ${COMBINED_CACHE_DIR}/{}
           # copy the contents of the .cache folders into the combined cache folder.
           cp -r */ql/src/.cache/* ${COMBINED_CACHE_DIR}/
           # clean up the .cache folders
           rm -rf */ql/src/.cache/*
-          rm folders.txt
 
           # compile the queries
           codeql query compile -j0 */ql/src --keep-going --warnings=error --compilation-cache ${COMBINED_CACHE_DIR}

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -56,4 +56,20 @@ jobs:
         # do full compile if running on main - this populates the cache
         if : ${{ github.event_name != 'pull_request' }}
         shell: bash
-        run: codeql query compile -j0 */ql/src --keep-going --warnings=error
+        run: |
+          # Move all the existing cache into another folder, so we only preserve the cache for the current queries.
+          mkdir -p ${COMBINED_CACHE_DIR}
+          rm */ql/src/.cache/{lock,size}
+          # replicate the folder structure from the .cache folders into the combined cache folder. (because cp doesn't have a "create missing folders" option)
+          find */ql/src/.cache -type d | cut -d "/" -f 6,7 | sort | uniq > folders.txt
+          cat folders.txt | xargs -I {} mkdir -p ${COMBINED_CACHE_DIR}/{}
+          # copy the contents of the .cache folders into the combined cache folder.
+          cp -r */ql/src/.cache/* ${COMBINED_CACHE_DIR}/
+          # clean up the .cache folders
+          rm -rf */ql/src/.cache/*
+          rm folders.txt
+
+          # compile the queries
+          codeql query compile -j0 */ql/src --keep-going --warnings=error --compilation-cache ${COMBINED_CACHE_DIR}
+        env: 
+          COMBINED_CACHE_DIR: ${{ github.workspace }}/compilation-dir


### PR DESCRIPTION
The cache was append-only, so it would keep monotonically increasing in size.  
It started at ~60mb, but it had grown to ~250mb.  

This PR makes sure that only the cache objects needed are preserved.  

The CodeQL CLI accepts a `--compilation-cache` option where it additionally reads cache objects from.  
But the CLI will still populate the relevant cache folders. 
Thereby effectively moving the relevant cache from the directory specified `--compilation-cache` into the relevant folders.  

In a [test run](https://github.com/github/codeql/actions/runs/3480558055/jobs/5820513882) this decreased the cache size from 251mb to 62mb.   
(See the cache read and cache write steps).  

This was inspired by DCA that uses `--compilation-cache` to achieve the same effect.  