### PR TITLE
Swift: Add `AdditionalTaintStep`

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/FlowSteps.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/FlowSteps.qll
@@ -2,6 +2,20 @@ import swift
 private import codeql.swift.dataflow.DataFlow
 
 /**
+ * A unit class for adding additional taint steps.
+ *
+ * Extend this class to add additional taint steps that should apply to all
+ * taint configurations.
+ */
+class AdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for all configurations.
+   */
+  abstract predicate step(DataFlow::Node node1, DataFlow::Node node2);
+}
+
+/**
  * A `Content` that should be implicitly regarded as tainted whenever an object with such `Content`
  * is itself tainted.
  *

--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
@@ -64,6 +64,8 @@ private module Cached {
     or
     // flow through a flow summary (extension of `SummaryModelCsv`)
     FlowSummaryImpl::Private::Steps::summaryLocalStep(nodeFrom, nodeTo, false)
+    or
+    any(AdditionalTaintStep a).step(nodeFrom, nodeTo)
   }
 
   /**


### PR DESCRIPTION
Adds the abstract class `AdditionalTaintStep` to allow creating flow steps that apply to all taint tracking configurations.