### PR TITLE
C++: Fix join order in `cpp/upcast-array-pointer-arithmetic`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
@@ -64,10 +64,15 @@ predicate introducesNewField(Class derived, Class base) {
   )
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, CastToPointerArithFlow cfg
+pragma[nomagic]
+predicate hasFullyConvertedType(DataFlow::PathNode node, Type t) {
+  t = node.getNode().asExpr().getFullyConverted().getUnspecifiedType()
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, CastToPointerArithFlow cfg, Type t
 where
-  cfg.hasFlowPath(source, sink) and
-  source.getNode().asExpr().getFullyConverted().getUnspecifiedType() =
-    sink.getNode().asExpr().getFullyConverted().getUnspecifiedType()
+  cfg.hasFlowPath(pragma[only_bind_into](source), pragma[only_bind_into](sink)) and
+  hasFullyConvertedType(source, t) and
+  hasFullyConvertedType(sink, t)
 select sink, source, sink, "This pointer arithmetic may be done with the wrong type because of $@.",
   source, "this cast"


### PR DESCRIPTION
Before:
```ql
[2022-11-17 18:08:23] Evaluated non-recursive predicate #select#cpe#1235#ffff@306862je in 40917ms (size: 10).
Evaluated relational algebra for predicate #select#cpe#1235#ffff@306862je with tuple counts:
      700124  ~0%    {3} r1 = JOIN DataFlowImpl#9021cc4c::PathNode::getNode#0#dispred#ff WITH DataFlowImpl#9021cc4c::PathNode#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.0
        9754  ~0%    {4} r2 = JOIN r1 WITH DataFlowImpl#9021cc4c::flowsTo#5#fffff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Lhs.2
        9754  ~0%    {4} r3 = JOIN r2 WITH DataFlowImpl#9021cc4c::PathNode#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3
        9754  ~3%    {6} r4 = JOIN r3 WITH DataFlowImpl#9021cc4c::PathNode::getNode#0#dispred#ff ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.3, Lhs.0, Rhs.1, Lhs.0
        9754  ~4%    {6} r5 = JOIN r4 WITH DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
        9754  ~0%    {6} r6 = JOIN r5 WITH Expr#ef463c5d::Expr::getFullyConverted#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
        9754  ~2%    {6} r7 = JOIN r6 WITH Expr#ef463c5d::Expr::getUnspecifiedType#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
   327119242  ~0%    {6} r8 = JOIN r7 WITH Expr#ef463c5d::Expr::getUnspecifiedType#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
   400675941  ~0%    {6} r9 = JOIN r8 WITH Expr#ef463c5d::Expr::getFullyConverted#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.4, Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.5
          10  ~0%    {4} r10 = JOIN r9 WITH DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff ON FIRST 2 OUTPUT Lhs.2, Lhs.4, Lhs.3, Lhs.5
                    return r10
....
Evaluated relational algebra for predicate let0@c1add5vk with tuple counts:
        10   ~0%    {4} r1 = SELECT #select#cpe#1235#ffff ON In.0 = In.2
        10   ~0%    {4} r2 = SELECT r1 ON In.1 = In.3
```
After:
```ql
[2022-11-17 18:17:58] Evaluated non-recursive predicate #select#cpe#1235#ffff@f7d935aq in 2ms (size: 10).
Evaluated relational algebra for predicate #select#cpe#1235#ffff@f7d935aq with tuple counts:
        9754  ~0%    {4} r1 = SCAN DataFlowImpl#9021cc4c::Configuration::hasFlowPath#2#dispred#fff OUTPUT In.1, In.2, In.2, In.1
        9754  ~2%    {5} r2 = JOIN r1 WITH CastArrayPointerArithmetic#b621a59c::hasFullyConvertedType#2#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.0, Lhs.2, Lhs.3
          10  ~0%    {4} r3 = JOIN r2 WITH CastArrayPointerArithmetic#b621a59c::hasFullyConvertedType#2#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.2, Lhs.3, Lhs.4
                     return r3
```