### PR TITLE
ReDoS: add missing additional keywords

### DIFF
--- a/java/ql/lib/semmle/code/java/regex/RegexTreeView.qll
+++ b/java/ql/lib/semmle/code/java/regex/RegexTreeView.qll
@@ -615,7 +615,7 @@ module Impl implements RegexTreeViewSig {
    * \p{Digit}
    * \p{IsLowerCase}
    */
-  class RegExpNamedProperty extends RegExpCharacterClassEscape {
+  additional class RegExpNamedProperty extends RegExpCharacterClassEscape {
     boolean inverted;
     string name;
 
@@ -745,7 +745,7 @@ module Impl implements RegexTreeViewSig {
    * \t
    * ```
    */
-  class RegExpNormalChar extends RegExpTerm, TRegExpNormalChar {
+  additional class RegExpNormalChar extends RegExpTerm, TRegExpNormalChar {
     RegExpNormalChar() { this = TRegExpNormalChar(re, start, end) }
 
     /**
@@ -770,7 +770,7 @@ module Impl implements RegexTreeViewSig {
    * \Qabc\E
    * ```
    */
-  class RegExpQuote extends RegExpTerm, TRegExpQuote {
+  additional class RegExpQuote extends RegExpTerm, TRegExpQuote {
     string value;
 
     RegExpQuote() {
@@ -880,7 +880,7 @@ module Impl implements RegexTreeViewSig {
    * .
    * ```
    */
-  class RegExpSpecialChar extends RegExpTerm, TRegExpSpecialChar {
+  additional class RegExpSpecialChar extends RegExpTerm, TRegExpSpecialChar {
     string char;
 
     RegExpSpecialChar() {
@@ -956,7 +956,7 @@ module Impl implements RegexTreeViewSig {
    * (?=\w)
    * ```
    */
-  class RegExpZeroWidthMatch extends RegExpGroup {
+  additional class RegExpZeroWidthMatch extends RegExpGroup {
     RegExpZeroWidthMatch() { re.zeroWidthMatch(start, end) }
 
     override RegExpTerm getChild(int i) { none() }
@@ -1023,7 +1023,7 @@ module Impl implements RegexTreeViewSig {
    * (?!\n)
    * ```
    */
-  class RegExpNegativeLookahead extends RegExpLookahead {
+  additional class RegExpNegativeLookahead extends RegExpLookahead {
     RegExpNegativeLookahead() { re.negativeLookaheadAssertionGroup(start, end) }
 
     override string getPrimaryQLClass() { result = "RegExpNegativeLookahead" }
@@ -1065,7 +1065,7 @@ module Impl implements RegexTreeViewSig {
    * (?<!\\)
    * ```
    */
-  class RegExpNegativeLookbehind extends RegExpLookbehind {
+  additional class RegExpNegativeLookbehind extends RegExpLookbehind {
     RegExpNegativeLookbehind() { re.negativeLookbehindAssertionGroup(start, end) }
 
     override string getPrimaryQLClass() { result = "RegExpNegativeLookbehind" }
@@ -1159,7 +1159,7 @@ module Impl implements RegexTreeViewSig {
   /**
    * Gets the flags for `root`, or the empty string if `root` has no flags.
    */
-  deprecated string getFlags(RegExpTerm root) {
+  additional deprecated string getFlags(RegExpTerm root) {
     root.isRootTerm() and
     result = root.getLiteral().getFlags()
   }

--- a/python/ql/lib/semmle/python/RegexTreeView.qll
+++ b/python/ql/lib/semmle/python/RegexTreeView.qll
@@ -454,7 +454,7 @@ module Impl implements RegexTreeViewSig {
     override string getPrimaryQLClass() { result = "RegExpAlt" }
   }
 
-  class RegExpCharEscape = RegExpEscape;
+  additional class RegExpCharEscape = RegExpEscape;
 
   /**
    * An escaped regular expression term, that is, a regular expression
@@ -684,7 +684,7 @@ module Impl implements RegexTreeViewSig {
    * \t
    * ```
    */
-  class RegExpNormalChar extends RegExpTerm, TRegExpNormalChar {
+  additional class RegExpNormalChar extends RegExpTerm, TRegExpNormalChar {
     RegExpNormalChar() { this = TRegExpNormalChar(re, start, end) }
 
     /**
@@ -792,7 +792,7 @@ module Impl implements RegexTreeViewSig {
    * .
    * ```
    */
-  class RegExpSpecialChar extends RegExpTerm, TRegExpSpecialChar {
+  additional class RegExpSpecialChar extends RegExpTerm, TRegExpSpecialChar {
     string char;
 
     RegExpSpecialChar() {
@@ -868,7 +868,7 @@ module Impl implements RegexTreeViewSig {
    * (?=\w)
    * ```
    */
-  class RegExpZeroWidthMatch extends RegExpGroup {
+  additional class RegExpZeroWidthMatch extends RegExpGroup {
     RegExpZeroWidthMatch() { re.zeroWidthMatch(start, end) }
 
     override RegExpTerm getChild(int i) { none() }
@@ -937,7 +937,7 @@ module Impl implements RegexTreeViewSig {
    * (?!\n)
    * ```
    */
-  class RegExpNegativeLookahead extends RegExpLookahead {
+  additional class RegExpNegativeLookahead extends RegExpLookahead {
     RegExpNegativeLookahead() { re.negativeLookaheadAssertionGroup(start, end) }
 
     override string getPrimaryQLClass() { result = "RegExpNegativeLookahead" }
@@ -979,7 +979,7 @@ module Impl implements RegexTreeViewSig {
    * (?<!\\)
    * ```
    */
-  class RegExpNegativeLookbehind extends RegExpLookbehind {
+  additional class RegExpNegativeLookbehind extends RegExpLookbehind {
     RegExpNegativeLookbehind() { re.negativeLookbehindAssertionGroup(start, end) }
 
     override string getPrimaryQLClass() { result = "RegExpNegativeLookbehind" }

--- a/ruby/ql/lib/codeql/ruby/regexp/RegExpTreeView.qll
+++ b/ruby/ql/lib/codeql/ruby/regexp/RegExpTreeView.qll
@@ -539,7 +539,7 @@ private module Impl implements RegexTreeViewSig {
     override predicate isNullable() { this.getAChild().isNullable() }
   }
 
-  class RegExpCharEscape = RegExpEscape;
+  additional class RegExpCharEscape = RegExpEscape;
 
   /**
    * An escaped regular expression term, that is, a regular expression
@@ -620,7 +620,7 @@ private module Impl implements RegexTreeViewSig {
   /**
    * A non-word boundary, that is, a regular expression term of the form `\B`.
    */
-  class RegExpNonWordBoundary extends RegExpSpecialChar {
+  additional class RegExpNonWordBoundary extends RegExpSpecialChar {
     RegExpNonWordBoundary() { this.getChar() = "\\B" }
 
     override string getAPrimaryQlClass() { result = "RegExpNonWordBoundary" }
@@ -756,7 +756,7 @@ private module Impl implements RegexTreeViewSig {
    * \t
    * ```
    */
-  class RegExpNormalChar extends RegExpTerm, TRegExpNormalChar {
+  additional class RegExpNormalChar extends RegExpTerm, TRegExpNormalChar {
     RegExpNormalChar() { this = TRegExpNormalChar(re, start, end) }
 
     /**
@@ -878,7 +878,7 @@ private module Impl implements RegexTreeViewSig {
    * .
    * ```
    */
-  class RegExpSpecialChar extends RegExpTerm, TRegExpSpecialChar {
+  additional class RegExpSpecialChar extends RegExpTerm, TRegExpSpecialChar {
     string char;
 
     RegExpSpecialChar() {
@@ -926,7 +926,7 @@ private module Impl implements RegexTreeViewSig {
    * \A
    * ```
    */
-  class RegExpAnchor extends RegExpSpecialChar {
+  additional class RegExpAnchor extends RegExpSpecialChar {
     RegExpAnchor() { this.getChar() = ["^", "$", "\\A", "\\Z", "\\z"] }
 
     override string getAPrimaryQlClass() { result = "RegExpAnchor" }
@@ -975,7 +975,7 @@ private module Impl implements RegexTreeViewSig {
    * (?=\w)
    * ```
    */
-  class RegExpZeroWidthMatch extends RegExpGroup {
+  additional class RegExpZeroWidthMatch extends RegExpGroup {
     RegExpZeroWidthMatch() { re.zeroWidthMatch(start, end) }
 
     override RegExpTerm getChild(int i) { none() }
@@ -1050,7 +1050,7 @@ private module Impl implements RegexTreeViewSig {
    * (?!\n)
    * ```
    */
-  class RegExpNegativeLookahead extends RegExpLookahead {
+  additional class RegExpNegativeLookahead extends RegExpLookahead {
     RegExpNegativeLookahead() { re.negativeLookaheadAssertionGroup(start, end) }
 
     override string getAPrimaryQlClass() { result = "RegExpNegativeLookahead" }
@@ -1092,7 +1092,7 @@ private module Impl implements RegexTreeViewSig {
    * (?<!\\)
    * ```
    */
-  class RegExpNegativeLookbehind extends RegExpLookbehind {
+  additional class RegExpNegativeLookbehind extends RegExpLookbehind {
     RegExpNegativeLookbehind() { re.negativeLookbehindAssertionGroup(start, end) }
 
     override string getAPrimaryQlClass() { result = "RegExpNegativeLookbehind" }
@@ -1142,7 +1142,7 @@ private module Impl implements RegexTreeViewSig {
    * A named character property. For example, the POSIX bracket expression
    * `[[:digit:]]`.
    */
-  class RegExpNamedCharacterProperty extends RegExpTerm, TRegExpNamedCharacterProperty {
+  additional class RegExpNamedCharacterProperty extends RegExpTerm, TRegExpNamedCharacterProperty {
     RegExpNamedCharacterProperty() { this = TRegExpNamedCharacterProperty(re, start, end) }
 
     override RegExpTerm getChild(int i) { none() }


### PR DESCRIPTION
The `additional` keyword is used in modules that implement a signature to indicate that a feature is not required by the signature.  
In the future it will become a compiler warning if they are missing, so we should fix them.  

It's not an issue for JS, as the `RegexTreeView` module is simply created by importing all of `javascript` into that module.  