### PR TITLE
C++: Fix CWE-611 XXE query to work with use-use dataflow - take 2

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -34,14 +34,14 @@ class XxeConfiguration extends DataFlow::Configuration {
     DataFlow::Node node1, string state1, DataFlow::Node node2, string state2
   ) {
     // create additional flow steps for `XxeFlowStateTransformer`s
-    state2 = node2.asConvertedExpr().(XxeFlowStateTransformer).transform(state1) and
+    state2 = node2.asIndirectExpr().(XxeFlowStateTransformer).transform(state1) and
     DataFlow::simpleLocalFlowStep(node1, node2)
   }
 
   override predicate isBarrier(DataFlow::Node node, string flowstate) {
     // when the flowstate is transformed at a call node, block the original
     // flowstate value.
-    node.asConvertedExpr().(XxeFlowStateTransformer).transform(flowstate) != flowstate
+    node.asIndirectExpr().(XxeFlowStateTransformer).transform(flowstate) != flowstate
   }
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-611/Xerces.qll
+++ b/cpp/ql/src/Security/CWE/CWE-611/Xerces.qll
@@ -65,9 +65,9 @@ class XercesDomParserLibrary extends XmlLibrary {
   override predicate configurationSource(DataFlow::Node node, string flowstate) {
     // source is the write on `this` of a call to the `XercesDOMParser`
     // constructor.
-    exists(CallInstruction call |
-      call.getStaticCallTarget() = any(XercesDomParserClass c).getAConstructor() and
-      node.asInstruction().(StoreInstruction).getSourceValue() = call.getThisArgument() and
+    exists(Call call |
+      call.getTarget() = any(XercesDomParserClass c).getAConstructor() and
+      node.asExpr() = call and
       encodeXercesFlowState(flowstate, 0, 1) // default configuration
     )
   }
@@ -76,7 +76,7 @@ class XercesDomParserLibrary extends XmlLibrary {
     // sink is the read of the qualifier of a call to `AbstractDOMParser.parse`.
     exists(Call call |
       call.getTarget().getClassAndName("parse") instanceof AbstractDomParserClass and
-      call.getQualifier() = node.asConvertedExpr()
+      call.getQualifier() = node.asIndirectConvertedExpr()
     ) and
     flowstate instanceof XercesFlowState and
     not encodeXercesFlowState(flowstate, 1, 1) // safe configuration
@@ -111,7 +111,7 @@ class CreateLSParserLibrary extends XmlLibrary {
     // source is the result of a call to `createLSParser`.
     exists(Call call |
       call.getTarget() instanceof CreateLSParser and
-      call = node.asExpr() and
+      call = node.asIndirectExpr() and
       encodeXercesFlowState(flowstate, 0, 1) // default configuration
     )
   }
@@ -120,7 +120,7 @@ class CreateLSParserLibrary extends XmlLibrary {
     // sink is the read of the qualifier of a call to `DOMLSParserClass.parse`.
     exists(Call call |
       call.getTarget().getClassAndName("parse") instanceof DomLSParserClass and
-      call.getQualifier() = node.asConvertedExpr()
+      call.getQualifier() = node.asIndirectConvertedExpr()
     ) and
     flowstate instanceof XercesFlowState and
     not encodeXercesFlowState(flowstate, 1, 1) // safe configuration
@@ -150,9 +150,9 @@ class SaxParserLibrary extends XmlLibrary {
   override predicate configurationSource(DataFlow::Node node, string flowstate) {
     // source is the write on `this` of a call to the `SAXParser`
     // constructor.
-    exists(CallInstruction call |
-      call.getStaticCallTarget() = any(SaxParserClass c).getAConstructor() and
-      node.asInstruction().(StoreInstruction).getSourceValue() = call.getThisArgument() and
+    exists(Call call |
+      call.getTarget() = any(SaxParserClass c).getAConstructor() and
+      node.asExpr() = call and
       encodeXercesFlowState(flowstate, 0, 1) // default configuration
     )
   }
@@ -161,7 +161,7 @@ class SaxParserLibrary extends XmlLibrary {
     // sink is the read of the qualifier of a call to `SAXParser.parse`.
     exists(Call call |
       call.getTarget().getClassAndName("parse") instanceof SaxParserClass and
-      call.getQualifier() = node.asConvertedExpr()
+      call.getQualifier() = node.asIndirectConvertedExpr()
     ) and
     flowstate instanceof XercesFlowState and
     not encodeXercesFlowState(flowstate, 1, 1) // safe configuration
@@ -189,7 +189,7 @@ class Sax2XmlReaderLibrary extends XmlLibrary {
     // source is the result of a call to `createXMLReader`.
     exists(Call call |
       call.getTarget() instanceof CreateXmlReader and
-      call = node.asExpr() and
+      call = node.asIndirectExpr() and
       encodeXercesFlowState(flowstate, 0, 1) // default configuration
     )
   }
@@ -198,7 +198,7 @@ class Sax2XmlReaderLibrary extends XmlLibrary {
     // sink is the read of the qualifier of a call to `SAX2XMLReader.parse`.
     exists(Call call |
       call.getTarget().getClassAndName("parse") instanceof Sax2XmlReader and
-      call.getQualifier() = node.asConvertedExpr()
+      call.getQualifier() = node.asIndirectConvertedExpr()
     ) and
     flowstate instanceof XercesFlowState and
     not encodeXercesFlowState(flowstate, 1, 1) // safe configuration

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
@@ -1,175 +1,139 @@
 edges
-| tests2.cpp:20:17:20:31 | Store | tests2.cpp:22:2:22:2 | p |
-| tests2.cpp:33:17:33:31 | Store | tests2.cpp:37:2:37:2 | p |
-| tests3.cpp:23:21:23:53 | call to createXMLReader | tests3.cpp:25:2:25:2 | p |
-| tests3.cpp:35:16:35:20 | p_3_3 | tests3.cpp:38:2:38:6 | Load |
-| tests3.cpp:35:24:35:56 | Store | tests3.cpp:35:16:35:20 | p_3_3 |
-| tests3.cpp:35:24:35:56 | call to createXMLReader | tests3.cpp:35:24:35:56 | Store |
-| tests3.cpp:38:2:38:6 | Load | tests3.cpp:38:2:38:6 | p_3_3 |
-| tests3.cpp:41:16:41:20 | p_3_4 | tests3.cpp:45:2:45:6 | Load |
-| tests3.cpp:41:24:41:56 | Store | tests3.cpp:41:16:41:20 | p_3_4 |
-| tests3.cpp:41:24:41:56 | call to createXMLReader | tests3.cpp:41:24:41:56 | Store |
-| tests3.cpp:45:2:45:6 | Load | tests3.cpp:45:2:45:6 | p_3_4 |
-| tests3.cpp:48:16:48:20 | p_3_5 | tests3.cpp:56:2:56:6 | Load |
-| tests3.cpp:48:24:48:56 | Store | tests3.cpp:48:16:48:20 | p_3_5 |
-| tests3.cpp:48:24:48:56 | call to createXMLReader | tests3.cpp:48:24:48:56 | Store |
-| tests3.cpp:56:2:56:6 | Load | tests3.cpp:56:2:56:6 | p_3_5 |
-| tests3.cpp:60:21:60:53 | call to createXMLReader | tests3.cpp:63:2:63:2 | p |
-| tests3.cpp:67:21:67:53 | call to createXMLReader | tests3.cpp:70:2:70:2 | p |
-| tests5.cpp:27:25:27:38 | call to createLSParser | tests5.cpp:29:2:29:2 | p |
-| tests5.cpp:40:25:40:38 | call to createLSParser | tests5.cpp:43:2:43:2 | p |
-| tests5.cpp:55:25:55:38 | call to createLSParser | tests5.cpp:59:2:59:2 | p |
-| tests5.cpp:63:14:63:17 | g_p1 | tests5.cpp:76:2:76:5 | Load |
-| tests5.cpp:63:21:63:24 | g_p2 | tests5.cpp:77:2:77:5 | Load |
-| tests5.cpp:67:2:67:32 | Store | tests5.cpp:63:14:63:17 | g_p1 |
-| tests5.cpp:67:17:67:30 | call to createLSParser | tests5.cpp:67:2:67:32 | Store |
-| tests5.cpp:70:2:70:32 | Store | tests5.cpp:63:21:63:24 | g_p2 |
-| tests5.cpp:70:17:70:30 | call to createLSParser | tests5.cpp:70:2:70:32 | Store |
-| tests5.cpp:76:2:76:5 | Load | tests5.cpp:76:2:76:5 | g_p1 |
-| tests5.cpp:77:2:77:5 | Load | tests5.cpp:77:2:77:5 | g_p2 |
-| tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:83:2:83:2 | p |
-| tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:85:2:85:2 | Load |
-| tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:85:2:85:2 | p indirection |
-| tests5.cpp:85:2:85:2 | Load | tests5.cpp:85:2:85:2 | p |
-| tests5.cpp:85:2:85:2 | p | tests5.cpp:88:2:88:2 | Load |
-| tests5.cpp:85:2:85:2 | p | tests5.cpp:88:2:88:2 | p indirection |
-| tests5.cpp:85:2:85:2 | p indirection | tests5.cpp:85:2:85:2 | p |
-| tests5.cpp:88:2:88:2 | Load | tests5.cpp:88:2:88:2 | p |
-| tests5.cpp:88:2:88:2 | p | tests5.cpp:89:2:89:2 | p |
-| tests5.cpp:88:2:88:2 | p indirection | tests5.cpp:88:2:88:2 | p |
-| tests.cpp:15:23:15:43 | Store | tests.cpp:17:2:17:2 | p |
-| tests.cpp:28:23:28:43 | Store | tests.cpp:31:2:31:2 | p |
-| tests.cpp:35:23:35:43 | Store | tests.cpp:37:2:37:2 | p |
-| tests.cpp:37:2:37:2 | p | tests.cpp:39:2:39:2 | p |
-| tests.cpp:51:23:51:43 | Store | tests.cpp:54:2:54:2 | p |
-| tests.cpp:54:2:54:2 | p | tests.cpp:56:2:56:2 | p |
-| tests.cpp:54:2:54:2 | p | tests.cpp:56:2:56:2 | p |
-| tests.cpp:56:2:56:2 | p | tests.cpp:58:2:58:2 | p |
-| tests.cpp:58:2:58:2 | p | tests.cpp:60:2:60:2 | p |
-| tests.cpp:66:23:66:43 | Store | tests.cpp:69:2:69:2 | p |
-| tests.cpp:73:23:73:43 | Store | tests.cpp:80:2:80:2 | p |
-| tests.cpp:85:24:85:44 | Store | tests.cpp:88:3:88:3 | q |
-| tests.cpp:100:24:100:44 | Store | tests.cpp:104:3:104:3 | q |
-| tests.cpp:112:39:112:39 | p | tests.cpp:113:2:113:2 | p |
-| tests.cpp:116:39:116:39 | p | tests.cpp:117:2:117:2 | p |
-| tests.cpp:122:23:122:43 | Store | tests.cpp:126:18:126:18 | q |
-| tests.cpp:122:23:122:43 | Store | tests.cpp:128:18:128:18 | q |
-| tests.cpp:126:18:126:18 | q | tests.cpp:112:39:112:39 | p |
-| tests.cpp:128:18:128:18 | q | tests.cpp:116:39:116:39 | p |
+| tests2.cpp:20:17:20:31 | call to SAXParser | tests2.cpp:22:2:22:2 | p indirection |
+| tests2.cpp:33:17:33:31 | call to SAXParser | tests2.cpp:37:2:37:2 | p indirection |
+| tests2.cpp:49:12:49:12 | call to SAXParser | tests2.cpp:51:2:51:2 | p indirection |
+| tests3.cpp:23:21:23:53 | call to createXMLReader indirection | tests3.cpp:25:2:25:2 | p indirection |
+| tests3.cpp:60:21:60:53 | call to createXMLReader indirection | tests3.cpp:63:2:63:2 | p indirection |
+| tests3.cpp:67:21:67:53 | call to createXMLReader indirection | tests3.cpp:70:2:70:2 | p indirection |
+| tests5.cpp:27:25:27:38 | call to createLSParser indirection | tests5.cpp:29:2:29:2 | p indirection |
+| tests5.cpp:40:25:40:38 | call to createLSParser indirection | tests5.cpp:43:2:43:2 | p indirection |
+| tests5.cpp:55:25:55:38 | call to createLSParser indirection | tests5.cpp:59:2:59:2 | p indirection |
+| tests5.cpp:81:25:81:38 | call to createLSParser indirection | tests5.cpp:83:2:83:2 | Load indirection |
+| tests5.cpp:81:25:81:38 | call to createLSParser indirection | tests5.cpp:83:2:83:2 | p indirection |
+| tests5.cpp:83:2:83:2 | Load indirection | tests5.cpp:85:2:85:2 | p indirection |
+| tests5.cpp:85:2:85:2 | p indirection | tests5.cpp:86:2:86:2 | Load indirection |
+| tests5.cpp:86:2:86:2 | Load indirection | tests5.cpp:88:2:88:2 | p indirection |
+| tests5.cpp:88:2:88:2 | p indirection | tests5.cpp:89:2:89:2 | p indirection |
+| tests.cpp:15:23:15:43 | call to XercesDOMParser | tests.cpp:17:2:17:2 | p indirection |
+| tests.cpp:28:23:28:43 | call to XercesDOMParser | tests.cpp:31:2:31:2 | p indirection |
+| tests.cpp:35:23:35:43 | Store indirection | tests.cpp:37:2:37:2 | p indirection |
+| tests.cpp:35:23:35:43 | call to XercesDOMParser | tests.cpp:35:23:35:43 | Store indirection |
+| tests.cpp:37:2:37:2 | ConvertToNonVirtualBase indirection | tests.cpp:38:2:38:2 | p indirection |
+| tests.cpp:37:2:37:2 | p indirection | tests.cpp:37:2:37:2 | ConvertToNonVirtualBase indirection |
+| tests.cpp:38:2:38:2 | p indirection | tests.cpp:39:2:39:2 | p indirection |
+| tests.cpp:51:23:51:43 | Store indirection | tests.cpp:53:2:53:2 | p indirection |
+| tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:51:23:51:43 | Store indirection |
+| tests.cpp:53:2:53:2 | p indirection | tests.cpp:54:2:54:2 | ConvertToNonVirtualBase indirection |
+| tests.cpp:54:2:54:2 | ConvertToNonVirtualBase indirection | tests.cpp:55:2:55:2 | p indirection |
+| tests.cpp:55:2:55:2 | p indirection | tests.cpp:56:2:56:2 | ConvertToNonVirtualBase indirection |
+| tests.cpp:55:2:55:2 | p indirection | tests.cpp:56:2:56:2 | p indirection |
+| tests.cpp:56:2:56:2 | ConvertToNonVirtualBase indirection | tests.cpp:57:2:57:2 | p indirection |
+| tests.cpp:57:2:57:2 | p indirection | tests.cpp:58:2:58:2 | ConvertToNonVirtualBase indirection |
+| tests.cpp:58:2:58:2 | ConvertToNonVirtualBase indirection | tests.cpp:59:2:59:2 | p indirection |
+| tests.cpp:59:2:59:2 | p indirection | tests.cpp:60:2:60:2 | p indirection |
+| tests.cpp:66:23:66:43 | call to XercesDOMParser | tests.cpp:69:2:69:2 | p indirection |
+| tests.cpp:73:23:73:43 | call to XercesDOMParser | tests.cpp:80:2:80:2 | p indirection |
+| tests.cpp:85:24:85:44 | call to XercesDOMParser | tests.cpp:88:3:88:3 | q indirection |
+| tests.cpp:100:24:100:44 | call to XercesDOMParser | tests.cpp:104:3:104:3 | q indirection |
+| tests.cpp:112:39:112:39 | p indirection | tests.cpp:113:2:113:2 | p indirection |
+| tests.cpp:116:39:116:39 | p indirection | tests.cpp:117:2:117:2 | p indirection |
+| tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:126:18:126:18 | Load indirection |
+| tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:128:18:128:18 | Load indirection |
+| tests.cpp:126:18:126:18 | Load indirection | tests.cpp:112:39:112:39 | p indirection |
+| tests.cpp:128:18:128:18 | Load indirection | tests.cpp:116:39:116:39 | p indirection |
 nodes
-| tests2.cpp:20:17:20:31 | Store | semmle.label | Store |
-| tests2.cpp:22:2:22:2 | p | semmle.label | p |
-| tests2.cpp:33:17:33:31 | Store | semmle.label | Store |
-| tests2.cpp:37:2:37:2 | p | semmle.label | p |
-| tests3.cpp:23:21:23:53 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:25:2:25:2 | p | semmle.label | p |
-| tests3.cpp:35:16:35:20 | p_3_3 | semmle.label | p_3_3 |
-| tests3.cpp:35:24:35:56 | Store | semmle.label | Store |
-| tests3.cpp:35:24:35:56 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:38:2:38:6 | Load | semmle.label | Load |
-| tests3.cpp:38:2:38:6 | p_3_3 | semmle.label | p_3_3 |
-| tests3.cpp:41:16:41:20 | p_3_4 | semmle.label | p_3_4 |
-| tests3.cpp:41:24:41:56 | Store | semmle.label | Store |
-| tests3.cpp:41:24:41:56 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:45:2:45:6 | Load | semmle.label | Load |
-| tests3.cpp:45:2:45:6 | p_3_4 | semmle.label | p_3_4 |
-| tests3.cpp:48:16:48:20 | p_3_5 | semmle.label | p_3_5 |
-| tests3.cpp:48:24:48:56 | Store | semmle.label | Store |
-| tests3.cpp:48:24:48:56 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:56:2:56:6 | Load | semmle.label | Load |
-| tests3.cpp:56:2:56:6 | p_3_5 | semmle.label | p_3_5 |
-| tests3.cpp:60:21:60:53 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:63:2:63:2 | p | semmle.label | p |
-| tests3.cpp:67:21:67:53 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:70:2:70:2 | p | semmle.label | p |
+| tests2.cpp:20:17:20:31 | call to SAXParser | semmle.label | call to SAXParser |
+| tests2.cpp:22:2:22:2 | p indirection | semmle.label | p indirection |
+| tests2.cpp:33:17:33:31 | call to SAXParser | semmle.label | call to SAXParser |
+| tests2.cpp:37:2:37:2 | p indirection | semmle.label | p indirection |
+| tests2.cpp:49:12:49:12 | call to SAXParser | semmle.label | call to SAXParser |
+| tests2.cpp:51:2:51:2 | p indirection | semmle.label | p indirection |
+| tests3.cpp:23:21:23:53 | call to createXMLReader indirection | semmle.label | call to createXMLReader indirection |
+| tests3.cpp:25:2:25:2 | p indirection | semmle.label | p indirection |
+| tests3.cpp:60:21:60:53 | call to createXMLReader indirection | semmle.label | call to createXMLReader indirection |
+| tests3.cpp:63:2:63:2 | p indirection | semmle.label | p indirection |
+| tests3.cpp:67:21:67:53 | call to createXMLReader indirection | semmle.label | call to createXMLReader indirection |
+| tests3.cpp:70:2:70:2 | p indirection | semmle.label | p indirection |
 | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | semmle.label | XML_PARSE_NOENT |
 | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | semmle.label | XML_PARSE_DTDLOAD |
 | tests4.cpp:46:34:46:68 | ... \| ... | semmle.label | ... \| ... |
 | tests4.cpp:77:34:77:38 | flags | semmle.label | flags |
 | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | semmle.label | XML_PARSE_DTDLOAD |
-| tests5.cpp:27:25:27:38 | call to createLSParser | semmle.label | call to createLSParser |
-| tests5.cpp:29:2:29:2 | p | semmle.label | p |
-| tests5.cpp:40:25:40:38 | call to createLSParser | semmle.label | call to createLSParser |
-| tests5.cpp:43:2:43:2 | p | semmle.label | p |
-| tests5.cpp:55:25:55:38 | call to createLSParser | semmle.label | call to createLSParser |
-| tests5.cpp:59:2:59:2 | p | semmle.label | p |
-| tests5.cpp:63:14:63:17 | g_p1 | semmle.label | g_p1 |
-| tests5.cpp:63:21:63:24 | g_p2 | semmle.label | g_p2 |
-| tests5.cpp:67:2:67:32 | Store | semmle.label | Store |
-| tests5.cpp:67:17:67:30 | call to createLSParser | semmle.label | call to createLSParser |
-| tests5.cpp:70:2:70:32 | Store | semmle.label | Store |
-| tests5.cpp:70:17:70:30 | call to createLSParser | semmle.label | call to createLSParser |
-| tests5.cpp:76:2:76:5 | Load | semmle.label | Load |
-| tests5.cpp:76:2:76:5 | g_p1 | semmle.label | g_p1 |
-| tests5.cpp:77:2:77:5 | Load | semmle.label | Load |
-| tests5.cpp:77:2:77:5 | g_p2 | semmle.label | g_p2 |
-| tests5.cpp:81:25:81:38 | call to createLSParser | semmle.label | call to createLSParser |
-| tests5.cpp:83:2:83:2 | p | semmle.label | p |
-| tests5.cpp:85:2:85:2 | Load | semmle.label | Load |
-| tests5.cpp:85:2:85:2 | p | semmle.label | p |
+| tests5.cpp:27:25:27:38 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
+| tests5.cpp:29:2:29:2 | p indirection | semmle.label | p indirection |
+| tests5.cpp:40:25:40:38 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
+| tests5.cpp:43:2:43:2 | p indirection | semmle.label | p indirection |
+| tests5.cpp:55:25:55:38 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
+| tests5.cpp:59:2:59:2 | p indirection | semmle.label | p indirection |
+| tests5.cpp:81:25:81:38 | call to createLSParser indirection | semmle.label | call to createLSParser indirection |
+| tests5.cpp:83:2:83:2 | Load indirection | semmle.label | Load indirection |
+| tests5.cpp:83:2:83:2 | p indirection | semmle.label | p indirection |
 | tests5.cpp:85:2:85:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:88:2:88:2 | Load | semmle.label | Load |
-| tests5.cpp:88:2:88:2 | p | semmle.label | p |
+| tests5.cpp:86:2:86:2 | Load indirection | semmle.label | Load indirection |
 | tests5.cpp:88:2:88:2 | p indirection | semmle.label | p indirection |
-| tests5.cpp:89:2:89:2 | p | semmle.label | p |
-| tests.cpp:15:23:15:43 | Store | semmle.label | Store |
-| tests.cpp:17:2:17:2 | p | semmle.label | p |
-| tests.cpp:28:23:28:43 | Store | semmle.label | Store |
-| tests.cpp:31:2:31:2 | p | semmle.label | p |
-| tests.cpp:35:23:35:43 | Store | semmle.label | Store |
-| tests.cpp:37:2:37:2 | p | semmle.label | p |
-| tests.cpp:39:2:39:2 | p | semmle.label | p |
-| tests.cpp:51:23:51:43 | Store | semmle.label | Store |
-| tests.cpp:54:2:54:2 | p | semmle.label | p |
-| tests.cpp:56:2:56:2 | p | semmle.label | p |
-| tests.cpp:56:2:56:2 | p | semmle.label | p |
-| tests.cpp:58:2:58:2 | p | semmle.label | p |
-| tests.cpp:60:2:60:2 | p | semmle.label | p |
-| tests.cpp:66:23:66:43 | Store | semmle.label | Store |
-| tests.cpp:69:2:69:2 | p | semmle.label | p |
-| tests.cpp:73:23:73:43 | Store | semmle.label | Store |
-| tests.cpp:80:2:80:2 | p | semmle.label | p |
-| tests.cpp:85:24:85:44 | Store | semmle.label | Store |
-| tests.cpp:88:3:88:3 | q | semmle.label | q |
-| tests.cpp:100:24:100:44 | Store | semmle.label | Store |
-| tests.cpp:104:3:104:3 | q | semmle.label | q |
-| tests.cpp:112:39:112:39 | p | semmle.label | p |
-| tests.cpp:113:2:113:2 | p | semmle.label | p |
-| tests.cpp:116:39:116:39 | p | semmle.label | p |
-| tests.cpp:117:2:117:2 | p | semmle.label | p |
-| tests.cpp:122:23:122:43 | Store | semmle.label | Store |
-| tests.cpp:126:18:126:18 | q | semmle.label | q |
-| tests.cpp:128:18:128:18 | q | semmle.label | q |
+| tests5.cpp:89:2:89:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:15:23:15:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:17:2:17:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:28:23:28:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:31:2:31:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:35:23:35:43 | Store indirection | semmle.label | Store indirection |
+| tests.cpp:35:23:35:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:37:2:37:2 | ConvertToNonVirtualBase indirection | semmle.label | ConvertToNonVirtualBase indirection |
+| tests.cpp:37:2:37:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:38:2:38:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:39:2:39:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:51:23:51:43 | Store indirection | semmle.label | Store indirection |
+| tests.cpp:51:23:51:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:53:2:53:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:54:2:54:2 | ConvertToNonVirtualBase indirection | semmle.label | ConvertToNonVirtualBase indirection |
+| tests.cpp:55:2:55:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:56:2:56:2 | ConvertToNonVirtualBase indirection | semmle.label | ConvertToNonVirtualBase indirection |
+| tests.cpp:56:2:56:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:57:2:57:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:58:2:58:2 | ConvertToNonVirtualBase indirection | semmle.label | ConvertToNonVirtualBase indirection |
+| tests.cpp:59:2:59:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:60:2:60:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:66:23:66:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:69:2:69:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:73:23:73:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:80:2:80:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:85:24:85:44 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:88:3:88:3 | q indirection | semmle.label | q indirection |
+| tests.cpp:100:24:100:44 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:104:3:104:3 | q indirection | semmle.label | q indirection |
+| tests.cpp:112:39:112:39 | p indirection | semmle.label | p indirection |
+| tests.cpp:113:2:113:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:116:39:116:39 | p indirection | semmle.label | p indirection |
+| tests.cpp:117:2:117:2 | p indirection | semmle.label | p indirection |
+| tests.cpp:122:23:122:43 | call to XercesDOMParser | semmle.label | call to XercesDOMParser |
+| tests.cpp:126:18:126:18 | Load indirection | semmle.label | Load indirection |
+| tests.cpp:128:18:128:18 | Load indirection | semmle.label | Load indirection |
 subpaths
 #select
-| tests2.cpp:22:2:22:2 | p | tests2.cpp:20:17:20:31 | Store | tests2.cpp:22:2:22:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:20:17:20:31 | Store | XML parser |
-| tests2.cpp:37:2:37:2 | p | tests2.cpp:33:17:33:31 | Store | tests2.cpp:37:2:37:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:33:17:33:31 | Store | XML parser |
-| tests3.cpp:25:2:25:2 | p | tests3.cpp:23:21:23:53 | call to createXMLReader | tests3.cpp:25:2:25:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:23:21:23:53 | call to createXMLReader | XML parser |
-| tests3.cpp:38:2:38:6 | p_3_3 | tests3.cpp:35:24:35:56 | call to createXMLReader | tests3.cpp:38:2:38:6 | p_3_3 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:35:24:35:56 | call to createXMLReader | XML parser |
-| tests3.cpp:45:2:45:6 | p_3_4 | tests3.cpp:41:24:41:56 | call to createXMLReader | tests3.cpp:45:2:45:6 | p_3_4 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:41:24:41:56 | call to createXMLReader | XML parser |
-| tests3.cpp:56:2:56:6 | p_3_5 | tests3.cpp:48:24:48:56 | call to createXMLReader | tests3.cpp:56:2:56:6 | p_3_5 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:48:24:48:56 | call to createXMLReader | XML parser |
-| tests3.cpp:63:2:63:2 | p | tests3.cpp:60:21:60:53 | call to createXMLReader | tests3.cpp:63:2:63:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:60:21:60:53 | call to createXMLReader | XML parser |
-| tests3.cpp:70:2:70:2 | p | tests3.cpp:67:21:67:53 | call to createXMLReader | tests3.cpp:70:2:70:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:67:21:67:53 | call to createXMLReader | XML parser |
+| tests2.cpp:22:2:22:2 | p indirection | tests2.cpp:20:17:20:31 | call to SAXParser | tests2.cpp:22:2:22:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:20:17:20:31 | call to SAXParser | XML parser |
+| tests2.cpp:37:2:37:2 | p indirection | tests2.cpp:33:17:33:31 | call to SAXParser | tests2.cpp:37:2:37:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:33:17:33:31 | call to SAXParser | XML parser |
+| tests2.cpp:51:2:51:2 | p indirection | tests2.cpp:49:12:49:12 | call to SAXParser | tests2.cpp:51:2:51:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:49:12:49:12 | call to SAXParser | XML parser |
+| tests3.cpp:25:2:25:2 | p indirection | tests3.cpp:23:21:23:53 | call to createXMLReader indirection | tests3.cpp:25:2:25:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:23:21:23:53 | call to createXMLReader indirection | XML parser |
+| tests3.cpp:63:2:63:2 | p indirection | tests3.cpp:60:21:60:53 | call to createXMLReader indirection | tests3.cpp:63:2:63:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:60:21:60:53 | call to createXMLReader indirection | XML parser |
+| tests3.cpp:70:2:70:2 | p indirection | tests3.cpp:67:21:67:53 | call to createXMLReader indirection | tests3.cpp:70:2:70:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:67:21:67:53 | call to createXMLReader indirection | XML parser |
 | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:26:34:26:48 | XML_PARSE_NOENT | XML parser |
 | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:36:34:36:50 | XML_PARSE_DTDLOAD | XML parser |
 | tests4.cpp:46:34:46:68 | ... \| ... | tests4.cpp:46:34:46:68 | ... \| ... | tests4.cpp:46:34:46:68 | ... \| ... | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:46:34:46:68 | ... \| ... | XML parser |
 | tests4.cpp:77:34:77:38 | flags | tests4.cpp:77:34:77:38 | flags | tests4.cpp:77:34:77:38 | flags | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:77:34:77:38 | flags | XML parser |
 | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:130:39:130:55 | XML_PARSE_DTDLOAD | XML parser |
-| tests5.cpp:29:2:29:2 | p | tests5.cpp:27:25:27:38 | call to createLSParser | tests5.cpp:29:2:29:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:27:25:27:38 | call to createLSParser | XML parser |
-| tests5.cpp:43:2:43:2 | p | tests5.cpp:40:25:40:38 | call to createLSParser | tests5.cpp:43:2:43:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:40:25:40:38 | call to createLSParser | XML parser |
-| tests5.cpp:59:2:59:2 | p | tests5.cpp:55:25:55:38 | call to createLSParser | tests5.cpp:59:2:59:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:55:25:55:38 | call to createLSParser | XML parser |
-| tests5.cpp:76:2:76:5 | g_p1 | tests5.cpp:67:17:67:30 | call to createLSParser | tests5.cpp:76:2:76:5 | g_p1 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:67:17:67:30 | call to createLSParser | XML parser |
-| tests5.cpp:77:2:77:5 | g_p2 | tests5.cpp:70:17:70:30 | call to createLSParser | tests5.cpp:77:2:77:5 | g_p2 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:70:17:70:30 | call to createLSParser | XML parser |
-| tests5.cpp:83:2:83:2 | p | tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:83:2:83:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser | XML parser |
-| tests5.cpp:89:2:89:2 | p | tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:89:2:89:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser | XML parser |
-| tests.cpp:17:2:17:2 | p | tests.cpp:15:23:15:43 | Store | tests.cpp:17:2:17:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:15:23:15:43 | Store | XML parser |
-| tests.cpp:31:2:31:2 | p | tests.cpp:28:23:28:43 | Store | tests.cpp:31:2:31:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:28:23:28:43 | Store | XML parser |
-| tests.cpp:39:2:39:2 | p | tests.cpp:35:23:35:43 | Store | tests.cpp:39:2:39:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:35:23:35:43 | Store | XML parser |
-| tests.cpp:56:2:56:2 | p | tests.cpp:51:23:51:43 | Store | tests.cpp:56:2:56:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | Store | XML parser |
-| tests.cpp:60:2:60:2 | p | tests.cpp:51:23:51:43 | Store | tests.cpp:60:2:60:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | Store | XML parser |
-| tests.cpp:69:2:69:2 | p | tests.cpp:66:23:66:43 | Store | tests.cpp:69:2:69:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:66:23:66:43 | Store | XML parser |
-| tests.cpp:80:2:80:2 | p | tests.cpp:73:23:73:43 | Store | tests.cpp:80:2:80:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:73:23:73:43 | Store | XML parser |
-| tests.cpp:88:3:88:3 | q | tests.cpp:85:24:85:44 | Store | tests.cpp:88:3:88:3 | q | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:85:24:85:44 | Store | XML parser |
-| tests.cpp:104:3:104:3 | q | tests.cpp:100:24:100:44 | Store | tests.cpp:104:3:104:3 | q | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:100:24:100:44 | Store | XML parser |
-| tests.cpp:113:2:113:2 | p | tests.cpp:122:23:122:43 | Store | tests.cpp:113:2:113:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | Store | XML parser |
-| tests.cpp:117:2:117:2 | p | tests.cpp:122:23:122:43 | Store | tests.cpp:117:2:117:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | Store | XML parser |
+| tests5.cpp:29:2:29:2 | p indirection | tests5.cpp:27:25:27:38 | call to createLSParser indirection | tests5.cpp:29:2:29:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:27:25:27:38 | call to createLSParser indirection | XML parser |
+| tests5.cpp:43:2:43:2 | p indirection | tests5.cpp:40:25:40:38 | call to createLSParser indirection | tests5.cpp:43:2:43:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:40:25:40:38 | call to createLSParser indirection | XML parser |
+| tests5.cpp:59:2:59:2 | p indirection | tests5.cpp:55:25:55:38 | call to createLSParser indirection | tests5.cpp:59:2:59:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:55:25:55:38 | call to createLSParser indirection | XML parser |
+| tests5.cpp:83:2:83:2 | p indirection | tests5.cpp:81:25:81:38 | call to createLSParser indirection | tests5.cpp:83:2:83:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser indirection | XML parser |
+| tests5.cpp:89:2:89:2 | p indirection | tests5.cpp:81:25:81:38 | call to createLSParser indirection | tests5.cpp:89:2:89:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser indirection | XML parser |
+| tests.cpp:17:2:17:2 | p indirection | tests.cpp:15:23:15:43 | call to XercesDOMParser | tests.cpp:17:2:17:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:15:23:15:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:31:2:31:2 | p indirection | tests.cpp:28:23:28:43 | call to XercesDOMParser | tests.cpp:31:2:31:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:28:23:28:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:39:2:39:2 | p indirection | tests.cpp:35:23:35:43 | call to XercesDOMParser | tests.cpp:39:2:39:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:35:23:35:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:56:2:56:2 | p indirection | tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:56:2:56:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:60:2:60:2 | p indirection | tests.cpp:51:23:51:43 | call to XercesDOMParser | tests.cpp:60:2:60:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:51:23:51:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:69:2:69:2 | p indirection | tests.cpp:66:23:66:43 | call to XercesDOMParser | tests.cpp:69:2:69:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:66:23:66:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:80:2:80:2 | p indirection | tests.cpp:73:23:73:43 | call to XercesDOMParser | tests.cpp:80:2:80:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:73:23:73:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:88:3:88:3 | q indirection | tests.cpp:85:24:85:44 | call to XercesDOMParser | tests.cpp:88:3:88:3 | q indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:85:24:85:44 | call to XercesDOMParser | XML parser |
+| tests.cpp:104:3:104:3 | q indirection | tests.cpp:100:24:100:44 | call to XercesDOMParser | tests.cpp:104:3:104:3 | q indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:100:24:100:44 | call to XercesDOMParser | XML parser |
+| tests.cpp:113:2:113:2 | p indirection | tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:113:2:113:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | call to XercesDOMParser | XML parser |
+| tests.cpp:117:2:117:2 | p indirection | tests.cpp:122:23:122:43 | call to XercesDOMParser | tests.cpp:117:2:117:2 | p indirection | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:122:23:122:43 | call to XercesDOMParser | XML parser |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests2.cpp
@@ -44,3 +44,16 @@ void test2_4(InputSource &data) {
 	p->setDisableDefaultEntityResolution(v);
 	p->parse(data); // GOOD
 }
+
+void test2_5(InputSource &data) {
+	SAXParser p;
+
+	p.parse(data); // BAD (parser not correctly configured)
+}
+
+void test2_6(InputSource &data) {
+	SAXParser p;
+
+	p.setDisableDefaultEntityResolution(true);
+	p.parse(data); // GOOD
+}


### PR DESCRIPTION
This commit ensures stack allocated parsers are also handled. Currently missing are the cases where the parser is assigned to global variable, as this requires indirect flow through global variables, which we know is currently missing from use-use dataflow.