### PR TITLE
Ruby: Rework call-context sensitivity logic

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -975,34 +975,26 @@ private DataFlow::Node trackSingletonMethodOnInstance(MethodBase method, string 
   result = trackSingletonMethodOnInstance(method, name, TypeTracker::end())
 }
 
-/** Same as `isInstance`, but includes local must-flow through SSA definitions. */
-private predicate isInstanceLocalMustFlow(DataFlow::Node n, Module tp, boolean exact) {
-  isInstance(n, tp, exact)
-  or
-  exists(DataFlow::Node mid | isInstanceLocalMustFlow(mid, tp, exact) |
-    n.asExpr() = mid.(SsaDefinitionNode).getDefinition().getARead()
-    or
-    n.(SsaDefinitionNode).getDefinition().(Ssa::WriteDefinition).assigns(mid.asExpr())
-  )
-}
-
 /**
  * Holds if `ctx` targets `encl`, which is the enclosing callable of `call`, the receiver
  * of `call` is a parameter access, where the corresponding argument of `ctx` is `arg`.
  *
- * `name` is the name of the method being called by `call`.
+ * `name` is the name of the method being called by `call`, `source` is a
+ * `LocalSourceNode` that flows to `arg`, and `paramDef` is the SSA definition for the
+ * parameter that is the receiver of `call`.
  */
 pragma[nomagic]
-private predicate argFlowsToReceiver(
-  RelevantCall ctx, ArgumentNode arg, RelevantCall call, Callable encl, string name
+private predicate argMustFlowToReceiver(
+  RelevantCall ctx, DataFlow::LocalSourceNode source, ArgumentNode arg, SsaDefinitionNode paramDef,
+  RelevantCall call, Callable encl, string name
 ) {
-  exists(
-    ParameterNodeImpl p, SsaDefinitionNode ssaNode, ParameterPosition ppos, ArgumentPosition apos
-  |
+  exists(ParameterNodeImpl p, ParameterPosition ppos, ArgumentPosition apos |
     // the receiver of `call` references `p`
-    LocalFlow::localFlowSsaParamInput(p, ssaNode) and
-    flowsToMethodCallReceiver(pragma[only_bind_into](call), pragma[only_bind_into](ssaNode),
-      pragma[only_bind_into](name)) and
+    exists(DataFlow::Node receiver |
+      LocalFlow::localFlowSsaParamInput(p, paramDef) and
+      methodCall(pragma[only_bind_into](call), receiver, pragma[only_bind_into](name)) and
+      receiver.asExpr() = paramDef.getDefinition().getARead()
+    ) and
     // `p` is a parameter of `encl`,
     encl = call.getScope() and
     p.isParameterOf(TCfgScope(encl), ppos) and
@@ -1010,7 +1002,8 @@ private predicate argFlowsToReceiver(
     getTarget(ctx) = encl and
     // `arg` is the argument for `p` in the call `ctx`
     arg.sourceArgumentOf(ctx, apos) and
-    parameterMatch(ppos, apos)
+    parameterMatch(ppos, apos) and
+    source.flowsTo(arg)
   )
 }
 
@@ -1027,20 +1020,11 @@ private predicate mayBenefitFromCallContextInstance(
   RelevantCall ctx, RelevantCall call, ArgumentNode arg, Callable encl, Module tp, boolean exact,
   string name
 ) {
-  argFlowsToReceiver(ctx, pragma[only_bind_into](arg), call, encl, pragma[only_bind_into](name)) and
-  // `arg` has a relevant instance type
-  isInstanceLocalMustFlow(arg, tp, exact) and
-  exists(lookupMethod(tp, pragma[only_bind_into](name)))
-}
-
-/** Same as `resolveConstantReadAccess`, but includes local must-flow through SSA definitions. */
-private predicate resolveConstantReadAccessMustFlow(DataFlow::Node n, Module tp) {
-  tp = resolveConstantReadAccess(n.asExpr().getExpr())
-  or
-  exists(DataFlow::Node mid | resolveConstantReadAccessMustFlow(mid, tp) |
-    n.asExpr() = mid.(SsaDefinitionNode).getDefinition().getARead()
-    or
-    n.(SsaDefinitionNode).getDefinition().(Ssa::WriteDefinition).assigns(mid.asExpr())
+  exists(DataFlow::LocalSourceNode source |
+    argMustFlowToReceiver(ctx, pragma[only_bind_into](source), arg, _, call, encl,
+      pragma[only_bind_into](name)) and
+    source = trackInstance(tp, exact) and
+    exists(lookupMethod(tp, pragma[only_bind_into](name)))
   )
 }
 
@@ -1057,10 +1041,12 @@ private predicate mayBenefitFromCallContextSingleton(
   RelevantCall ctx, RelevantCall call, ArgumentNode arg, Callable encl, Module tp, boolean exact,
   string name
 ) {
-  argFlowsToReceiver(ctx, pragma[only_bind_into](arg), call, encl, pragma[only_bind_into](name)) and
-  // `arg` has a relevant module type
-  (
-    resolveConstantReadAccessMustFlow(arg, tp) and
+  exists(DataFlow::LocalSourceNode source |
+    argMustFlowToReceiver(ctx, pragma[only_bind_into](source), pragma[only_bind_into](arg), _, call,
+      encl, pragma[only_bind_into](name)) and
+    exists(lookupSingletonMethod(tp, pragma[only_bind_into](name), exact))
+  |
+    source = trackModuleAccess(tp) and
     exact = true
     or
     exists(SelfVariable self | arg.asExpr().getExpr() = self.getAnAccess() |
@@ -1073,8 +1059,7 @@ private predicate mayBenefitFromCallContextSingleton(
         exact = false
       )
     )
-  ) and
-  exists(lookupSingletonMethod(tp, pragma[only_bind_into](name), exact))
+  )
 }
 
 /**
@@ -1101,7 +1086,7 @@ DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
     exists(RelevantCall call0, Callable res |
       call0 = call.asCall() and
       res = result.asCallable() and
-      res = getTarget(call0) and // make sure to not include e.g. private methods
+      result = viableSourceCallable(call) and // make sure to not include e.g. private methods
       exists(Module m, boolean exact, string name |
         mayBenefitFromCallContextInstance(ctx.asCall(), pragma[only_bind_into](call0), _, _,
           pragma[only_bind_into](m), exact, pragma[only_bind_into](name)) and
@@ -1113,18 +1098,22 @@ DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
       )
     )
     or
-    // `ctx` cannot provide a type bound
-    exists(RelevantCall call0, RelevantCall ctx0, ArgumentNode arg, string name |
+    // `ctx` cannot provide a type bound, and the receiver of the call is `self`;
+    // in this case, still apply an open-world assumption
+    exists(
+      RelevantCall call0, RelevantCall ctx0, ArgumentNode arg, SsaSelfDefinitionNode self,
+      string name
+    |
       call0 = call.asCall() and
       ctx0 = ctx.asCall() and
-      argFlowsToReceiver(ctx0, arg, call0, _, name) and
+      argMustFlowToReceiver(ctx0, _, arg, self, call0, _, name) and
       not mayBenefitFromCallContextInstance(ctx0, call0, arg, _, _, _, name) and
       not mayBenefitFromCallContextSingleton(ctx0, call0, arg, _, _, _, name) and
       result = viableSourceCallable(call)
     )
     or
     // library calls should always be able to resolve
-    argFlowsToReceiver(ctx.asCall(), _, call.asCall(), _, _) and
+    argMustFlowToReceiver(ctx.asCall(), _, _, _, call.asCall(), _, _) and
     result = viableLibraryCallable(call)
   )
 }

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -64,46 +64,54 @@ edges
 | call_sensitivity.rb:67:24:67:24 | x :  | call_sensitivity.rb:62:18:62:18 | y :  |
 | call_sensitivity.rb:70:30:70:30 | x :  | call_sensitivity.rb:71:10:71:10 | x |
 | call_sensitivity.rb:70:30:70:30 | x :  | call_sensitivity.rb:71:10:71:10 | x |
-| call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
-| call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
-| call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
-| call_sensitivity.rb:74:30:74:30 | x :  | call_sensitivity.rb:75:23:75:23 | x :  |
-| call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
-| call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
-| call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
-| call_sensitivity.rb:75:23:75:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
-| call_sensitivity.rb:78:35:78:35 | x :  | call_sensitivity.rb:79:28:79:28 | x :  |
-| call_sensitivity.rb:78:35:78:35 | x :  | call_sensitivity.rb:79:28:79:28 | x :  |
-| call_sensitivity.rb:79:28:79:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
-| call_sensitivity.rb:79:28:79:28 | x :  | call_sensitivity.rb:74:30:74:30 | x :  |
-| call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
-| call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
-| call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
-| call_sensitivity.rb:82:33:82:33 | y :  | call_sensitivity.rb:83:25:83:25 | y :  |
-| call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
-| call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
-| call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
-| call_sensitivity.rb:83:25:83:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
-| call_sensitivity.rb:86:35:86:35 | x :  | call_sensitivity.rb:87:34:87:34 | x :  |
-| call_sensitivity.rb:86:35:86:35 | x :  | call_sensitivity.rb:87:34:87:34 | x :  |
-| call_sensitivity.rb:87:34:87:34 | x :  | call_sensitivity.rb:82:33:82:33 | y :  |
-| call_sensitivity.rb:87:34:87:34 | x :  | call_sensitivity.rb:82:33:82:33 | y :  |
-| call_sensitivity.rb:92:11:92:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:92:11:92:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:93:16:93:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
-| call_sensitivity.rb:93:16:93:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
-| call_sensitivity.rb:94:14:94:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
-| call_sensitivity.rb:94:14:94:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
-| call_sensitivity.rb:95:16:95:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
-| call_sensitivity.rb:95:16:95:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
-| call_sensitivity.rb:97:21:97:28 | call to taint :  | call_sensitivity.rb:74:30:74:30 | x :  |
-| call_sensitivity.rb:97:21:97:28 | call to taint :  | call_sensitivity.rb:74:30:74:30 | x :  |
-| call_sensitivity.rb:98:26:98:33 | call to taint :  | call_sensitivity.rb:78:35:78:35 | x :  |
-| call_sensitivity.rb:98:26:98:33 | call to taint :  | call_sensitivity.rb:78:35:78:35 | x :  |
-| call_sensitivity.rb:99:24:99:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
-| call_sensitivity.rb:99:24:99:32 | call to taint :  | call_sensitivity.rb:82:33:82:33 | y :  |
-| call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:86:35:86:35 | x :  |
-| call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:86:35:86:35 | x :  |
+| call_sensitivity.rb:74:18:74:18 | y :  | call_sensitivity.rb:76:17:76:17 | y :  |
+| call_sensitivity.rb:74:18:74:18 | y :  | call_sensitivity.rb:76:17:76:17 | y :  |
+| call_sensitivity.rb:76:17:76:17 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:76:17:76:17 | y :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:80:30:80:30 | x :  | call_sensitivity.rb:81:23:81:23 | x :  |
+| call_sensitivity.rb:80:30:80:30 | x :  | call_sensitivity.rb:81:23:81:23 | x :  |
+| call_sensitivity.rb:80:30:80:30 | x :  | call_sensitivity.rb:81:23:81:23 | x :  |
+| call_sensitivity.rb:80:30:80:30 | x :  | call_sensitivity.rb:81:23:81:23 | x :  |
+| call_sensitivity.rb:81:23:81:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:81:23:81:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:81:23:81:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:81:23:81:23 | x :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:84:35:84:35 | x :  | call_sensitivity.rb:85:28:85:28 | x :  |
+| call_sensitivity.rb:84:35:84:35 | x :  | call_sensitivity.rb:85:28:85:28 | x :  |
+| call_sensitivity.rb:85:28:85:28 | x :  | call_sensitivity.rb:80:30:80:30 | x :  |
+| call_sensitivity.rb:85:28:85:28 | x :  | call_sensitivity.rb:80:30:80:30 | x :  |
+| call_sensitivity.rb:88:33:88:33 | y :  | call_sensitivity.rb:89:25:89:25 | y :  |
+| call_sensitivity.rb:88:33:88:33 | y :  | call_sensitivity.rb:89:25:89:25 | y :  |
+| call_sensitivity.rb:88:33:88:33 | y :  | call_sensitivity.rb:89:25:89:25 | y :  |
+| call_sensitivity.rb:88:33:88:33 | y :  | call_sensitivity.rb:89:25:89:25 | y :  |
+| call_sensitivity.rb:89:25:89:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:89:25:89:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:89:25:89:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:89:25:89:25 | y :  | call_sensitivity.rb:70:30:70:30 | x :  |
+| call_sensitivity.rb:92:35:92:35 | x :  | call_sensitivity.rb:93:34:93:34 | x :  |
+| call_sensitivity.rb:92:35:92:35 | x :  | call_sensitivity.rb:93:34:93:34 | x :  |
+| call_sensitivity.rb:93:34:93:34 | x :  | call_sensitivity.rb:88:33:88:33 | y :  |
+| call_sensitivity.rb:93:34:93:34 | x :  | call_sensitivity.rb:88:33:88:33 | y :  |
+| call_sensitivity.rb:98:11:98:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:98:11:98:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:99:16:99:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
+| call_sensitivity.rb:99:16:99:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
+| call_sensitivity.rb:100:14:100:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:100:14:100:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:101:16:101:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
+| call_sensitivity.rb:101:16:101:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
+| call_sensitivity.rb:102:14:102:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:102:14:102:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:104:21:104:28 | call to taint :  | call_sensitivity.rb:80:30:80:30 | x :  |
+| call_sensitivity.rb:104:21:104:28 | call to taint :  | call_sensitivity.rb:80:30:80:30 | x :  |
+| call_sensitivity.rb:105:26:105:33 | call to taint :  | call_sensitivity.rb:84:35:84:35 | x :  |
+| call_sensitivity.rb:105:26:105:33 | call to taint :  | call_sensitivity.rb:84:35:84:35 | x :  |
+| call_sensitivity.rb:106:24:106:32 | call to taint :  | call_sensitivity.rb:88:33:88:33 | y :  |
+| call_sensitivity.rb:106:24:106:32 | call to taint :  | call_sensitivity.rb:88:33:88:33 | y :  |
+| call_sensitivity.rb:107:26:107:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
+| call_sensitivity.rb:107:26:107:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
+| call_sensitivity.rb:140:14:140:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:140:14:140:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
@@ -183,46 +191,54 @@ nodes
 | call_sensitivity.rb:70:30:70:30 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:71:10:71:10 | x | semmle.label | x |
 | call_sensitivity.rb:71:10:71:10 | x | semmle.label | x |
-| call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:74:30:74:30 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:75:23:75:23 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:78:35:78:35 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:78:35:78:35 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:79:28:79:28 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:79:28:79:28 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:82:33:82:33 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:83:25:83:25 | y :  | semmle.label | y :  |
-| call_sensitivity.rb:86:35:86:35 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:86:35:86:35 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:87:34:87:34 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:87:34:87:34 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:92:11:92:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:92:11:92:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:93:16:93:23 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:93:16:93:23 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:94:14:94:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:94:14:94:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:95:16:95:24 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:95:16:95:24 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:97:21:97:28 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:97:21:97:28 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:98:26:98:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:98:26:98:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:99:24:99:32 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:99:24:99:32 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:100:26:100:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:100:26:100:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:74:18:74:18 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:74:18:74:18 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:76:17:76:17 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:76:17:76:17 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:80:30:80:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:80:30:80:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:80:30:80:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:80:30:80:30 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:81:23:81:23 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:81:23:81:23 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:81:23:81:23 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:81:23:81:23 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:84:35:84:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:84:35:84:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:85:28:85:28 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:85:28:85:28 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:88:33:88:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:88:33:88:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:88:33:88:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:88:33:88:33 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:89:25:89:25 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:89:25:89:25 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:89:25:89:25 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:89:25:89:25 | y :  | semmle.label | y :  |
+| call_sensitivity.rb:92:35:92:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:92:35:92:35 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:93:34:93:34 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:93:34:93:34 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:98:11:98:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:98:11:98:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:99:16:99:23 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:99:16:99:23 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:100:14:100:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:100:14:100:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:101:16:101:24 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:101:16:101:24 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:102:14:102:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:102:14:102:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:104:21:104:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:104:21:104:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:105:26:105:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:105:26:105:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:106:24:106:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:106:24:106:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:107:26:107:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:107:26:107:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:140:14:140:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:140:14:140:22 | call to taint :  | semmle.label | call to taint :  |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint :  | call to taint :  |
@@ -230,56 +246,59 @@ subpaths
 | call_sensitivity.rb:31:27:31:27 | x | call_sensitivity.rb:32:25:32:32 | call to taint :  | call_sensitivity.rb:31:27:31:27 | x | $@ | call_sensitivity.rb:32:25:32:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:40:31:40:31 | x | call_sensitivity.rb:41:25:41:32 | call to taint :  | call_sensitivity.rb:40:31:40:31 | x | $@ | call_sensitivity.rb:41:25:41:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:43:32:43:32 | x | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:43:32:43:32 | x | $@ | call_sensitivity.rb:44:26:44:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:92:11:92:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:92:11:92:18 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:93:16:93:23 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:93:16:93:23 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:94:14:94:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:94:14:94:22 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:95:16:95:24 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:95:16:95:24 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:97:21:97:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:97:21:97:28 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:98:26:98:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:98:26:98:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:99:24:99:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:99:24:99:32 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:100:26:100:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:100:26:100:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:98:11:98:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:98:11:98:18 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:99:16:99:23 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:99:16:99:23 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:100:14:100:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:100:14:100:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:101:16:101:24 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:101:16:101:24 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:102:14:102:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:102:14:102:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:140:14:140:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:140:14:140:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:104:21:104:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:104:21:104:28 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:105:26:105:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:105:26:105:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:106:24:106:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:106:24:106:32 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:107:26:107:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:107:26:107:33 | call to taint :  | call to taint :  |
 mayBenefitFromCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:50:3:52:5 | method1 |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:54:3:56:5 | method2 |
 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:58:3:60:5 | call_method2 |
 | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:62:3:64:5 | method3 |
 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:66:3:68:5 | call_method3 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:74:3:76:5 | singleton_method2 |
-| call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:78:3:80:5 | call_singleton_method2 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:82:3:84:5 | singleton_method3 |
-| call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:86:3:88:5 | call_singleton_method3 |
-| call_sensitivity.rb:112:5:112:18 | call to method2 | call_sensitivity.rb:111:3:113:5 | call_method2 |
-| call_sensitivity.rb:116:5:116:25 | call to method3 | call_sensitivity.rb:115:3:117:5 | call_method3 |
-| call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:119:3:121:5 | call_singleton_method2 |
-| call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:123:3:125:5 | call_singleton_method3 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:80:3:82:5 | singleton_method2 |
+| call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:84:3:86:5 | call_singleton_method2 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |
+| call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:92:3:94:5 | call_singleton_method3 |
+| call_sensitivity.rb:119:5:119:18 | call to method2 | call_sensitivity.rb:118:3:120:5 | call_method2 |
+| call_sensitivity.rb:123:5:123:25 | call to method3 | call_sensitivity.rb:122:3:124:5 | call_method3 |
+| call_sensitivity.rb:127:5:127:28 | call to singleton_method2 | call_sensitivity.rb:126:3:128:5 | call_singleton_method2 |
+| call_sensitivity.rb:131:5:131:35 | call to singleton_method3 | call_sensitivity.rb:130:3:132:5 | call_singleton_method3 |
 viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:76:7:76:18 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:103:3:105:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:92:1:92:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:112:5:112:18 | call to method2 | call_sensitivity.rb:103:3:105:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:129:1:129:19 | call to method2 | call_sensitivity.rb:103:3:105:5 | method1 |
-| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:93:1:93:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:110:3:112:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:98:1:98:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:119:5:119:18 | call to method2 | call_sensitivity.rb:110:3:112:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:136:1:136:19 | call to method2 | call_sensitivity.rb:110:3:112:5 | method1 |
+| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:99:1:99:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
 | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:103:3:105:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:94:1:94:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:116:5:116:25 | call to method3 | call_sensitivity.rb:103:3:105:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:131:1:131:23 | call to method3 | call_sensitivity.rb:103:3:105:5 | method1 |
-| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:95:1:95:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:97:1:97:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:75:5:75:23 | call to singleton_method1 | call_sensitivity.rb:134:1:134:29 | call to singleton_method2 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:79:5:79:28 | call to singleton_method2 | call_sensitivity.rb:98:1:98:34 | call to call_singleton_method2 | call_sensitivity.rb:74:3:76:5 | singleton_method2 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:99:1:99:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:83:5:83:26 | call to singleton_method1 | call_sensitivity.rb:136:1:136:33 | call to singleton_method3 | call_sensitivity.rb:107:3:109:5 | singleton_method1 |
-| call_sensitivity.rb:87:5:87:35 | call to singleton_method3 | call_sensitivity.rb:100:1:100:34 | call to call_singleton_method3 | call_sensitivity.rb:82:3:84:5 | singleton_method3 |
-| call_sensitivity.rb:112:5:112:18 | call to method2 | call_sensitivity.rb:130:1:130:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
-| call_sensitivity.rb:116:5:116:25 | call to method3 | call_sensitivity.rb:132:1:132:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
-| call_sensitivity.rb:120:5:120:28 | call to singleton_method2 | call_sensitivity.rb:135:1:135:34 | call to call_singleton_method2 | call_sensitivity.rb:74:3:76:5 | singleton_method2 |
-| call_sensitivity.rb:124:5:124:35 | call to singleton_method3 | call_sensitivity.rb:137:1:137:34 | call to call_singleton_method3 | call_sensitivity.rb:82:3:84:5 | singleton_method3 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:110:3:112:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:100:1:100:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:123:5:123:25 | call to method3 | call_sensitivity.rb:110:3:112:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:138:1:138:23 | call to method3 | call_sensitivity.rb:110:3:112:5 | method1 |
+| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:101:1:101:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:104:1:104:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:127:5:127:28 | call to singleton_method2 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
+| call_sensitivity.rb:81:5:81:23 | call to singleton_method1 | call_sensitivity.rb:142:1:142:29 | call to singleton_method2 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
+| call_sensitivity.rb:85:5:85:28 | call to singleton_method2 | call_sensitivity.rb:105:1:105:34 | call to call_singleton_method2 | call_sensitivity.rb:80:3:82:5 | singleton_method2 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:106:1:106:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:131:5:131:35 | call to singleton_method3 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:26 | call to singleton_method1 | call_sensitivity.rb:144:1:144:33 | call to singleton_method3 | call_sensitivity.rb:114:3:116:5 | singleton_method1 |
+| call_sensitivity.rb:93:5:93:35 | call to singleton_method3 | call_sensitivity.rb:107:1:107:34 | call to call_singleton_method3 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |
+| call_sensitivity.rb:119:5:119:18 | call to method2 | call_sensitivity.rb:137:1:137:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:123:5:123:25 | call to method3 | call_sensitivity.rb:139:1:139:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:127:5:127:28 | call to singleton_method2 | call_sensitivity.rb:143:1:143:34 | call to call_singleton_method2 | call_sensitivity.rb:80:3:82:5 | singleton_method2 |
+| call_sensitivity.rb:131:5:131:35 | call to singleton_method3 | call_sensitivity.rb:145:1:145:34 | call to call_singleton_method3 | call_sensitivity.rb:88:3:90:5 | singleton_method3 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
@@ -48,7 +48,7 @@ apply_lambda(MY_LAMBDA2, taint(9))
 
 class A
   def method1 x
-    sink x # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13
+    sink x # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ SPURIOUS: hasValueFlow=27
   end
 
   def method2 x
@@ -69,6 +69,12 @@ class A
 
   def self.singleton_method1 x
     sink x # $ hasValueFlow=14 $ hasValueFlow=15 # $ hasValueFlow=16 $ hasValueFlow=17
+  end
+
+  def method4(x, y)
+    [0, 1, 3].each do
+      x.method1(y)
+    end
   end
 
   def self.singleton_method2 x
@@ -93,6 +99,7 @@ a.method2(taint 10)
 a.call_method2(taint 11)
 a.method3(a, taint(12))
 a.call_method3(taint(13))
+a.method4(a, taint(26))
 
 A.singleton_method2(taint 14)
 A.call_singleton_method2(taint 15)
@@ -130,6 +137,7 @@ b.method2(taint 18)
 b.call_method2(taint 19)
 b.method3(b, taint(20))
 b.call_method3(taint(21))
+b.method4(b, taint(27))
 
 B.singleton_method2(taint 22)
 B.call_singleton_method2(taint 23)


### PR DESCRIPTION
In preparation for https://github.com/github/codeql/pull/10714.

- When determining whether a parameter may be the receiver of a call, use must-flow instead of may-flow.
- When restricting the possible call targets based on an argument, consider all possible argument types (may flow) instead of requiring a unique argument type (must flow).
- When a call context cannot provide any argument types, and the argument is the receiver of the call, still use an open-world assumption for `self` inside the callee.

I checked some of the now missing results from DCA, and they looked like false positives.