### PR TITLE
C++: Fix CWE-611 XXE query to work with use-use dataflow

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-611/Xerces.qll
+++ b/cpp/ql/src/Security/CWE/CWE-611/Xerces.qll
@@ -67,8 +67,7 @@ class XercesDomParserLibrary extends XmlLibrary {
     // constructor.
     exists(CallInstruction call |
       call.getStaticCallTarget() = any(XercesDomParserClass c).getAConstructor() and
-      node.asInstruction().(WriteSideEffectInstruction).getDestinationAddress() =
-        call.getThisArgument() and
+      node.asInstruction().(StoreInstruction).getSourceValue() = call.getThisArgument() and
       encodeXercesFlowState(flowstate, 0, 1) // default configuration
     )
   }
@@ -153,8 +152,7 @@ class SaxParserLibrary extends XmlLibrary {
     // constructor.
     exists(CallInstruction call |
       call.getStaticCallTarget() = any(SaxParserClass c).getAConstructor() and
-      node.asInstruction().(WriteSideEffectInstruction).getDestinationAddress() =
-        call.getThisArgument() and
+      node.asInstruction().(StoreInstruction).getSourceValue() = call.getThisArgument() and
       encodeXercesFlowState(flowstate, 0, 1) // default configuration
     )
   }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
@@ -1,4 +1,6 @@
 edges
+| tests2.cpp:20:17:20:31 | Store | tests2.cpp:22:2:22:2 | p |
+| tests2.cpp:33:17:33:31 | Store | tests2.cpp:37:2:37:2 | p |
 | tests3.cpp:23:21:23:53 | call to createXMLReader | tests3.cpp:25:2:25:2 | p |
 | tests3.cpp:35:16:35:20 | p_3_3 | tests3.cpp:38:2:38:6 | Load |
 | tests3.cpp:35:24:35:56 | Store | tests3.cpp:35:16:35:20 | p_3_3 |
@@ -35,7 +37,30 @@ edges
 | tests5.cpp:88:2:88:2 | Load | tests5.cpp:88:2:88:2 | p |
 | tests5.cpp:88:2:88:2 | p | tests5.cpp:89:2:89:2 | p |
 | tests5.cpp:88:2:88:2 | p indirection | tests5.cpp:88:2:88:2 | p |
+| tests.cpp:15:23:15:43 | Store | tests.cpp:17:2:17:2 | p |
+| tests.cpp:28:23:28:43 | Store | tests.cpp:31:2:31:2 | p |
+| tests.cpp:35:23:35:43 | Store | tests.cpp:37:2:37:2 | p |
+| tests.cpp:37:2:37:2 | p | tests.cpp:39:2:39:2 | p |
+| tests.cpp:51:23:51:43 | Store | tests.cpp:54:2:54:2 | p |
+| tests.cpp:54:2:54:2 | p | tests.cpp:56:2:56:2 | p |
+| tests.cpp:54:2:54:2 | p | tests.cpp:56:2:56:2 | p |
+| tests.cpp:56:2:56:2 | p | tests.cpp:58:2:58:2 | p |
+| tests.cpp:58:2:58:2 | p | tests.cpp:60:2:60:2 | p |
+| tests.cpp:66:23:66:43 | Store | tests.cpp:69:2:69:2 | p |
+| tests.cpp:73:23:73:43 | Store | tests.cpp:80:2:80:2 | p |
+| tests.cpp:85:24:85:44 | Store | tests.cpp:88:3:88:3 | q |
+| tests.cpp:100:24:100:44 | Store | tests.cpp:104:3:104:3 | q |
+| tests.cpp:112:39:112:39 | p | tests.cpp:113:2:113:2 | p |
+| tests.cpp:116:39:116:39 | p | tests.cpp:117:2:117:2 | p |
+| tests.cpp:122:23:122:43 | Store | tests.cpp:126:18:126:18 | q |
+| tests.cpp:122:23:122:43 | Store | tests.cpp:128:18:128:18 | q |
+| tests.cpp:126:18:126:18 | q | tests.cpp:112:39:112:39 | p |
+| tests.cpp:128:18:128:18 | q | tests.cpp:116:39:116:39 | p |
 nodes
+| tests2.cpp:20:17:20:31 | Store | semmle.label | Store |
+| tests2.cpp:22:2:22:2 | p | semmle.label | p |
+| tests2.cpp:33:17:33:31 | Store | semmle.label | Store |
+| tests2.cpp:37:2:37:2 | p | semmle.label | p |
 | tests3.cpp:23:21:23:53 | call to createXMLReader | semmle.label | call to createXMLReader |
 | tests3.cpp:25:2:25:2 | p | semmle.label | p |
 | tests3.cpp:35:16:35:20 | p_3_3 | semmle.label | p_3_3 |
@@ -87,8 +112,38 @@ nodes
 | tests5.cpp:88:2:88:2 | p | semmle.label | p |
 | tests5.cpp:88:2:88:2 | p indirection | semmle.label | p indirection |
 | tests5.cpp:89:2:89:2 | p | semmle.label | p |
+| tests.cpp:15:23:15:43 | Store | semmle.label | Store |
+| tests.cpp:17:2:17:2 | p | semmle.label | p |
+| tests.cpp:28:23:28:43 | Store | semmle.label | Store |
+| tests.cpp:31:2:31:2 | p | semmle.label | p |
+| tests.cpp:35:23:35:43 | Store | semmle.label | Store |
+| tests.cpp:37:2:37:2 | p | semmle.label | p |
+| tests.cpp:39:2:39:2 | p | semmle.label | p |
+| tests.cpp:51:23:51:43 | Store | semmle.label | Store |
+| tests.cpp:54:2:54:2 | p | semmle.label | p |
+| tests.cpp:56:2:56:2 | p | semmle.label | p |
+| tests.cpp:56:2:56:2 | p | semmle.label | p |
+| tests.cpp:58:2:58:2 | p | semmle.label | p |
+| tests.cpp:60:2:60:2 | p | semmle.label | p |
+| tests.cpp:66:23:66:43 | Store | semmle.label | Store |
+| tests.cpp:69:2:69:2 | p | semmle.label | p |
+| tests.cpp:73:23:73:43 | Store | semmle.label | Store |
+| tests.cpp:80:2:80:2 | p | semmle.label | p |
+| tests.cpp:85:24:85:44 | Store | semmle.label | Store |
+| tests.cpp:88:3:88:3 | q | semmle.label | q |
+| tests.cpp:100:24:100:44 | Store | semmle.label | Store |
+| tests.cpp:104:3:104:3 | q | semmle.label | q |
+| tests.cpp:112:39:112:39 | p | semmle.label | p |
+| tests.cpp:113:2:113:2 | p | semmle.label | p |
+| tests.cpp:116:39:116:39 | p | semmle.label | p |
+| tests.cpp:117:2:117:2 | p | semmle.label | p |
+| tests.cpp:122:23:122:43 | Store | semmle.label | Store |
+| tests.cpp:126:18:126:18 | q | semmle.label | q |
+| tests.cpp:128:18:128:18 | q | semmle.label | q |
 subpaths
 #select
+| tests2.cpp:22:2:22:2 | p | tests2.cpp:20:17:20:31 | Store | tests2.cpp:22:2:22:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:20:17:20:31 | Store | XML parser |
+| tests2.cpp:37:2:37:2 | p | tests2.cpp:33:17:33:31 | Store | tests2.cpp:37:2:37:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:33:17:33:31 | Store | XML parser |
 | tests3.cpp:25:2:25:2 | p | tests3.cpp:23:21:23:53 | call to createXMLReader | tests3.cpp:25:2:25:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:23:21:23:53 | call to createXMLReader | XML parser |
 | tests3.cpp:38:2:38:6 | p_3_3 | tests3.cpp:35:24:35:56 | call to createXMLReader | tests3.cpp:38:2:38:6 | p_3_3 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:35:24:35:56 | call to createXMLReader | XML parser |
 | tests3.cpp:45:2:45:6 | p_3_4 | tests3.cpp:41:24:41:56 | call to createXMLReader | tests3.cpp:45:2:45:6 | p_3_4 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:41:24:41:56 | call to createXMLReader | XML parser |
@@ -107,3 +162,14 @@ subpaths
 | tests5.cpp:77:2:77:5 | g_p2 | tests5.cpp:70:17:70:30 | call to createLSParser | tests5.cpp:77:2:77:5 | g_p2 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:70:17:70:30 | call to createLSParser | XML parser |
 | tests5.cpp:83:2:83:2 | p | tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:83:2:83:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser | XML parser |
 | tests5.cpp:89:2:89:2 | p | tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:89:2:89:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser | XML parser |
+| tests.cpp:17:2:17:2 | p | tests.cpp:15:23:15:43 | Store | tests.cpp:17:2:17:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:15:23:15:43 | Store | XML parser |
+| tests.cpp:31:2:31:2 | p | tests.cpp:28:23:28:43 | Store | tests.cpp:31:2:31:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:28:23:28:43 | Store | XML parser |
+| tests.cpp:39:2:39:2 | p | tests.cpp:35:23:35:43 | Store | tests.cpp:39:2:39:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:35:23:35:43 | Store | XML parser |
+| tests.cpp:56:2:56:2 | p | tests.cpp:51:23:51:43 | Store | tests.cpp:56:2:56:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | Store | XML parser |
+| tests.cpp:60:2:60:2 | p | tests.cpp:51:23:51:43 | Store | tests.cpp:60:2:60:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | Store | XML parser |
+| tests.cpp:69:2:69:2 | p | tests.cpp:66:23:66:43 | Store | tests.cpp:69:2:69:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:66:23:66:43 | Store | XML parser |
+| tests.cpp:80:2:80:2 | p | tests.cpp:73:23:73:43 | Store | tests.cpp:80:2:80:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:73:23:73:43 | Store | XML parser |
+| tests.cpp:88:3:88:3 | q | tests.cpp:85:24:85:44 | Store | tests.cpp:88:3:88:3 | q | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:85:24:85:44 | Store | XML parser |
+| tests.cpp:104:3:104:3 | q | tests.cpp:100:24:100:44 | Store | tests.cpp:104:3:104:3 | q | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:100:24:100:44 | Store | XML parser |
+| tests.cpp:113:2:113:2 | p | tests.cpp:122:23:122:43 | Store | tests.cpp:113:2:113:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | Store | XML parser |
+| tests.cpp:117:2:117:2 | p | tests.cpp:122:23:122:43 | Store | tests.cpp:117:2:117:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | Store | XML parser |


### PR DESCRIPTION
I'm not completely sure if this is the optimal fix, so I happily discuss that. I does restore all the missing results.