### PR TITLE
Swift: Update queries to use LocalFlowSource

### DIFF
--- a/swift/ql/src/queries/Security/CWE-089/SqlInjection.ql
+++ b/swift/ql/src/queries/Security/CWE-089/SqlInjection.ql
@@ -69,7 +69,7 @@ class SQLiteSwiftSqlSink extends SqlSink {
 class SqlInjectionConfig extends TaintTracking::Configuration {
   SqlInjectionConfig() { this = "SqlInjectionConfig" }
 
-  override predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
+  override predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
 
   override predicate isSink(DataFlow::Node node) { node instanceof SqlSink }
 }

--- a/swift/ql/src/queries/Security/CWE-094/UnsafeJsEval.ql
+++ b/swift/ql/src/queries/Security/CWE-094/UnsafeJsEval.ql
@@ -20,9 +20,8 @@ import DataFlow::PathGraph
 
 /**
  * A source of untrusted, user-controlled data.
- * TODO: Extend to more (non-remote) sources in the future.
  */
-class Source = RemoteFlowSource;
+class Source = FlowSource;
 
 /**
  * A sink that evaluates a string of JavaScript code.


### PR DESCRIPTION
Update the `swift/unsafe-js-eval` and `swift/sql-injection` queries to use `FlowSource` (which includes `LocalFlowSource`) rather than `RemoteFlowSource`.  Results for these queries are likely to be interesting (if less severe) even when they derive from local user input.