### PR TITLE
Kotlin: Enable java/non-serializable-field for Kotlin

### DIFF
--- a/java/ql/src/Likely Bugs/Serialization/NonSerializableField.ql
+++ b/java/ql/src/Likely Bugs/Serialization/NonSerializableField.ql
@@ -55,6 +55,8 @@ string nonSerialReason(RefType t) {
 predicate exceptions(Class c, Field f) {
   f.getDeclaringType() = c and
   (
+    c.isCompilerGenerated()
+    or
     // `Serializable` objects with custom `readObject` or `writeObject` methods
     // may write out the "non-serializable" fields in a different way.
     c.declaresMethod("readObject")
@@ -90,7 +92,7 @@ predicate exceptions(Class c, Field f) {
 
 from Class c, Field f, string reason
 where
-  c.getFile().isJavaSourceFile() and
+  c.fromSource() and
   c.getAStrictAncestor() instanceof TypeSerializable and
   f.getDeclaringType() = c and
   not exceptions(c, f) and

--- a/java/ql/src/change-notes/2022-11-25-NonSerializableField-kotlin.md
+++ b/java/ql/src/change-notes/2022-11-25-NonSerializableField-kotlin.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `java/non-serializable-field` is now enabled for Kotlin.


### PR DESCRIPTION
It now ignores compiler-generated classes