### PR TITLE
Make model generator emit trailing comma for set literals

### DIFF
--- a/misc/scripts/models-as-data/generate_flow_model.py
+++ b/misc/scripts/models-as-data/generate_flow_model.py
@@ -153,7 +153,7 @@ Requirements: `codeql` should both appear on your path.
         for (row) in results['#select']['tuples']:
             rows += "            \"" + row[0] + "\",\n"
 
-        return rows[:-2]
+        return rows[:-1]
 
 
     def asCsvModel(self, superclass, kind, rows):


### PR DESCRIPTION
Adjusts the model generator to emit trailing commas for set literals (see also https://github.com/github/codeql-cli-binaries/issues/76). This reduces the Git diff when new lines are added at the end.

Note that I am not very familiar with the model generator scripts, but I did not notice any issues locally with this change.