### PR TITLE
Java: Consider taint through bitwise operations on PendingIntent flags

### DIFF
--- a/java/ql/src/change-notes/2022-11-22-bitwise-implicit-intent-flags.md
+++ b/java/ql/src/change-notes/2022-11-22-bitwise-implicit-intent-flags.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed an issue in the query `java/android/implicit-pendingintents` by which an implicit Pending Intent marked as immutable was not correctly recognized as such.

--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
@@ -156,7 +156,7 @@ public class ImplicitPendingIntentsTest {
             PendingIntent pi = PendingIntent.getActivity(ctx, 0, baseIntent, flag); // Sanitizer
             Intent fwdIntent = new Intent();
             fwdIntent.putExtra("fwdIntent", pi);
-            ctx.startActivity(fwdIntent); // $ SPURIOUS: $ hasImplicitPendingIntent
+            ctx.startActivity(fwdIntent); // Safe
         }
     }
 


### PR DESCRIPTION
This fixes spurious results when `PendingIntent.FLAG_IMMUTABLE` is correctly used on a `PendingIntent` but it goes through a bitwise operation, which previously broke taint flow. 