### PR TITLE
Java: Add new Mockito runner class location.

### DIFF
--- a/java/ql/lib/semmle/code/java/frameworks/Mockito.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Mockito.qll
@@ -53,9 +53,11 @@ class MockitoInitedTest extends Class {
   MockitoInitedTest() {
     // Tests run with the Mockito runner.
     exists(RunWithAnnotation a | a = this.getAnAncestor().getAnAnnotation() |
+      a.getRunner().(RefType).hasQualifiedName("org.mockito.junit", "MockitoJUnitRunner")
+      or
+      // Deprecated styles.
       a.getRunner().(RefType).hasQualifiedName("org.mockito.runners", "MockitoJUnitRunner")
       or
-      // Deprecated style.
       a.getRunner().(RefType).hasQualifiedName("org.mockito.runners", "MockitoJUnit44Runner")
     )
     or


### PR DESCRIPTION
With mockito 3 this class was moved to `org.mockito.junit.MockitoJUnitRunner` and removed in mockito 4.