### PR TITLE
C++: Repair `MustFlow` library for use-use flow

### DIFF
--- a/cpp/ql/lib/change-notes/2022-11-16-must-flow.md
+++ b/cpp/ql/lib/change-notes/2022-11-16-must-flow.md
@@ -1,0 +1,4 @@
+---
+category: breaking
+---
+The predicates in the `MustFlow::Configuration` class used by the `MustFlow` library (`semmle.code.cpp.ir.dataflow.MustFlow`) has changed to be defined directly in terms of the C++ IR instead of IR dataflow nodes.

--- a/cpp/ql/lib/change-notes/2022-11-16-must-flow.md
+++ b/cpp/ql/lib/change-notes/2022-11-16-must-flow.md
@@ -1,4 +1,4 @@
 ---
 category: breaking
 ---
-The predicates in the `MustFlow::Configuration` class used by the `MustFlow` library (`semmle.code.cpp.ir.dataflow.MustFlow`) has changed to be defined directly in terms of the C++ IR instead of IR dataflow nodes.
+The predicates in the `MustFlow::Configuration` class used by the `MustFlow` library (`semmle.code.cpp.ir.dataflow.MustFlow`) have changed to be defined directly in terms of the C++ IR instead of IR dataflow nodes.

--- a/cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
+++ b/cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
@@ -22,37 +22,35 @@ import PathGraph
 class UnsafeUseOfThisConfig extends MustFlowConfiguration {
   UnsafeUseOfThisConfig() { this = "UnsafeUseOfThisConfig" }
 
-  override predicate isSource(DataFlow::Node source) { isSource(source, _, _) }
+  override predicate isSource(Instruction source) { isSource(source, _, _) }
 
-  override predicate isSink(DataFlow::Node sink) { isSink(sink, _) }
+  override predicate isSink(Operand sink) { isSink(sink, _) }
 }
 
 /** Holds if `instr` is a `this` pointer used by the call instruction `call`. */
-predicate isSink(DataFlow::Node sink, CallInstruction call) {
+predicate isSink(Operand sink, CallInstruction call) {
   exists(PureVirtualFunction func |
     call.getStaticCallTarget() = func and
-    call.getThisArgument() = sink.asInstruction() and
+    call.getThisArgumentOperand() = sink and
     // Weed out implicit calls to destructors of a base class
     not func instanceof Destructor
   )
 }
 
 /** Holds if `init` initializes the `this` pointer in class `c`. */
-predicate isSource(DataFlow::Node source, string msg, Class c) {
-  exists(InitializeParameterInstruction init | init = source.asInstruction() |
-    (
-      exists(Constructor func |
-        not func instanceof CopyConstructor and
-        not func instanceof MoveConstructor and
-        func = init.getEnclosingFunction() and
-        msg = "construction"
-      )
-      or
-      init.getEnclosingFunction() instanceof Destructor and msg = "destruction"
-    ) and
-    init.getIRVariable() instanceof IRThisVariable and
-    init.getEnclosingFunction().getDeclaringType() = c
-  )
+predicate isSource(InitializeParameterInstruction source, string msg, Class c) {
+  (
+    exists(Constructor func |
+      not func instanceof CopyConstructor and
+      not func instanceof MoveConstructor and
+      func = source.getEnclosingFunction() and
+      msg = "construction"
+    )
+    or
+    source.getEnclosingFunction() instanceof Destructor and msg = "destruction"
+  ) and
+  source.getIRVariable() instanceof IRThisVariable and
+  source.getEnclosingFunction().getDeclaringType() = c
 }
 
 /**
@@ -68,8 +66,8 @@ predicate flows(
 ) {
   exists(UnsafeUseOfThisConfig conf |
     conf.hasFlowPath(source, sink) and
-    isSource(source.getNode(), msg, sourceClass) and
-    isSink(sink.getNode(), call)
+    isSource(source.getInstruction(), msg, sourceClass) and
+    isSink(sink.getInstruction().getAUse(), call)
   )
 }
 

--- a/cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
+++ b/cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
@@ -27,7 +27,7 @@ class UnsafeUseOfThisConfig extends MustFlowConfiguration {
   override predicate isSink(Operand sink) { isSink(sink, _) }
 }
 
-/** Holds if `instr` is a `this` pointer used by the call instruction `call`. */
+/** Holds if `sink` is a `this` pointer used by the call instruction `call`. */
 predicate isSink(Operand sink, CallInstruction call) {
   exists(PureVirtualFunction func |
     call.getStaticCallTarget() = func and
@@ -37,7 +37,12 @@ predicate isSink(Operand sink, CallInstruction call) {
   )
 }
 
-/** Holds if `init` initializes the `this` pointer in class `c`. */
+/**
+ * Holds if `source` initializes the `this` pointer in class `c`.
+ *
+ * The string `msg` describes whether the enclosing function is a
+ * constructor or destructor.
+ */
 predicate isSource(InitializeParameterInstruction source, string msg, Class c) {
   (
     exists(Constructor func |

--- a/cpp/ql/test/query-tests/Critical/UnsafeUseOfThis/UnsafeUseOfThis.expected
+++ b/cpp/ql/test/query-tests/Critical/UnsafeUseOfThis/UnsafeUseOfThis.expected
@@ -1,103 +1,61 @@
 edges
-| test.cpp:7:3:7:3 | this | test.cpp:8:12:8:15 | Load |
-| test.cpp:8:12:8:15 | Load | test.cpp:8:12:8:15 | this |
+| test.cpp:7:3:7:3 | B | test.cpp:8:12:8:15 | this |
 | test.cpp:8:12:8:15 | this | test.cpp:34:16:34:16 | x |
-| test.cpp:11:8:11:8 | b | test.cpp:12:5:12:5 | Load |
-| test.cpp:12:5:12:5 | (reference dereference) | test.cpp:12:5:12:5 | Unary |
-| test.cpp:12:5:12:5 | Load | test.cpp:12:5:12:5 | b |
-| test.cpp:12:5:12:5 | Unary | test.cpp:12:5:12:5 | (A)... |
-| test.cpp:12:5:12:5 | Unary | test.cpp:12:5:12:5 | (reference dereference) |
-| test.cpp:12:5:12:5 | b | test.cpp:12:5:12:5 | Unary |
-| test.cpp:15:3:15:4 | this | test.cpp:16:5:16:5 | Load |
-| test.cpp:16:5:16:5 | Load | test.cpp:16:5:16:5 | this |
-| test.cpp:16:5:16:5 | Unary | file://:0:0:0:0 | (A *)... |
-| test.cpp:16:5:16:5 | this | test.cpp:16:5:16:5 | Unary |
-| test.cpp:21:3:21:3 | Unary | test.cpp:21:13:21:13 | ConvertToNonVirtualBase |
-| test.cpp:21:3:21:3 | this | test.cpp:21:3:21:3 | Unary |
-| test.cpp:21:3:21:3 | this | test.cpp:22:12:22:15 | Load |
-| test.cpp:21:3:21:3 | this | test.cpp:25:7:25:10 | Load |
-| test.cpp:21:13:21:13 | ConvertToNonVirtualBase | test.cpp:7:3:7:3 | this |
+| test.cpp:11:8:11:8 | b | test.cpp:12:5:12:5 | b |
+| test.cpp:12:5:12:5 | (reference dereference) | test.cpp:12:5:12:5 | (A)... |
+| test.cpp:12:5:12:5 | b | test.cpp:12:5:12:5 | (reference dereference) |
+| test.cpp:15:3:15:4 | ~B | test.cpp:16:5:16:5 | this |
+| test.cpp:16:5:16:5 | this | file://:0:0:0:0 | (A *)... |
+| test.cpp:21:3:21:3 | C | test.cpp:21:13:21:13 | call to B |
+| test.cpp:21:3:21:3 | C | test.cpp:22:12:22:15 | this |
+| test.cpp:21:3:21:3 | C | test.cpp:25:7:25:10 | this |
+| test.cpp:21:13:21:13 | call to B | test.cpp:7:3:7:3 | B |
 | test.cpp:22:12:22:15 | (B *)... | test.cpp:34:16:34:16 | x |
-| test.cpp:22:12:22:15 | Load | test.cpp:22:12:22:15 | this |
-| test.cpp:22:12:22:15 | Unary | test.cpp:22:12:22:15 | (B *)... |
-| test.cpp:22:12:22:15 | this | test.cpp:22:12:22:15 | Unary |
-| test.cpp:25:7:25:10 | (B *)... | test.cpp:25:7:25:10 | Unary |
-| test.cpp:25:7:25:10 | Load | test.cpp:25:7:25:10 | this |
-| test.cpp:25:7:25:10 | Unary | test.cpp:25:7:25:10 | (A *)... |
-| test.cpp:25:7:25:10 | Unary | test.cpp:25:7:25:10 | (B *)... |
-| test.cpp:25:7:25:10 | this | test.cpp:25:7:25:10 | Unary |
-| test.cpp:31:3:31:3 | this | test.cpp:31:12:31:15 | Load |
-| test.cpp:31:11:31:15 | (B)... | test.cpp:31:11:31:15 | Unary |
+| test.cpp:22:12:22:15 | this | test.cpp:22:12:22:15 | (B *)... |
+| test.cpp:25:7:25:10 | (B *)... | test.cpp:25:7:25:10 | (A *)... |
+| test.cpp:25:7:25:10 | this | test.cpp:25:7:25:10 | (B *)... |
+| test.cpp:31:3:31:3 | D | test.cpp:31:12:31:15 | this |
+| test.cpp:31:11:31:15 | (B)... | test.cpp:31:11:31:15 | (reference to) |
 | test.cpp:31:11:31:15 | (reference to) | test.cpp:11:8:11:8 | b |
-| test.cpp:31:11:31:15 | * ... | test.cpp:31:11:31:15 | Unary |
-| test.cpp:31:11:31:15 | Unary | test.cpp:31:11:31:15 | (B)... |
-| test.cpp:31:11:31:15 | Unary | test.cpp:31:11:31:15 | (reference to) |
-| test.cpp:31:12:31:15 | Load | test.cpp:31:12:31:15 | this |
-| test.cpp:31:12:31:15 | Unary | test.cpp:31:11:31:15 | * ... |
-| test.cpp:31:12:31:15 | this | test.cpp:31:12:31:15 | Unary |
-| test.cpp:34:16:34:16 | x | test.cpp:35:3:35:3 | Load |
-| test.cpp:35:3:35:3 | Load | test.cpp:35:3:35:3 | x |
-| test.cpp:35:3:35:3 | Unary | test.cpp:35:3:35:3 | (A *)... |
-| test.cpp:35:3:35:3 | x | test.cpp:35:3:35:3 | Unary |
-| test.cpp:47:3:47:3 | this | test.cpp:48:10:48:13 | Load |
-| test.cpp:48:10:48:13 | (E *)... | test.cpp:48:10:48:13 | Unary |
-| test.cpp:48:10:48:13 | Load | test.cpp:48:10:48:13 | this |
-| test.cpp:48:10:48:13 | Unary | test.cpp:48:6:48:13 | (A *)... |
-| test.cpp:48:10:48:13 | Unary | test.cpp:48:10:48:13 | (E *)... |
-| test.cpp:48:10:48:13 | this | test.cpp:48:10:48:13 | Unary |
+| test.cpp:31:11:31:15 | * ... | test.cpp:31:11:31:15 | (B)... |
+| test.cpp:31:12:31:15 | this | test.cpp:31:11:31:15 | * ... |
+| test.cpp:34:16:34:16 | x | test.cpp:35:3:35:3 | x |
+| test.cpp:35:3:35:3 | x | test.cpp:35:3:35:3 | (A *)... |
+| test.cpp:47:3:47:3 | F | test.cpp:48:10:48:13 | this |
+| test.cpp:48:10:48:13 | (E *)... | test.cpp:48:6:48:13 | (A *)... |
+| test.cpp:48:10:48:13 | this | test.cpp:48:10:48:13 | (E *)... |
 nodes
 | file://:0:0:0:0 | (A *)... | semmle.label | (A *)... |
-| test.cpp:7:3:7:3 | this | semmle.label | this |
-| test.cpp:8:12:8:15 | Load | semmle.label | Load |
+| test.cpp:7:3:7:3 | B | semmle.label | B |
 | test.cpp:8:12:8:15 | this | semmle.label | this |
 | test.cpp:11:8:11:8 | b | semmle.label | b |
 | test.cpp:12:5:12:5 | (A)... | semmle.label | (A)... |
 | test.cpp:12:5:12:5 | (reference dereference) | semmle.label | (reference dereference) |
-| test.cpp:12:5:12:5 | Load | semmle.label | Load |
-| test.cpp:12:5:12:5 | Unary | semmle.label | Unary |
-| test.cpp:12:5:12:5 | Unary | semmle.label | Unary |
 | test.cpp:12:5:12:5 | b | semmle.label | b |
-| test.cpp:15:3:15:4 | this | semmle.label | this |
-| test.cpp:16:5:16:5 | Load | semmle.label | Load |
-| test.cpp:16:5:16:5 | Unary | semmle.label | Unary |
+| test.cpp:15:3:15:4 | ~B | semmle.label | ~B |
 | test.cpp:16:5:16:5 | this | semmle.label | this |
-| test.cpp:21:3:21:3 | Unary | semmle.label | Unary |
-| test.cpp:21:3:21:3 | this | semmle.label | this |
-| test.cpp:21:13:21:13 | ConvertToNonVirtualBase | semmle.label | ConvertToNonVirtualBase |
+| test.cpp:21:3:21:3 | C | semmle.label | C |
+| test.cpp:21:13:21:13 | call to B | semmle.label | call to B |
 | test.cpp:22:12:22:15 | (B *)... | semmle.label | (B *)... |
-| test.cpp:22:12:22:15 | Load | semmle.label | Load |
-| test.cpp:22:12:22:15 | Unary | semmle.label | Unary |
 | test.cpp:22:12:22:15 | this | semmle.label | this |
 | test.cpp:25:7:25:10 | (A *)... | semmle.label | (A *)... |
 | test.cpp:25:7:25:10 | (B *)... | semmle.label | (B *)... |
-| test.cpp:25:7:25:10 | Load | semmle.label | Load |
-| test.cpp:25:7:25:10 | Unary | semmle.label | Unary |
-| test.cpp:25:7:25:10 | Unary | semmle.label | Unary |
 | test.cpp:25:7:25:10 | this | semmle.label | this |
-| test.cpp:31:3:31:3 | this | semmle.label | this |
+| test.cpp:31:3:31:3 | D | semmle.label | D |
 | test.cpp:31:11:31:15 | (B)... | semmle.label | (B)... |
 | test.cpp:31:11:31:15 | (reference to) | semmle.label | (reference to) |
 | test.cpp:31:11:31:15 | * ... | semmle.label | * ... |
-| test.cpp:31:11:31:15 | Unary | semmle.label | Unary |
-| test.cpp:31:11:31:15 | Unary | semmle.label | Unary |
-| test.cpp:31:12:31:15 | Load | semmle.label | Load |
-| test.cpp:31:12:31:15 | Unary | semmle.label | Unary |
 | test.cpp:31:12:31:15 | this | semmle.label | this |
 | test.cpp:34:16:34:16 | x | semmle.label | x |
 | test.cpp:35:3:35:3 | (A *)... | semmle.label | (A *)... |
-| test.cpp:35:3:35:3 | Load | semmle.label | Load |
-| test.cpp:35:3:35:3 | Unary | semmle.label | Unary |
 | test.cpp:35:3:35:3 | x | semmle.label | x |
-| test.cpp:47:3:47:3 | this | semmle.label | this |
+| test.cpp:47:3:47:3 | F | semmle.label | F |
 | test.cpp:48:6:48:13 | (A *)... | semmle.label | (A *)... |
 | test.cpp:48:10:48:13 | (E *)... | semmle.label | (E *)... |
-| test.cpp:48:10:48:13 | Load | semmle.label | Load |
-| test.cpp:48:10:48:13 | Unary | semmle.label | Unary |
-| test.cpp:48:10:48:13 | Unary | semmle.label | Unary |
 | test.cpp:48:10:48:13 | this | semmle.label | this |
 #select
-| test.cpp:12:7:12:7 | call to f | test.cpp:31:3:31:3 | this | test.cpp:12:5:12:5 | (A)... | Call to pure virtual function during construction. |
-| test.cpp:16:5:16:5 | call to f | test.cpp:15:3:15:4 | this | file://:0:0:0:0 | (A *)... | Call to pure virtual function during destruction. |
-| test.cpp:25:13:25:13 | call to f | test.cpp:21:3:21:3 | this | test.cpp:25:7:25:10 | (A *)... | Call to pure virtual function during construction. |
-| test.cpp:35:6:35:6 | call to f | test.cpp:7:3:7:3 | this | test.cpp:35:3:35:3 | (A *)... | Call to pure virtual function during construction. |
-| test.cpp:35:6:35:6 | call to f | test.cpp:21:3:21:3 | this | test.cpp:35:3:35:3 | (A *)... | Call to pure virtual function during construction. |
+| test.cpp:12:7:12:7 | call to f | test.cpp:31:3:31:3 | D | test.cpp:12:5:12:5 | (A)... | Call to pure virtual function during construction. |
+| test.cpp:16:5:16:5 | call to f | test.cpp:15:3:15:4 | ~B | file://:0:0:0:0 | (A *)... | Call to pure virtual function during destruction. |
+| test.cpp:25:13:25:13 | call to f | test.cpp:21:3:21:3 | C | test.cpp:25:7:25:10 | (A *)... | Call to pure virtual function during construction. |
+| test.cpp:35:6:35:6 | call to f | test.cpp:7:3:7:3 | B | test.cpp:35:3:35:3 | (A *)... | Call to pure virtual function during construction. |
+| test.cpp:35:6:35:6 | call to f | test.cpp:21:3:21:3 | C | test.cpp:35:3:35:3 | (A *)... | Call to pure virtual function during construction. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -1,231 +1,117 @@
 edges
-| test.cpp:17:9:17:11 | & ... | test.cpp:17:9:17:11 | StoreValue |
-| test.cpp:17:10:17:11 | Unary | test.cpp:17:9:17:11 | & ... |
-| test.cpp:17:10:17:11 | mc | test.cpp:17:10:17:11 | Unary |
-| test.cpp:23:17:23:19 | & ... | test.cpp:23:17:23:19 | StoreValue |
-| test.cpp:23:17:23:19 | Store | test.cpp:25:9:25:11 | Load |
-| test.cpp:23:17:23:19 | StoreValue | test.cpp:23:17:23:19 | Store |
-| test.cpp:23:18:23:19 | Unary | test.cpp:23:17:23:19 | & ... |
-| test.cpp:23:18:23:19 | mc | test.cpp:23:18:23:19 | Unary |
-| test.cpp:25:9:25:11 | Load | test.cpp:25:9:25:11 | ptr |
-| test.cpp:25:9:25:11 | ptr | test.cpp:25:9:25:11 | StoreValue |
-| test.cpp:39:17:39:18 | (reference to) | test.cpp:39:17:39:18 | StoreValue |
-| test.cpp:39:17:39:18 | Store | test.cpp:41:10:41:12 | Load |
-| test.cpp:39:17:39:18 | StoreValue | test.cpp:39:17:39:18 | Store |
-| test.cpp:39:17:39:18 | Unary | test.cpp:39:17:39:18 | (reference to) |
-| test.cpp:39:17:39:18 | mc | test.cpp:39:17:39:18 | Unary |
-| test.cpp:41:9:41:12 | & ... | test.cpp:41:9:41:12 | StoreValue |
-| test.cpp:41:10:41:12 | (reference dereference) | test.cpp:41:10:41:12 | Unary |
-| test.cpp:41:10:41:12 | Load | test.cpp:41:10:41:12 | ref |
-| test.cpp:41:10:41:12 | Unary | test.cpp:41:9:41:12 | & ... |
-| test.cpp:41:10:41:12 | Unary | test.cpp:41:10:41:12 | (reference dereference) |
-| test.cpp:41:10:41:12 | ref | test.cpp:41:10:41:12 | Unary |
-| test.cpp:47:9:47:10 | (reference to) | test.cpp:47:9:47:10 | StoreValue |
-| test.cpp:47:9:47:10 | Unary | test.cpp:47:9:47:10 | (reference to) |
-| test.cpp:47:9:47:10 | mc | test.cpp:47:9:47:10 | Unary |
-| test.cpp:54:9:54:15 | & ... | test.cpp:54:9:54:15 | StoreValue |
-| test.cpp:54:11:54:12 | Unary | test.cpp:54:14:54:14 | a |
-| test.cpp:54:11:54:12 | mc | test.cpp:54:11:54:12 | Unary |
-| test.cpp:54:14:54:14 | Unary | test.cpp:54:9:54:15 | & ... |
-| test.cpp:54:14:54:14 | a | test.cpp:54:14:54:14 | Unary |
-| test.cpp:89:3:89:11 | Store | test.cpp:92:9:92:11 | Load |
-| test.cpp:89:9:89:11 | & ... | test.cpp:89:9:89:11 | StoreValue |
-| test.cpp:89:9:89:11 | StoreValue | test.cpp:89:3:89:11 | Store |
-| test.cpp:89:10:89:11 | Unary | test.cpp:89:9:89:11 | & ... |
-| test.cpp:89:10:89:11 | mc | test.cpp:89:10:89:11 | Unary |
-| test.cpp:92:9:92:11 | Load | test.cpp:92:9:92:11 | ptr |
-| test.cpp:92:9:92:11 | ptr | test.cpp:92:9:92:11 | StoreValue |
-| test.cpp:112:9:112:11 | Unary | test.cpp:112:9:112:11 | array to pointer conversion |
-| test.cpp:112:9:112:11 | arr | test.cpp:112:9:112:11 | Unary |
-| test.cpp:112:9:112:11 | array to pointer conversion | test.cpp:112:9:112:11 | StoreValue |
-| test.cpp:119:9:119:18 | & ... | test.cpp:119:9:119:18 | StoreValue |
-| test.cpp:119:11:119:13 | Left | test.cpp:119:11:119:17 | access to array |
-| test.cpp:119:11:119:13 | Unary | test.cpp:119:11:119:13 | array to pointer conversion |
-| test.cpp:119:11:119:13 | arr | test.cpp:119:11:119:13 | Unary |
-| test.cpp:119:11:119:13 | array to pointer conversion | test.cpp:119:11:119:13 | Left |
-| test.cpp:119:11:119:17 | Unary | test.cpp:119:9:119:18 | & ... |
-| test.cpp:119:11:119:17 | access to array | test.cpp:119:11:119:17 | Unary |
-| test.cpp:134:2:134:14 | Store | test.cpp:135:2:135:4 | Load |
-| test.cpp:134:8:134:10 | Left | test.cpp:134:8:134:14 | ... + ... |
-| test.cpp:134:8:134:10 | Unary | test.cpp:134:8:134:10 | array to pointer conversion |
-| test.cpp:134:8:134:10 | arr | test.cpp:134:8:134:10 | Unary |
-| test.cpp:134:8:134:10 | array to pointer conversion | test.cpp:134:8:134:10 | Left |
-| test.cpp:134:8:134:14 | ... + ... | test.cpp:134:8:134:14 | StoreValue |
-| test.cpp:134:8:134:14 | StoreValue | test.cpp:134:2:134:14 | Store |
-| test.cpp:135:2:135:4 | Left | test.cpp:135:2:135:6 | PointerAdd |
-| test.cpp:135:2:135:4 | Load | test.cpp:135:2:135:4 | ptr |
-| test.cpp:135:2:135:4 | ptr | test.cpp:135:2:135:4 | Left |
-| test.cpp:135:2:135:6 | PointerAdd | test.cpp:135:2:135:6 | StoreValue |
-| test.cpp:135:2:135:6 | Store | test.cpp:137:9:137:11 | Load |
-| test.cpp:135:2:135:6 | StoreValue | test.cpp:135:2:135:6 | Store |
-| test.cpp:137:9:137:11 | Load | test.cpp:137:9:137:11 | ptr |
-| test.cpp:137:9:137:11 | ptr | test.cpp:137:9:137:11 | StoreValue |
-| test.cpp:170:26:170:41 | (void *)... | test.cpp:170:26:170:41 | StoreValue |
-| test.cpp:170:26:170:41 | Store | test.cpp:171:10:171:23 | Load |
-| test.cpp:170:26:170:41 | StoreValue | test.cpp:170:26:170:41 | Store |
-| test.cpp:170:34:170:41 | & ... | test.cpp:170:34:170:41 | Unary |
-| test.cpp:170:34:170:41 | Unary | test.cpp:170:26:170:41 | (void *)... |
-| test.cpp:170:35:170:41 | Unary | test.cpp:170:34:170:41 | & ... |
-| test.cpp:170:35:170:41 | myLocal | test.cpp:170:35:170:41 | Unary |
-| test.cpp:171:10:171:23 | Load | test.cpp:171:10:171:23 | pointerToLocal |
-| test.cpp:171:10:171:23 | pointerToLocal | test.cpp:171:10:171:23 | StoreValue |
-| test.cpp:176:25:176:34 | Store | test.cpp:177:10:177:23 | Load |
-| test.cpp:176:25:176:34 | StoreValue | test.cpp:176:25:176:34 | Store |
-| test.cpp:176:25:176:34 | Unary | test.cpp:176:25:176:34 | array to pointer conversion |
-| test.cpp:176:25:176:34 | array to pointer conversion | test.cpp:176:25:176:34 | StoreValue |
-| test.cpp:176:25:176:34 | localArray | test.cpp:176:25:176:34 | Unary |
-| test.cpp:177:10:177:23 | (void *)... | test.cpp:177:10:177:23 | StoreValue |
-| test.cpp:177:10:177:23 | Load | test.cpp:177:10:177:23 | pointerToLocal |
-| test.cpp:177:10:177:23 | Unary | test.cpp:177:10:177:23 | (void *)... |
-| test.cpp:177:10:177:23 | pointerToLocal | test.cpp:177:10:177:23 | Unary |
-| test.cpp:182:21:182:27 | (reference to) | test.cpp:182:21:182:27 | StoreValue |
-| test.cpp:182:21:182:27 | Store | test.cpp:183:10:183:19 | Load |
-| test.cpp:182:21:182:27 | StoreValue | test.cpp:182:21:182:27 | Store |
-| test.cpp:182:21:182:27 | Unary | test.cpp:182:21:182:27 | (reference to) |
-| test.cpp:182:21:182:27 | myLocal | test.cpp:182:21:182:27 | Unary |
-| test.cpp:183:10:183:19 | (reference dereference) | test.cpp:183:10:183:19 | Unary |
-| test.cpp:183:10:183:19 | (reference to) | test.cpp:183:10:183:19 | StoreValue |
-| test.cpp:183:10:183:19 | Load | test.cpp:183:10:183:19 | refToLocal |
-| test.cpp:183:10:183:19 | Unary | test.cpp:183:10:183:19 | (reference dereference) |
-| test.cpp:183:10:183:19 | Unary | test.cpp:183:10:183:19 | (reference to) |
-| test.cpp:183:10:183:19 | refToLocal | test.cpp:183:10:183:19 | Unary |
-| test.cpp:189:16:189:16 | (reference to) | test.cpp:189:16:189:16 | StoreValue |
-| test.cpp:189:16:189:16 | Store | test.cpp:190:10:190:13 | Load |
-| test.cpp:189:16:189:16 | StoreValue | test.cpp:189:16:189:16 | Store |
-| test.cpp:189:16:189:16 | Unary | test.cpp:189:16:189:16 | (reference to) |
-| test.cpp:189:16:189:16 | p | test.cpp:189:16:189:16 | Unary |
-| test.cpp:190:10:190:13 | (reference dereference) | test.cpp:190:10:190:13 | Unary |
-| test.cpp:190:10:190:13 | (reference to) | test.cpp:190:10:190:13 | StoreValue |
-| test.cpp:190:10:190:13 | Load | test.cpp:190:10:190:13 | pRef |
-| test.cpp:190:10:190:13 | Unary | test.cpp:190:10:190:13 | (reference dereference) |
-| test.cpp:190:10:190:13 | Unary | test.cpp:190:10:190:13 | (reference to) |
-| test.cpp:190:10:190:13 | pRef | test.cpp:190:10:190:13 | Unary |
+| test.cpp:17:10:17:11 | mc | test.cpp:17:9:17:11 | & ... |
+| test.cpp:23:17:23:19 | & ... | test.cpp:23:17:23:19 | & ... |
+| test.cpp:23:17:23:19 | & ... | test.cpp:25:9:25:11 | ptr |
+| test.cpp:23:18:23:19 | mc | test.cpp:23:17:23:19 | & ... |
+| test.cpp:39:17:39:18 | (reference to) | test.cpp:39:17:39:18 | (reference to) |
+| test.cpp:39:17:39:18 | (reference to) | test.cpp:41:10:41:12 | ref |
+| test.cpp:39:17:39:18 | mc | test.cpp:39:17:39:18 | (reference to) |
+| test.cpp:41:10:41:12 | (reference dereference) | test.cpp:41:9:41:12 | & ... |
+| test.cpp:41:10:41:12 | ref | test.cpp:41:10:41:12 | (reference dereference) |
+| test.cpp:47:9:47:10 | mc | test.cpp:47:9:47:10 | (reference to) |
+| test.cpp:54:11:54:12 | mc | test.cpp:54:14:54:14 | a |
+| test.cpp:54:14:54:14 | a | test.cpp:54:9:54:15 | & ... |
+| test.cpp:89:3:89:11 | ... = ... | test.cpp:92:9:92:11 | ptr |
+| test.cpp:89:9:89:11 | & ... | test.cpp:89:3:89:11 | ... = ... |
+| test.cpp:89:10:89:11 | mc | test.cpp:89:9:89:11 | & ... |
+| test.cpp:112:9:112:11 | arr | test.cpp:112:9:112:11 | array to pointer conversion |
+| test.cpp:119:11:119:13 | arr | test.cpp:119:11:119:13 | array to pointer conversion |
+| test.cpp:119:11:119:13 | array to pointer conversion | test.cpp:119:11:119:17 | access to array |
+| test.cpp:119:11:119:17 | access to array | test.cpp:119:9:119:18 | & ... |
+| test.cpp:134:2:134:14 | ... = ... | test.cpp:135:2:135:4 | ptr |
+| test.cpp:134:8:134:10 | arr | test.cpp:134:8:134:10 | array to pointer conversion |
+| test.cpp:134:8:134:10 | array to pointer conversion | test.cpp:134:8:134:14 | ... + ... |
+| test.cpp:134:8:134:14 | ... + ... | test.cpp:134:2:134:14 | ... = ... |
+| test.cpp:135:2:135:4 | ptr | test.cpp:135:2:135:6 | ... ++ |
+| test.cpp:135:2:135:6 | ... ++ | test.cpp:135:2:135:6 | ... ++ |
+| test.cpp:135:2:135:6 | ... ++ | test.cpp:137:9:137:11 | ptr |
+| test.cpp:170:26:170:41 | (void *)... | test.cpp:170:26:170:41 | (void *)... |
+| test.cpp:170:26:170:41 | (void *)... | test.cpp:171:10:171:23 | pointerToLocal |
+| test.cpp:170:34:170:41 | & ... | test.cpp:170:26:170:41 | (void *)... |
+| test.cpp:170:35:170:41 | myLocal | test.cpp:170:34:170:41 | & ... |
+| test.cpp:176:25:176:34 | array to pointer conversion | test.cpp:176:25:176:34 | array to pointer conversion |
+| test.cpp:176:25:176:34 | array to pointer conversion | test.cpp:177:10:177:23 | pointerToLocal |
+| test.cpp:176:25:176:34 | localArray | test.cpp:176:25:176:34 | array to pointer conversion |
+| test.cpp:177:10:177:23 | pointerToLocal | test.cpp:177:10:177:23 | (void *)... |
+| test.cpp:182:21:182:27 | (reference to) | test.cpp:182:21:182:27 | (reference to) |
+| test.cpp:182:21:182:27 | (reference to) | test.cpp:183:10:183:19 | refToLocal |
+| test.cpp:182:21:182:27 | myLocal | test.cpp:182:21:182:27 | (reference to) |
+| test.cpp:183:10:183:19 | (reference dereference) | test.cpp:183:10:183:19 | (reference to) |
+| test.cpp:183:10:183:19 | refToLocal | test.cpp:183:10:183:19 | (reference dereference) |
+| test.cpp:189:16:189:16 | (reference to) | test.cpp:189:16:189:16 | (reference to) |
+| test.cpp:189:16:189:16 | (reference to) | test.cpp:190:10:190:13 | pRef |
+| test.cpp:189:16:189:16 | p | test.cpp:189:16:189:16 | (reference to) |
+| test.cpp:190:10:190:13 | (reference dereference) | test.cpp:190:10:190:13 | (reference to) |
+| test.cpp:190:10:190:13 | pRef | test.cpp:190:10:190:13 | (reference dereference) |
 nodes
 | test.cpp:17:9:17:11 | & ... | semmle.label | & ... |
-| test.cpp:17:9:17:11 | StoreValue | semmle.label | StoreValue |
-| test.cpp:17:10:17:11 | Unary | semmle.label | Unary |
 | test.cpp:17:10:17:11 | mc | semmle.label | mc |
 | test.cpp:23:17:23:19 | & ... | semmle.label | & ... |
-| test.cpp:23:17:23:19 | Store | semmle.label | Store |
-| test.cpp:23:17:23:19 | StoreValue | semmle.label | StoreValue |
-| test.cpp:23:18:23:19 | Unary | semmle.label | Unary |
+| test.cpp:23:17:23:19 | & ... | semmle.label | & ... |
 | test.cpp:23:18:23:19 | mc | semmle.label | mc |
-| test.cpp:25:9:25:11 | Load | semmle.label | Load |
-| test.cpp:25:9:25:11 | StoreValue | semmle.label | StoreValue |
 | test.cpp:25:9:25:11 | ptr | semmle.label | ptr |
 | test.cpp:39:17:39:18 | (reference to) | semmle.label | (reference to) |
-| test.cpp:39:17:39:18 | Store | semmle.label | Store |
-| test.cpp:39:17:39:18 | StoreValue | semmle.label | StoreValue |
-| test.cpp:39:17:39:18 | Unary | semmle.label | Unary |
+| test.cpp:39:17:39:18 | (reference to) | semmle.label | (reference to) |
 | test.cpp:39:17:39:18 | mc | semmle.label | mc |
 | test.cpp:41:9:41:12 | & ... | semmle.label | & ... |
-| test.cpp:41:9:41:12 | StoreValue | semmle.label | StoreValue |
 | test.cpp:41:10:41:12 | (reference dereference) | semmle.label | (reference dereference) |
-| test.cpp:41:10:41:12 | Load | semmle.label | Load |
-| test.cpp:41:10:41:12 | Unary | semmle.label | Unary |
-| test.cpp:41:10:41:12 | Unary | semmle.label | Unary |
 | test.cpp:41:10:41:12 | ref | semmle.label | ref |
 | test.cpp:47:9:47:10 | (reference to) | semmle.label | (reference to) |
-| test.cpp:47:9:47:10 | StoreValue | semmle.label | StoreValue |
-| test.cpp:47:9:47:10 | Unary | semmle.label | Unary |
 | test.cpp:47:9:47:10 | mc | semmle.label | mc |
 | test.cpp:54:9:54:15 | & ... | semmle.label | & ... |
-| test.cpp:54:9:54:15 | StoreValue | semmle.label | StoreValue |
-| test.cpp:54:11:54:12 | Unary | semmle.label | Unary |
 | test.cpp:54:11:54:12 | mc | semmle.label | mc |
-| test.cpp:54:14:54:14 | Unary | semmle.label | Unary |
 | test.cpp:54:14:54:14 | a | semmle.label | a |
-| test.cpp:89:3:89:11 | Store | semmle.label | Store |
+| test.cpp:89:3:89:11 | ... = ... | semmle.label | ... = ... |
 | test.cpp:89:9:89:11 | & ... | semmle.label | & ... |
-| test.cpp:89:9:89:11 | StoreValue | semmle.label | StoreValue |
-| test.cpp:89:10:89:11 | Unary | semmle.label | Unary |
 | test.cpp:89:10:89:11 | mc | semmle.label | mc |
-| test.cpp:92:9:92:11 | Load | semmle.label | Load |
-| test.cpp:92:9:92:11 | StoreValue | semmle.label | StoreValue |
 | test.cpp:92:9:92:11 | ptr | semmle.label | ptr |
-| test.cpp:112:9:112:11 | StoreValue | semmle.label | StoreValue |
-| test.cpp:112:9:112:11 | Unary | semmle.label | Unary |
 | test.cpp:112:9:112:11 | arr | semmle.label | arr |
 | test.cpp:112:9:112:11 | array to pointer conversion | semmle.label | array to pointer conversion |
 | test.cpp:119:9:119:18 | & ... | semmle.label | & ... |
-| test.cpp:119:9:119:18 | StoreValue | semmle.label | StoreValue |
-| test.cpp:119:11:119:13 | Left | semmle.label | Left |
-| test.cpp:119:11:119:13 | Unary | semmle.label | Unary |
 | test.cpp:119:11:119:13 | arr | semmle.label | arr |
 | test.cpp:119:11:119:13 | array to pointer conversion | semmle.label | array to pointer conversion |
-| test.cpp:119:11:119:17 | Unary | semmle.label | Unary |
 | test.cpp:119:11:119:17 | access to array | semmle.label | access to array |
-| test.cpp:134:2:134:14 | Store | semmle.label | Store |
-| test.cpp:134:8:134:10 | Left | semmle.label | Left |
-| test.cpp:134:8:134:10 | Unary | semmle.label | Unary |
+| test.cpp:134:2:134:14 | ... = ... | semmle.label | ... = ... |
 | test.cpp:134:8:134:10 | arr | semmle.label | arr |
 | test.cpp:134:8:134:10 | array to pointer conversion | semmle.label | array to pointer conversion |
 | test.cpp:134:8:134:14 | ... + ... | semmle.label | ... + ... |
-| test.cpp:134:8:134:14 | StoreValue | semmle.label | StoreValue |
-| test.cpp:135:2:135:4 | Left | semmle.label | Left |
-| test.cpp:135:2:135:4 | Load | semmle.label | Load |
 | test.cpp:135:2:135:4 | ptr | semmle.label | ptr |
-| test.cpp:135:2:135:6 | PointerAdd | semmle.label | PointerAdd |
-| test.cpp:135:2:135:6 | Store | semmle.label | Store |
-| test.cpp:135:2:135:6 | StoreValue | semmle.label | StoreValue |
-| test.cpp:137:9:137:11 | Load | semmle.label | Load |
-| test.cpp:137:9:137:11 | StoreValue | semmle.label | StoreValue |
+| test.cpp:135:2:135:6 | ... ++ | semmle.label | ... ++ |
+| test.cpp:135:2:135:6 | ... ++ | semmle.label | ... ++ |
 | test.cpp:137:9:137:11 | ptr | semmle.label | ptr |
 | test.cpp:170:26:170:41 | (void *)... | semmle.label | (void *)... |
-| test.cpp:170:26:170:41 | Store | semmle.label | Store |
-| test.cpp:170:26:170:41 | StoreValue | semmle.label | StoreValue |
+| test.cpp:170:26:170:41 | (void *)... | semmle.label | (void *)... |
 | test.cpp:170:34:170:41 | & ... | semmle.label | & ... |
-| test.cpp:170:34:170:41 | Unary | semmle.label | Unary |
-| test.cpp:170:35:170:41 | Unary | semmle.label | Unary |
 | test.cpp:170:35:170:41 | myLocal | semmle.label | myLocal |
-| test.cpp:171:10:171:23 | Load | semmle.label | Load |
-| test.cpp:171:10:171:23 | StoreValue | semmle.label | StoreValue |
 | test.cpp:171:10:171:23 | pointerToLocal | semmle.label | pointerToLocal |
-| test.cpp:176:25:176:34 | Store | semmle.label | Store |
-| test.cpp:176:25:176:34 | StoreValue | semmle.label | StoreValue |
-| test.cpp:176:25:176:34 | Unary | semmle.label | Unary |
+| test.cpp:176:25:176:34 | array to pointer conversion | semmle.label | array to pointer conversion |
 | test.cpp:176:25:176:34 | array to pointer conversion | semmle.label | array to pointer conversion |
 | test.cpp:176:25:176:34 | localArray | semmle.label | localArray |
 | test.cpp:177:10:177:23 | (void *)... | semmle.label | (void *)... |
-| test.cpp:177:10:177:23 | Load | semmle.label | Load |
-| test.cpp:177:10:177:23 | StoreValue | semmle.label | StoreValue |
-| test.cpp:177:10:177:23 | Unary | semmle.label | Unary |
 | test.cpp:177:10:177:23 | pointerToLocal | semmle.label | pointerToLocal |
 | test.cpp:182:21:182:27 | (reference to) | semmle.label | (reference to) |
-| test.cpp:182:21:182:27 | Store | semmle.label | Store |
-| test.cpp:182:21:182:27 | StoreValue | semmle.label | StoreValue |
-| test.cpp:182:21:182:27 | Unary | semmle.label | Unary |
+| test.cpp:182:21:182:27 | (reference to) | semmle.label | (reference to) |
 | test.cpp:182:21:182:27 | myLocal | semmle.label | myLocal |
 | test.cpp:183:10:183:19 | (reference dereference) | semmle.label | (reference dereference) |
 | test.cpp:183:10:183:19 | (reference to) | semmle.label | (reference to) |
-| test.cpp:183:10:183:19 | Load | semmle.label | Load |
-| test.cpp:183:10:183:19 | StoreValue | semmle.label | StoreValue |
-| test.cpp:183:10:183:19 | Unary | semmle.label | Unary |
-| test.cpp:183:10:183:19 | Unary | semmle.label | Unary |
 | test.cpp:183:10:183:19 | refToLocal | semmle.label | refToLocal |
 | test.cpp:189:16:189:16 | (reference to) | semmle.label | (reference to) |
-| test.cpp:189:16:189:16 | Store | semmle.label | Store |
-| test.cpp:189:16:189:16 | StoreValue | semmle.label | StoreValue |
-| test.cpp:189:16:189:16 | Unary | semmle.label | Unary |
+| test.cpp:189:16:189:16 | (reference to) | semmle.label | (reference to) |
 | test.cpp:189:16:189:16 | p | semmle.label | p |
 | test.cpp:190:10:190:13 | (reference dereference) | semmle.label | (reference dereference) |
 | test.cpp:190:10:190:13 | (reference to) | semmle.label | (reference to) |
-| test.cpp:190:10:190:13 | Load | semmle.label | Load |
-| test.cpp:190:10:190:13 | StoreValue | semmle.label | StoreValue |
-| test.cpp:190:10:190:13 | Unary | semmle.label | Unary |
-| test.cpp:190:10:190:13 | Unary | semmle.label | Unary |
 | test.cpp:190:10:190:13 | pRef | semmle.label | pRef |
 #select
-| test.cpp:17:9:17:11 | StoreValue | test.cpp:17:10:17:11 | mc | test.cpp:17:9:17:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:17:10:17:11 | mc | mc |
-| test.cpp:25:9:25:11 | StoreValue | test.cpp:23:18:23:19 | mc | test.cpp:25:9:25:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:23:18:23:19 | mc | mc |
-| test.cpp:41:9:41:12 | StoreValue | test.cpp:39:17:39:18 | mc | test.cpp:41:9:41:12 | StoreValue | May return stack-allocated memory from $@. | test.cpp:39:17:39:18 | mc | mc |
-| test.cpp:47:9:47:10 | StoreValue | test.cpp:47:9:47:10 | mc | test.cpp:47:9:47:10 | StoreValue | May return stack-allocated memory from $@. | test.cpp:47:9:47:10 | mc | mc |
-| test.cpp:54:9:54:15 | StoreValue | test.cpp:54:11:54:12 | mc | test.cpp:54:9:54:15 | StoreValue | May return stack-allocated memory from $@. | test.cpp:54:11:54:12 | mc | mc |
-| test.cpp:92:9:92:11 | StoreValue | test.cpp:89:10:89:11 | mc | test.cpp:92:9:92:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:89:10:89:11 | mc | mc |
-| test.cpp:112:9:112:11 | StoreValue | test.cpp:112:9:112:11 | arr | test.cpp:112:9:112:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:112:9:112:11 | arr | arr |
-| test.cpp:119:9:119:18 | StoreValue | test.cpp:119:11:119:13 | arr | test.cpp:119:9:119:18 | StoreValue | May return stack-allocated memory from $@. | test.cpp:119:11:119:13 | arr | arr |
-| test.cpp:137:9:137:11 | StoreValue | test.cpp:134:8:134:10 | arr | test.cpp:137:9:137:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:134:8:134:10 | arr | arr |
-| test.cpp:171:10:171:23 | StoreValue | test.cpp:170:35:170:41 | myLocal | test.cpp:171:10:171:23 | StoreValue | May return stack-allocated memory from $@. | test.cpp:170:35:170:41 | myLocal | myLocal |
-| test.cpp:177:10:177:23 | StoreValue | test.cpp:176:25:176:34 | localArray | test.cpp:177:10:177:23 | StoreValue | May return stack-allocated memory from $@. | test.cpp:176:25:176:34 | localArray | localArray |
-| test.cpp:183:10:183:19 | StoreValue | test.cpp:182:21:182:27 | myLocal | test.cpp:183:10:183:19 | StoreValue | May return stack-allocated memory from $@. | test.cpp:182:21:182:27 | myLocal | myLocal |
-| test.cpp:190:10:190:13 | StoreValue | test.cpp:189:16:189:16 | p | test.cpp:190:10:190:13 | StoreValue | May return stack-allocated memory from $@. | test.cpp:189:16:189:16 | p | p |
+| test.cpp:17:9:17:11 | CopyValue: & ... | test.cpp:17:10:17:11 | mc | test.cpp:17:9:17:11 | & ... | May return stack-allocated memory from $@. | test.cpp:17:10:17:11 | mc | mc |
+| test.cpp:25:9:25:11 | Load: ptr | test.cpp:23:18:23:19 | mc | test.cpp:25:9:25:11 | ptr | May return stack-allocated memory from $@. | test.cpp:23:18:23:19 | mc | mc |
+| test.cpp:41:9:41:12 | CopyValue: & ... | test.cpp:39:17:39:18 | mc | test.cpp:41:9:41:12 | & ... | May return stack-allocated memory from $@. | test.cpp:39:17:39:18 | mc | mc |
+| test.cpp:47:9:47:10 | CopyValue: (reference to) | test.cpp:47:9:47:10 | mc | test.cpp:47:9:47:10 | (reference to) | May return stack-allocated memory from $@. | test.cpp:47:9:47:10 | mc | mc |
+| test.cpp:54:9:54:15 | CopyValue: & ... | test.cpp:54:11:54:12 | mc | test.cpp:54:9:54:15 | & ... | May return stack-allocated memory from $@. | test.cpp:54:11:54:12 | mc | mc |
+| test.cpp:92:9:92:11 | Load: ptr | test.cpp:89:10:89:11 | mc | test.cpp:92:9:92:11 | ptr | May return stack-allocated memory from $@. | test.cpp:89:10:89:11 | mc | mc |
+| test.cpp:112:9:112:11 | Convert: array to pointer conversion | test.cpp:112:9:112:11 | arr | test.cpp:112:9:112:11 | array to pointer conversion | May return stack-allocated memory from $@. | test.cpp:112:9:112:11 | arr | arr |
+| test.cpp:119:9:119:18 | CopyValue: & ... | test.cpp:119:11:119:13 | arr | test.cpp:119:9:119:18 | & ... | May return stack-allocated memory from $@. | test.cpp:119:11:119:13 | arr | arr |
+| test.cpp:137:9:137:11 | Load: ptr | test.cpp:134:8:134:10 | arr | test.cpp:137:9:137:11 | ptr | May return stack-allocated memory from $@. | test.cpp:134:8:134:10 | arr | arr |
+| test.cpp:171:10:171:23 | Load: pointerToLocal | test.cpp:170:35:170:41 | myLocal | test.cpp:171:10:171:23 | pointerToLocal | May return stack-allocated memory from $@. | test.cpp:170:35:170:41 | myLocal | myLocal |
+| test.cpp:177:10:177:23 | Convert: (void *)... | test.cpp:176:25:176:34 | localArray | test.cpp:177:10:177:23 | (void *)... | May return stack-allocated memory from $@. | test.cpp:176:25:176:34 | localArray | localArray |
+| test.cpp:183:10:183:19 | CopyValue: (reference to) | test.cpp:182:21:182:27 | myLocal | test.cpp:183:10:183:19 | (reference to) | May return stack-allocated memory from $@. | test.cpp:182:21:182:27 | myLocal | myLocal |
+| test.cpp:190:10:190:13 | CopyValue: (reference to) | test.cpp:189:16:189:16 | p | test.cpp:190:10:190:13 | (reference to) | May return stack-allocated memory from $@. | test.cpp:189:16:189:16 | p | p |


### PR DESCRIPTION
The `MustFlow` library was previously defined in terms of the IR-based dataflow nodes, and implicitly relied on the assumption that all relevant instructions had dataflow nodes.

On the feature branch, this is no longer the case. Thus, we cannot use the dataflow nodes, and we have to use the IR directly.

Sadly, this is a breaking change. I think this is okay, however, because:
1. I haven't seen any uses of it outside the two queries we have in Code Scanning that use it.
2. It's really easy to transition from the dataflow nodes to the instructions (since the library was already using the IR-based dataflow library).

