### PR TITLE
CI: use read-only-cache when running on a PR

### DIFF
--- a/.github/actions/cache-query-compilation/action.yml
+++ b/.github/actions/cache-query-compilation/action.yml
@@ -26,9 +26,10 @@ runs:
         echo "merge_base=$MERGE_BASE" >> $GITHUB_ENV
     - name: Read CodeQL query compilation - PR
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/cache@v3
+      uses: erik-krogh/actions-cache@a88d0603fe5fb5606db9f002dfcadeb32b5f84c6
       with:
         path: '**/.cache'
+        read-only: true
         key: codeql-compile-${{ inputs.key }}-pr-${{ github.sha }} # deliberately not using the `compile-compile-main` keys here.
         restore-keys: |
           codeql-compile-${{ inputs.key }}-${{ github.base_ref }}-${{ env.merge_base }}
@@ -36,7 +37,7 @@ runs:
           codeql-compile-${{ inputs.key }}-main-
     - name: Fill CodeQL query compilation cache - main
       if: ${{ github.event_name != 'pull_request' }}
-      uses: actions/cache@v3
+      uses: erik-krogh/actions-cache@a88d0603fe5fb5606db9f002dfcadeb32b5f84c6
       with:
         path: '**/.cache'
         key: codeql-compile-${{ inputs.key }}-${{ github.ref_name }}-${{ github.sha }} # just fill on main


### PR DESCRIPTION
[The actions cache is currently filling up with loads of useless `codeql-compile-*` caches that will never be read](https://github.com/github/codeql/actions/caches).  
Currently our oldest cache is 22 hours old, everything older has been evicted from the actions cache.   

My solution is to not save the compilation cache when running on PRs, but only do it on pushes to `main`.  
That way we only save the caches that we expect to read.  

Read-only caches is not a feature currently supported by `actions/cache`, so I'm using my own fork.  
We should go back to `actions/cache` once https://github.com/actions/cache/pull/995 (or similar) has been merged.   