### PR TITLE
Ruby: model ActiveSupport `json_escape` flow

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
@@ -312,6 +312,20 @@ module ActiveSupport {
     }
   }
 
+  module Erb {
+    module Util {
+      private class JsonEscapeSummary extends SimpleSummarizedCallable {
+        JsonEscapeSummary() { this = "json_escape" }
+
+        override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+          input = "Argument[0]" and
+          output = "ReturnValue" and
+          preservesValue = false
+        }
+      }
+    }
+  }
+
   /**
    * Type summaries for extensions to the `Pathname` module.
    */

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
@@ -312,7 +312,13 @@ module ActiveSupport {
     }
   }
 
+  /**
+   * `ActiveSupport::ERB`
+   */
   module Erb {
+    /**
+     * `ActiveSupport::ERB::Util`
+     */
     module Util {
       private class JsonEscapeSummary extends SimpleSummarizedCallable {
         JsonEscapeSummary() { this = "json_escape" }

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
@@ -186,6 +186,9 @@ edges
 | active_support.rb:290:7:290:16 | call to source :  | active_support.rb:291:8:291:8 | x :  |
 | active_support.rb:291:8:291:8 | x :  | active_support.rb:291:8:291:17 | call to deep_dup |
 | active_support.rb:291:8:291:8 | x :  | active_support.rb:291:8:291:17 | call to deep_dup |
+| active_support.rb:303:7:303:16 | call to source :  | active_support.rb:304:19:304:19 | a :  |
+| active_support.rb:304:7:304:19 | call to json_escape :  | active_support.rb:305:8:305:8 | b |
+| active_support.rb:304:19:304:19 | a :  | active_support.rb:304:7:304:19 | call to json_escape :  |
 | hash_extensions.rb:2:14:2:24 | call to source :  | hash_extensions.rb:3:9:3:9 | h [element :a] :  |
 | hash_extensions.rb:2:14:2:24 | call to source :  | hash_extensions.rb:3:9:3:9 | h [element :a] :  |
 | hash_extensions.rb:3:9:3:9 | h [element :a] :  | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] :  |
@@ -532,6 +535,10 @@ nodes
 | active_support.rb:291:8:291:8 | x :  | semmle.label | x :  |
 | active_support.rb:291:8:291:17 | call to deep_dup | semmle.label | call to deep_dup |
 | active_support.rb:291:8:291:17 | call to deep_dup | semmle.label | call to deep_dup |
+| active_support.rb:303:7:303:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:304:7:304:19 | call to json_escape :  | semmle.label | call to json_escape :  |
+| active_support.rb:304:19:304:19 | a :  | semmle.label | a :  |
+| active_support.rb:305:8:305:8 | b | semmle.label | b |
 | hash_extensions.rb:2:14:2:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:2:14:2:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:3:9:3:9 | h [element :a] :  | semmle.label | h [element :a] :  |

--- a/ruby/ql/test/library-tests/frameworks/active_support/active_support.rb
+++ b/ruby/ql/test/library-tests/frameworks/active_support/active_support.rb
@@ -298,3 +298,9 @@ def m_try(method)
     x.try!(:upcase).try!(:downcase)
     x.try!(method)
 end
+
+def m_json_escape
+  a = source "a"
+  b = json_escape a
+  sink b # $hasTaintFlow=a
+end


### PR DESCRIPTION
Adds taint flow from arg to return value. This is not a general purpose sanitizer for XSS https://api.rubyonrails.org/v7.0.4/classes/ERB/Util.html#method-c-json_escape