### PR TITLE
C++: Add more tests that exercise the default taint barrier implementation

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
@@ -333,3 +333,12 @@ void ptr_diff_case() {
 	int offset = admin_begin_pos ? user - admin_begin_pos : 0; 
 	malloc(offset); // GOOD
 }
+
+void equality_barrier() {
+	int size1 = atoi(getenv("USER"));
+	int size2 = atoi(getenv("USER"));
+
+	if (size1 == size2) {
+		int* a = (int*)malloc(size1 * sizeof(int)); // GOOD
+	}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/test.c
@@ -95,5 +95,12 @@ int main(int argc, char** argv) {
     }
   }
 
+  // GOOD: check the user input first
+  int maxConnections3 = atoi(argv[1]);
+  int maxConnections4 = atoi(argv[1]);
+  if (maxConnections3 == maxConnections4) {
+    startServer(maxConnections3 * 1000);
+  }
+
   return 0;
 }


### PR DESCRIPTION
These demonstrate that the barrier on the sue-use dataflow feature branch is broken.