### PR TITLE
C#: Add workflow for running QL tests

### DIFF
--- a/.github/workflows/csharp-qltest.yml
+++ b/.github/workflows/csharp-qltest.yml
@@ -1,0 +1,72 @@
+name: "C#: Run QL Tests"
+
+on:
+  push:
+    paths:
+      - "csharp/**"
+      - "shared/**"
+      - .github/actions/fetch-codeql/action.yml
+      - codeql-workspace.yml
+    branches:
+      - main
+      - "rc/*"
+  pull_request:
+    paths:
+      - "csharp/**"
+      - "shared/**"
+      - .github/workflows/csharp-qltest.yml
+      - .github/actions/fetch-codeql/action.yml
+      - codeql-workspace.yml
+    branches:
+      - main
+      - "rc/*"
+
+defaults:
+  run:
+    working-directory: csharp
+
+jobs:
+  qlupgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/fetch-codeql
+      - name: Check DB upgrade scripts
+        run: |
+          echo >empty.trap
+          codeql dataset import -S ql/lib/upgrades/initial/semmlecode.csharp.dbscheme testdb empty.trap
+          codeql dataset upgrade testdb --additional-packs ql/lib
+          diff -q testdb/semmlecode.csharp.dbscheme ql/lib/semmlecode.csharp.dbscheme
+      - name: Check DB downgrade scripts
+        run: |
+          echo >empty.trap
+          rm -rf testdb; codeql dataset import -S ql/lib/semmlecode.csharp.dbscheme testdb empty.trap
+          codeql resolve upgrades --format=lines --allow-downgrades --additional-packs downgrades \
+           --dbscheme=ql/lib/semmlecode.csharp.dbscheme --target-dbscheme=downgrades/initial/semmlecode.csharp.dbscheme |
+           xargs codeql execute upgrades testdb
+          diff -q testdb/semmlecode.csharp.dbscheme downgrades/initial/semmlecode.csharp.dbscheme
+  qltest:
+    runs-on: ubuntu-latest-xl
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: ["1/2", "2/2"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/fetch-codeql
+      - uses: ./csharp/actions/create-extractor-pack
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with:
+          key: csharp-qltest-${{ matrix.slice }}
+      - name: Run QL tests
+        run: |
+          CODEQL_PATH=$(gh codeql version --format=json | jq -r .unpackedLocation)
+          # The legacy ASP extractor is not in this repo, so take the one from the nightly build
+          mv "$CODEQL_PATH/csharp/tools/extractor-asp.jar" "${{ github.workspace }}/csharp/extractor-pack/tools"
+          # Safe guard against using the bundled extractor
+          rm -rf "$CODEQL_PATH/csharp"
+          codeql test run --threads=0 --ram 52000 --slice ${{ matrix.slice }} --search-path "${{ github.workspace }}/csharp/extractor-pack" --check-databases --check-undefined-labels --check-repeated-labels --check-redefined-labels --consistency-queries ql/consistency-queries ql/test --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,6 @@
 # It's useful (though not required) to be able to unpack codeql in the ql checkout itself
 /codeql/
 
-csharp/extractor/Semmle.Extraction.CSharp.Driver/Properties/launchSettings.json
-
 # Avoid committing cached package components
 .codeql
 

--- a/csharp/.gitignore
+++ b/csharp/.gitignore
@@ -12,3 +12,6 @@ csharp.log
 .vs
 *.user
 .vscode/launch.json
+
+extractor/Semmle.Extraction.CSharp.Driver/Properties/launchSettings.json
+extractor-pack

--- a/csharp/actions/create-extractor-pack/action.yml
+++ b/csharp/actions/create-extractor-pack/action.yml
@@ -1,0 +1,13 @@
+name: Build C# CodeQL pack
+description: Builds the C# CodeQL pack
+runs:
+  using: composite
+  steps:
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.202
+    - name: Build Extractor
+      shell: bash
+      run: scripts/create-extractor-pack.sh
+      working-directory: csharp

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/Completion.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/Completion.qll
@@ -103,7 +103,6 @@ abstract class Completion extends TCompletion {
    * otherwise it is a normal non-Boolean completion.
    */
   predicate isValidFor(ControlFlowElement cfe) {
-    cfe instanceof NonReturningCall and
     this = cfe.(NonReturningCall).getACompletion()
     or
     this = TThrowCompletion(cfe.(TriedControlFlowElement).getAThrownException())

--- a/csharp/scripts/create-extractor-pack.sh
+++ b/csharp/scripts/create-extractor-pack.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eux
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  platform="linux64"
+  dotnet_platform="linux-x64"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  platform="osx64"
+  dotnet_platform="osx-x64"
+else
+  echo "Unknown OS"
+  exit 1
+fi
+
+rm -rf extractor-pack
+mkdir -p extractor-pack
+mkdir -p extractor-pack/tools/${platform}
+
+function dotnet_publish {
+  dotnet publish --self-contained --configuration Release --runtime ${dotnet_platform} -p:RuntimeFrameworkVersion=6.0.4 $1 --output extractor-pack/tools/${platform}
+}
+
+dotnet_publish extractor/Semmle.Extraction.CSharp.Standalone
+dotnet_publish extractor/Semmle.Extraction.CSharp.Driver
+dotnet_publish autobuilder/Semmle.Autobuild.CSharp
+
+cp -r codeql-extractor.yml tools/* downgrades tools ql/lib/semmlecode.csharp.dbscheme ql/lib/semmlecode.csharp.dbscheme.stats extractor-pack/


### PR DESCRIPTION
This PR adds a job for executing C# QL tests directly in this repo, like we do for Ruby. That is, we
- Fetch a nightly `codeql` CLI.
- Build the C# extractor.
- Execute tests with the nightly CLI, using the freshly built C# extractor and the bundled (legacy) ASP extractor.

Additionally, we make use of Actions cache to cache the compilation cache (like Ruby), and we dispatch the workload onto two `ubuntu-latest-xl` machines (Ruby only uses one).

Comparison:
- The internal `C# Language Tests`, which uses one `ubuntu-latest-xl` machine, typically takes 1h20min.
- The tests introduced by this PR typically take 20 min on a cold cache, and 10 min on a warm cache.

In addition to achieving a very significant speedup, running the tests in this repo also means that external contributors will have access to the results, so we will no longer have to communicate test failures by proxy.