### PR TITLE
Python: Add change note for module resolution

### DIFF
--- a/python/ql/lib/change-notes/2022-11-21-module-resolution-rewrite.md
+++ b/python/ql/lib/change-notes/2022-11-21-module-resolution-rewrite.md
@@ -1,0 +1,5 @@
+---
+ category: minorAnalysis
+---
+ * The data-flow library has been rewritten to no longer rely on the points-to analysis in order to
+   resolve references to modules. This should result in more results for data-flow queries.

--- a/python/ql/test/experimental/import-resolution/importflow.ql
+++ b/python/ql/test/experimental/import-resolution/importflow.ql
@@ -93,26 +93,29 @@ class ResolutionTest extends InlineExpectationsTest {
   }
 }
 
-class ResolutionTest3 extends InlineExpectationsTest {
-  ResolutionTest3() { this = "ResolutionTest3" }
+class VersionSpecificResolutionTest extends InlineExpectationsTest {
+  VersionSpecificResolutionTest() { this = "VersionSpecificResolutionTest" }
 
-  override string getARelevantTag() { result = "prints3" and major_version() = 3 }
+  override string getARelevantTag() { result = getTagForVersion(_) }
+
+  private string getTagForVersion(int version) {
+    result = "prints" + version and
+    version = major_version()
+  }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     (
       exists(DataFlow::PathNode source, DataFlow::PathNode sink, ImportConfiguration config |
         config.hasFlowPath(source, sink) and
-        sink.getNode().(VersionGuardedNode).getVersion() = 3 and
-        tag = "prints3" and
+        tag = getTagForVersion(sink.getNode().(VersionGuardedNode).getVersion()) and
         location = sink.getNode().getLocation() and
         value = source.getNode().(SourceString).getContents() and
         element = sink.getNode().toString()
       )
       or
       exists(ModuleRef ref |
-        ref.(VersionGuardedNode).getVersion() = 3 and
         ref instanceof CheckArgument and
-        tag = "prints3" and
+        tag = getTagForVersion(ref.(VersionGuardedNode).getVersion()) and
         location = ref.getLocation() and
         value = "\"<module " + ref.getName() + ">\"" and
         element = ref.toString()


### PR DESCRIPTION
Also adapts the version-specific tests to support results specific to Python 2 (though at the moment there are no such tests).