### PR TITLE
Swift: remove double newlines in schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v1.6.0
     hooks:
       - id: autopep8
-        files: ^swift/codegen/.*\.py
+        files: ^swift/.*\.py
 
   - repo: local
     hooks:
@@ -44,7 +44,7 @@ repos:
 
       - id: swift-codegen
         name: Run Swift checked in code generation
-        files: ^swift/(codegen/|.*/generated/|ql/lib/(swift\.dbscheme$|codeql/swift/elements))
+        files: ^swift/(schema.py$|codegen/|.*/generated/|ql/lib/(swift\.dbscheme$|codeql/swift/elements))
         language: system
         entry: bazel run //swift/codegen -- --quiet
         pass_filenames: false

--- a/swift/integration-tests/posix-only/cross-references/test.py
+++ b/swift/integration-tests/posix-only/cross-references/test.py
@@ -1,6 +1,6 @@
 from create_database_utils import *
 
 run_codeql_database_create([
- 'swift package clean',
- 'swift build'
+    'swift package clean',
+    'swift build'
 ], lang='swift')

--- a/swift/integration-tests/posix-only/frontend-invocations/test.py
+++ b/swift/integration-tests/posix-only/frontend-invocations/test.py
@@ -1,5 +1,5 @@
 from create_database_utils import *
 
 run_codeql_database_create([
- 'make',
+    'make',
 ], lang='swift')

--- a/swift/integration-tests/posix-only/hello-world/test.py
+++ b/swift/integration-tests/posix-only/hello-world/test.py
@@ -1,6 +1,6 @@
 from create_database_utils import *
 
 run_codeql_database_create([
- 'swift package clean',
- 'swift build'
+    'swift package clean',
+    'swift build'
 ], lang='swift')

--- a/swift/integration-tests/posix-only/partial-modules/test.py
+++ b/swift/integration-tests/posix-only/partial-modules/test.py
@@ -1,7 +1,7 @@
 from create_database_utils import *
 
 run_codeql_database_create([
- 'env',
- 'swift package clean',
- 'swift build'
+    'env',
+    'swift package clean',
+    'swift build'
 ], lang='swift', keep_trap=True)

--- a/swift/integration-tests/runner.py
+++ b/swift/integration-tests/runner.py
@@ -21,7 +21,7 @@ this_dir = pathlib.Path(__file__).parent.resolve()
 def options():
     p = argparse.ArgumentParser()
     p.add_argument("--test-dir", "-d", type=pathlib.Path, action="append")
-    #FIXME: the following should be the default
+    # FIXME: the following should be the default
     p.add_argument("--check-databases", action="store_true")
     p.add_argument("--learn", action="store_true")
     p.add_argument("--threads", "-j", type=int, default=0)

--- a/swift/schema.py
+++ b/swift/schema.py
@@ -11,16 +11,13 @@ from swift.codegen.lib.schema.defs import *
 
 include("prefix.dbscheme")
 
-
 @qltest.skip
 class Element:
     is_unknown: predicate | cpp.skip
 
-
 @qltest.collapse_hierarchy
 class File(Element):
     name: string
-
 
 @qltest.skip
 @qltest.collapse_hierarchy
@@ -31,18 +28,15 @@ class Location(Element):
     end_line: int
     end_column: int
 
-
 @qltest.skip
 class Locatable(Element):
     location: optional[Location] | cpp.skip | doc("location associated with this element in the code")
-
 
 @qltest.collapse_hierarchy
 @qltest.skip
 class ErrorElement(Locatable):
     """The superclass of all elements indicating some kind of error."""
     pass
-
 
 @use_for_null
 class UnspecifiedElement(ErrorElement):
@@ -51,129 +45,102 @@ class UnspecifiedElement(ErrorElement):
     index: optional[int]
     error: string
 
-
 class Comment(Locatable):
     text: string
-
 
 class Diagnostics(Locatable):
     text: string
     kind: int
 
-
 class DbFile(File):
     pass
 
-
 class DbLocation(Location):
     pass
-
 
 @synth.on_arguments()
 class UnknownFile(File):
     pass
 
-
 @synth.on_arguments()
 class UnknownLocation(Location):
     pass
 
-
 class AstNode(Locatable):
     pass
-
 
 @group("type")
 class Type(Element):
     name: string
     canonical_type: "Type"
 
-
 @group("decl")
 class Decl(AstNode):
     module: "ModuleDecl"
-
 
 @group("expr")
 class Expr(AstNode):
     """The base class for all expressions in Swift."""
     type: optional[Type]
 
-
 @group("pattern")
 class Pattern(AstNode):
     pass
-
 
 @group("stmt")
 class Stmt(AstNode):
     pass
 
-
 @group("decl")
 class GenericContext(Element):
     generic_type_params: list["GenericTypeParamDecl"] | child
-
 
 @group("decl")
 class IterableDeclContext(Element):
     members: list[Decl] | child
 
-
 class EnumCaseDecl(Decl):
     elements: list["EnumElementDecl"]
-
 
 class ExtensionDecl(GenericContext, IterableDeclContext, Decl):
     extended_type_decl: "NominalTypeDecl"
 
-
 class IfConfigDecl(Decl):
     active_elements: list[AstNode]
-
 
 class ImportDecl(Decl):
     is_exported: predicate
     imported_module: optional["ModuleDecl"]
     declarations: list["ValueDecl"]
 
-
 @qltest.skip
 class MissingMemberDecl(Decl):
     """A placeholder for missing declarations that can arise on object deserialization."""
     name: string
 
-
 class OperatorDecl(Decl):
     name: string
-
 
 class PatternBindingDecl(Decl):
     inits: list[optional[Expr]] | child
     patterns: list[Pattern] | child
-
 
 class PoundDiagnosticDecl(Decl):
     """ A diagnostic directive, which is either `#error` or `#warning`."""
     kind: int | doc("""This is 1 for `#error` and 2 for `#warning`""")
     message: "StringLiteralExpr" | child
 
-
 class PrecedenceGroupDecl(Decl):
     pass
-
 
 class TopLevelCodeDecl(Decl):
     body: "BraceStmt" | child
 
-
 class ValueDecl(Decl):
     interface_type: Type
 
-
 class AbstractStorageDecl(ValueDecl):
     accessor_decls: list["AccessorDecl"] | child
-
 
 class VarDecl(AbstractStorageDecl):
     name: string
@@ -198,7 +165,6 @@ class VarDecl(AbstractStorageDecl):
         prefixed with `$`.
     """)
 
-
 class ParamDecl(VarDecl):
     is_inout: predicate | doc("this is an `inout` parameter")
     property_wrapper_local_wrapped_var_binding: optional[PatternBindingDecl] | child | desc("""
@@ -210,58 +176,45 @@ class ParamDecl(VarDecl):
         has a property wrapper.
     """)
 
-
 class Callable(Element):
     self_param: optional[ParamDecl] | child
     params: list[ParamDecl] | child
     body: optional["BraceStmt"] | child | desc("The body is absent within protocol declarations.")
 
-
 class AbstractFunctionDecl(GenericContext, ValueDecl, Callable):
     name: string | doc("name of this function")
-
 
 class EnumElementDecl(ValueDecl):
     name: string
     params: list[ParamDecl] | child
 
-
 class InfixOperatorDecl(OperatorDecl):
     precedence_group: optional[PrecedenceGroupDecl]
-
 
 class PostfixOperatorDecl(OperatorDecl):
     pass
 
-
 class PrefixOperatorDecl(OperatorDecl):
     pass
-
 
 class TypeDecl(ValueDecl):
     name: string
     base_types: list[Type]
 
-
 class AbstractTypeParamDecl(TypeDecl):
     pass
-
 
 class ConstructorDecl(AbstractFunctionDecl):
     pass
 
-
 class DestructorDecl(AbstractFunctionDecl):
     pass
-
 
 class FuncDecl(AbstractFunctionDecl):
     pass
 
-
 class GenericTypeDecl(GenericContext, TypeDecl):
     pass
-
 
 class ModuleDecl(TypeDecl):
     is_builtin_module: predicate | doc("this module is the built-in one")
@@ -269,12 +222,10 @@ class ModuleDecl(TypeDecl):
     imported_modules: list["ModuleDecl"]
     exported_modules: list["ModuleDecl"]
 
-
 class SubscriptDecl(AbstractStorageDecl, GenericContext):
     params: list[ParamDecl] | child
     element_type: Type
     element_type: Type
-
 
 class AccessorDecl(FuncDecl):
     is_getter: predicate | doc('this accessor is a getter')
@@ -282,28 +233,22 @@ class AccessorDecl(FuncDecl):
     is_will_set: predicate | doc('this accessor is a `willSet`, called before the property is set')
     is_did_set: predicate | doc('this accessor is a `didSet`, called after the property is set')
 
-
 class AssociatedTypeDecl(AbstractTypeParamDecl):
     pass
 
-
 class ConcreteFuncDecl(FuncDecl):
     pass
-
 
 class ConcreteVarDecl(VarDecl):
     introducer_int: int | doc("introducer enumeration value") | desc("""
         This is 0 if the variable was introduced with `let` and 1 if it was introduced with `var`.
     """)
 
-
 class GenericTypeParamDecl(AbstractTypeParamDecl):
     pass
 
-
 class NominalTypeDecl(GenericTypeDecl, IterableDeclContext):
     type: Type
-
 
 class OpaqueTypeDecl(GenericTypeDecl):
     """
@@ -321,40 +266,31 @@ class OpaqueTypeDecl(GenericTypeDecl):
     opaque_generic_params: list["GenericTypeParamType"]
     opaque_generic_params: list["GenericTypeParamType"]
 
-
 class TypeAliasDecl(GenericTypeDecl):
     pass
-
 
 class ClassDecl(NominalTypeDecl):
     pass
 
-
 class EnumDecl(NominalTypeDecl):
     pass
-
 
 class ProtocolDecl(NominalTypeDecl):
     pass
 
-
 class StructDecl(NominalTypeDecl):
     pass
-
 
 @group("expr")
 class Argument(Locatable):
     label: string
     expr: Expr | child
 
-
 class AbstractClosureExpr(Expr, Callable):
     pass
 
-
 class AnyTryExpr(Expr):
     sub_expr: Expr | child
-
 
 class AppliedPropertyWrapperExpr(Expr):
     """An implicit application of a property wrapper on the argument of a call."""
@@ -362,29 +298,23 @@ class AppliedPropertyWrapperExpr(Expr):
     value: Expr | child | desc("The value on which the wrapper is applied.")
     param: ParamDecl | doc("parameter declaration owning this wrapper application")
 
-
 class ApplyExpr(Expr):
     function: Expr | child | doc("function being applied")
     arguments: list[Argument] | child | doc("arguments passed to the applied function")
-
 
 class AssignExpr(Expr):
     dest: Expr | child
     source: Expr | child
 
-
 class BindOptionalExpr(Expr):
     sub_expr: Expr | child
-
 
 class CaptureListExpr(Expr):
     binding_decls: list[PatternBindingDecl] | child
     closure_body: "ClosureExpr" | child
 
-
 class CollectionExpr(Expr):
     pass
-
 
 class DeclRefExpr(Expr):
     decl: Decl
@@ -393,124 +323,98 @@ class DeclRefExpr(Expr):
     has_direct_to_implementation_semantics: predicate
     has_ordinary_semantics: predicate
 
-
 class DefaultArgumentExpr(Expr):
     param_decl: ParamDecl
     param_index: int
     caller_side_default: optional[Expr]
 
-
 class DiscardAssignmentExpr(Expr):
     pass
-
 
 class DotSyntaxBaseIgnoredExpr(Expr):
     qualifier: Expr | child
     sub_expr: Expr | child
 
-
 class DynamicTypeExpr(Expr):
     base: Expr | child
-
 
 class EnumIsCaseExpr(Expr):
     sub_expr: Expr | child
     element: EnumElementDecl
 
-
 @qltest.skip
 class ErrorExpr(Expr, ErrorElement):
     pass
 
-
 class ExplicitCastExpr(Expr):
     sub_expr: Expr | child
-
 
 class ForceValueExpr(Expr):
     sub_expr: Expr | child
 
-
 @qltest.collapse_hierarchy
 class IdentityExpr(Expr):
     sub_expr: Expr | child
-
 
 class IfExpr(Expr):
     condition: Expr | child
     then_expr: Expr | child
     else_expr: Expr | child
 
-
 @qltest.collapse_hierarchy
 class ImplicitConversionExpr(Expr):
     sub_expr: Expr | child
 
-
 class InOutExpr(Expr):
     sub_expr: Expr | child
-
 
 class KeyPathApplicationExpr(Expr):
     base: Expr | child
     key_path: Expr | child
 
-
 class KeyPathDotExpr(Expr):
     pass
-
 
 class KeyPathExpr(Expr):
     root: optional["TypeRepr"] | child
     parsed_path: optional[Expr] | child
 
-
 class LazyInitializerExpr(Expr):
     sub_expr: Expr | child
-
 
 class LiteralExpr(Expr):
     pass
 
-
 class LookupExpr(Expr):
     base: Expr | child
     member: optional[Decl]
-
 
 class MakeTemporarilyEscapableExpr(Expr):
     escaping_closure: "OpaqueValueExpr" | child
     nonescaping_closure: Expr | child
     sub_expr: Expr | child
 
-
 @qltest.skip
 class ObjCSelectorExpr(Expr):
     sub_expr: Expr | child
     method: AbstractFunctionDecl
 
-
 class OneWayExpr(Expr):
     sub_expr: Expr | child
 
-
 class OpaqueValueExpr(Expr):
     pass
-
 
 class OpenExistentialExpr(Expr):
     sub_expr: Expr | child
     existential: Expr | child
     opaque_expr: OpaqueValueExpr | child
 
-
 class OptionalEvaluationExpr(Expr):
     sub_expr: Expr | child
 
-
 class OtherConstructorDeclRefExpr(Expr):
     constructor_decl: ConstructorDecl
-
 
 class PropertyWrapperValuePlaceholderExpr(Expr):
     """
@@ -520,195 +424,148 @@ class PropertyWrapperValuePlaceholderExpr(Expr):
     wrapped_value: optional[Expr]
     placeholder: OpaqueValueExpr
 
-
 class RebindSelfInConstructorExpr(Expr):
     sub_expr: Expr | child
     self: VarDecl
-
 
 @qltest.skip
 class SequenceExpr(Expr):
     elements: list[Expr] | child
 
-
 class SuperRefExpr(Expr):
     self: VarDecl
-
 
 class TapExpr(Expr):
     sub_expr: optional[Expr] | child
     body: "BraceStmt" | child
     var: VarDecl
 
-
 class TupleElementExpr(Expr):
     sub_expr: Expr | child
     index: int
 
-
 class TupleExpr(Expr):
     elements: list[Expr] | child
 
-
 class TypeExpr(Expr):
     type_repr: optional["TypeRepr"] | child
-
 class UnresolvedDeclRefExpr(Expr, ErrorElement):
     name: optional[string]
-
 class UnresolvedDotExpr(Expr, ErrorElement):
     base: Expr | child
     name: string
-
 class UnresolvedMemberExpr(Expr, ErrorElement):
     name: string
-
 class UnresolvedPatternExpr(Expr, ErrorElement):
     sub_pattern: Pattern | child
-
 class UnresolvedSpecializeExpr(Expr, ErrorElement):
     sub_expr: Expr | child
-
 
 class VarargExpansionExpr(Expr):
     sub_expr: Expr | child
 
-
 class AnyHashableErasureExpr(ImplicitConversionExpr):
     pass
-
 
 class ArchetypeToSuperExpr(ImplicitConversionExpr):
     pass
 
-
 class ArrayExpr(CollectionExpr):
     elements: list[Expr] | child
-
 
 class ArrayToPointerExpr(ImplicitConversionExpr):
     pass
 
-
 class AutoClosureExpr(AbstractClosureExpr):
     pass
-
 
 class AwaitExpr(IdentityExpr):
     pass
 
-
 class BinaryExpr(ApplyExpr):
     pass
-
 
 @qltest.skip
 class BridgeFromObjCExpr(ImplicitConversionExpr):
     pass
 
-
 @qltest.skip
 class BridgeToObjCExpr(ImplicitConversionExpr):
     pass
 
-
 class BuiltinLiteralExpr(LiteralExpr):
     pass
-
 
 class CallExpr(ApplyExpr):
     pass
 
-
 class CheckedCastExpr(ExplicitCastExpr):
     pass
-
 
 class ClassMetatypeToObjectExpr(ImplicitConversionExpr):
     pass
 
-
 class ClosureExpr(AbstractClosureExpr):
     pass
-
 
 class CoerceExpr(ExplicitCastExpr):
     pass
 
-
 class CollectionUpcastConversionExpr(ImplicitConversionExpr):
     pass
-
 
 @qltest.skip
 class ConditionalBridgeFromObjCExpr(ImplicitConversionExpr):
     pass
 
-
 class CovariantFunctionConversionExpr(ImplicitConversionExpr):
     pass
-
 
 class CovariantReturnConversionExpr(ImplicitConversionExpr):
     pass
 
-
 class DerivedToBaseExpr(ImplicitConversionExpr):
     pass
-
 
 class DestructureTupleExpr(ImplicitConversionExpr):
     pass
 
-
 class DictionaryExpr(CollectionExpr):
     elements: list[Expr] | child
-
 
 class DifferentiableFunctionExpr(ImplicitConversionExpr):
     pass
 
-
 class DifferentiableFunctionExtractOriginalExpr(ImplicitConversionExpr):
     pass
 
-
 class DotSelfExpr(IdentityExpr):
     pass
-
 
 @qltest.collapse_hierarchy
 class DynamicLookupExpr(LookupExpr):
     pass
 
-
 class ErasureExpr(ImplicitConversionExpr):
     pass
-
 
 class ExistentialMetatypeToObjectExpr(ImplicitConversionExpr):
     pass
 
-
 class ForceTryExpr(AnyTryExpr):
     pass
-
 
 class ForeignObjectConversionExpr(ImplicitConversionExpr):
     pass
 
-
 class FunctionConversionExpr(ImplicitConversionExpr):
     pass
-
 
 class InOutToPointerExpr(ImplicitConversionExpr):
     pass
 
-
 class InjectIntoOptionalExpr(ImplicitConversionExpr):
     pass
-
 
 class InterpolatedStringLiteralExpr(LiteralExpr):
     interpolation_expr: optional[OpaqueValueExpr]
@@ -716,36 +573,28 @@ class InterpolatedStringLiteralExpr(LiteralExpr):
     literal_capacity_expr: optional[Expr] | child
     appending_expr: optional[TapExpr] | child
 
-
 class LinearFunctionExpr(ImplicitConversionExpr):
     pass
-
 
 class LinearFunctionExtractOriginalExpr(ImplicitConversionExpr):
     pass
 
-
 class LinearToDifferentiableFunctionExpr(ImplicitConversionExpr):
     pass
 
-
 class LoadExpr(ImplicitConversionExpr):
     pass
-
 
 class MemberRefExpr(LookupExpr):
     has_direct_to_storage_semantics: predicate
     has_direct_to_implementation_semantics: predicate
     has_ordinary_semantics: predicate
 
-
 class MetatypeConversionExpr(ImplicitConversionExpr):
     pass
 
-
 class NilLiteralExpr(LiteralExpr):
     pass
-
 
 class ObjectLiteralExpr(LiteralExpr):
     """
@@ -754,10 +603,8 @@ class ObjectLiteralExpr(LiteralExpr):
     kind: int | desc("""This is 0 for `#fileLiteral`, 1 for `#imageLiteral` and 2 for `#colorLiteral`.""")
     arguments: list[Argument] | child
 
-
 class OptionalTryExpr(AnyTryExpr):
     pass
-
 
 class OverloadedDeclRefExpr(Expr, ErrorElement):
     """
@@ -766,38 +613,29 @@ class OverloadedDeclRefExpr(Expr, ErrorElement):
     """
     possible_declarations: list[ValueDecl]
 
-
 class ParenExpr(IdentityExpr):
     pass
-
 
 class PointerToPointerExpr(ImplicitConversionExpr):
     pass
 
-
 class PostfixUnaryExpr(ApplyExpr):
     pass
-
 
 class PrefixUnaryExpr(ApplyExpr):
     pass
 
-
 class ProtocolMetatypeToObjectExpr(ImplicitConversionExpr):
     pass
-
 
 class RegexLiteralExpr(LiteralExpr):
     pass
 
-
 class SelfApplyExpr(ApplyExpr):
     base: Expr
 
-
 class StringToPointerExpr(ImplicitConversionExpr):
     pass
-
 
 class SubscriptExpr(LookupExpr):
     arguments: list[Argument] | child
@@ -805,133 +643,101 @@ class SubscriptExpr(LookupExpr):
     has_direct_to_implementation_semantics: predicate
     has_ordinary_semantics: predicate
 
-
 class TryExpr(AnyTryExpr):
     pass
-
 
 class UnderlyingToOpaqueExpr(ImplicitConversionExpr):
     pass
 
-
 class UnevaluatedInstanceExpr(ImplicitConversionExpr):
     pass
-
 class UnresolvedMemberChainResultExpr(IdentityExpr, ErrorElement):
     pass
-
 class UnresolvedTypeConversionExpr(ImplicitConversionExpr, ErrorElement):
     pass
-
 class BooleanLiteralExpr(BuiltinLiteralExpr):
     value: boolean
-
 
 class ConditionalCheckedCastExpr(CheckedCastExpr):
     pass
 
-
 class ConstructorRefCallExpr(SelfApplyExpr):
     pass
 
-
 class DotSyntaxCallExpr(SelfApplyExpr):
     pass
-
 
 @synth.from_class(DotSyntaxCallExpr)
 class MethodRefExpr(LookupExpr):
     pass
 
-
 class DynamicMemberRefExpr(DynamicLookupExpr):
     pass
-
 
 class DynamicSubscriptExpr(DynamicLookupExpr):
     pass
 
-
 class ForcedCheckedCastExpr(CheckedCastExpr):
     pass
-
 
 class IsExpr(CheckedCastExpr):
     pass
 
-
 class MagicIdentifierLiteralExpr(BuiltinLiteralExpr):
     kind: string
-
 
 class NumberLiteralExpr(BuiltinLiteralExpr):
     pass
 
-
 class StringLiteralExpr(BuiltinLiteralExpr):
     value: string
-
 
 class FloatLiteralExpr(NumberLiteralExpr):
     string_value: string
 
-
 class IntegerLiteralExpr(NumberLiteralExpr):
     string_value: string
-
 
 class AnyPattern(Pattern):
     pass
 
-
 class BindingPattern(Pattern):
     sub_pattern: Pattern | child
 
-
 class BoolPattern(Pattern):
     value: boolean
-
 
 class EnumElementPattern(Pattern):
     element: EnumElementDecl
     sub_pattern: optional[Pattern] | child
 
-
 class ExprPattern(Pattern):
     sub_expr: Expr | child
-
 
 class IsPattern(Pattern):
     cast_type_repr: optional["TypeRepr"] | child
     sub_pattern: optional[Pattern] | child
 
-
 class NamedPattern(Pattern):
     name: string
-
 
 class OptionalSomePattern(Pattern):
     sub_pattern: Pattern | child
 
-
 class ParenPattern(Pattern):
     sub_pattern: Pattern | child
 
-
 class TuplePattern(Pattern):
     elements: list[Pattern] | child
-
 
 class TypedPattern(Pattern):
     sub_pattern: Pattern | child
     type_repr: optional["TypeRepr"] | child
 
-
 @group("stmt")
 class CaseLabelItem(AstNode):
     pattern: Pattern | child
     guard: optional[Expr] | child
-
 
 @group("stmt")
 class ConditionElement(AstNode):
@@ -939,74 +745,58 @@ class ConditionElement(AstNode):
     pattern: optional[Pattern] | child
     initializer: optional[Expr] | child
 
-
 @group("stmt")
 class StmtCondition(AstNode):
     elements: list[ConditionElement] | child
 
-
 class BraceStmt(Stmt):
     elements: list[AstNode] | child
-
 
 class BreakStmt(Stmt):
     target_name: optional[string]
     target: optional[Stmt]
-
 
 class CaseStmt(Stmt):
     body: Stmt | child
     labels: list[CaseLabelItem] | child
     variables: list[VarDecl]
 
-
 class ContinueStmt(Stmt):
     target_name: optional[string]
     target: optional[Stmt]
 
-
 class DeferStmt(Stmt):
     body: BraceStmt | child
 
-
 class FailStmt(Stmt):
     pass
-
 
 class FallthroughStmt(Stmt):
     fallthrough_source: CaseStmt
     fallthrough_dest: CaseStmt
 
-
 class LabeledStmt(Stmt):
     label: optional[string]
-
 
 class PoundAssertStmt(Stmt):
     condition: Expr
     message: string
 
-
 class ReturnStmt(Stmt):
     result: optional[Expr] | child
-
 
 class ThrowStmt(Stmt):
     sub_expr: Expr | child
 
-
 class YieldStmt(Stmt):
     results: list[Expr] | child
-
 
 class DoCatchStmt(LabeledStmt):
     body: Stmt | child
     catches: list[CaseStmt] | child
 
-
 class DoStmt(LabeledStmt):
     body: BraceStmt | child
-
 
 class ForEachStmt(LabeledStmt):
     pattern: Pattern | child
@@ -1014,38 +804,30 @@ class ForEachStmt(LabeledStmt):
     where: optional[Expr] | child
     body: BraceStmt | child
 
-
 class LabeledConditionalStmt(LabeledStmt):
     condition: StmtCondition | child
-
 
 class RepeatWhileStmt(LabeledStmt):
     condition: Expr | child
     body: Stmt | child
 
-
 class SwitchStmt(LabeledStmt):
     expr: Expr | child
     cases: list[CaseStmt] | child
 
-
 class GuardStmt(LabeledConditionalStmt):
     body: BraceStmt | child
-
 
 class IfStmt(LabeledConditionalStmt):
     then: Stmt | child
     else_: optional[Stmt] | child
 
-
 class WhileStmt(LabeledConditionalStmt):
     body: Stmt | child
-
 
 @group("type")
 class TypeRepr(AstNode):
     type: Type
-
 
 @ql.default_doc_name("function type")
 class AnyFunctionType(Type):
@@ -1055,196 +837,149 @@ class AnyFunctionType(Type):
     is_throwing: predicate | doc("this type refers to a throwing function")
     is_async: predicate | doc("this type refers to an `async` function")
 
-
 class AnyGenericType(Type):
     parent: optional[Type]
     declaration: Decl
 
-
 class AnyMetatypeType(Type):
     pass
-
 
 @qltest.collapse_hierarchy
 class BuiltinType(Type):
     pass
 
-
 class DependentMemberType(Type):
     base_type: Type
     associated_type_decl: AssociatedTypeDecl
 
-
 class DynamicSelfType(Type):
     static_self_type: Type
-
 class ErrorType(Type, ErrorElement):
     pass
-
 
 class ExistentialType(Type):
     constraint: Type
 
-
 class InOutType(Type):
     object_type: Type
-
 
 class LValueType(Type):
     object_type: Type
 
-
 class ModuleType(Type):
     module: ModuleDecl
-
 
 class ProtocolCompositionType(Type):
     members: list[Type]
 
-
 class ReferenceStorageType(Type):
     referent_type: Type
-
 
 class SubstitutableType(Type):
     pass
 
-
 class SugarType(Type):
     pass
-
 
 class TupleType(Type):
     types: list[Type]
     names: list[optional[string]]
-
 class UnresolvedType(Type, ErrorElement):
     pass
-
 class AnyBuiltinIntegerType(BuiltinType):
     pass
-
 
 class ArchetypeType(SubstitutableType):
     interface_type: Type
     superclass: optional[Type]
     protocols: list[ProtocolDecl]
 
-
 class BuiltinBridgeObjectType(BuiltinType):
     pass
-
 
 class BuiltinDefaultActorStorageType(BuiltinType):
     pass
 
-
 class BuiltinExecutorType(BuiltinType):
     pass
-
 
 class BuiltinFloatType(BuiltinType):
     pass
 
-
 class BuiltinJobType(BuiltinType):
     pass
-
 
 class BuiltinNativeObjectType(BuiltinType):
     pass
 
-
 class BuiltinRawPointerType(BuiltinType):
     pass
-
 
 class BuiltinRawUnsafeContinuationType(BuiltinType):
     pass
 
-
 class BuiltinUnsafeValueBufferType(BuiltinType):
     pass
-
 
 class BuiltinVectorType(BuiltinType):
     pass
 
-
 class ExistentialMetatypeType(AnyMetatypeType):
     pass
 
-
 class FunctionType(AnyFunctionType):
     pass
-
 
 class GenericFunctionType(AnyFunctionType):
     """ The type of a generic function with type parameters """
     generic_params: list["GenericTypeParamType"] | doc("type {parameters} of this generic type")
 
-
 class GenericTypeParamType(SubstitutableType):
     pass
-
 
 class MetatypeType(AnyMetatypeType):
     pass
 
-
 class NominalOrBoundGenericNominalType(AnyGenericType):
     pass
-
 
 class ParenType(SugarType):
     type: Type
 
-
 class SyntaxSugarType(SugarType):
     pass
-
 
 class TypeAliasType(SugarType):
     decl: TypeAliasDecl
 
-
 class UnboundGenericType(AnyGenericType):
     pass
-
 
 class UnmanagedStorageType(ReferenceStorageType):
     pass
 
-
 class UnownedStorageType(ReferenceStorageType):
     pass
-
 
 class WeakStorageType(ReferenceStorageType):
     pass
 
-
 class BoundGenericType(NominalOrBoundGenericNominalType):
     arg_types: list[Type]
 
-
 class BuiltinIntegerLiteralType(AnyBuiltinIntegerType):
     pass
-
 
 @qltest.uncollapse_hierarchy
 class BuiltinIntegerType(AnyBuiltinIntegerType):
     width: optional[int]
 
-
 class DictionaryType(SyntaxSugarType):
     key_type: Type
     value_type: Type
 
-
 class NominalType(NominalOrBoundGenericNominalType):
     pass
-
 
 class OpaqueTypeArchetypeType(ArchetypeType):
     """An opaque type, that is a type formally equivalent to an underlying type but abstracting it away.
@@ -1252,57 +987,43 @@ class OpaqueTypeArchetypeType(ArchetypeType):
     See https://docs.swift.org/swift-book/LanguageGuide/OpaqueTypes.html."""
     declaration: OpaqueTypeDecl
 
-
 class OpenedArchetypeType(ArchetypeType):
     pass
 
-
 class PrimaryArchetypeType(ArchetypeType):
     pass
-
 class UnarySyntaxSugarType(SyntaxSugarType):
     base_type: Type
-
 
 class ArraySliceType(UnarySyntaxSugarType):
     pass
 
-
 class BoundGenericClassType(BoundGenericType):
     pass
-
 
 class BoundGenericEnumType(BoundGenericType):
     pass
 
-
 class BoundGenericStructType(BoundGenericType):
     pass
-
 
 class ClassType(NominalType):
     pass
 
-
 class EnumType(NominalType):
     pass
-
 
 class OptionalType(UnarySyntaxSugarType):
     pass
 
-
 class ProtocolType(NominalType):
     pass
-
 
 class StructType(NominalType):
     pass
 
-
 class VariadicSequenceType(UnarySyntaxSugarType):
     pass
-
 
 class ParameterizedProtocolType(Type):
     """


### PR DESCRIPTION
While PEP8 mandates those, they look bad in the schema file.

`autopep8` already ignores those, and they were single newlines at some point until an overeager IDE has "fixed" them at some point without me realizing.

Also, the pre-commit configuration was updated to take `schema.py` into account.