### PR TITLE
Java: Adjust the prioritisation between MaD and source dispatch.

### DIFF
--- a/java/ql/lib/semmle/code/java/dispatch/VirtualDispatch.qll
+++ b/java/ql/lib/semmle/code/java/dispatch/VirtualDispatch.qll
@@ -99,9 +99,11 @@ private module Dispatch {
   private predicate lowConfidenceDispatchType(SrcRefType t) {
     t instanceof TypeObject
     or
-    t instanceof FunctionalInterface
+    t instanceof Interface and not t.fromSource()
     or
     t.hasQualifiedName("java.io", "Serializable")
+    or
+    t.hasQualifiedName("java.lang", "Iterable")
     or
     t.hasQualifiedName("java.lang", "Cloneable")
     or


### PR DESCRIPTION
When we have a combination of a good manual model for a callable and low confidence in the virtual dispatch to source targets, then we want to only use the model and disregard the source dispatch.
Selecting these cases involves a good deal of heuristics, and this PR tweaks this by allowing source dispatch to implementations of interfaces (with suitable flow models) unless those interfaces are from a different project, i.e. typically some interface in a library that the code depends on.
The reasoning is that if a library interface has flow models then it's likely because it comes with typically used default implementations of that interface, which makes any custom implementations unlikely dispatch targets if we don't have other indications that such a custom implementation might be in use at the call site.
Within a library that defines an interface, source dispatch happens as usual with the exception of a selection of core jdk interfaces for which we always want to use the flow models.