### PR TITLE
C#: ExternalFlow.qll cleanup.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -91,43 +91,6 @@ private import internal.FlowSummaryImpl::Private::External
 private import internal.FlowSummaryImplSpecific
 
 /**
- * A module importing the frameworks that provide external flow data,
- * ensuring that they are visible to the taint tracking / data flow library.
- */
-private module Frameworks {
-  private import semmle.code.csharp.frameworks.EntityFramework
-  private import semmle.code.csharp.frameworks.JsonNET
-  private import semmle.code.csharp.frameworks.ServiceStack
-  private import semmle.code.csharp.frameworks.Sql
-  private import semmle.code.csharp.frameworks.System
-  private import semmle.code.csharp.frameworks.system.CodeDom
-  private import semmle.code.csharp.frameworks.system.Collections
-  private import semmle.code.csharp.frameworks.system.collections.Generic
-  private import semmle.code.csharp.frameworks.system.collections.Specialized
-  private import semmle.code.csharp.frameworks.system.Data
-  private import semmle.code.csharp.frameworks.system.data.Common
-  private import semmle.code.csharp.frameworks.system.Diagnostics
-  private import semmle.code.csharp.frameworks.system.Linq
-  private import semmle.code.csharp.frameworks.system.Net
-  private import semmle.code.csharp.frameworks.system.net.Mail
-  private import semmle.code.csharp.frameworks.system.IO
-  private import semmle.code.csharp.frameworks.system.io.Compression
-  private import semmle.code.csharp.frameworks.system.runtime.CompilerServices
-  private import semmle.code.csharp.frameworks.system.Security
-  private import semmle.code.csharp.frameworks.system.security.Cryptography
-  private import semmle.code.csharp.frameworks.system.security.cryptography.X509Certificates
-  private import semmle.code.csharp.frameworks.system.Text
-  private import semmle.code.csharp.frameworks.system.text.RegularExpressions
-  private import semmle.code.csharp.frameworks.system.threading.Tasks
-  private import semmle.code.csharp.frameworks.system.Web
-  private import semmle.code.csharp.frameworks.system.web.ui.WebControls
-  private import semmle.code.csharp.frameworks.system.Xml
-  private import semmle.code.csharp.security.dataflow.flowsinks.Html
-  private import semmle.code.csharp.security.dataflow.flowsources.Local
-  private import semmle.code.csharp.security.dataflow.XSSSinks
-}
-
-/**
  * DEPRECATED: Define source models as data extensions instead.
  *
  * A unit class for adding additional source model rows.

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -6,7 +6,6 @@ private import DataFlowPublic
 private import DataFlowPrivate
 private import FlowSummaryImpl as FlowSummaryImpl
 private import semmle.code.csharp.dataflow.FlowSummary as FlowSummary
-private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.csharp.dispatch.Dispatch
 private import semmle.code.csharp.dispatch.RuntimeCallable
 private import semmle.code.csharp.frameworks.system.Collections

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/EntityFramework.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/EntityFramework.qll
@@ -9,7 +9,6 @@ private import semmle.code.csharp.frameworks.system.data.Entity
 private import semmle.code.csharp.frameworks.system.collections.Generic
 private import semmle.code.csharp.frameworks.Sql
 private import semmle.code.csharp.dataflow.FlowSummary
-private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/JsonNET.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/JsonNET.qll
@@ -3,7 +3,6 @@
  */
 
 import csharp
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** Definitions relating to the `Json.NET` package. */
 module JsonNET {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/ServiceStack.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/ServiceStack.qll
@@ -6,7 +6,6 @@
  */
 
 import csharp
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** A class representing a Service */
 private class ServiceClass extends Class {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/Sql.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/Sql.qll
@@ -7,7 +7,6 @@ private import semmle.code.csharp.frameworks.EntityFramework
 private import semmle.code.csharp.frameworks.NHibernate
 private import semmle.code.csharp.frameworks.Dapper
 private import semmle.code.csharp.dataflow.DataFlow4
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** An expression containing a SQL command. */
 abstract class SqlExpr extends Expr {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import system.Reflection
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System` namespace. */
 class SystemNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/CodeDom.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/CodeDom.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.System
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.CodeDome` namespace. */
 class SystemCodeDomNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Collections.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Collections.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.System
-private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.csharp.dataflow.FlowSummary
 
 /** The `System.Collections` namespace. */

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Data.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Data.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.System
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Data` namespace. */
 class SystemDataNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Diagnostics.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Diagnostics.qll
@@ -2,7 +2,6 @@
 
 import semmle.code.csharp.Type
 private import semmle.code.csharp.frameworks.System
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Diagnostics` namespace. */
 class SystemDiagnosticsNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/IO.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/IO.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.System
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.IO` namespace. */
 class SystemIONamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Linq.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Linq.qll
@@ -4,7 +4,6 @@
 
 private import csharp as CSharp
 private import semmle.code.csharp.frameworks.System as System
-private import semmle.code.csharp.dataflow.ExternalFlow as ExternalFlow
 
 /** Definitions relating to the `System.Linq` namespace. */
 module SystemLinq {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Net.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Net.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.System
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Net` namespace. */
 class SystemNetNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Security.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Security.qll
@@ -1,7 +1,6 @@
 /** Provides classes related to the namespace `System.Security`. */
 
 import csharp
-private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.csharp.frameworks.System
 
 /** The `System.Security` namespace. */

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Text.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Text.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.System
-private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.csharp.dataflow.FlowSummary
 
 /** The `System.Text` namespace. */

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Web.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Web.qll
@@ -3,7 +3,6 @@
 import csharp
 private import semmle.code.csharp.frameworks.System
 private import semmle.code.csharp.frameworks.system.collections.Specialized
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Web` namespace. */
 class SystemWebNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Xml.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Xml.qll
@@ -3,7 +3,6 @@
 import csharp
 private import semmle.code.csharp.frameworks.System
 private import semmle.code.csharp.dataflow.DataFlow3
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Xml` namespace. */
 class SystemXmlNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/collections/Generic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/collections/Generic.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.system.Collections
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Collections.Generic` namespace. */
 class SystemCollectionsGenericNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/collections/Specialized.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/collections/Specialized.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.system.Collections
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Collections.Specialized` namespace. */
 class SystemCollectionsSpecializedNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/data/Common.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/data/Common.qll
@@ -4,7 +4,6 @@
 
 private import csharp as CSharp
 private import semmle.code.csharp.frameworks.system.Data as Data
-private import semmle.code.csharp.dataflow.ExternalFlow as ExternalFlow
 
 /** Definitions relating to the `System.Data.Common` namespace. */
 module SystemDataCommon {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/io/Compression.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/io/Compression.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.system.IO
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.IO.Compression` namespace. */
 class SystemIOCompressionNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/net/Mail.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/net/Mail.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.system.Net
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Net.Mail` namespace. */
 class SystemNetMailNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/runtime/CompilerServices.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/runtime/CompilerServices.qll
@@ -3,7 +3,6 @@
 import csharp
 private import semmle.code.csharp.frameworks.system.Runtime
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Runtime.CompilerServices` namespace. */
 class SystemRuntimeCompilerServicesNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/security/Cryptography.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/security/Cryptography.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.system.Security
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Security.Cryptography` namespace. */
 class SystemSecurityCryptographyNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/security/cryptography/X509Certificates.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/security/cryptography/X509Certificates.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.system.security.Cryptography
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Security.Cryptography.X509Certificates` namespace. */
 class SystemSecurityCryptographyX509CertificatesNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/text/RegularExpressions.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/text/RegularExpressions.qll
@@ -4,7 +4,6 @@
 
 import default
 import semmle.code.csharp.frameworks.system.Text
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Text.RegularExpressions` namespace. */
 class SystemTextRegularExpressionsNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/threading/Tasks.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/threading/Tasks.qll
@@ -3,7 +3,6 @@
 import csharp
 private import semmle.code.csharp.frameworks.system.Threading
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Threading.Tasks` namespace. */
 class SystemThreadingTasksNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/web/ui/WebControls.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/web/ui/WebControls.qll
@@ -2,7 +2,6 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.system.web.UI
-private import semmle.code.csharp.dataflow.ExternalFlow
 
 /** The `System.Web.UI.WebControls` namespace. */
 class SystemWebUIWebControlsNamespace extends Namespace {

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
@@ -19,6 +19,13 @@ abstract class RemoteFlowSource extends DataFlow::Node {
   abstract string getSourceType();
 }
 
+/**
+ * A module for importing frameworks that defines remote flow sources.
+ */
+private module RemoteFlowSources {
+  private import semmle.code.csharp.frameworks.ServiceStack
+}
+
 /** A data flow source of remote user input (ASP.NET). */
 abstract class AspNetRemoteFlowSource extends RemoteFlowSource { }
 

--- a/csharp/ql/src/utils/model-generator/CaptureTypeBasedSummaryModels.ql
+++ b/csharp/ql/src/utils/model-generator/CaptureTypeBasedSummaryModels.ql
@@ -6,7 +6,6 @@
  * @tags model-generator
  */
 
-import semmle.code.csharp.dataflow.ExternalFlow
 import utils.modelgenerator.internal.CaptureTypeBasedSummaryModels
 
 from TypeBasedFlowTargetApi api, string flow


### PR DESCRIPTION
In this PR we delete the bi-directional import of `ExternalFlow` that was needed to include all models defined in the framework specific files.
It turned out that some other parts of the code relied on the SCC that was generated from the bi-directional import. Most cases were fixed on https://github.com/github/codeql/pull/10777 and this PR fixes the remaining one and deletes all the un-needed import code.