### PR TITLE
Java: Add binding between annotation and sink-param in MyBatis SQL Injection query

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
@@ -135,7 +135,8 @@ predicate isMybatisXmlOrAnnotationSqlInjection(
               "%}") and
       annotation.getType() instanceof TypeParam and
       ma.getAnArgument() = node.asExpr() and
-      annotation.getTarget() = ma.getMethod().getParameter(node.asExpr().(Argument).getParameterPos())
+      annotation.getTarget() =
+        ma.getMethod().getParameter(node.asExpr().(Argument).getParameterPos())
     )
     or
     // MyBatis default parameter sql injection vulnerabilities.the default parameter form of the method is arg[0...n] or param[1...n].

--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
@@ -134,7 +134,8 @@ predicate isMybatisXmlOrAnnotationSqlInjection(
           .matches("${" + annotation.getValue("value").(CompileTimeConstantExpr).getStringValue() +
               "%}") and
       annotation.getType() instanceof TypeParam and
-      ma.getAnArgument() = node.asExpr()
+      ma.getAnArgument() = node.asExpr() and
+      annotation.getTarget() = ma.getMethod().getParameter(node.asExpr().getIndex())
     )
     or
     // MyBatis default parameter sql injection vulnerabilities.the default parameter form of the method is arg[0...n] or param[1...n].

--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisCommonLib.qll
@@ -135,7 +135,7 @@ predicate isMybatisXmlOrAnnotationSqlInjection(
               "%}") and
       annotation.getType() instanceof TypeParam and
       ma.getAnArgument() = node.asExpr() and
-      annotation.getTarget() = ma.getMethod().getParameter(node.asExpr().getIndex())
+      annotation.getTarget() = ma.getMethod().getParameter(node.asExpr().(Argument).getParameterPos())
     )
     or
     // MyBatis default parameter sql injection vulnerabilities.the default parameter form of the method is arg[0...n] or param[1...n].

--- a/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MyBatisAnnotationSqlInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MyBatisAnnotationSqlInjection.expected
@@ -1,16 +1,30 @@
 edges
 | MybatisSqlInjection.java:62:19:62:43 | name : String | MybatisSqlInjection.java:63:35:63:38 | name : String |
 | MybatisSqlInjection.java:63:35:63:38 | name : String | MybatisSqlInjectionService.java:48:19:48:29 | name : String |
+| MybatisSqlInjection.java:94:21:94:45 | name : String | MybatisSqlInjection.java:95:37:95:40 | name : String |
+| MybatisSqlInjection.java:95:37:95:40 | name : String | MybatisSqlInjectionService.java:76:21:76:31 | name : String |
+| MybatisSqlInjection.java:99:21:99:44 | age : String | MybatisSqlInjection.java:100:37:100:39 | age : String |
+| MybatisSqlInjection.java:100:37:100:39 | age : String | MybatisSqlInjectionService.java:80:21:80:30 | age : String |
 | MybatisSqlInjectionService.java:48:19:48:29 | name : String | MybatisSqlInjectionService.java:50:23:50:26 | name : String |
 | MybatisSqlInjectionService.java:50:3:50:9 | hashMap [post update] [<map.value>] : String | MybatisSqlInjectionService.java:51:27:51:33 | hashMap |
 | MybatisSqlInjectionService.java:50:23:50:26 | name : String | MybatisSqlInjectionService.java:50:3:50:9 | hashMap [post update] [<map.value>] : String |
+| MybatisSqlInjectionService.java:76:21:76:31 | name : String | MybatisSqlInjectionService.java:77:29:77:32 | name |
+| MybatisSqlInjectionService.java:80:21:80:30 | age : String | MybatisSqlInjectionService.java:81:29:81:31 | age |
 nodes
 | MybatisSqlInjection.java:62:19:62:43 | name : String | semmle.label | name : String |
 | MybatisSqlInjection.java:63:35:63:38 | name : String | semmle.label | name : String |
+| MybatisSqlInjection.java:94:21:94:45 | name : String | semmle.label | name : String |
+| MybatisSqlInjection.java:95:37:95:40 | name : String | semmle.label | name : String |
+| MybatisSqlInjection.java:99:21:99:44 | age : String | semmle.label | age : String |
+| MybatisSqlInjection.java:100:37:100:39 | age : String | semmle.label | age : String |
 | MybatisSqlInjectionService.java:48:19:48:29 | name : String | semmle.label | name : String |
 | MybatisSqlInjectionService.java:50:3:50:9 | hashMap [post update] [<map.value>] : String | semmle.label | hashMap [post update] [<map.value>] : String |
 | MybatisSqlInjectionService.java:50:23:50:26 | name : String | semmle.label | name : String |
 | MybatisSqlInjectionService.java:51:27:51:33 | hashMap | semmle.label | hashMap |
+| MybatisSqlInjectionService.java:76:21:76:31 | name : String | semmle.label | name : String |
+| MybatisSqlInjectionService.java:77:29:77:32 | name | semmle.label | name |
+| MybatisSqlInjectionService.java:80:21:80:30 | age : String | semmle.label | age : String |
+| MybatisSqlInjectionService.java:81:29:81:31 | age | semmle.label | age |
 subpaths
 #select
 | MybatisSqlInjectionService.java:51:27:51:33 | hashMap | MybatisSqlInjection.java:62:19:62:43 | name : String | MybatisSqlInjectionService.java:51:27:51:33 | hashMap | MyBatis annotation SQL injection might include code from $@ to $@. | MybatisSqlInjection.java:62:19:62:43 | name | this user input | SqlInjectionMapper.java:33:2:33:54 | Select | this SQL operation |

--- a/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MyBatisAnnotationSqlInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MyBatisAnnotationSqlInjection.expected
@@ -1,30 +1,30 @@
 edges
 | MybatisSqlInjection.java:62:19:62:43 | name : String | MybatisSqlInjection.java:63:35:63:38 | name : String |
 | MybatisSqlInjection.java:63:35:63:38 | name : String | MybatisSqlInjectionService.java:48:19:48:29 | name : String |
-| MybatisSqlInjection.java:94:21:94:45 | name : String | MybatisSqlInjection.java:95:37:95:40 | name : String |
-| MybatisSqlInjection.java:95:37:95:40 | name : String | MybatisSqlInjectionService.java:76:21:76:31 | name : String |
-| MybatisSqlInjection.java:99:21:99:44 | age : String | MybatisSqlInjection.java:100:37:100:39 | age : String |
-| MybatisSqlInjection.java:100:37:100:39 | age : String | MybatisSqlInjectionService.java:80:21:80:30 | age : String |
+| MybatisSqlInjection.java:94:20:94:44 | name : String | MybatisSqlInjection.java:95:36:95:39 | name : String |
+| MybatisSqlInjection.java:95:36:95:39 | name : String | MybatisSqlInjectionService.java:76:20:76:30 | name : String |
+| MybatisSqlInjection.java:99:20:99:43 | age : String | MybatisSqlInjection.java:100:36:100:38 | age : String |
+| MybatisSqlInjection.java:100:36:100:38 | age : String | MybatisSqlInjectionService.java:80:20:80:29 | age : String |
 | MybatisSqlInjectionService.java:48:19:48:29 | name : String | MybatisSqlInjectionService.java:50:23:50:26 | name : String |
 | MybatisSqlInjectionService.java:50:3:50:9 | hashMap [post update] [<map.value>] : String | MybatisSqlInjectionService.java:51:27:51:33 | hashMap |
 | MybatisSqlInjectionService.java:50:23:50:26 | name : String | MybatisSqlInjectionService.java:50:3:50:9 | hashMap [post update] [<map.value>] : String |
-| MybatisSqlInjectionService.java:76:21:76:31 | name : String | MybatisSqlInjectionService.java:77:29:77:32 | name |
-| MybatisSqlInjectionService.java:80:21:80:30 | age : String | MybatisSqlInjectionService.java:81:29:81:31 | age |
+| MybatisSqlInjectionService.java:76:20:76:30 | name : String | MybatisSqlInjectionService.java:77:28:77:31 | name |
+| MybatisSqlInjectionService.java:80:20:80:29 | age : String | MybatisSqlInjectionService.java:81:28:81:30 | age |
 nodes
 | MybatisSqlInjection.java:62:19:62:43 | name : String | semmle.label | name : String |
 | MybatisSqlInjection.java:63:35:63:38 | name : String | semmle.label | name : String |
-| MybatisSqlInjection.java:94:21:94:45 | name : String | semmle.label | name : String |
-| MybatisSqlInjection.java:95:37:95:40 | name : String | semmle.label | name : String |
-| MybatisSqlInjection.java:99:21:99:44 | age : String | semmle.label | age : String |
-| MybatisSqlInjection.java:100:37:100:39 | age : String | semmle.label | age : String |
+| MybatisSqlInjection.java:94:20:94:44 | name : String | semmle.label | name : String |
+| MybatisSqlInjection.java:95:36:95:39 | name : String | semmle.label | name : String |
+| MybatisSqlInjection.java:99:20:99:43 | age : String | semmle.label | age : String |
+| MybatisSqlInjection.java:100:36:100:38 | age : String | semmle.label | age : String |
 | MybatisSqlInjectionService.java:48:19:48:29 | name : String | semmle.label | name : String |
 | MybatisSqlInjectionService.java:50:3:50:9 | hashMap [post update] [<map.value>] : String | semmle.label | hashMap [post update] [<map.value>] : String |
 | MybatisSqlInjectionService.java:50:23:50:26 | name : String | semmle.label | name : String |
 | MybatisSqlInjectionService.java:51:27:51:33 | hashMap | semmle.label | hashMap |
-| MybatisSqlInjectionService.java:76:21:76:31 | name : String | semmle.label | name : String |
-| MybatisSqlInjectionService.java:77:29:77:32 | name | semmle.label | name |
-| MybatisSqlInjectionService.java:80:21:80:30 | age : String | semmle.label | age : String |
-| MybatisSqlInjectionService.java:81:29:81:31 | age | semmle.label | age |
+| MybatisSqlInjectionService.java:76:20:76:30 | name : String | semmle.label | name : String |
+| MybatisSqlInjectionService.java:77:28:77:31 | name | semmle.label | name |
+| MybatisSqlInjectionService.java:80:20:80:29 | age : String | semmle.label | age : String |
+| MybatisSqlInjectionService.java:81:28:81:30 | age | semmle.label | age |
 subpaths
 #select
 | MybatisSqlInjectionService.java:51:27:51:33 | hashMap | MybatisSqlInjection.java:62:19:62:43 | name : String | MybatisSqlInjectionService.java:51:27:51:33 | hashMap | MyBatis annotation SQL injection might include code from $@ to $@. | MybatisSqlInjection.java:62:19:62:43 | name | this user input | SqlInjectionMapper.java:33:2:33:54 | Select | this SQL operation |

--- a/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MybatisSqlInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MybatisSqlInjection.java
@@ -90,13 +90,13 @@ public class MybatisSqlInjection {
 		mybatisSqlInjectionService.badInsert(name);
 	}
 
-	@GetMapping(value = "kkbad1")
-	public void kkbad1(@RequestParam String name, @RequestParam Integer age) {
-		mybatisSqlInjectionService.kkbad1(name, age);
+	@GetMapping(value = "good2")
+	public void good2(@RequestParam String name, @RequestParam Integer age) {
+		mybatisSqlInjectionService.good2(name, age);
 	}
 
-	@GetMapping(value = "kkbad2")
-	public void kkbad2(@RequestParam String age) {
-		mybatisSqlInjectionService.kkbad2(age);
+	@GetMapping(value = "good3")
+	public void good3(@RequestParam String age) {
+		mybatisSqlInjectionService.good3(age);
 	}
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MybatisSqlInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MybatisSqlInjection.java
@@ -79,7 +79,7 @@ public class MybatisSqlInjection {
 	public void badDelete(@RequestParam String name) {
 		mybatisSqlInjectionService.badDelete(name);
 	}
-	
+
 	@GetMapping(value = "badUpdate")
 	public void badUpdate(@RequestParam String name) {
 		mybatisSqlInjectionService.badUpdate(name);
@@ -88,5 +88,15 @@ public class MybatisSqlInjection {
 	@GetMapping(value = "badInsert")
 	public void badInsert(@RequestParam String name) {
 		mybatisSqlInjectionService.badInsert(name);
+	}
+
+	@GetMapping(value = "kkbad1")
+	public void kkbad1(@RequestParam String name, @RequestParam Integer age) {
+		mybatisSqlInjectionService.kkbad1(name, age);
+	}
+
+	@GetMapping(value = "kkbad2")
+	public void kkbad2(@RequestParam String age) {
+		mybatisSqlInjectionService.kkbad2(age);
 	}
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MybatisSqlInjectionService.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MybatisSqlInjectionService.java
@@ -72,4 +72,12 @@ public class MybatisSqlInjectionService {
 	public void badInsert(String input) {
 		sqlInjectionMapper.badInsert(input);
 	}
+
+	public void kkbad1(String name, Integer age){
+		sqlInjectionMapper.kkbad1(name, age);
+	}
+
+	public void kkbad2(String age){
+		sqlInjectionMapper.kkbad2(age);
+	}
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MybatisSqlInjectionService.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-089/src/main/MybatisSqlInjectionService.java
@@ -73,11 +73,11 @@ public class MybatisSqlInjectionService {
 		sqlInjectionMapper.badInsert(input);
 	}
 
-	public void kkbad1(String name, Integer age){
-		sqlInjectionMapper.kkbad1(name, age);
+	public void good2(String name, Integer age){
+		sqlInjectionMapper.good2(name, age);
 	}
 
-	public void kkbad2(String age){
-		sqlInjectionMapper.kkbad2(age);
+	public void good3(String age){
+		sqlInjectionMapper.good3(age);
 	}
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-089/src/main/SqlInjectionMapper.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-089/src/main/SqlInjectionMapper.java
@@ -37,26 +37,33 @@ public interface SqlInjectionMapper {
 
 	//using providers
 	@SelectProvider(
-		type = MyBatisProvider.class,
-		method = "badSelect"
+			type = MyBatisProvider.class,
+			method = "badSelect"
 	)
 	String badSelect(String input);
 
 	@DeleteProvider(
-		type = MyBatisProvider.class,
-		method = "badDelete"
+			type = MyBatisProvider.class,
+			method = "badDelete"
 	)
 	void badDelete(String input);
 
 	@UpdateProvider(
-		type = MyBatisProvider.class,
-		method = "badUpdate"
+			type = MyBatisProvider.class,
+			method = "badUpdate"
 	)
 	void badUpdate(String input);
 
 	@InsertProvider(
-		type = MyBatisProvider.class,
-		method = "badInsert"
+			type = MyBatisProvider.class,
+			method = "badInsert"
 	)
 	void badInsert(String input);
+
+	@Select("select * from user_info where name = #{name} and age = ${age}")
+	String kkbad1(@Param("name") String name, Integer age);
+
+	@Select("select * from user_info where age = #{age}")
+	String kkbad2(@Param("age") String age);
+
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-089/src/main/SqlInjectionMapper.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-089/src/main/SqlInjectionMapper.java
@@ -61,9 +61,9 @@ public interface SqlInjectionMapper {
 	void badInsert(String input);
 
 	@Select("select * from user_info where name = #{name} and age = ${age}")
-	String kkbad1(@Param("name") String name, Integer age);
+	String good2(@Param("name") String name, Integer age);
 
 	@Select("select * from user_info where age = #{age}")
-	String kkbad2(@Param("age") String age);
+	String good3(@Param("age") String age);
 
 }


### PR DESCRIPTION
Add binding between annotation and sink-param.

In below case, the rule `MyBatisAnnotationSqlInjection.ql` will find a vulnerability at `parameter name` in function `testParamAnno1()`. That is false positive.

```java
@Select("select * from user_info where name = #{name} and age = ${age}")
String testParamAnno1(@Param("name") String name, Integer age);

@Select("select * from user_info where age = #{age}")
String testParamAnno2(@Param("age") String age);
```

The root cause is, `isMybatisXmlOrAnnotationSqlInjection()` find `annotation @Param` in `testParamAnno2()` and bind it to `${age}` in `@Select("select * from user_info where name = #{name} and age = ${age}")` when processing `parameter name in testParamAnno1()`. So it raise a vulnerability to `name` when it saw `${age}` binding with `@Param("age")`.
