### PR TITLE
Swift: do not abort if cannot archive a source file

### DIFF
--- a/swift/extractor/SwiftExtractor.cpp
+++ b/swift/extractor/SwiftExtractor.cpp
@@ -46,7 +46,6 @@ static void archiveFile(const SwiftExtractorConfiguration& config, swift::Source
   if (ec) {
     std::cerr << "Cannot archive source file " << srcFilePath << " -> " << dstFilePath << ": "
               << ec.message() << "\n";
-    std::abort();
   }
 }
 


### PR DESCRIPTION
After upgrading to Xcode 14.1 we started getting incomplete extractions as the extractor would fail to remap its own Swift modules to the modules from the original compiler.
The remapping was not happening because the extractor was aborting early thus not producing the required modules.
I observed that the extractor started crashing because it could not archive the source file with a "permission denied" error message: this is unlikely event, so we decided to `abort` in such cases.
Further, I noticed that several processes tried to archive the same source file concurrently, and this is likely the cause of this erroneous behaviour.
I did relax this "constraint" and I cannot see any issues anymore.

Related fix that should go together with this one https://github.com/github/codeql/pull/11381