### PR TITLE
Swift: expand definition of `ipa` in `qlgen`

### DIFF
--- a/swift/codegen/templates/ql_db.mustache
+++ b/swift/codegen/templates/ql_db.mustache
@@ -1,5 +1,6 @@
 module Raw {
   {{#classes}}
+  {{^ipa}}
   class {{name}} extends {{db_id}}{{#bases}}, {{.}}{{/bases}} {
     {{#root}}string toString() { none() }{{/root}}
     {{#final}}override string toString() { result = "{{name}}" }{{/final}}
@@ -10,6 +11,6 @@ module Raw {
     }
     {{/properties}}
   }
-
+  {{/ipa}}
   {{/classes}}
 }


### PR DESCRIPTION
This will now cover non-final classes that even though are not marked with `@synth` explicitly, they only have `@synth` final descendants.

We currently do not have such example, hence the absence of changes in generated code.

There are currently no unit tests covering the synth part of `qlgen`, as it is planned to split this script into smaller ones, and it would require more effort to port unit tests rather than write them anew when the split happens.