### PR TITLE
Ruby: delete the target/packs folder in the `compile-queries` job

### DIFF
--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -98,6 +98,7 @@ jobs:
           key: ruby-build
       - name: Build Query Pack
         run: |
+          rm -rf target/packs
           codeql pack create ../shared/ssa --output target/packs
           codeql pack create ../misc/suite-helpers --output target/packs
           codeql pack create ../shared/regex --output target/packs


### PR DESCRIPTION
Restoring the `.cache` folders meant that some old `target` folders was restored (specifically the `0.4.4-dev` folder).  
Even though there are no files in there (my cache job cleans them up), the folders are still there, and are picked up by `PACK_FOLDER=$(readlink -f target/packs/codeql/ruby-queries/*)` in the `compile-queries` job.  

The fix is simple: delete the entire `target/packs` folder.  
There is nothing but empty folders anyway.  

Example failing workflow: https://github.com/github/codeql/actions/runs/3518802552/jobs/5898153387

Found when testing the improved workflow in this PR: https://github.com/github/codeql/pull/10782  
(I also got the fix in that PR).   