### PR TITLE
Swift: CI cache fixes

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -35,6 +35,7 @@ jobs:
   # not using a matrix as you cannot depend on a specific job in a matrix, and we want to start linux checks
   # without waiting for the macOS build
   build-and-test-macos:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: macos-12-xl
     steps:
       - uses: actions/checkout@v3

--- a/swift/actions/run-integration-tests/action.yml
+++ b/swift/actions/run-integration-tests/action.yml
@@ -20,7 +20,7 @@ runs:
     - id: query-cache
       uses: ./.github/actions/cache-query-compilation
       with:
-        key: swift-qltest
+        key: swift-integration
     - name: Run integration tests
       shell: bash
       run: |


### PR DESCRIPTION
I merged https://github.com/github/codeql/pull/11364 and observed the workflows running on `main` to see if everything went as it should.  

I noticed two issues:  
- In [this workflow ](https://github.com/github/codeql/actions/runs/3565278550/jobs/5990271356) there was an issue: `Cache already exists`, because the same cache keys was used for two different caches.  
- [This job ran](https://github.com/github/codeql/actions/runs/3565278550/jobs/5990232692), but there's no reason for it to run.   

Both should be fixed here.  