### PR TITLE
Swift: don't crash on non-existing cache

### DIFF
--- a/swift/actions/build-and-test/action.yml
+++ b/swift/actions/build-and-test/action.yml
@@ -50,5 +50,5 @@ runs:
       if: ${{ github.event_name != 'pull_request' }}
       shell: bash
       run: |
-        find "~/.cache/bazel-repository-cache" "~/.cache/bazel-disk-cache" -atime +0 -type f -delete
-        du -sh "~/.cache/bazel-repository-cache" "~/.cache/bazel-disk-cache"
+        find "~/.cache/bazel-repository-cache" "~/.cache/bazel-disk-cache" -atime +0 -type f -delete || : # ignore errors if the cache is empty
+        du -sh "~/.cache/bazel-repository-cache" "~/.cache/bazel-disk-cache" || : # ignore errors if the cache is empty


### PR DESCRIPTION
Followup from: https://github.com/github/codeql/pull/11466#event-7912611963 

See e.g. this crashing workflow: https://github.com/github/codeql/actions/runs/3574550538/jobs/6009956577 