### PR TITLE
Swift: Add models for NSData and NSMutableData

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -81,6 +81,7 @@ private module Frameworks {
   private import codeql.swift.frameworks.StandardLibrary.CustomUrlSchemes
   private import codeql.swift.frameworks.StandardLibrary.Data
   private import codeql.swift.frameworks.StandardLibrary.InputStream
+  private import codeql.swift.frameworks.StandardLibrary.NSData
   private import codeql.swift.frameworks.StandardLibrary.String
   private import codeql.swift.frameworks.StandardLibrary.Url
   private import codeql.swift.frameworks.StandardLibrary.UrlSession

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NSData.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NSData.qll
@@ -1,0 +1,92 @@
+/** Provides classes and models to work with `NSData`-related objects. */
+
+import swift
+private import codeql.swift.dataflow.DataFlow
+private import codeql.swift.dataflow.ExternalFlow
+private import codeql.swift.dataflow.FlowSteps
+
+/** The class `NSData`. */
+class NsData extends ClassDecl {
+  NsData() { this.getFullName() = "NSData" }
+}
+
+/** The class `NSMutableData`. */
+class NsMutableData extends ClassDecl {
+  NsMutableData() { this.getFullName() = "NSMutableData" }
+}
+
+private class NsDataSources extends SourceModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";NSData;true;init(contentsOf:);;;ReturnValue;remote",
+        ";NSData;true;init(contentsOf:options:);;;ReturnValue;remote"
+      ]
+  }
+}
+
+private class NsDataSummaries extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";NSData;true;init(bytes:length:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(bytesNoCopy:length:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(bytesNoCopy:length:deallocator:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(bytesNoCopy:length:freeWhenDone:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(data:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(contentsOfFile:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(contentsOfFile:options:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(contentsOf:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(contentsOf:options:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(contentsOfMappedFile:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(base64Encoded:options:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;init(base64Encoding:);;;Argument[0];ReturnValue;taint",
+        ";NSData;true;base64EncodedData(options:);;;Argument[-1];ReturnValue;taint",
+        ";NSData;true;base64EncodedString(options:);;;Argument[-1];ReturnValue;taint",
+        ";NSData;true;base64Encoding();;;Argument[-1];ReturnValue;taint",
+        ";NSData;true;dataWithContentsOfMappedFile(_:);;;Argument[0];ReturnValue;taint",
+        // TODO: Needs block flow
+        // ";NSData;true;enumerateBytes(_:);;;Argument[-1];Argument[0].Parameter[0];taint"
+        ";NSData;true;getBytes(_:);;;Argument[-1];Argument[0];taint",
+        ";NSData;true;getBytes(_:length:);;;Argument[-1];Argument[0];taint",
+        ";NSData;true;getBytes(_:range:);;;Argument[-1];Argument[0];taint",
+        ";NSData;true;subdata(with:);;;Argument[-1];ReturnValue;taint",
+        ";NSData;true;compressed(using:);;;Argument[-1];ReturnValue;taint",
+        ";NSData;true;decompressed(using:);;;Argument[-1];ReturnValue;taint"
+      ]
+  }
+}
+
+private class NsMutableDataSummaries extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";NSMutableData;true;append(_:length:);;;Argument[0];Argument[-1];taint",
+        ";NSMutableData;true;append(_:);;;Argument[0];Argument[-1];taint",
+        ";NSMutableData;true;replaceBytes(in:withBytes:);;;Argument[1];Argument[-1];taint",
+        ";NSMutableData;true;replaceBytes(in:withBytes:length:);;;Argument[1];Argument[-1];taint",
+        ";NSMutableData;true;setData(_:);;;Argument[0];Argument[-1];taint",
+      ]
+  }
+}
+
+/** A content implying that, if a `NSData` object is tainted, some of its fields are also tainted. */
+private class NsDataTaintedFields extends TaintInheritingContent, DataFlow::Content::FieldContent {
+  NsDataTaintedFields() {
+    exists(FieldDecl f | this.getField() = f |
+      f.getEnclosingDecl() instanceof NsData and
+      f.getName() = ["bytes", "description"]
+    )
+  }
+}
+
+/** A content implying that, if a `NSMutableData` object is tainted, some of its fields are also tainted. */
+private class NsMutableDataTaintedFields extends TaintInheritingContent,
+  DataFlow::Content::FieldContent {
+  NsMutableDataTaintedFields() {
+    exists(FieldDecl f | this.getField() = f |
+      f.getEnclosingDecl() instanceof NsMutableData and
+      f.getName() = "mutableBytes"
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NSData.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NSData.qll
@@ -45,8 +45,7 @@ private class NsDataSummaries extends SummaryModelCsv {
         ";NSData;true;base64EncodedString(options:);;;Argument[-1];ReturnValue;taint",
         ";NSData;true;base64Encoding();;;Argument[-1];ReturnValue;taint",
         ";NSData;true;dataWithContentsOfMappedFile(_:);;;Argument[0];ReturnValue;taint",
-        // TODO: Needs block flow
-        // ";NSData;true;enumerateBytes(_:);;;Argument[-1];Argument[0].Parameter[0];taint"
+        ";NSData;true;enumerateBytes(_:);;;Argument[-1];Argument[0].Parameter[0];taint",
         ";NSData;true;getBytes(_:);;;Argument[-1];Argument[0];taint",
         ";NSData;true;getBytes(_:length:);;;Argument[-1];Argument[0];taint",
         ";NSData;true;getBytes(_:range:);;;Argument[-1];Argument[0];taint",

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -3,6 +3,10 @@
 | customurlschemes.swift:38:52:38:62 | url | external |
 | customurlschemes.swift:43:9:43:28 | ...[...] | Remote URL in UIApplicationDelegate.application.launchOptions |
 | customurlschemes.swift:48:9:48:28 | ...[...] | Remote URL in UIApplicationDelegate.application.launchOptions |
+| nsdata.swift:18:17:18:17 | call to init(contentsOf:) | external |
+| nsdata.swift:18:17:18:40 | call to init(contentsOf:) | external |
+| nsdata.swift:19:17:19:17 | call to init(contentsOf:options:) | external |
+| nsdata.swift:19:17:19:53 | call to init(contentsOf:options:) | external |
 | string.swift:56:21:56:21 | call to init(contentsOf:) | external |
 | string.swift:56:21:56:44 | call to init(contentsOf:) | external |
 | string.swift:57:21:57:21 | call to init(contentsOf:encoding:) | external |

--- a/swift/ql/test/library-tests/dataflow/flowsources/nsdata.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/nsdata.swift
@@ -1,0 +1,20 @@
+// --- stubs ---
+
+struct URL
+{
+	init?(string: String) {}
+}
+
+class NSData {
+    struct ReadingOptions : OptionSet { let rawValue: Int }
+    init?(contentsOf: URL) {}
+    init?(contentsOf: URL, options: NSData.ReadingOptions) {}
+}
+
+// --- tests ---
+
+func testNSData() {
+    let url = URL(string: "http://example.com/")
+    let _ = try NSData(contentsOf: url!) // SOURCE
+    let _ = try NSData(contentsOf: url!, options: []) // SOURCE
+}

--- a/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
@@ -1,3 +1,6 @@
+| nsdata.swift:139:15:139:15 | nsDataTainted24 | nsdata.swift:139:15:139:31 | .bytes |
+| nsdata.swift:140:15:140:15 | nsDataTainted24 | nsdata.swift:140:15:140:31 | .description |
+| nsmutabledata.swift:49:15:49:15 | nsMutableDataTainted6 | nsmutabledata.swift:49:15:49:37 | .mutableBytes |
 | string.swift:7:13:7:13 |  | string.swift:7:13:7:13 | [post]  |
 | string.swift:7:13:7:13 |  | string.swift:7:14:7:14 | [post] &... |
 | string.swift:7:13:7:13 | TapExpr | string.swift:7:13:7:13 | "..." |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -1,5 +1,141 @@
 edges
 | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  | url.swift:120:61:120:61 | data :  |
+| nsdata.swift:22:9:22:9 | self :  | file://:0:0:0:0 | .bytes :  |
+| nsdata.swift:23:9:23:9 | self :  | file://:0:0:0:0 | .description :  |
+| nsdata.swift:24:5:24:50 | [summary param] 0 in init(bytes:length:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bytes:length:) :  |
+| nsdata.swift:25:5:25:68 | [summary param] 0 in init(bytesNoCopy:length:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:) :  |
+| nsdata.swift:26:5:26:130 | [summary param] 0 in init(bytesNoCopy:length:deallocator:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:deallocator:) :  |
+| nsdata.swift:27:5:27:90 | [summary param] 0 in init(bytesNoCopy:length:freeWhenDone:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:freeWhenDone:) :  |
+| nsdata.swift:28:5:28:23 | [summary param] 0 in init(data:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(data:) :  |
+| nsdata.swift:29:5:29:36 | [summary param] 0 in init(contentsOfFile:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfFile:) :  |
+| nsdata.swift:30:5:30:93 | [summary param] 0 in init(contentsOfFile:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfFile:options:) :  |
+| nsdata.swift:31:5:31:29 | [summary param] 0 in init(contentsOf:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOf:) :  |
+| nsdata.swift:32:5:32:61 | [summary param] 0 in init(contentsOf:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOf:options:) :  |
+| nsdata.swift:33:5:33:47 | [summary param] 0 in init(contentsOfMappedFile:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfMappedFile:) :  |
+| nsdata.swift:34:5:34:88 | [summary param] 0 in init(base64Encoded:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  |
+| nsdata.swift:35:5:35:92 | [summary param] 0 in init(base64Encoded:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  |
+| nsdata.swift:36:5:36:49 | [summary param] 0 in init(base64Encoding:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoding:) :  |
+| nsdata.swift:37:5:37:98 | [summary param] this in base64EncodedData(options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedData(options:) :  |
+| nsdata.swift:38:5:38:96 | [summary param] this in base64EncodedString(options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedString(options:) :  |
+| nsdata.swift:39:5:39:49 | [summary param] this in base64Encoding() :  | file://:0:0:0:0 | [summary] to write: return (return) in base64Encoding() :  |
+| nsdata.swift:40:5:40:82 | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:42:5:42:55 | [summary param] this in getBytes(_:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:) :  |
+| nsdata.swift:43:5:43:68 | [summary param] this in getBytes(_:length:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:length:) :  |
+| nsdata.swift:44:5:44:71 | [summary param] this in getBytes(_:range:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:range:) :  |
+| nsdata.swift:45:5:45:65 | [summary param] this in subdata(with:) :  | file://:0:0:0:0 | [summary] to write: return (return) in subdata(with:) :  |
+| nsdata.swift:46:5:46:89 | [summary param] this in compressed(using:) :  | file://:0:0:0:0 | [summary] to write: return (return) in compressed(using:) :  |
+| nsdata.swift:47:5:47:91 | [summary param] this in decompressed(using:) :  | file://:0:0:0:0 | [summary] to write: return (return) in decompressed(using:) :  |
+| nsdata.swift:57:26:57:80 | call to init(bytes:length:) :  | nsdata.swift:58:15:58:15 | nsDataTainted1 |
+| nsdata.swift:57:40:57:47 | call to source() :  | nsdata.swift:24:5:24:50 | [summary param] 0 in init(bytes:length:) :  |
+| nsdata.swift:57:40:57:47 | call to source() :  | nsdata.swift:57:26:57:80 | call to init(bytes:length:) :  |
+| nsdata.swift:60:26:60:93 | call to init(bytesNoCopy:length:) :  | nsdata.swift:61:15:61:15 | nsDataTainted2 |
+| nsdata.swift:60:46:60:53 | call to source() :  | nsdata.swift:25:5:25:68 | [summary param] 0 in init(bytesNoCopy:length:) :  |
+| nsdata.swift:60:46:60:53 | call to source() :  | nsdata.swift:60:26:60:93 | call to init(bytesNoCopy:length:) :  |
+| nsdata.swift:63:26:63:111 | call to init(bytesNoCopy:length:deallocator:) :  | nsdata.swift:64:15:64:15 | nsDataTainted3 |
+| nsdata.swift:63:46:63:53 | call to source() :  | nsdata.swift:26:5:26:130 | [summary param] 0 in init(bytesNoCopy:length:deallocator:) :  |
+| nsdata.swift:63:46:63:53 | call to source() :  | nsdata.swift:63:26:63:111 | call to init(bytesNoCopy:length:deallocator:) :  |
+| nsdata.swift:66:26:66:113 | call to init(bytesNoCopy:length:freeWhenDone:) :  | nsdata.swift:67:15:67:15 | nsDataTainted4 |
+| nsdata.swift:66:46:66:53 | call to source() :  | nsdata.swift:27:5:27:90 | [summary param] 0 in init(bytesNoCopy:length:freeWhenDone:) :  |
+| nsdata.swift:66:46:66:53 | call to source() :  | nsdata.swift:66:26:66:113 | call to init(bytesNoCopy:length:freeWhenDone:) :  |
+| nsdata.swift:69:26:69:56 | call to init(data:) :  | nsdata.swift:70:15:70:15 | nsDataTainted5 |
+| nsdata.swift:69:39:69:46 | call to source() :  | nsdata.swift:28:5:28:23 | [summary param] 0 in init(data:) :  |
+| nsdata.swift:69:39:69:46 | call to source() :  | nsdata.swift:69:26:69:56 | call to init(data:) :  |
+| nsdata.swift:72:26:72:68 | call to init(contentsOfFile:) :  | nsdata.swift:73:15:73:29 | ...! |
+| nsdata.swift:72:49:72:56 | call to source() :  | nsdata.swift:29:5:29:36 | [summary param] 0 in init(contentsOfFile:) :  |
+| nsdata.swift:72:49:72:56 | call to source() :  | nsdata.swift:72:26:72:68 | call to init(contentsOfFile:) :  |
+| nsdata.swift:75:26:75:81 | call to init(contentsOfFile:options:) :  | nsdata.swift:76:15:76:15 | nsDataTainted7 |
+| nsdata.swift:75:49:75:56 | call to source() :  | nsdata.swift:30:5:30:93 | [summary param] 0 in init(contentsOfFile:options:) :  |
+| nsdata.swift:75:49:75:56 | call to source() :  | nsdata.swift:75:26:75:81 | call to init(contentsOfFile:options:) :  |
+| nsdata.swift:78:26:78:61 | call to init(contentsOf:) :  | nsdata.swift:79:15:79:29 | ...! |
+| nsdata.swift:78:45:78:52 | call to source() :  | nsdata.swift:31:5:31:29 | [summary param] 0 in init(contentsOf:) :  |
+| nsdata.swift:78:45:78:52 | call to source() :  | nsdata.swift:78:26:78:61 | call to init(contentsOf:) :  |
+| nsdata.swift:81:26:81:74 | call to init(contentsOf:options:) :  | nsdata.swift:82:15:82:29 | ...! |
+| nsdata.swift:81:45:81:52 | call to source() :  | nsdata.swift:32:5:32:61 | [summary param] 0 in init(contentsOf:options:) :  |
+| nsdata.swift:81:45:81:52 | call to source() :  | nsdata.swift:81:26:81:74 | call to init(contentsOf:options:) :  |
+| nsdata.swift:84:27:84:75 | call to init(contentsOfMappedFile:) :  | nsdata.swift:85:15:85:30 | ...! |
+| nsdata.swift:84:56:84:63 | call to source() :  | nsdata.swift:33:5:33:47 | [summary param] 0 in init(contentsOfMappedFile:) :  |
+| nsdata.swift:84:56:84:63 | call to source() :  | nsdata.swift:84:27:84:75 | call to init(contentsOfMappedFile:) :  |
+| nsdata.swift:87:27:87:79 | call to init(base64Encoded:options:) :  | nsdata.swift:88:15:88:30 | ...! |
+| nsdata.swift:87:49:87:56 | call to source() :  | nsdata.swift:34:5:34:88 | [summary param] 0 in init(base64Encoded:options:) :  |
+| nsdata.swift:87:49:87:56 | call to source() :  | nsdata.swift:87:27:87:79 | call to init(base64Encoded:options:) :  |
+| nsdata.swift:89:27:89:81 | call to init(base64Encoded:options:) :  | nsdata.swift:90:15:90:30 | ...! |
+| nsdata.swift:89:49:89:56 | call to source() :  | nsdata.swift:35:5:35:92 | [summary param] 0 in init(base64Encoded:options:) :  |
+| nsdata.swift:89:49:89:56 | call to source() :  | nsdata.swift:89:27:89:81 | call to init(base64Encoded:options:) :  |
+| nsdata.swift:92:27:92:69 | call to init(base64Encoding:) :  | nsdata.swift:93:15:93:30 | ...! |
+| nsdata.swift:92:50:92:57 | call to source() :  | nsdata.swift:36:5:36:49 | [summary param] 0 in init(base64Encoding:) :  |
+| nsdata.swift:92:50:92:57 | call to source() :  | nsdata.swift:92:27:92:69 | call to init(base64Encoding:) :  |
+| nsdata.swift:95:27:95:34 | call to source() :  | nsdata.swift:96:15:96:15 | nsDataTainted14 :  |
+| nsdata.swift:95:27:95:34 | call to source() :  | nsdata.swift:97:15:97:15 | nsDataTainted14 :  |
+| nsdata.swift:96:15:96:15 | nsDataTainted14 :  | nsdata.swift:37:5:37:98 | [summary param] this in base64EncodedData(options:) :  |
+| nsdata.swift:96:15:96:15 | nsDataTainted14 :  | nsdata.swift:96:15:96:49 | call to base64EncodedData(options:) |
+| nsdata.swift:97:15:97:15 | nsDataTainted14 :  | nsdata.swift:37:5:37:98 | [summary param] this in base64EncodedData(options:) :  |
+| nsdata.swift:97:15:97:15 | nsDataTainted14 :  | nsdata.swift:97:15:97:60 | call to base64EncodedData(options:) |
+| nsdata.swift:99:27:99:34 | call to source() :  | nsdata.swift:100:15:100:15 | nsDataTainted15 :  |
+| nsdata.swift:99:27:99:34 | call to source() :  | nsdata.swift:101:15:101:15 | nsDataTainted15 :  |
+| nsdata.swift:100:15:100:15 | nsDataTainted15 :  | nsdata.swift:38:5:38:96 | [summary param] this in base64EncodedString(options:) :  |
+| nsdata.swift:100:15:100:15 | nsDataTainted15 :  | nsdata.swift:100:15:100:51 | call to base64EncodedString(options:) |
+| nsdata.swift:101:15:101:15 | nsDataTainted15 :  | nsdata.swift:38:5:38:96 | [summary param] this in base64EncodedString(options:) :  |
+| nsdata.swift:101:15:101:15 | nsDataTainted15 :  | nsdata.swift:101:15:101:62 | call to base64EncodedString(options:) |
+| nsdata.swift:103:27:103:34 | call to source() :  | nsdata.swift:104:15:104:15 | nsDataTainted16 :  |
+| nsdata.swift:104:15:104:15 | nsDataTainted16 :  | nsdata.swift:39:5:39:49 | [summary param] this in base64Encoding() :  |
+| nsdata.swift:104:15:104:15 | nsDataTainted16 :  | nsdata.swift:104:15:104:46 | call to base64Encoding() |
+| nsdata.swift:106:15:106:70 | call to dataWithContentsOfMappedFile(_:) :  | nsdata.swift:106:15:106:71 | ...! |
+| nsdata.swift:106:51:106:58 | call to source() :  | nsdata.swift:40:5:40:82 | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:106:51:106:58 | call to source() :  | nsdata.swift:106:15:106:70 | call to dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:113:27:113:34 | call to source() :  | nsdata.swift:115:5:115:5 | nsDataTainted18 :  |
+| nsdata.swift:115:5:115:5 | nsDataTainted18 :  | nsdata.swift:42:5:42:55 | [summary param] this in getBytes(_:) :  |
+| nsdata.swift:115:5:115:5 | nsDataTainted18 :  | nsdata.swift:115:30:115:30 | [post] bufferTainted18 :  |
+| nsdata.swift:115:30:115:30 | [post] bufferTainted18 :  | nsdata.swift:116:15:116:15 | bufferTainted18 |
+| nsdata.swift:118:27:118:34 | call to source() :  | nsdata.swift:120:5:120:5 | nsDataTainted19 :  |
+| nsdata.swift:120:5:120:5 | nsDataTainted19 :  | nsdata.swift:43:5:43:68 | [summary param] this in getBytes(_:length:) :  |
+| nsdata.swift:120:5:120:5 | nsDataTainted19 :  | nsdata.swift:120:30:120:30 | [post] bufferTainted19 :  |
+| nsdata.swift:120:30:120:30 | [post] bufferTainted19 :  | nsdata.swift:121:15:121:15 | bufferTainted19 |
+| nsdata.swift:123:27:123:34 | call to source() :  | nsdata.swift:125:5:125:5 | nsDataTainted20 :  |
+| nsdata.swift:125:5:125:5 | nsDataTainted20 :  | nsdata.swift:44:5:44:71 | [summary param] this in getBytes(_:range:) :  |
+| nsdata.swift:125:5:125:5 | nsDataTainted20 :  | nsdata.swift:125:30:125:30 | [post] bufferTainted20 :  |
+| nsdata.swift:125:30:125:30 | [post] bufferTainted20 :  | nsdata.swift:126:15:126:15 | bufferTainted20 |
+| nsdata.swift:128:27:128:34 | call to source() :  | nsdata.swift:129:15:129:15 | nsDataTainted21 :  |
+| nsdata.swift:129:15:129:15 | nsDataTainted21 :  | nsdata.swift:45:5:45:65 | [summary param] this in subdata(with:) :  |
+| nsdata.swift:129:15:129:15 | nsDataTainted21 :  | nsdata.swift:129:15:129:54 | call to subdata(with:) |
+| nsdata.swift:131:27:131:34 | call to source() :  | nsdata.swift:132:15:132:15 | nsDataTainted22 :  |
+| nsdata.swift:132:15:132:15 | nsDataTainted22 :  | nsdata.swift:46:5:46:89 | [summary param] this in compressed(using:) :  |
+| nsdata.swift:132:15:132:15 | nsDataTainted22 :  | nsdata.swift:132:15:132:81 | call to compressed(using:) |
+| nsdata.swift:134:27:134:34 | call to source() :  | nsdata.swift:135:15:135:15 | nsDataTainted23 :  |
+| nsdata.swift:135:15:135:15 | nsDataTainted23 :  | nsdata.swift:47:5:47:91 | [summary param] this in decompressed(using:) :  |
+| nsdata.swift:135:15:135:15 | nsDataTainted23 :  | nsdata.swift:135:15:135:83 | call to decompressed(using:) |
+| nsdata.swift:138:27:138:34 | call to source() :  | nsdata.swift:139:15:139:15 | nsDataTainted24 :  |
+| nsdata.swift:138:27:138:34 | call to source() :  | nsdata.swift:139:15:139:31 | .bytes |
+| nsdata.swift:138:27:138:34 | call to source() :  | nsdata.swift:140:15:140:15 | nsDataTainted24 :  |
+| nsdata.swift:138:27:138:34 | call to source() :  | nsdata.swift:140:15:140:31 | .description |
+| nsdata.swift:139:15:139:15 | nsDataTainted24 :  | nsdata.swift:22:9:22:9 | self :  |
+| nsdata.swift:139:15:139:15 | nsDataTainted24 :  | nsdata.swift:139:15:139:31 | .bytes |
+| nsdata.swift:140:15:140:15 | nsDataTainted24 :  | nsdata.swift:23:9:23:9 | self :  |
+| nsdata.swift:140:15:140:15 | nsDataTainted24 :  | nsdata.swift:140:15:140:31 | .description |
+| nsmutabledata.swift:13:9:13:9 | self :  | file://:0:0:0:0 | .mutableBytes :  |
+| nsmutabledata.swift:14:5:14:58 | [summary param] 0 in append(_:length:) :  | file://:0:0:0:0 | [summary] to write: argument this in append(_:length:) :  |
+| nsmutabledata.swift:15:5:15:33 | [summary param] 0 in append(_:) :  | file://:0:0:0:0 | [summary] to write: argument this in append(_:) :  |
+| nsmutabledata.swift:16:5:16:78 | [summary param] 1 in replaceBytes(in:withBytes:) :  | file://:0:0:0:0 | [summary] to write: argument this in replaceBytes(in:withBytes:) :  |
+| nsmutabledata.swift:17:5:17:121 | [summary param] 1 in replaceBytes(in:withBytes:length:) :  | file://:0:0:0:0 | [summary] to write: argument this in replaceBytes(in:withBytes:length:) :  |
+| nsmutabledata.swift:18:5:18:33 | [summary param] 0 in setData(_:) :  | file://:0:0:0:0 | [summary] to write: argument this in setData(_:) :  |
+| nsmutabledata.swift:28:5:28:5 | [post] nsMutableDataTainted1 :  | nsmutabledata.swift:29:15:29:15 | nsMutableDataTainted1 |
+| nsmutabledata.swift:28:34:28:41 | call to source() :  | nsmutabledata.swift:14:5:14:58 | [summary param] 0 in append(_:length:) :  |
+| nsmutabledata.swift:28:34:28:41 | call to source() :  | nsmutabledata.swift:28:5:28:5 | [post] nsMutableDataTainted1 :  |
+| nsmutabledata.swift:32:5:32:5 | [post] nsMutableDataTainted2 :  | nsmutabledata.swift:33:15:33:15 | nsMutableDataTainted2 |
+| nsmutabledata.swift:32:34:32:41 | call to source() :  | nsmutabledata.swift:15:5:15:33 | [summary param] 0 in append(_:) :  |
+| nsmutabledata.swift:32:34:32:41 | call to source() :  | nsmutabledata.swift:32:5:32:5 | [post] nsMutableDataTainted2 :  |
+| nsmutabledata.swift:36:5:36:5 | [post] nsMutableDataTainted3 :  | nsmutabledata.swift:37:15:37:15 | nsMutableDataTainted3 |
+| nsmutabledata.swift:36:66:36:73 | call to source() :  | nsmutabledata.swift:16:5:16:78 | [summary param] 1 in replaceBytes(in:withBytes:) :  |
+| nsmutabledata.swift:36:66:36:73 | call to source() :  | nsmutabledata.swift:36:5:36:5 | [post] nsMutableDataTainted3 :  |
+| nsmutabledata.swift:40:5:40:5 | [post] nsMutableDataTainted4 :  | nsmutabledata.swift:41:15:41:15 | nsMutableDataTainted4 |
+| nsmutabledata.swift:40:66:40:73 | call to source() :  | nsmutabledata.swift:17:5:17:121 | [summary param] 1 in replaceBytes(in:withBytes:length:) :  |
+| nsmutabledata.swift:40:66:40:73 | call to source() :  | nsmutabledata.swift:40:5:40:5 | [post] nsMutableDataTainted4 :  |
+| nsmutabledata.swift:44:5:44:5 | [post] nsMutableDataTainted5 :  | nsmutabledata.swift:45:15:45:15 | nsMutableDataTainted5 |
+| nsmutabledata.swift:44:35:44:42 | call to source() :  | nsmutabledata.swift:18:5:18:33 | [summary param] 0 in setData(_:) :  |
+| nsmutabledata.swift:44:35:44:42 | call to source() :  | nsmutabledata.swift:44:5:44:5 | [post] nsMutableDataTainted5 :  |
+| nsmutabledata.swift:48:33:48:40 | call to source() :  | nsmutabledata.swift:49:15:49:15 | nsMutableDataTainted6 :  |
+| nsmutabledata.swift:48:33:48:40 | call to source() :  | nsmutabledata.swift:49:15:49:37 | .mutableBytes |
+| nsmutabledata.swift:49:15:49:15 | nsMutableDataTainted6 :  | nsmutabledata.swift:13:9:13:9 | self :  |
+| nsmutabledata.swift:49:15:49:15 | nsMutableDataTainted6 :  | nsmutabledata.swift:49:15:49:37 | .mutableBytes |
 | string.swift:5:11:5:18 | call to source() :  | string.swift:7:13:7:13 | "..." |
 | string.swift:5:11:5:18 | call to source() :  | string.swift:9:13:9:13 | "..." |
 | string.swift:5:11:5:18 | call to source() :  | string.swift:11:13:11:13 | "..." |
@@ -240,13 +376,43 @@ edges
 | webview.swift:97:17:97:17 | s :  | webview.swift:44:5:44:48 | [summary param] 0 in setValue(_:forProperty:) :  |
 | webview.swift:97:17:97:17 | s :  | webview.swift:97:5:97:5 | [post] v3 :  |
 nodes
+| file://:0:0:0:0 | .bytes :  | semmle.label | .bytes :  |
+| file://:0:0:0:0 | .description :  | semmle.label | .description :  |
+| file://:0:0:0:0 | .mutableBytes :  | semmle.label | .mutableBytes :  |
+| file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:) :  | semmle.label | [summary] to write: argument 0 in getBytes(_:) :  |
+| file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:length:) :  | semmle.label | [summary] to write: argument 0 in getBytes(_:length:) :  |
+| file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:range:) :  | semmle.label | [summary] to write: argument 0 in getBytes(_:range:) :  |
 | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  | semmle.label | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
+| file://:0:0:0:0 | [summary] to write: argument this in append(_:) :  | semmle.label | [summary] to write: argument this in append(_:) :  |
+| file://:0:0:0:0 | [summary] to write: argument this in append(_:length:) :  | semmle.label | [summary] to write: argument this in append(_:length:) :  |
 | file://:0:0:0:0 | [summary] to write: argument this in defineProperty(_:descriptor:) :  | semmle.label | [summary] to write: argument this in defineProperty(_:descriptor:) :  |
+| file://:0:0:0:0 | [summary] to write: argument this in replaceBytes(in:withBytes:) :  | semmle.label | [summary] to write: argument this in replaceBytes(in:withBytes:) :  |
+| file://:0:0:0:0 | [summary] to write: argument this in replaceBytes(in:withBytes:length:) :  | semmle.label | [summary] to write: argument this in replaceBytes(in:withBytes:length:) :  |
+| file://:0:0:0:0 | [summary] to write: argument this in setData(_:) :  | semmle.label | [summary] to write: argument this in setData(_:) :  |
 | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:at:) :  | semmle.label | [summary] to write: argument this in setValue(_:at:) :  |
 | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:forProperty:) :  | semmle.label | [summary] to write: argument this in setValue(_:forProperty:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in atIndex(_:) :  | semmle.label | [summary] to write: return (return) in atIndex(_:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedData(options:) :  | semmle.label | [summary] to write: return (return) in base64EncodedData(options:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedString(options:) :  | semmle.label | [summary] to write: return (return) in base64EncodedString(options:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in base64Encoding() :  | semmle.label | [summary] to write: return (return) in base64Encoding() :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in compressed(using:) :  | semmle.label | [summary] to write: return (return) in compressed(using:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in dataWithContentsOfMappedFile(_:) :  | semmle.label | [summary] to write: return (return) in dataWithContentsOfMappedFile(_:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in decompressed(using:) :  | semmle.label | [summary] to write: return (return) in decompressed(using:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  | semmle.label | [summary] to write: return (return) in forProperty(_:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  | semmle.label | [summary] to write: return (return) in init(base64Encoded:options:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  | semmle.label | [summary] to write: return (return) in init(base64Encoded:options:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoding:) :  | semmle.label | [summary] to write: return (return) in init(base64Encoding:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(bool:in:) :  | semmle.label | [summary] to write: return (return) in init(bool:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(bytes:length:) :  | semmle.label | [summary] to write: return (return) in init(bytes:length:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:) :  | semmle.label | [summary] to write: return (return) in init(bytesNoCopy:length:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:deallocator:) :  | semmle.label | [summary] to write: return (return) in init(bytesNoCopy:length:deallocator:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:freeWhenDone:) :  | semmle.label | [summary] to write: return (return) in init(bytesNoCopy:length:freeWhenDone:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOf:) :  | semmle.label | [summary] to write: return (return) in init(contentsOf:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOf:options:) :  | semmle.label | [summary] to write: return (return) in init(contentsOf:options:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfFile:) :  | semmle.label | [summary] to write: return (return) in init(contentsOfFile:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfFile:options:) :  | semmle.label | [summary] to write: return (return) in init(contentsOfFile:options:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfMappedFile:) :  | semmle.label | [summary] to write: return (return) in init(contentsOfMappedFile:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in init(data:) :  | semmle.label | [summary] to write: return (return) in init(data:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(double:in:) :  | semmle.label | [summary] to write: return (return) in init(double:in:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(int32:in:) :  | semmle.label | [summary] to write: return (return) in init(int32:in:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(object:in:) :  | semmle.label | [summary] to write: return (return) in init(object:in:) :  |
@@ -258,6 +424,7 @@ nodes
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | semmle.label | [summary] to write: return (return) in init(string:relativeTo:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in init(uInt32:in:) :  | semmle.label | [summary] to write: return (return) in init(uInt32:in:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in subdata(with:) :  | semmle.label | [summary] to write: return (return) in subdata(with:) :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in toArray() :  | semmle.label | [summary] to write: return (return) in toArray() :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in toBool() :  | semmle.label | [summary] to write: return (return) in toBool() :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in toDate() :  | semmle.label | [summary] to write: return (return) in toDate() :  |
@@ -273,6 +440,136 @@ nodes
 | file://:0:0:0:0 | [summary] to write: return (return) in toSize() :  | semmle.label | [summary] to write: return (return) in toSize() :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in toString() :  | semmle.label | [summary] to write: return (return) in toString() :  |
 | file://:0:0:0:0 | [summary] to write: return (return) in toUInt32() :  | semmle.label | [summary] to write: return (return) in toUInt32() :  |
+| nsdata.swift:22:9:22:9 | self :  | semmle.label | self :  |
+| nsdata.swift:23:9:23:9 | self :  | semmle.label | self :  |
+| nsdata.swift:24:5:24:50 | [summary param] 0 in init(bytes:length:) :  | semmle.label | [summary param] 0 in init(bytes:length:) :  |
+| nsdata.swift:25:5:25:68 | [summary param] 0 in init(bytesNoCopy:length:) :  | semmle.label | [summary param] 0 in init(bytesNoCopy:length:) :  |
+| nsdata.swift:26:5:26:130 | [summary param] 0 in init(bytesNoCopy:length:deallocator:) :  | semmle.label | [summary param] 0 in init(bytesNoCopy:length:deallocator:) :  |
+| nsdata.swift:27:5:27:90 | [summary param] 0 in init(bytesNoCopy:length:freeWhenDone:) :  | semmle.label | [summary param] 0 in init(bytesNoCopy:length:freeWhenDone:) :  |
+| nsdata.swift:28:5:28:23 | [summary param] 0 in init(data:) :  | semmle.label | [summary param] 0 in init(data:) :  |
+| nsdata.swift:29:5:29:36 | [summary param] 0 in init(contentsOfFile:) :  | semmle.label | [summary param] 0 in init(contentsOfFile:) :  |
+| nsdata.swift:30:5:30:93 | [summary param] 0 in init(contentsOfFile:options:) :  | semmle.label | [summary param] 0 in init(contentsOfFile:options:) :  |
+| nsdata.swift:31:5:31:29 | [summary param] 0 in init(contentsOf:) :  | semmle.label | [summary param] 0 in init(contentsOf:) :  |
+| nsdata.swift:32:5:32:61 | [summary param] 0 in init(contentsOf:options:) :  | semmle.label | [summary param] 0 in init(contentsOf:options:) :  |
+| nsdata.swift:33:5:33:47 | [summary param] 0 in init(contentsOfMappedFile:) :  | semmle.label | [summary param] 0 in init(contentsOfMappedFile:) :  |
+| nsdata.swift:34:5:34:88 | [summary param] 0 in init(base64Encoded:options:) :  | semmle.label | [summary param] 0 in init(base64Encoded:options:) :  |
+| nsdata.swift:35:5:35:92 | [summary param] 0 in init(base64Encoded:options:) :  | semmle.label | [summary param] 0 in init(base64Encoded:options:) :  |
+| nsdata.swift:36:5:36:49 | [summary param] 0 in init(base64Encoding:) :  | semmle.label | [summary param] 0 in init(base64Encoding:) :  |
+| nsdata.swift:37:5:37:98 | [summary param] this in base64EncodedData(options:) :  | semmle.label | [summary param] this in base64EncodedData(options:) :  |
+| nsdata.swift:38:5:38:96 | [summary param] this in base64EncodedString(options:) :  | semmle.label | [summary param] this in base64EncodedString(options:) :  |
+| nsdata.swift:39:5:39:49 | [summary param] this in base64Encoding() :  | semmle.label | [summary param] this in base64Encoding() :  |
+| nsdata.swift:40:5:40:82 | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  | semmle.label | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:42:5:42:55 | [summary param] this in getBytes(_:) :  | semmle.label | [summary param] this in getBytes(_:) :  |
+| nsdata.swift:43:5:43:68 | [summary param] this in getBytes(_:length:) :  | semmle.label | [summary param] this in getBytes(_:length:) :  |
+| nsdata.swift:44:5:44:71 | [summary param] this in getBytes(_:range:) :  | semmle.label | [summary param] this in getBytes(_:range:) :  |
+| nsdata.swift:45:5:45:65 | [summary param] this in subdata(with:) :  | semmle.label | [summary param] this in subdata(with:) :  |
+| nsdata.swift:46:5:46:89 | [summary param] this in compressed(using:) :  | semmle.label | [summary param] this in compressed(using:) :  |
+| nsdata.swift:47:5:47:91 | [summary param] this in decompressed(using:) :  | semmle.label | [summary param] this in decompressed(using:) :  |
+| nsdata.swift:57:26:57:80 | call to init(bytes:length:) :  | semmle.label | call to init(bytes:length:) :  |
+| nsdata.swift:57:40:57:47 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:58:15:58:15 | nsDataTainted1 | semmle.label | nsDataTainted1 |
+| nsdata.swift:60:26:60:93 | call to init(bytesNoCopy:length:) :  | semmle.label | call to init(bytesNoCopy:length:) :  |
+| nsdata.swift:60:46:60:53 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:61:15:61:15 | nsDataTainted2 | semmle.label | nsDataTainted2 |
+| nsdata.swift:63:26:63:111 | call to init(bytesNoCopy:length:deallocator:) :  | semmle.label | call to init(bytesNoCopy:length:deallocator:) :  |
+| nsdata.swift:63:46:63:53 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:64:15:64:15 | nsDataTainted3 | semmle.label | nsDataTainted3 |
+| nsdata.swift:66:26:66:113 | call to init(bytesNoCopy:length:freeWhenDone:) :  | semmle.label | call to init(bytesNoCopy:length:freeWhenDone:) :  |
+| nsdata.swift:66:46:66:53 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:67:15:67:15 | nsDataTainted4 | semmle.label | nsDataTainted4 |
+| nsdata.swift:69:26:69:56 | call to init(data:) :  | semmle.label | call to init(data:) :  |
+| nsdata.swift:69:39:69:46 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:70:15:70:15 | nsDataTainted5 | semmle.label | nsDataTainted5 |
+| nsdata.swift:72:26:72:68 | call to init(contentsOfFile:) :  | semmle.label | call to init(contentsOfFile:) :  |
+| nsdata.swift:72:49:72:56 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:73:15:73:29 | ...! | semmle.label | ...! |
+| nsdata.swift:75:26:75:81 | call to init(contentsOfFile:options:) :  | semmle.label | call to init(contentsOfFile:options:) :  |
+| nsdata.swift:75:49:75:56 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:76:15:76:15 | nsDataTainted7 | semmle.label | nsDataTainted7 |
+| nsdata.swift:78:26:78:61 | call to init(contentsOf:) :  | semmle.label | call to init(contentsOf:) :  |
+| nsdata.swift:78:45:78:52 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:79:15:79:29 | ...! | semmle.label | ...! |
+| nsdata.swift:81:26:81:74 | call to init(contentsOf:options:) :  | semmle.label | call to init(contentsOf:options:) :  |
+| nsdata.swift:81:45:81:52 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:82:15:82:29 | ...! | semmle.label | ...! |
+| nsdata.swift:84:27:84:75 | call to init(contentsOfMappedFile:) :  | semmle.label | call to init(contentsOfMappedFile:) :  |
+| nsdata.swift:84:56:84:63 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:85:15:85:30 | ...! | semmle.label | ...! |
+| nsdata.swift:87:27:87:79 | call to init(base64Encoded:options:) :  | semmle.label | call to init(base64Encoded:options:) :  |
+| nsdata.swift:87:49:87:56 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:88:15:88:30 | ...! | semmle.label | ...! |
+| nsdata.swift:89:27:89:81 | call to init(base64Encoded:options:) :  | semmle.label | call to init(base64Encoded:options:) :  |
+| nsdata.swift:89:49:89:56 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:90:15:90:30 | ...! | semmle.label | ...! |
+| nsdata.swift:92:27:92:69 | call to init(base64Encoding:) :  | semmle.label | call to init(base64Encoding:) :  |
+| nsdata.swift:92:50:92:57 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:93:15:93:30 | ...! | semmle.label | ...! |
+| nsdata.swift:95:27:95:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:96:15:96:15 | nsDataTainted14 :  | semmle.label | nsDataTainted14 :  |
+| nsdata.swift:96:15:96:49 | call to base64EncodedData(options:) | semmle.label | call to base64EncodedData(options:) |
+| nsdata.swift:97:15:97:15 | nsDataTainted14 :  | semmle.label | nsDataTainted14 :  |
+| nsdata.swift:97:15:97:60 | call to base64EncodedData(options:) | semmle.label | call to base64EncodedData(options:) |
+| nsdata.swift:99:27:99:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:100:15:100:15 | nsDataTainted15 :  | semmle.label | nsDataTainted15 :  |
+| nsdata.swift:100:15:100:51 | call to base64EncodedString(options:) | semmle.label | call to base64EncodedString(options:) |
+| nsdata.swift:101:15:101:15 | nsDataTainted15 :  | semmle.label | nsDataTainted15 :  |
+| nsdata.swift:101:15:101:62 | call to base64EncodedString(options:) | semmle.label | call to base64EncodedString(options:) |
+| nsdata.swift:103:27:103:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:104:15:104:15 | nsDataTainted16 :  | semmle.label | nsDataTainted16 :  |
+| nsdata.swift:104:15:104:46 | call to base64Encoding() | semmle.label | call to base64Encoding() |
+| nsdata.swift:106:15:106:70 | call to dataWithContentsOfMappedFile(_:) :  | semmle.label | call to dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:106:15:106:71 | ...! | semmle.label | ...! |
+| nsdata.swift:106:51:106:58 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:113:27:113:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:115:5:115:5 | nsDataTainted18 :  | semmle.label | nsDataTainted18 :  |
+| nsdata.swift:115:30:115:30 | [post] bufferTainted18 :  | semmle.label | [post] bufferTainted18 :  |
+| nsdata.swift:116:15:116:15 | bufferTainted18 | semmle.label | bufferTainted18 |
+| nsdata.swift:118:27:118:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:120:5:120:5 | nsDataTainted19 :  | semmle.label | nsDataTainted19 :  |
+| nsdata.swift:120:30:120:30 | [post] bufferTainted19 :  | semmle.label | [post] bufferTainted19 :  |
+| nsdata.swift:121:15:121:15 | bufferTainted19 | semmle.label | bufferTainted19 |
+| nsdata.swift:123:27:123:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:125:5:125:5 | nsDataTainted20 :  | semmle.label | nsDataTainted20 :  |
+| nsdata.swift:125:30:125:30 | [post] bufferTainted20 :  | semmle.label | [post] bufferTainted20 :  |
+| nsdata.swift:126:15:126:15 | bufferTainted20 | semmle.label | bufferTainted20 |
+| nsdata.swift:128:27:128:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:129:15:129:15 | nsDataTainted21 :  | semmle.label | nsDataTainted21 :  |
+| nsdata.swift:129:15:129:54 | call to subdata(with:) | semmle.label | call to subdata(with:) |
+| nsdata.swift:131:27:131:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:132:15:132:15 | nsDataTainted22 :  | semmle.label | nsDataTainted22 :  |
+| nsdata.swift:132:15:132:81 | call to compressed(using:) | semmle.label | call to compressed(using:) |
+| nsdata.swift:134:27:134:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:135:15:135:15 | nsDataTainted23 :  | semmle.label | nsDataTainted23 :  |
+| nsdata.swift:135:15:135:83 | call to decompressed(using:) | semmle.label | call to decompressed(using:) |
+| nsdata.swift:138:27:138:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:139:15:139:15 | nsDataTainted24 :  | semmle.label | nsDataTainted24 :  |
+| nsdata.swift:139:15:139:31 | .bytes | semmle.label | .bytes |
+| nsdata.swift:140:15:140:15 | nsDataTainted24 :  | semmle.label | nsDataTainted24 :  |
+| nsdata.swift:140:15:140:31 | .description | semmle.label | .description |
+| nsmutabledata.swift:13:9:13:9 | self :  | semmle.label | self :  |
+| nsmutabledata.swift:14:5:14:58 | [summary param] 0 in append(_:length:) :  | semmle.label | [summary param] 0 in append(_:length:) :  |
+| nsmutabledata.swift:15:5:15:33 | [summary param] 0 in append(_:) :  | semmle.label | [summary param] 0 in append(_:) :  |
+| nsmutabledata.swift:16:5:16:78 | [summary param] 1 in replaceBytes(in:withBytes:) :  | semmle.label | [summary param] 1 in replaceBytes(in:withBytes:) :  |
+| nsmutabledata.swift:17:5:17:121 | [summary param] 1 in replaceBytes(in:withBytes:length:) :  | semmle.label | [summary param] 1 in replaceBytes(in:withBytes:length:) :  |
+| nsmutabledata.swift:18:5:18:33 | [summary param] 0 in setData(_:) :  | semmle.label | [summary param] 0 in setData(_:) :  |
+| nsmutabledata.swift:28:5:28:5 | [post] nsMutableDataTainted1 :  | semmle.label | [post] nsMutableDataTainted1 :  |
+| nsmutabledata.swift:28:34:28:41 | call to source() :  | semmle.label | call to source() :  |
+| nsmutabledata.swift:29:15:29:15 | nsMutableDataTainted1 | semmle.label | nsMutableDataTainted1 |
+| nsmutabledata.swift:32:5:32:5 | [post] nsMutableDataTainted2 :  | semmle.label | [post] nsMutableDataTainted2 :  |
+| nsmutabledata.swift:32:34:32:41 | call to source() :  | semmle.label | call to source() :  |
+| nsmutabledata.swift:33:15:33:15 | nsMutableDataTainted2 | semmle.label | nsMutableDataTainted2 |
+| nsmutabledata.swift:36:5:36:5 | [post] nsMutableDataTainted3 :  | semmle.label | [post] nsMutableDataTainted3 :  |
+| nsmutabledata.swift:36:66:36:73 | call to source() :  | semmle.label | call to source() :  |
+| nsmutabledata.swift:37:15:37:15 | nsMutableDataTainted3 | semmle.label | nsMutableDataTainted3 |
+| nsmutabledata.swift:40:5:40:5 | [post] nsMutableDataTainted4 :  | semmle.label | [post] nsMutableDataTainted4 :  |
+| nsmutabledata.swift:40:66:40:73 | call to source() :  | semmle.label | call to source() :  |
+| nsmutabledata.swift:41:15:41:15 | nsMutableDataTainted4 | semmle.label | nsMutableDataTainted4 |
+| nsmutabledata.swift:44:5:44:5 | [post] nsMutableDataTainted5 :  | semmle.label | [post] nsMutableDataTainted5 :  |
+| nsmutabledata.swift:44:35:44:42 | call to source() :  | semmle.label | call to source() :  |
+| nsmutabledata.swift:45:15:45:15 | nsMutableDataTainted5 | semmle.label | nsMutableDataTainted5 |
+| nsmutabledata.swift:48:33:48:40 | call to source() :  | semmle.label | call to source() :  |
+| nsmutabledata.swift:49:15:49:15 | nsMutableDataTainted6 :  | semmle.label | nsMutableDataTainted6 :  |
+| nsmutabledata.swift:49:15:49:37 | .mutableBytes | semmle.label | .mutableBytes |
 | string.swift:5:11:5:18 | call to source() :  | semmle.label | call to source() :  |
 | string.swift:7:13:7:13 | "..." | semmle.label | "..." |
 | string.swift:9:13:9:13 | "..." | semmle.label | "..." |
@@ -474,6 +771,39 @@ nodes
 | webview.swift:97:17:97:17 | s :  | semmle.label | s :  |
 | webview.swift:98:10:98:10 | v3 | semmle.label | v3 |
 subpaths
+| nsdata.swift:57:40:57:47 | call to source() :  | nsdata.swift:24:5:24:50 | [summary param] 0 in init(bytes:length:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bytes:length:) :  | nsdata.swift:57:26:57:80 | call to init(bytes:length:) :  |
+| nsdata.swift:60:46:60:53 | call to source() :  | nsdata.swift:25:5:25:68 | [summary param] 0 in init(bytesNoCopy:length:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:) :  | nsdata.swift:60:26:60:93 | call to init(bytesNoCopy:length:) :  |
+| nsdata.swift:63:46:63:53 | call to source() :  | nsdata.swift:26:5:26:130 | [summary param] 0 in init(bytesNoCopy:length:deallocator:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:deallocator:) :  | nsdata.swift:63:26:63:111 | call to init(bytesNoCopy:length:deallocator:) :  |
+| nsdata.swift:66:46:66:53 | call to source() :  | nsdata.swift:27:5:27:90 | [summary param] 0 in init(bytesNoCopy:length:freeWhenDone:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(bytesNoCopy:length:freeWhenDone:) :  | nsdata.swift:66:26:66:113 | call to init(bytesNoCopy:length:freeWhenDone:) :  |
+| nsdata.swift:69:39:69:46 | call to source() :  | nsdata.swift:28:5:28:23 | [summary param] 0 in init(data:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(data:) :  | nsdata.swift:69:26:69:56 | call to init(data:) :  |
+| nsdata.swift:72:49:72:56 | call to source() :  | nsdata.swift:29:5:29:36 | [summary param] 0 in init(contentsOfFile:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfFile:) :  | nsdata.swift:72:26:72:68 | call to init(contentsOfFile:) :  |
+| nsdata.swift:75:49:75:56 | call to source() :  | nsdata.swift:30:5:30:93 | [summary param] 0 in init(contentsOfFile:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfFile:options:) :  | nsdata.swift:75:26:75:81 | call to init(contentsOfFile:options:) :  |
+| nsdata.swift:78:45:78:52 | call to source() :  | nsdata.swift:31:5:31:29 | [summary param] 0 in init(contentsOf:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOf:) :  | nsdata.swift:78:26:78:61 | call to init(contentsOf:) :  |
+| nsdata.swift:81:45:81:52 | call to source() :  | nsdata.swift:32:5:32:61 | [summary param] 0 in init(contentsOf:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOf:options:) :  | nsdata.swift:81:26:81:74 | call to init(contentsOf:options:) :  |
+| nsdata.swift:84:56:84:63 | call to source() :  | nsdata.swift:33:5:33:47 | [summary param] 0 in init(contentsOfMappedFile:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(contentsOfMappedFile:) :  | nsdata.swift:84:27:84:75 | call to init(contentsOfMappedFile:) :  |
+| nsdata.swift:87:49:87:56 | call to source() :  | nsdata.swift:34:5:34:88 | [summary param] 0 in init(base64Encoded:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  | nsdata.swift:87:27:87:79 | call to init(base64Encoded:options:) :  |
+| nsdata.swift:89:49:89:56 | call to source() :  | nsdata.swift:35:5:35:92 | [summary param] 0 in init(base64Encoded:options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoded:options:) :  | nsdata.swift:89:27:89:81 | call to init(base64Encoded:options:) :  |
+| nsdata.swift:92:50:92:57 | call to source() :  | nsdata.swift:36:5:36:49 | [summary param] 0 in init(base64Encoding:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(base64Encoding:) :  | nsdata.swift:92:27:92:69 | call to init(base64Encoding:) :  |
+| nsdata.swift:96:15:96:15 | nsDataTainted14 :  | nsdata.swift:37:5:37:98 | [summary param] this in base64EncodedData(options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedData(options:) :  | nsdata.swift:96:15:96:49 | call to base64EncodedData(options:) |
+| nsdata.swift:97:15:97:15 | nsDataTainted14 :  | nsdata.swift:37:5:37:98 | [summary param] this in base64EncodedData(options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedData(options:) :  | nsdata.swift:97:15:97:60 | call to base64EncodedData(options:) |
+| nsdata.swift:100:15:100:15 | nsDataTainted15 :  | nsdata.swift:38:5:38:96 | [summary param] this in base64EncodedString(options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedString(options:) :  | nsdata.swift:100:15:100:51 | call to base64EncodedString(options:) |
+| nsdata.swift:101:15:101:15 | nsDataTainted15 :  | nsdata.swift:38:5:38:96 | [summary param] this in base64EncodedString(options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedString(options:) :  | nsdata.swift:101:15:101:62 | call to base64EncodedString(options:) |
+| nsdata.swift:104:15:104:15 | nsDataTainted16 :  | nsdata.swift:39:5:39:49 | [summary param] this in base64Encoding() :  | file://:0:0:0:0 | [summary] to write: return (return) in base64Encoding() :  | nsdata.swift:104:15:104:46 | call to base64Encoding() |
+| nsdata.swift:106:51:106:58 | call to source() :  | nsdata.swift:40:5:40:82 | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in dataWithContentsOfMappedFile(_:) :  | nsdata.swift:106:15:106:70 | call to dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:115:5:115:5 | nsDataTainted18 :  | nsdata.swift:42:5:42:55 | [summary param] this in getBytes(_:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:) :  | nsdata.swift:115:30:115:30 | [post] bufferTainted18 :  |
+| nsdata.swift:120:5:120:5 | nsDataTainted19 :  | nsdata.swift:43:5:43:68 | [summary param] this in getBytes(_:length:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:length:) :  | nsdata.swift:120:30:120:30 | [post] bufferTainted19 :  |
+| nsdata.swift:125:5:125:5 | nsDataTainted20 :  | nsdata.swift:44:5:44:71 | [summary param] this in getBytes(_:range:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:range:) :  | nsdata.swift:125:30:125:30 | [post] bufferTainted20 :  |
+| nsdata.swift:129:15:129:15 | nsDataTainted21 :  | nsdata.swift:45:5:45:65 | [summary param] this in subdata(with:) :  | file://:0:0:0:0 | [summary] to write: return (return) in subdata(with:) :  | nsdata.swift:129:15:129:54 | call to subdata(with:) |
+| nsdata.swift:132:15:132:15 | nsDataTainted22 :  | nsdata.swift:46:5:46:89 | [summary param] this in compressed(using:) :  | file://:0:0:0:0 | [summary] to write: return (return) in compressed(using:) :  | nsdata.swift:132:15:132:81 | call to compressed(using:) |
+| nsdata.swift:135:15:135:15 | nsDataTainted23 :  | nsdata.swift:47:5:47:91 | [summary param] this in decompressed(using:) :  | file://:0:0:0:0 | [summary] to write: return (return) in decompressed(using:) :  | nsdata.swift:135:15:135:83 | call to decompressed(using:) |
+| nsdata.swift:139:15:139:15 | nsDataTainted24 :  | nsdata.swift:22:9:22:9 | self :  | file://:0:0:0:0 | .bytes :  | nsdata.swift:139:15:139:31 | .bytes |
+| nsdata.swift:140:15:140:15 | nsDataTainted24 :  | nsdata.swift:23:9:23:9 | self :  | file://:0:0:0:0 | .description :  | nsdata.swift:140:15:140:31 | .description |
+| nsmutabledata.swift:28:34:28:41 | call to source() :  | nsmutabledata.swift:14:5:14:58 | [summary param] 0 in append(_:length:) :  | file://:0:0:0:0 | [summary] to write: argument this in append(_:length:) :  | nsmutabledata.swift:28:5:28:5 | [post] nsMutableDataTainted1 :  |
+| nsmutabledata.swift:32:34:32:41 | call to source() :  | nsmutabledata.swift:15:5:15:33 | [summary param] 0 in append(_:) :  | file://:0:0:0:0 | [summary] to write: argument this in append(_:) :  | nsmutabledata.swift:32:5:32:5 | [post] nsMutableDataTainted2 :  |
+| nsmutabledata.swift:36:66:36:73 | call to source() :  | nsmutabledata.swift:16:5:16:78 | [summary param] 1 in replaceBytes(in:withBytes:) :  | file://:0:0:0:0 | [summary] to write: argument this in replaceBytes(in:withBytes:) :  | nsmutabledata.swift:36:5:36:5 | [post] nsMutableDataTainted3 :  |
+| nsmutabledata.swift:40:66:40:73 | call to source() :  | nsmutabledata.swift:17:5:17:121 | [summary param] 1 in replaceBytes(in:withBytes:length:) :  | file://:0:0:0:0 | [summary] to write: argument this in replaceBytes(in:withBytes:length:) :  | nsmutabledata.swift:40:5:40:5 | [post] nsMutableDataTainted4 :  |
+| nsmutabledata.swift:44:35:44:42 | call to source() :  | nsmutabledata.swift:18:5:18:33 | [summary param] 0 in setData(_:) :  | file://:0:0:0:0 | [summary] to write: argument this in setData(_:) :  | nsmutabledata.swift:44:5:44:5 | [post] nsMutableDataTainted5 :  |
+| nsmutabledata.swift:49:15:49:15 | nsMutableDataTainted6 :  | nsmutabledata.swift:13:9:13:9 | self :  | file://:0:0:0:0 | .mutableBytes :  | nsmutabledata.swift:49:15:49:37 | .mutableBytes |
 | url.swift:59:31:59:31 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:) :  | url.swift:59:19:59:38 | call to init(string:) :  |
 | url.swift:83:24:83:24 | tainted :  | url.swift:9:2:9:43 | [summary param] 0 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:83:12:83:48 | call to init(string:relativeTo:) :  |
 | url.swift:86:43:86:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in init(string:relativeTo:) :  | url.swift:86:12:86:53 | call to init(string:relativeTo:) :  |
@@ -524,6 +854,39 @@ subpaths
 | webview.swift:93:17:93:17 | s :  | webview.swift:43:5:43:38 | [summary param] 0 in setValue(_:at:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:at:) :  | webview.swift:93:5:93:5 | [post] v2 :  |
 | webview.swift:97:17:97:17 | s :  | webview.swift:44:5:44:48 | [summary param] 0 in setValue(_:forProperty:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:forProperty:) :  | webview.swift:97:5:97:5 | [post] v3 :  |
 #select
+| nsdata.swift:58:15:58:15 | nsDataTainted1 | nsdata.swift:57:40:57:47 | call to source() :  | nsdata.swift:58:15:58:15 | nsDataTainted1 | result |
+| nsdata.swift:61:15:61:15 | nsDataTainted2 | nsdata.swift:60:46:60:53 | call to source() :  | nsdata.swift:61:15:61:15 | nsDataTainted2 | result |
+| nsdata.swift:64:15:64:15 | nsDataTainted3 | nsdata.swift:63:46:63:53 | call to source() :  | nsdata.swift:64:15:64:15 | nsDataTainted3 | result |
+| nsdata.swift:67:15:67:15 | nsDataTainted4 | nsdata.swift:66:46:66:53 | call to source() :  | nsdata.swift:67:15:67:15 | nsDataTainted4 | result |
+| nsdata.swift:70:15:70:15 | nsDataTainted5 | nsdata.swift:69:39:69:46 | call to source() :  | nsdata.swift:70:15:70:15 | nsDataTainted5 | result |
+| nsdata.swift:73:15:73:29 | ...! | nsdata.swift:72:49:72:56 | call to source() :  | nsdata.swift:73:15:73:29 | ...! | result |
+| nsdata.swift:76:15:76:15 | nsDataTainted7 | nsdata.swift:75:49:75:56 | call to source() :  | nsdata.swift:76:15:76:15 | nsDataTainted7 | result |
+| nsdata.swift:79:15:79:29 | ...! | nsdata.swift:78:45:78:52 | call to source() :  | nsdata.swift:79:15:79:29 | ...! | result |
+| nsdata.swift:82:15:82:29 | ...! | nsdata.swift:81:45:81:52 | call to source() :  | nsdata.swift:82:15:82:29 | ...! | result |
+| nsdata.swift:85:15:85:30 | ...! | nsdata.swift:84:56:84:63 | call to source() :  | nsdata.swift:85:15:85:30 | ...! | result |
+| nsdata.swift:88:15:88:30 | ...! | nsdata.swift:87:49:87:56 | call to source() :  | nsdata.swift:88:15:88:30 | ...! | result |
+| nsdata.swift:90:15:90:30 | ...! | nsdata.swift:89:49:89:56 | call to source() :  | nsdata.swift:90:15:90:30 | ...! | result |
+| nsdata.swift:93:15:93:30 | ...! | nsdata.swift:92:50:92:57 | call to source() :  | nsdata.swift:93:15:93:30 | ...! | result |
+| nsdata.swift:96:15:96:49 | call to base64EncodedData(options:) | nsdata.swift:95:27:95:34 | call to source() :  | nsdata.swift:96:15:96:49 | call to base64EncodedData(options:) | result |
+| nsdata.swift:97:15:97:60 | call to base64EncodedData(options:) | nsdata.swift:95:27:95:34 | call to source() :  | nsdata.swift:97:15:97:60 | call to base64EncodedData(options:) | result |
+| nsdata.swift:100:15:100:51 | call to base64EncodedString(options:) | nsdata.swift:99:27:99:34 | call to source() :  | nsdata.swift:100:15:100:51 | call to base64EncodedString(options:) | result |
+| nsdata.swift:101:15:101:62 | call to base64EncodedString(options:) | nsdata.swift:99:27:99:34 | call to source() :  | nsdata.swift:101:15:101:62 | call to base64EncodedString(options:) | result |
+| nsdata.swift:104:15:104:46 | call to base64Encoding() | nsdata.swift:103:27:103:34 | call to source() :  | nsdata.swift:104:15:104:46 | call to base64Encoding() | result |
+| nsdata.swift:106:15:106:71 | ...! | nsdata.swift:106:51:106:58 | call to source() :  | nsdata.swift:106:15:106:71 | ...! | result |
+| nsdata.swift:116:15:116:15 | bufferTainted18 | nsdata.swift:113:27:113:34 | call to source() :  | nsdata.swift:116:15:116:15 | bufferTainted18 | result |
+| nsdata.swift:121:15:121:15 | bufferTainted19 | nsdata.swift:118:27:118:34 | call to source() :  | nsdata.swift:121:15:121:15 | bufferTainted19 | result |
+| nsdata.swift:126:15:126:15 | bufferTainted20 | nsdata.swift:123:27:123:34 | call to source() :  | nsdata.swift:126:15:126:15 | bufferTainted20 | result |
+| nsdata.swift:129:15:129:54 | call to subdata(with:) | nsdata.swift:128:27:128:34 | call to source() :  | nsdata.swift:129:15:129:54 | call to subdata(with:) | result |
+| nsdata.swift:132:15:132:81 | call to compressed(using:) | nsdata.swift:131:27:131:34 | call to source() :  | nsdata.swift:132:15:132:81 | call to compressed(using:) | result |
+| nsdata.swift:135:15:135:83 | call to decompressed(using:) | nsdata.swift:134:27:134:34 | call to source() :  | nsdata.swift:135:15:135:83 | call to decompressed(using:) | result |
+| nsdata.swift:139:15:139:31 | .bytes | nsdata.swift:138:27:138:34 | call to source() :  | nsdata.swift:139:15:139:31 | .bytes | result |
+| nsdata.swift:140:15:140:31 | .description | nsdata.swift:138:27:138:34 | call to source() :  | nsdata.swift:140:15:140:31 | .description | result |
+| nsmutabledata.swift:29:15:29:15 | nsMutableDataTainted1 | nsmutabledata.swift:28:34:28:41 | call to source() :  | nsmutabledata.swift:29:15:29:15 | nsMutableDataTainted1 | result |
+| nsmutabledata.swift:33:15:33:15 | nsMutableDataTainted2 | nsmutabledata.swift:32:34:32:41 | call to source() :  | nsmutabledata.swift:33:15:33:15 | nsMutableDataTainted2 | result |
+| nsmutabledata.swift:37:15:37:15 | nsMutableDataTainted3 | nsmutabledata.swift:36:66:36:73 | call to source() :  | nsmutabledata.swift:37:15:37:15 | nsMutableDataTainted3 | result |
+| nsmutabledata.swift:41:15:41:15 | nsMutableDataTainted4 | nsmutabledata.swift:40:66:40:73 | call to source() :  | nsmutabledata.swift:41:15:41:15 | nsMutableDataTainted4 | result |
+| nsmutabledata.swift:45:15:45:15 | nsMutableDataTainted5 | nsmutabledata.swift:44:35:44:42 | call to source() :  | nsmutabledata.swift:45:15:45:15 | nsMutableDataTainted5 | result |
+| nsmutabledata.swift:49:15:49:37 | .mutableBytes | nsmutabledata.swift:48:33:48:40 | call to source() :  | nsmutabledata.swift:49:15:49:37 | .mutableBytes | result |
 | string.swift:7:13:7:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:7:13:7:13 | "..." | result |
 | string.swift:9:13:9:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:9:13:9:13 | "..." | result |
 | string.swift:11:13:11:13 | "..." | string.swift:5:11:5:18 | call to source() :  | string.swift:11:13:11:13 | "..." | result |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -1,4 +1,5 @@
 edges
+| file://:0:0:0:0 | [summary] to write: argument 0.parameter 0 in enumerateBytes(_:) :  | nsdata.swift:110:9:110:9 | bytes :  |
 | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  | url.swift:120:61:120:61 | data :  |
 | nsdata.swift:22:9:22:9 | self :  | file://:0:0:0:0 | .bytes :  |
 | nsdata.swift:23:9:23:9 | self :  | file://:0:0:0:0 | .description :  |
@@ -19,6 +20,7 @@ edges
 | nsdata.swift:38:5:38:96 | [summary param] this in base64EncodedString(options:) :  | file://:0:0:0:0 | [summary] to write: return (return) in base64EncodedString(options:) :  |
 | nsdata.swift:39:5:39:49 | [summary param] this in base64Encoding() :  | file://:0:0:0:0 | [summary] to write: return (return) in base64Encoding() :  |
 | nsdata.swift:40:5:40:82 | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:41:5:41:104 | [summary param] this in enumerateBytes(_:) :  | file://:0:0:0:0 | [summary] to write: argument 0.parameter 0 in enumerateBytes(_:) :  |
 | nsdata.swift:42:5:42:55 | [summary param] this in getBytes(_:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:) :  |
 | nsdata.swift:43:5:43:68 | [summary param] this in getBytes(_:length:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:length:) :  |
 | nsdata.swift:44:5:44:71 | [summary param] this in getBytes(_:range:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:range:) :  |
@@ -82,6 +84,9 @@ edges
 | nsdata.swift:106:15:106:70 | call to dataWithContentsOfMappedFile(_:) :  | nsdata.swift:106:15:106:71 | ...! |
 | nsdata.swift:106:51:106:58 | call to source() :  | nsdata.swift:40:5:40:82 | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  |
 | nsdata.swift:106:51:106:58 | call to source() :  | nsdata.swift:106:15:106:70 | call to dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:108:27:108:34 | call to source() :  | nsdata.swift:109:5:109:5 | nsDataTainted17 :  |
+| nsdata.swift:109:5:109:5 | nsDataTainted17 :  | nsdata.swift:41:5:41:104 | [summary param] this in enumerateBytes(_:) :  |
+| nsdata.swift:110:9:110:9 | bytes :  | nsdata.swift:110:45:110:45 | bytes |
 | nsdata.swift:113:27:113:34 | call to source() :  | nsdata.swift:115:5:115:5 | nsDataTainted18 :  |
 | nsdata.swift:115:5:115:5 | nsDataTainted18 :  | nsdata.swift:42:5:42:55 | [summary param] this in getBytes(_:) :  |
 | nsdata.swift:115:5:115:5 | nsDataTainted18 :  | nsdata.swift:115:30:115:30 | [post] bufferTainted18 :  |
@@ -382,6 +387,7 @@ nodes
 | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:) :  | semmle.label | [summary] to write: argument 0 in getBytes(_:) :  |
 | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:length:) :  | semmle.label | [summary] to write: argument 0 in getBytes(_:length:) :  |
 | file://:0:0:0:0 | [summary] to write: argument 0 in getBytes(_:range:) :  | semmle.label | [summary] to write: argument 0 in getBytes(_:range:) :  |
+| file://:0:0:0:0 | [summary] to write: argument 0.parameter 0 in enumerateBytes(_:) :  | semmle.label | [summary] to write: argument 0.parameter 0 in enumerateBytes(_:) :  |
 | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  | semmle.label | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
 | file://:0:0:0:0 | [summary] to write: argument this in append(_:) :  | semmle.label | [summary] to write: argument this in append(_:) :  |
 | file://:0:0:0:0 | [summary] to write: argument this in append(_:length:) :  | semmle.label | [summary] to write: argument this in append(_:length:) :  |
@@ -459,6 +465,7 @@ nodes
 | nsdata.swift:38:5:38:96 | [summary param] this in base64EncodedString(options:) :  | semmle.label | [summary param] this in base64EncodedString(options:) :  |
 | nsdata.swift:39:5:39:49 | [summary param] this in base64Encoding() :  | semmle.label | [summary param] this in base64Encoding() :  |
 | nsdata.swift:40:5:40:82 | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  | semmle.label | [summary param] 0 in dataWithContentsOfMappedFile(_:) :  |
+| nsdata.swift:41:5:41:104 | [summary param] this in enumerateBytes(_:) :  | semmle.label | [summary param] this in enumerateBytes(_:) :  |
 | nsdata.swift:42:5:42:55 | [summary param] this in getBytes(_:) :  | semmle.label | [summary param] this in getBytes(_:) :  |
 | nsdata.swift:43:5:43:68 | [summary param] this in getBytes(_:length:) :  | semmle.label | [summary param] this in getBytes(_:length:) :  |
 | nsdata.swift:44:5:44:71 | [summary param] this in getBytes(_:range:) :  | semmle.label | [summary param] this in getBytes(_:range:) :  |
@@ -520,6 +527,10 @@ nodes
 | nsdata.swift:106:15:106:70 | call to dataWithContentsOfMappedFile(_:) :  | semmle.label | call to dataWithContentsOfMappedFile(_:) :  |
 | nsdata.swift:106:15:106:71 | ...! | semmle.label | ...! |
 | nsdata.swift:106:51:106:58 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:108:27:108:34 | call to source() :  | semmle.label | call to source() :  |
+| nsdata.swift:109:5:109:5 | nsDataTainted17 :  | semmle.label | nsDataTainted17 :  |
+| nsdata.swift:110:9:110:9 | bytes :  | semmle.label | bytes :  |
+| nsdata.swift:110:45:110:45 | bytes | semmle.label | bytes |
 | nsdata.swift:113:27:113:34 | call to source() :  | semmle.label | call to source() :  |
 | nsdata.swift:115:5:115:5 | nsDataTainted18 :  | semmle.label | nsDataTainted18 :  |
 | nsdata.swift:115:30:115:30 | [post] bufferTainted18 :  | semmle.label | [post] bufferTainted18 :  |
@@ -873,6 +884,7 @@ subpaths
 | nsdata.swift:101:15:101:62 | call to base64EncodedString(options:) | nsdata.swift:99:27:99:34 | call to source() :  | nsdata.swift:101:15:101:62 | call to base64EncodedString(options:) | result |
 | nsdata.swift:104:15:104:46 | call to base64Encoding() | nsdata.swift:103:27:103:34 | call to source() :  | nsdata.swift:104:15:104:46 | call to base64Encoding() | result |
 | nsdata.swift:106:15:106:71 | ...! | nsdata.swift:106:51:106:58 | call to source() :  | nsdata.swift:106:15:106:71 | ...! | result |
+| nsdata.swift:110:45:110:45 | bytes | nsdata.swift:108:27:108:34 | call to source() :  | nsdata.swift:110:45:110:45 | bytes | result |
 | nsdata.swift:116:15:116:15 | bufferTainted18 | nsdata.swift:113:27:113:34 | call to source() :  | nsdata.swift:116:15:116:15 | bufferTainted18 | result |
 | nsdata.swift:121:15:121:15 | bufferTainted19 | nsdata.swift:118:27:118:34 | call to source() :  | nsdata.swift:121:15:121:15 | bufferTainted19 | result |
 | nsdata.swift:126:15:126:15 | bufferTainted20 | nsdata.swift:123:27:123:34 | call to source() :  | nsdata.swift:126:15:126:15 | bufferTainted20 | result |

--- a/swift/ql/test/library-tests/dataflow/taint/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/TaintInline.expected
@@ -1,0 +1,1 @@
+| nsdata.swift:110:45:110:45 | bytes | Unexpected result: tainted=108 |

--- a/swift/ql/test/library-tests/dataflow/taint/nsdata.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/nsdata.swift
@@ -1,0 +1,141 @@
+// --- stubs ---
+
+struct URL
+{
+	init?(string: String) {}
+}
+
+struct Data
+{
+    init<S>(_ elements: S) {}
+}
+
+struct NSRange {}
+
+struct ObjCBool {}
+
+class NSData {
+    struct ReadingOptions : OptionSet { let rawValue: Int }
+    struct Base64EncodingOptions : OptionSet { let rawValue: Int }
+    struct Base64DecodingOptions : OptionSet { let rawValue: Int }
+    enum CompressionAlgorithm : Int { case none }
+    var bytes: UnsafeRawPointer = UnsafeRawPointer(bitPattern: 0)!
+    var description: String = ""
+    init(bytes: UnsafeRawPointer?, length: Int) {}
+    init(bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int) {}
+    init(bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)? = nil) {}
+    init(bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int, freeWhenDone b: Bool) {}
+    init(data: Data) {}
+    init?(contentsOfFile: String) {}
+    init(contentsOfFile path: String, options readOptionsMask: NSData.ReadingOptions = []) {} 
+    init?(contentsOf: URL) {}
+    init?(contentsOf: URL, options: NSData.ReadingOptions) {}
+    init?(contentsOfMappedFile path: String) {}
+    init?(base64Encoded base64Data: Data, options: NSData.Base64DecodingOptions = []) {}
+    init?(base64Encoded base64String: String, options: NSData.Base64DecodingOptions = []) {}
+    init?(base64Encoding base64String: String) {}
+    func base64EncodedData(options: NSData.Base64EncodingOptions = []) -> Data { return Data("") }
+    func base64EncodedString(options: NSData.Base64EncodingOptions = []) -> String { return "" }
+    func base64Encoding() -> String { return "" }
+    class func dataWithContentsOfMappedFile(_ path: String) -> Any? { return nil }
+    func enumerateBytes(_ block: (UnsafeRawPointer, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {}
+    func getBytes(_ buffer: UnsafeMutableRawPointer) {}
+    func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {}
+    func getBytes(_ buffer: UnsafeMutableRawPointer, range: NSRange) {}
+    func subdata(with range: NSRange) -> Data { return Data("") }
+    func compressed(using algorithm: NSData.CompressionAlgorithm) -> Self { return self }
+    func decompressed(using algorithm: NSData.CompressionAlgorithm) -> Self { return self }
+}
+
+// --- tests ---
+
+func source() -> Any { return "" }
+func sink(arg: Any) {}
+
+func test() {
+    // ";NSData;true;init(bytes:length:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted1 = NSData(bytes: source() as? UnsafeRawPointer, length: 0)
+    sink(arg: nsDataTainted1) // $ tainted=57
+    // ";NSData;true;init(bytesNoCopy:length:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted2 = NSData(bytesNoCopy: source() as! UnsafeMutableRawPointer, length: 0)
+    sink(arg: nsDataTainted2) // $ tainted=60
+    // ";NSData;true;init(bytesNoCopy:length:deallocator:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted3 = NSData(bytesNoCopy: source() as! UnsafeMutableRawPointer, length: 0, deallocator: nil)
+    sink(arg: nsDataTainted3) // $ tainted=63
+    // ";NSData;true;init(bytesNoCopy:length:freeWhenDone:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted4 = NSData(bytesNoCopy: source() as! UnsafeMutableRawPointer, length: 0, freeWhenDone: true)
+    sink(arg: nsDataTainted4) // $ tainted=66
+    // ";NSData;true;init(data:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted5 = NSData(data: source() as! Data)
+    sink(arg: nsDataTainted5) // $ tainted=69
+    // ";NSData;true;init(contentsOfFile:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted6 = NSData(contentsOfFile: source() as! String)
+    sink(arg: nsDataTainted6!) // $ tainted=72
+    // ";NSData;true;init(contentsOfFile:options:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted7 = NSData(contentsOfFile: source() as! String, options: [])
+    sink(arg: nsDataTainted7) // $ tainted=75
+    // ";NSData;true;init(contentsOf:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted8 = NSData(contentsOf: source() as! URL)
+    sink(arg: nsDataTainted8!) // $ tainted=78
+    // ";NSData;true;init(contentsOf:options:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted9 = NSData(contentsOf: source() as! URL, options: [])
+    sink(arg: nsDataTainted9!) // $ tainted=81
+    // ";NSData;true;init(contentsOfMappedFile:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted10 = NSData(contentsOfMappedFile: source() as! String)
+    sink(arg: nsDataTainted10!) // $ tainted=84
+    // ";NSData;true;init(base64Encoded:options:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted11 = NSData(base64Encoded: source() as! Data, options: [])
+    sink(arg: nsDataTainted11!) // $ tainted=87
+    let nsDataTainted12 = NSData(base64Encoded: source() as! String, options: [])
+    sink(arg: nsDataTainted12!) // $ tainted=89
+    // ";NSData;true;init(base64Encoding:);;;Argument[0];ReturnValue;taint",
+    let nsDataTainted13 = NSData(base64Encoding: source() as! String)
+    sink(arg: nsDataTainted13!) // $ tainted=92
+    // ";NSData;true;base64EncodedData(options:);;;Argument[-1];ReturnValue;taint",
+    let nsDataTainted14 = source() as! NSData
+    sink(arg: nsDataTainted14.base64EncodedData()) // $ tainted=95
+    sink(arg: nsDataTainted14.base64EncodedData(options: [])) // $ tainted=95
+    // ";NSData;true;base64EncodedString(options:);;;Argument[-1];ReturnValue;taint",
+    let nsDataTainted15 = source() as! NSData
+    sink(arg: nsDataTainted15.base64EncodedString()) // $ tainted=99
+    sink(arg: nsDataTainted15.base64EncodedString(options: [])) // $ tainted=99
+    // ";NSData;true;base64Encoding();;;Argument[-1];ReturnValue;taint",
+    let nsDataTainted16 = source() as! NSData
+    sink(arg: nsDataTainted16.base64Encoding()) // $ tainted=103
+    // ";NSData;true;dataWithContentsOfMappedFile(_:);;;Argument[0];ReturnValue;taint",
+    sink(arg: NSData.dataWithContentsOfMappedFile(source() as! String)!) // $ tainted=106
+    // ";NSData;true;enumerateBytes(_:);;;Argument[-1];Argument[0].Parameter[0];taint"
+    let nsDataTainted17 = source() as! NSData
+    nsDataTainted17.enumerateBytes {
+        bytes, byteRange, stop in sink(arg: bytes) // $ MISSING: tainted=108
+    }
+    // ";NSData;true;getBytes(_:);;;Argument[-1];Argument[0];taint",
+    let nsDataTainted18 = source() as! NSData
+    let bufferTainted18 = UnsafeMutableRawPointer(bitPattern: 0)!
+    nsDataTainted18.getBytes(bufferTainted18)
+    sink(arg: bufferTainted18) // $ tainted=113
+    // ";NSData;true;getBytes(_:length:);;;Argument[-1];Argument[0];taint",
+    let nsDataTainted19 = source() as! NSData
+    let bufferTainted19 = UnsafeMutableRawPointer(bitPattern: 0)!
+    nsDataTainted19.getBytes(bufferTainted19, length: 0)
+    sink(arg: bufferTainted19) // $ tainted=118
+    // ";NSData;true;getBytes(_:range:);;;Argument[-1];Argument[0];taint",
+    let nsDataTainted20 = source() as! NSData
+    let bufferTainted20 = UnsafeMutableRawPointer(bitPattern: 0)!
+    nsDataTainted20.getBytes(bufferTainted20, range: NSRange())
+    sink(arg: bufferTainted20) // $ tainted=123
+    // ";NSData;true;subdata(with:);;;Argument[-1];ReturnValue;taint",
+    let nsDataTainted21 = source() as! NSData
+    sink(arg: nsDataTainted21.subdata(with: NSRange())) // $ tainted=128
+    // ";NSData;true;compressed(using:);;;Argument[-1];ReturnValue;taint",
+    let nsDataTainted22 = source() as! NSData
+    sink(arg: nsDataTainted22.compressed(using: NSData.CompressionAlgorithm.none)) // $ tainted=131
+    // ";NSData;true;decompressed(using:);;;Argument[-1];ReturnValue;taint"
+    let nsDataTainted23 = source() as! NSData
+    sink(arg: nsDataTainted23.decompressed(using: NSData.CompressionAlgorithm.none)) // $ tainted=134
+
+    // Fields
+    let nsDataTainted24 = source() as! NSData
+    sink(arg: nsDataTainted24.bytes) // $ tainted=138
+    sink(arg: nsDataTainted24.description) // $ tainted=138
+}

--- a/swift/ql/test/library-tests/dataflow/taint/nsdata.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/nsdata.swift
@@ -107,7 +107,7 @@ func test() {
     // ";NSData;true;enumerateBytes(_:);;;Argument[-1];Argument[0].Parameter[0];taint"
     let nsDataTainted17 = source() as! NSData
     nsDataTainted17.enumerateBytes {
-        bytes, byteRange, stop in sink(arg: bytes) // $ MISSING: tainted=108
+        bytes, byteRange, stop in sink(arg: bytes) // tainted=108
     }
     // ";NSData;true;getBytes(_:);;;Argument[-1];Argument[0];taint",
     let nsDataTainted18 = source() as! NSData

--- a/swift/ql/test/library-tests/dataflow/taint/nsmutabledata.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/nsmutabledata.swift
@@ -1,0 +1,50 @@
+// --- stubs ---
+
+struct Data
+{
+    init<S>(_ elements: S) {}
+}
+
+struct NSRange {}
+
+class NSData {}
+
+class NSMutableData : NSData {
+    var mutableBytes: UnsafeMutableRawPointer = UnsafeMutableRawPointer(bitPattern: 0)!
+    func append(_ bytes: UnsafeRawPointer, length: Int) {}
+    func append(_ other: Data) {}
+    func replaceBytes(in range: NSRange, withBytes bytes: UnsafeRawPointer) {}
+    func replaceBytes(in range: NSRange, withBytes replacementBytes: UnsafeRawPointer?, length replacementLength: Int) {}
+    func setData(_ data: Data) {}
+}
+
+// --- tests ---
+func source() -> Any { return "" }
+func sink(arg: Any) {}
+
+func test() {
+    // ";NSMutableData;true;append(_:length:);;;Argument[0];Argument[-1];taint",
+    let nsMutableDataTainted1 = NSMutableData()
+    nsMutableDataTainted1.append(source() as! UnsafeRawPointer, length: 0)
+    sink(arg: nsMutableDataTainted1) // $ tainted=28
+    // ";MutableNSData;true;append(_:);;;Argument[0];Argument[-1];taint",
+    let nsMutableDataTainted2 = NSMutableData()
+    nsMutableDataTainted2.append(source() as! Data)
+    sink(arg: nsMutableDataTainted2) // $ tainted=32
+    // ";NSMutableData;true;replaceBytes(in:withBytes:);;;Argument[1];Argument[-1];taint",
+    let nsMutableDataTainted3 = NSMutableData()
+    nsMutableDataTainted3.replaceBytes(in: NSRange(), withBytes: source() as! UnsafeRawPointer)
+    sink(arg: nsMutableDataTainted3) // $ tainted=36
+    // ";NSMutableData;true;replaceBytes(in:withBytes:length:);;;Argument[1];Argument[-1];taint",
+    let nsMutableDataTainted4 = NSMutableData()
+    nsMutableDataTainted4.replaceBytes(in: NSRange(), withBytes: source() as? UnsafeRawPointer, length: 0)
+    sink(arg: nsMutableDataTainted4) // $ tainted=40
+    // ";NSMutableData;true;setData(_:);;;Argument[1];Argument[-1];taint",
+    let nsMutableDataTainted5 = NSMutableData()
+    nsMutableDataTainted5.setData(source() as! Data)
+    sink(arg: nsMutableDataTainted5) // $ tainted=44
+
+    // Fields
+    let nsMutableDataTainted6 = source() as! NSMutableData
+    sink(arg: nsMutableDataTainted6.mutableBytes) // $ tainted=48
+}


### PR DESCRIPTION
Note that models requiring flow through code blocks have been left out (see `TODO` comments).