### PR TITLE
Make qldoc clearer about behaviour of override

### DIFF
--- a/go/ql/lib/semmle/go/Scopes.qll
+++ b/go/ql/lib/semmle/go/Scopes.qll
@@ -95,7 +95,12 @@ class Entity extends @object {
   /** Gets the package in which this entity is declared, if any. */
   Package getPackage() { result.getScope() = this.getScope() }
 
-  /** Holds if this entity is declared in a package with path `pkg` and has the given `name`. */
+  /**
+   * Holds if this entity is declared in a package with path `pkg` and has the given `name`.
+   *
+   * Note that for methods `pkg` is the package path followed by `.` followed
+   * by the name of the receiver type, for example `io.Writer`.
+   */
   predicate hasQualifiedName(string pkg, string name) {
     pkg = this.getPackage().getPath() and
     name = this.getName()


### PR DESCRIPTION
The example that prompted this change was `e.getTarget().hasQualifiedName("a","b")`, where `e` is a `CallExpr`. Because the result of `getTarget` is a `Function` and the override is on its subclass `Method`, the documentation for the override on `Method` is not readily available. Since the behaviour is quite different for `Method`, we note it in the documentation of the original predicate.