### PR TITLE
C#: Add integration test that checks whether env vars are passed through autobuilder

### DIFF
--- a/csharp/ql/integration-tests/posix-only/inherit-env-vars/Program.cs
+++ b/csharp/ql/integration-tests/posix-only/inherit-env-vars/Program.cs
@@ -1,0 +1,1 @@
+﻿Console.WriteLine(args[0]);

--- a/csharp/ql/integration-tests/posix-only/inherit-env-vars/build.sh
+++ b/csharp/ql/integration-tests/posix-only/inherit-env-vars/build.sh
@@ -1,0 +1,2 @@
+cp $PROJECT_TO_BUILD temp.csproj
+dotnet build temp.csproj

--- a/csharp/ql/integration-tests/posix-only/inherit-env-vars/proj.csproj.no_auto
+++ b/csharp/ql/integration-tests/posix-only/inherit-env-vars/proj.csproj.no_auto
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/csharp/ql/integration-tests/posix-only/inherit-env-vars/test.py
+++ b/csharp/ql/integration-tests/posix-only/inherit-env-vars/test.py
@@ -1,0 +1,6 @@
+from create_database_utils import *
+import os
+
+os.environ["PROJECT_TO_BUILD"] = "proj.csproj.no_auto"
+
+run_codeql_database_create([], test_db="default-db", db=None, lang="csharp")


### PR DESCRIPTION
An integration test for verifying that all environment variables get passed through the C# auto-builder.