### PR TITLE
Swift: reject uppercase acronyms in schema

### DIFF
--- a/swift/codegen/test/test_schema.py
+++ b/swift/codegen/test/test_schema.py
@@ -669,5 +669,16 @@ def test_null_class_cannot_be_defined_multiple_times():
                 pass
 
 
+def test_uppercase_acronyms_are_rejected():
+    with pytest.raises(schema.Error):
+        @schema.load
+        class data:
+            class Root:
+                pass
+
+            class ROTFLNode(Root):
+                pass
+
+
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
This was causing hardly debuggable errors because names are transformed to underscored lowercase names in the dbscheme and back to camelcase for trap emission classes, which is not a noop in case uppercase acronyms (like SIL or ABI) are in the name.

This makes the error be surfaced early with a helpful message.