### PR TITLE
C++: Fix flow out of const member functions

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -153,10 +153,6 @@
 | by_reference.cpp:16:11:16:11 | a | AST only |
 | by_reference.cpp:32:15:32:15 | s | IR only |
 | by_reference.cpp:36:18:36:18 | this | IR only |
-| by_reference.cpp:40:12:40:15 | this | AST only |
-| by_reference.cpp:51:8:51:8 | s | AST only |
-| by_reference.cpp:57:8:57:8 | s | AST only |
-| by_reference.cpp:63:8:63:8 | s | AST only |
 | by_reference.cpp:84:10:84:10 | a | AST only |
 | by_reference.cpp:88:9:88:9 | a | AST only |
 | by_reference.cpp:92:3:92:5 | * ... | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
@@ -332,14 +332,18 @@
 | by_reference.cpp:24:25:24:29 | value |
 | by_reference.cpp:32:12:32:12 | s |
 | by_reference.cpp:36:12:36:15 | this |
+| by_reference.cpp:40:12:40:15 | this |
 | by_reference.cpp:50:3:50:3 | s |
 | by_reference.cpp:50:17:50:26 | call to user_input |
+| by_reference.cpp:51:8:51:8 | s |
 | by_reference.cpp:51:10:51:20 | call to getDirectly |
 | by_reference.cpp:56:3:56:3 | s |
 | by_reference.cpp:56:19:56:28 | call to user_input |
+| by_reference.cpp:57:8:57:8 | s |
 | by_reference.cpp:57:10:57:22 | call to getIndirectly |
 | by_reference.cpp:62:3:62:3 | s |
 | by_reference.cpp:62:25:62:34 | call to user_input |
+| by_reference.cpp:63:8:63:8 | s |
 | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
 | by_reference.cpp:68:17:68:18 | & ... |
 | by_reference.cpp:68:21:68:30 | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/smart_pointer.cpp
@@ -35,16 +35,16 @@ void test_reverse_taint_shared() {
     std::shared_ptr<int> p = std::make_shared<int>();
 
     *p = source();
-    sink(p); // $ ast MISSING: ir
-    sink(*p); // $ ast MISSING: ir
+    sink(p); // $ ast,ir
+    sink(*p); // $ ast,ir
 }
 
 void test_reverse_taint_unique() {
     std::unique_ptr<int> p = std::unique_ptr<int>();
 
     *p = source();
-    sink(p); // $ ast MISSING: ir
-    sink(*p); // $ ast MISSING: ir
+    sink(p); // $ ast,ir
+    sink(*p); // $ ast,ir
 }
 
 void test_shared_get() {
@@ -134,5 +134,5 @@ int nested_shared_ptr_taint_cref(std::shared_ptr<C> p1, std::unique_ptr<std::sha
   sink(p1->q->x); // $ ast MISSING: ir
 
   getNumberCRef(*p2);
-  sink(**p2); // $ ast MISSING: ir
+  sink(**p2); // $ ast,ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -677,7 +677,7 @@ public:
 void test_with_const_member(char* source) {
   C_const_member_function c;
   memcpy(c.data(), source, 16);
-  sink(c.data()); // $ ast MISSING: ir
+  sink(c.data()); // $ ast,ir
 }
 
 void argument_source(void*);


### PR DESCRIPTION
This implements https://github.com/github/codeql/pull/5196, but for IR-based use-use dataflow library. The motivation for this "hack" is to get flow in the following example (which I've taken from our library tests):
```cpp
class C_const_member_function {
  char* data_;
public:
  char* data() const { return data_; }
};

void test_with_const_member(char* source) {
  C_const_member_function c;
  memcpy(c.data(), source, 16);
  sink(c.data()); // $ ast,ir
}
```
and apparently, this was also the missing flow for some of the smart pointer tests 🎉.