### PR TITLE
Swift: fix remapping bug

### DIFF
--- a/swift/extractor/remapping/SwiftOpenInterception.macOS.cpp
+++ b/swift/extractor/remapping/SwiftOpenInterception.macOS.cpp
@@ -61,7 +61,7 @@ void finalizeRemapping(
     }
     auto hash = originalHashFile(original);
     auto hashed = scratchDir / hash;
-    if (!hash.empty() && fs::exists(hashed)) {
+    if (!hash.empty() && fs::exists(patched)) {
       std::error_code ec;
       fs::create_symlink(/* target */ patched, /* symlink */ hashed, ec);
       if (ec) {


### PR DESCRIPTION
This issue has slipped during a recent refactoring: https://github.com/github/codeql/pull/10987/files#diff-c5ab26a06a93c4507a834859a6a56878d5bfe16c4d7cbac4afc4f081d46f461aL63-R64