### PR TITLE
Swift: Simplify some QL.

### DIFF
--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
@@ -32,7 +32,7 @@ class StaticInitializationVectorSource extends Expr {
 class EncryptionInitializationSink extends Expr {
   EncryptionInitializationSink() {
     // `iv` arg in `init` is a sink
-    exists(CallExpr call, string fName, int arg |
+    exists(CallExpr call, string fName |
       call.getStaticTarget()
           .(MethodDecl)
           .hasQualifiedName([
@@ -40,9 +40,7 @@ class EncryptionInitializationSink extends Expr {
               "CCM", "CTR"
             ], fName) and
       fName.matches("%init(%iv:%") and
-      arg = [0, 1] and
-      call.getStaticTarget().(MethodDecl).getParam(pragma[only_bind_into](arg)).getName() = "iv" and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = this
+      call.getArgumentWithLabel("iv").getExpr() = this
     )
   }
 }

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
@@ -39,7 +39,7 @@ class EncryptionInitializationSink extends Expr {
               "AES", "ChaCha20", "Blowfish", "Rabbit", "CBC", "CFB", "GCM", "OCB", "OFB", "PCBC",
               "CCM", "CTR"
             ], fName) and
-      fName.matches("%init(%iv:%") and
+      fName.matches("%init(%") and
       call.getArgumentWithLabel("iv").getExpr() = this
     )
   }

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -162,7 +162,7 @@ class StringLengthConflationConfiguration extends DataFlow::Configuration {
         call.getStaticTarget() = funcDecl and
         flowstate = "String"
       ) and
-      // match up `funcName`, `paramName`, `arg`, `node`.
+      // match up `funcName`, `arg`, `node`.
       funcDecl.getName() = funcName and
       call.getArgument(arg).getExpr() = node.asExpr()
     )

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
@@ -32,13 +32,12 @@ class ConstantPasswordSource extends Expr {
 class ConstantPasswordSink extends Expr {
   ConstantPasswordSink() {
     // `password` arg in `init` is a sink
-    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call, int arg |
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getFullName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
       c.getAMember() = f and
       f.getName().matches("%init(%password:%") and
       call.getStaticTarget() = f and
-      f.getParam(pragma[only_bind_into](arg)).getName() = "password" and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = this
+      call.getArgumentWithLabel("password").getExpr() = this
     )
   }
 }

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
@@ -35,7 +35,7 @@ class ConstantPasswordSink extends Expr {
     exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getFullName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
       c.getAMember() = f and
-      f.getName().matches("%init(%password:%") and
+      f.getName().matches("%init(%") and
       call.getStaticTarget() = f and
       call.getArgumentWithLabel("password").getExpr() = this
     )

--- a/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
+++ b/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
@@ -35,7 +35,7 @@ class ConstantSaltSink extends Expr {
     exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getFullName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
       c.getAMember() = f and
-      f.getName().matches("%init(%salt:%") and
+      f.getName().matches("%init(%") and
       call.getStaticTarget() = f and
       call.getArgumentWithLabel("salt").getExpr() = this
     )

--- a/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
+++ b/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
@@ -32,13 +32,12 @@ class ConstantSaltSource extends Expr {
 class ConstantSaltSink extends Expr {
   ConstantSaltSink() {
     // `salt` arg in `init` is a sink
-    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call, int arg |
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getFullName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
       c.getAMember() = f and
       f.getName().matches("%init(%salt:%") and
       call.getStaticTarget() = f and
-      f.getParam(pragma[only_bind_into](arg)).getName() = "salt" and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = this
+      call.getArgumentWithLabel("salt").getExpr() = this
     )
   }
 }

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
@@ -33,13 +33,12 @@ class IntLiteralSource extends IterationsSource instanceof IntegerLiteralExpr {
 class InsufficientHashIterationsSink extends Expr {
   InsufficientHashIterationsSink() {
     // `iterations` arg in `init` is a sink
-    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call, int arg |
+    exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getFullName() = ["PBKDF1", "PBKDF2"] and
       c.getAMember() = f and
       f.getName().matches("init(%iterations:%") and
       call.getStaticTarget() = f and
-      f.getParam(pragma[only_bind_into](arg)).getName() = "iterations" and
-      call.getArgument(pragma[only_bind_into](arg)).getExpr() = this
+      call.getArgumentWithLabel("iterations").getExpr() = this
     )
   }
 }

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
@@ -36,7 +36,7 @@ class InsufficientHashIterationsSink extends Expr {
     exists(ClassOrStructDecl c, AbstractFunctionDecl f, CallExpr call |
       c.getFullName() = ["PBKDF1", "PBKDF2"] and
       c.getAMember() = f and
-      f.getName().matches("init(%iterations:%") and
+      f.getName().matches("init(%") and
       call.getStaticTarget() = f and
       call.getArgumentWithLabel("iterations").getExpr() = this
     )


### PR DESCRIPTION
Use `ApplyExpr.getArgumentWithLabel` to simplify some query QL.

Note that the QL does not have exactly the same meaning as what we had before - because parameter names and argument names are different things in Swift.  Using argument names is preferred though, because they're generally more stable (being part of the external API), plus the QL in these cases is cleaner after the change.

The tests for these queries should verify correctness (they're fairly thorough), in addition I have ad-hoc checked the argument names do indeed match expectations using other sources such as API docs as well.  In [one case](https://github.com/krzyzanowskim/CryptoSwift/blob/main/Sources/CryptoSwift/ChaCha20.swift#L31) I believe we may now catch results that we would have missed before.

I will do a DCA run to check performance since I have touched code with `pragma`s here.