### PR TITLE
Add macOS 13 to supported platforms

### DIFF
--- a/docs/codeql/support/reusables/platforms.rst
+++ b/docs/codeql/support/reusables/platforms.rst
@@ -18,7 +18,11 @@
 
    macOS 11 Big Sur
 
-   macOS 12 Monterey","x86-64
+   macOS 12 Monterey
+
+   macOS 13 Ventura","x86-64
+
+   x86-64, arm64 (Apple Silicon)
 
    x86-64, arm64 (Apple Silicon)
 


### PR DESCRIPTION
I noticed that the list of supported platforms in the documentation does not yet include macOS 13. As far as I can tell, everything runs fine on it, so this change adds macOS 13 to the list of supported platforms.