### PR TITLE
ATM: use the query compilation cache in the ATM qltest

### DIFF
--- a/.github/workflows/js-ml-tests.yml
+++ b/.github/workflows/js-ml-tests.yml
@@ -23,9 +23,9 @@ defaults:
     working-directory: javascript/ql/experimental/adaptivethreatmodeling
 
 jobs:
-  qlcompile:
-    name: Check QL compilation
-    runs-on: ubuntu-latest
+  qltest:
+    name: Test QL
+    runs-on: ubuntu-latest-xl
     steps:
       - uses: actions/checkout@v3
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install pack dependencies
         run: |
-          for pack in modelbuilding src; do
+          for pack in modelbuilding src test; do
             codeql pack install --mode verify -- "${pack}"
           done
       
@@ -41,41 +41,24 @@ jobs:
         id: query-cache
         uses: ./.github/actions/cache-query-compilation
         with: 
-          key: js-ml-compilation
+          key: js-ml-test
 
       - name: Check QL compilation
         run: |
           codeql query compile \
             --check-only \
-            --ram 5120 \
+            --ram 52000 \
             --additional-packs "${{ github.workspace }}" \
             --threads=0 \
             --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}" \
             -- \
             lib modelbuilding src
 
-  qltest:
-    name: Run QL tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/actions/fetch-codeql
-
-      - name: Install pack dependencies
-        run: codeql pack install -- test
-
-      - name: Cache compilation cache
-        id: query-cache
-        uses: ./.github/actions/cache-query-compilation
-        with: 
-          key: js-ml-tests
-
       - name: Run QL tests
         run: |
           codeql test run \
             --threads=0 \
-            --ram 5120 \
+            --ram 52000 \
             --additional-packs "${{ github.workspace }}" \
             --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}" \
             -- \

--- a/.github/workflows/js-ml-tests.yml
+++ b/.github/workflows/js-ml-tests.yml
@@ -36,6 +36,12 @@ jobs:
           for pack in modelbuilding src; do
             codeql pack install --mode verify -- "${pack}"
           done
+      
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with: 
+          key: js-ml-compilation
 
       - name: Check QL compilation
         run: |
@@ -44,6 +50,7 @@ jobs:
             --ram 5120 \
             --additional-packs "${{ github.workspace }}" \
             --threads=0 \
+            --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}" \
             -- \
             lib modelbuilding src
 
@@ -58,11 +65,18 @@ jobs:
       - name: Install pack dependencies
         run: codeql pack install -- test
 
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with: 
+          key: js-ml-tests
+
       - name: Run QL tests
         run: |
           codeql test run \
             --threads=0 \
             --ram 5120 \
             --additional-packs "${{ github.workspace }}" \
+            --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}" \
             -- \
             test


### PR DESCRIPTION
The turnaround is faster just from running on an XL worker, even though I'm doing both QL compilation and qltest as a single job.  
And when the cache is populated, then it will get way faster (in the best case).  