### PR TITLE
Go: Add query to check for deferred calls to functions which may return errors

### DIFF
--- a/go/ql/src/InconsistentCode/DeferredErrorCall.go
+++ b/go/ql/src/InconsistentCode/DeferredErrorCall.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+func example() {
+	defer io.WriteString(os.Stdout, "All done!")
+
+	if _, err := io.WriteString(os.Stdout, "Hello"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go/ql/src/InconsistentCode/DeferredErrorCall.qhelp
+++ b/go/ql/src/InconsistentCode/DeferredErrorCall.qhelp
@@ -22,7 +22,7 @@ handled explicitly.
 <example>
 <p>
 In the following example, a call to <code>io.WriteLine</code> is deferred with the intention of
-appendending some data to a file after some other data has been written to it. However, the call
+appending some data to a file after some other data has been written to it. However, the call
 may not succeed and return and error, as demonstrated in the other use of
 <code>io.WriteLine</code>.
 </p>

--- a/go/ql/src/InconsistentCode/DeferredErrorCall.qhelp
+++ b/go/ql/src/InconsistentCode/DeferredErrorCall.qhelp
@@ -1,0 +1,45 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+When calling a function which may return an error, we should check whether an error has
+occurred and handle it in some meaningful way. Deferring a function call does not allow
+us to perform such a check. Therefore, calls to functions which may return errors should
+not be deferred.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Examine the deferred function call carefully to check whether any errors that may arise should be
+handled explicitly.
+</p>
+</recommendation>
+
+<example>
+<p>
+In the following example, a call to <code>io.WriteLine</code> is deferred with the intention of
+appendending some data to a file after some other data has been written to it. However, the call
+may not succeed and return and error, as demonstrated in the other use of
+<code>io.WriteLine</code>.
+</p>
+
+<sample src="DeferredErrorCall.go" />
+
+<p>
+To correct this issue, do not defer the function call that may return an error and handle the
+error explicitly instead:
+</p>
+
+<sample src="DeferredErrorCallGood.go" />
+
+</example>
+
+<references>
+    <li>The Go Programming Language Specification: <a href="https://go.dev/ref/spec#Defer_statements">Defer statements</a>.</li>
+    <li>The Go Programming Language Specification: <a href="https://go.dev/ref/spec#Errors">Errors</a>.</li>
+</references>
+</qhelp>

--- a/go/ql/src/InconsistentCode/DeferredErrorCall.ql
+++ b/go/ql/src/InconsistentCode/DeferredErrorCall.ql
@@ -15,7 +15,7 @@ import go
 from DeferStmt defer, SignatureType sig
 where
   // match all deferred function calls and obtain their type signatures
-  sig = defer.getCall().getCalleeExpr().getType().(SignatureType) and
+  sig = defer.getCall().getCalleeExpr().getType() and
   // check that one of the results is an error
   sig.getResultType(_).implements(Builtin::error().getType().getUnderlyingType())
 select defer,

--- a/go/ql/src/InconsistentCode/DeferredErrorCall.ql
+++ b/go/ql/src/InconsistentCode/DeferredErrorCall.ql
@@ -1,0 +1,22 @@
+/**
+ * @name Deferred call may return an error
+ * @description Deferring a call to a function which may return an error means that an error may not be handled.
+ * @kind problem
+ * @problem.severity warning
+ * @id go/deferred-error-call
+ * @tags maintainability
+ *  correctness
+ *  call
+ *  defer
+ */
+
+import go
+
+from DeferStmt defer, SignatureType sig
+where
+  // match all deferred function calls and obtain their type signatures
+  sig = defer.getCall().getCalleeExpr().getType().(SignatureType) and
+  // check that one of the results is an error
+  sig.getResultType(_).implements(Builtin::error().getType().getUnderlyingType())
+select defer,
+  "Deferred a call to " + defer.getCall().getCalleeName() + ", which may return an error."

--- a/go/ql/src/InconsistentCode/DeferredErrorCall.ql
+++ b/go/ql/src/InconsistentCode/DeferredErrorCall.ql
@@ -12,11 +12,17 @@
 
 import go
 
+string getFunctionName(CallExpr call) {
+  if exists(call.getCalleeName())
+  then result = call.getCalleeName()
+  else result = "an anonymous function"
+}
+
 from DeferStmt defer, SignatureType sig
 where
   // match all deferred function calls and obtain their type signatures
   sig = defer.getCall().getCalleeExpr().getType() and
   // check that one of the results is an error
   sig.getResultType(_).implements(Builtin::error().getType().getUnderlyingType())
-select defer,
-  "Deferred a call to " + defer.getCall().getCalleeName() + ", which may return an error."
+select defer, "Deferred a call to $@, which may return an error.", defer.getCall().getCalleeExpr(),
+  getFunctionName(defer.getCall())

--- a/go/ql/src/InconsistentCode/DeferredErrorCallGood.go
+++ b/go/ql/src/InconsistentCode/DeferredErrorCallGood.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+func example() {
+	if _, err := io.WriteString(os.Stdout, "Hello"); err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := io.WriteString(os.Stdout, "All done!"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go/ql/src/change-notes/2022-11-25-deferred-error-query.md
+++ b/go/ql/src/change-notes/2022-11-25-deferred-error-query.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* Added a new query, `go/deferred-error-call`, to detect deferred calls to functions which may return errors.

--- a/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/DeferredErrorCall.expected
+++ b/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/DeferredErrorCall.expected
@@ -1,0 +1,2 @@
+| tests.go:16:2:16:20 | defer statement | Deferred a call to returnsPair, which may return an error. |
+| tests.go:17:2:17:23 | defer statement | Deferred a call to checkSomething, which may return an error. |

--- a/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/DeferredErrorCall.expected
+++ b/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/DeferredErrorCall.expected
@@ -1,2 +1,4 @@
-| tests.go:16:2:16:20 | defer statement | Deferred a call to returnsPair, which may return an error. |
-| tests.go:17:2:17:23 | defer statement | Deferred a call to checkSomething, which may return an error. |
+| tests.go:17:2:17:20 | defer statement | Deferred a call to $@, which may return an error. | tests.go:17:8:17:18 | returnsPair | returnsPair |
+| tests.go:18:2:18:23 | defer statement | Deferred a call to $@, which may return an error. | tests.go:18:8:18:21 | checkSomething | checkSomething |
+| tests.go:21:2:21:12 | defer statement | Deferred a call to $@, which may return an error. | tests.go:21:8:21:10 | fun | fun |
+| tests.go:23:2:23:36 | defer statement | Deferred a call to $@, which may return an error. | tests.go:23:8:23:34 | function literal | an anonymous function |

--- a/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/DeferredErrorCall.qlref
+++ b/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/DeferredErrorCall.qlref
@@ -1,0 +1,1 @@
+InconsistentCode/DeferredErrorCall.ql

--- a/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/tests.go
+++ b/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/tests.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"errors"
+	"log"
 )
 
 func returnsPair() (string, error) {
@@ -15,9 +16,28 @@ func checkSomething() error {
 func deferredCalls() {
 	defer returnsPair()
 	defer checkSomething()
+
+	var fun = checkSomething
+	defer fun()
+
+	defer func() error { return nil }()
 }
 
 func notDeferred() {
-	res, err := returnsPair()
-	err2 := checkSomething()
+	if _, err := returnsPair(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := checkSomething(); err != nil {
+		log.Fatal(err)
+	}
+
+	var fun = checkSomething
+	if err := fun(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := func() error { return nil }(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/tests.go
+++ b/go/ql/test/query-tests/InconsistentCode/DeferredErrorCall/tests.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"errors"
+)
+
+func returnsPair() (string, error) {
+	return "", errors.New("Test error")
+}
+
+func checkSomething() error {
+	return nil
+}
+
+func deferredCalls() {
+	defer returnsPair()
+	defer checkSomething()
+}
+
+func notDeferred() {
+	res, err := returnsPair()
+	err2 := checkSomething()
+}


### PR DESCRIPTION
A simple query which checks that there are no deferred calls to functions which may return errors, since it prevents errors from being handled. 