### PR TITLE
Add binding between annotation and sink-param

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
@@ -134,7 +134,8 @@ predicate isMybatisXmlOrAnnotationSqlInjection(
           .matches("${" + annotation.getValue("value").(CompileTimeConstantExpr).getStringValue() +
               "%}") and
       annotation.getType() instanceof TypeParam and
-      ma.getAnArgument() = node.asExpr()
+      ma.getAnArgument() = node.asExpr() and
+      annotation.getTarget() = ma.getMethod().getParameter(node.asExpr().getIndex())
     )
     or
     // MyBatis default parameter sql injection vulnerabilities.the default parameter form of the method is arg[0...n] or param[1...n].


### PR DESCRIPTION
Add binding between annotation and sink-param.

In below case, result will show parameter "name" in testParamAnno() is vulnerable.
```java
```