### PR TITLE
GO: get the Go CI to go fast!

### DIFF
--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -1,26 +1,17 @@
-name: "Go: Run Tests"
+name: "Go: Run Tests - Other OS"
 on:
-  push:
-    paths:
-      - "go/**"
-      - .github/workflows/go-tests.yml
-      - .github/actions/fetch-codeql/action.yml
-      - .github/actions/cache-query-compilation/action.yml
-      - codeql-workspace.yml
-    branches:
-      - main
-      - "rc/*"
   pull_request:
     paths:
       - "go/**"
-      - .github/workflows/go-tests.yml
+      - "!go/ql/**" # don't run other-os if only ql/ files changed
+      - .github/workflows/go-tests-other-os.yml
       - .github/actions/fetch-codeql/action.yml
       - .github/actions/cache-query-compilation/action.yml
       - codeql-workspace.yml
 jobs:
-  test-linux:
-    name: Test Linux (Ubuntu)
-    runs-on: ubuntu-latest-xl
+  test-mac:
+    name: Test MacOS
+    runs-on: macos-latest
     steps:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
@@ -43,28 +34,47 @@ jobs:
           cd go
           make
 
-      - name: Check that all Go code is autoformatted
-        run: |
-          cd go
-          make check-formatting
-
-      - name: Compile qhelp files to markdown
-        run: |
-          cd go
-          env QHELP_OUT_DIR=qhelp-out make qhelp-to-markdown
-
-      - name: Upload qhelp markdown
-        uses: actions/upload-artifact@v3
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
         with:
-          name: qhelp-markdown
-          path: go/qhelp-out/**/*.md
+          key: go-qltest
+      - name: Test
+        run: |
+          cd go
+          make test cache="${{ steps.query-cache.outputs.cache-dir }}"
+
+  test-win:
+    name: Test Windows
+    runs-on: windows-latest-xl
+    steps:
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up CodeQL CLI
+        uses: ./.github/actions/fetch-codeql
+
+      - name: Enable problem matchers in repository
+        shell: bash
+        run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
+
+      - name: Build
+        run: |
+          cd go
+          make
 
       - name: Cache compilation cache
         id: query-cache
         uses: ./.github/actions/cache-query-compilation
         with:
           key: go-qltest
-    
+
       - name: Test
         run: |
           cd go

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,10 +1,21 @@
 name: "Go: Run Tests"
 on:
+  push:
+    paths:
+      - "go/**"
+      - .github/workflows/go-tests.yml
+      - .github/actions/fetch-codeql/action.yml
+      - .github/actions/cache-query-compilation/action.yml
+      - codeql-workspace.yml
+    branches:
+      - main
+      - "rc/*"
   pull_request:
     paths:
       - "go/**"
       - .github/workflows/go-tests.yml
       - .github/actions/fetch-codeql/action.yml
+      - .github/actions/cache-query-compilation/action.yml
       - codeql-workspace.yml
 jobs:
   test-linux:
@@ -48,14 +59,21 @@ jobs:
           name: qhelp-markdown
           path: go/qhelp-out/**/*.md
 
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with:
+          key: go-qltest
+    
       - name: Test
         run: |
           cd go
-          make test
+          make test cache="${{ steps.query-cache.outputs.cache-dir }}"
 
   test-mac:
     name: Test MacOS
     runs-on: macos-latest-xl
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
@@ -78,14 +96,20 @@ jobs:
           cd go
           make
 
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with:
+          key: go-qltest
       - name: Test
         run: |
           cd go
-          make test
+          make test cache="${{ steps.query-cache.outputs.cache-dir }}"
 
   test-win:
     name: Test Windows
     runs-on: windows-latest-xl
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
@@ -108,7 +132,13 @@ jobs:
           cd go
           make
 
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with:
+          key: go-qltest
+
       - name: Test
         run: |
           cd go
-          make test
+          make test cache="${{ steps.query-cache.outputs.cache-dir }}"

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-linux:
     name: Test Linux (Ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     steps:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
@@ -55,7 +55,7 @@ jobs:
 
   test-mac:
     name: Test MacOS
-    runs-on: macos-latest
+    runs-on: macos-latest-xl
     steps:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
@@ -85,7 +85,7 @@ jobs:
 
   test-win:
     name: Test Windows
-    runs-on: windows-2019
+    runs-on: windows-latest-xl
     steps:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
   test-mac:
     name: Test MacOS
-    runs-on: macos-latest-xl
+    runs-on: macos-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Set up Go 1.19

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -32,7 +32,7 @@ jobs:
           cd go
           make
 
-      - name: Check that all QL and Go code is autoformatted
+      - name: Check that all Go code is autoformatted
         run: |
           cd go
           make check-formatting

--- a/go/Makefile
+++ b/go/Makefile
@@ -34,7 +34,6 @@ autoformat:
 	find . -path '**/vendor' -prune -or -type f -iname '*.go' ! -empty -print0 | xargs -0 grep -L "//\s*autoformat-ignore" | xargs gofmt -w
 
 check-formatting:
-	find ql -iregex '.*\.qll?' -print0 | xargs -0 codeql query format --check-only
 	test -z "$$(find . -path '**/vendor' -prune -or -type f -iname '*.go' ! -empty -print0 | xargs -0 grep -L "//\s*autoformat-ignore" | xargs gofmt -l)"
 
 install-deps:

--- a/go/Makefile
+++ b/go/Makefile
@@ -116,9 +116,9 @@ ql/lib/go.dbscheme.stats: ql/lib/go.dbscheme build/stats/src.stamp extractor
 	codeql dataset measure -o $@ build/stats/database/db-go
 
 test: all build/testdb/check-upgrade-path
-	codeql test run ql/test --search-path build/codeql-extractor-go --consistency-queries ql/test/consistency
+	codeql test run -j0 ql/test --search-path build/codeql-extractor-go --consistency-queries ql/test/consistency
   #	use GOOS=linux because GOOS=darwin GOARCH=386 is no longer supported
-	env GOOS=linux GOARCH=386 codeql$(EXE) test run ql/test/query-tests/Security/CWE-681 --search-path build/codeql-extractor-go --consistency-queries ql/test/consistency
+	env GOOS=linux GOARCH=386 codeql$(EXE) test run -j0 ql/test/query-tests/Security/CWE-681 --search-path build/codeql-extractor-go --consistency-queries ql/test/consistency
 	cd extractor; go test -mod=vendor ./... | grep -vF "[no test files]"
 	bash extractor-smoke-test/test.sh || (echo "Extractor smoke test FAILED"; exit 1)
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -116,9 +116,9 @@ ql/lib/go.dbscheme.stats: ql/lib/go.dbscheme build/stats/src.stamp extractor
 	codeql dataset measure -o $@ build/stats/database/db-go
 
 test: all build/testdb/check-upgrade-path
-	codeql test run -j0 ql/test --search-path build/codeql-extractor-go --consistency-queries ql/test/consistency
+	codeql test run -j0 ql/test --search-path build/codeql-extractor-go --consistency-queries ql/test/consistency --compilation-cache=$(cache)
   #	use GOOS=linux because GOOS=darwin GOARCH=386 is no longer supported
-	env GOOS=linux GOARCH=386 codeql$(EXE) test run -j0 ql/test/query-tests/Security/CWE-681 --search-path build/codeql-extractor-go --consistency-queries ql/test/consistency
+	env GOOS=linux GOARCH=386 codeql$(EXE) test run -j0 ql/test/query-tests/Security/CWE-681 --search-path build/codeql-extractor-go --consistency-queries ql/test/consistency --compilation-cache=$(cache)
 	cd extractor; go test -mod=vendor ./... | grep -vF "[no test files]"
 	bash extractor-smoke-test/test.sh || (echo "Extractor smoke test FAILED"; exit 1)
 


### PR DESCRIPTION
Lowers the CI turn-around time from 2+ hours to 5-10 minutes on QL changes.  

The Mac/Windows tests are way slower than the Linux tests, so I've changed it such that they only run on changes outside the `go/ql/` directory.  
Even though they are still slower than the Linux tests, they should complete within an hour (see the runs below).  
I haven't tested the final configuration with a warm cache, so the CI should be faster once this PR is merged.  

I tried to use `macos-latest-xl` runners, but during testing the jobs just kept queuing, so I reverted back to `macos-latest`.  

There is now a format check that checks all `.qll`/`.ql` files on all PRs, so the language specific format check is redundant, and I've therefore deleted it.  

The CI runs will get faster than what you can see below once this PR is merged, thanks to the compilation cache.  
(The compilation cache should be shared between the operating-systems, but that's not tested yet).  

Example fast run: https://github.com/github/codeql/actions/runs/3548416133