### PR TITLE
Java: Handle disabled Maven repositories

### DIFF
--- a/java/ql/lib/semmle/code/xml/MavenPom.qll
+++ b/java/ql/lib/semmle/code/xml/MavenPom.qll
@@ -381,6 +381,15 @@ class DeclaredRepository extends PomElement {
    * be the string contents of that tag.
    */
   string getRepositoryUrl() { result = this.getAChild("url").(PomElement).getValue() }
+
+  /**
+   * Holds if this repository is disabled in both the `releases` and `snapshots` policies.
+   */
+  predicate isDisabled() {
+    forex(PomElement policy | policy = this.getAChild(["releases", "snapshots"]) |
+      policy.getAChild("enabled").(PomElement).getValue() = "false"
+    )
+  }
 }
 
 /**

--- a/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql
+++ b/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql
@@ -17,7 +17,8 @@ import java
 import semmle.code.xml.MavenPom
 
 predicate isInsecureRepositoryUsage(DeclaredRepository repository) {
-  repository.getRepositoryUrl().regexpMatch("(?i)^(http|ftp)://(?!localhost[:/]).*")
+  repository.getRepositoryUrl().regexpMatch("(?i)^(http|ftp)://(?!localhost[:/]).*") and
+  not repository.isDisabled()
 }
 
 from DeclaredRepository repository

--- a/java/ql/test/query-tests/security/CWE-829/semmle/tests/secure-pom.xml
+++ b/java/ql/test/query-tests/security/CWE-829/semmle/tests/secure-pom.xml
@@ -61,5 +61,17 @@
             <!-- GOOD! Use HTTPS -->
             <url>https://insecure-repository.example</url>
         </pluginRepository>
+        <pluginRepository>
+            <id>disabled-repo</id>
+            <name>Disabled Repository</name>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <!-- GOOD! Disabled repo -->
+            <url>http://insecure-repository.example</url>
+        </pluginRepository>
     </pluginRepositories>
 </project>


### PR DESCRIPTION
Completely disabled Maven repositories (i.e. `enabled` = `false` in both `releases` and `snapshots`) shouldn't raise an alert even if they are configured with unsafe URLs. Fixes https://github.com/github/codeql/issues/11326. 