### PR TITLE
Java/C#: add SupportedExternalApis telemetry query

### DIFF
--- a/csharp/ql/src/Telemetry/SupportedExternalApis.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalApis.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Usage of supported APIs coming from external libraries
+ * @description A list of supported 3rd party APIs used in the codebase. Excludes APIs exposed by test libraries.
+ * @kind metric
+ * @tags summary telemetry
+ * @id csharp/telemetry/supported-external-api
+ */
+
+private import csharp
+private import semmle.code.csharp.dispatch.Dispatch
+private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
+private import ExternalApi
+
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  (
+    api.isSupported() or
+    api instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable
+  )
+}
+
+from string info, int usages
+where Results<relevant/1>::restrict(info, usages)
+select info, usages order by usages desc

--- a/csharp/ql/src/change-notes/2022-12-01-supported-external-apis-query.md
+++ b/csharp/ql/src/change-notes/2022-12-01-supported-external-apis-query.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* Added a new query, `csharp/telemetry/supported-external-api`, to detect supported 3rd party APIs used in a codebase.

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.cs
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Web;
+
+public class SupportedExternalApis
+{
+    public void M1()
+    {
+        var l = new List<object>(); // Uninteresting parameterless constructor
+        var o = new object(); // Uninteresting parameterless constructor
+        l.Add(o); // Has flow summary
+        l.Add(o); // Has flow summary
+    }
+
+    public void M2()
+    {
+        var d0 = new DateTime(); // Uninteresting parameterless constructor
+        var next0 = d0.AddYears(30); // Has no flow summary, supported as negative summary
+
+        var d1 = new DateTime(2000, 1, 1); // Interesting constructor, supported as negative summary
+        var next1 = next0.AddDays(3); // Has no flow summary, supported as negative summary
+        var next2 = next1.AddYears(5); // Has no flow summary, supported as negative summary
+    }
+
+    public void M3()
+    {
+        var guid1 = Guid.Parse("{12345678-1234-1234-1234-123456789012}"); // Has no flow summary, supported as negative summary
+    }
+
+     public void M4()
+    {
+        var o = new object(); // Uninteresting parameterless constructor
+        var response = new HttpResponse(); // Uninteresting parameterless constructor
+        response.AddHeader("header", "value"); // Unsupported
+        response.AppendHeader("header", "value"); // Unsupported
+        response.Write(o); // Known sink
+        response.WriteFile("filename"); // Known sink
+        response.Write(o); // Known sink
+    }
+
+     public void M5()
+    {
+        var l1 = Console.ReadLine(); // Known source
+        var l2 = Console.ReadLine(); // Known source
+        Console.SetError(Console.Out); // Has no flow summary, supported as negative summary
+        var x = Console.Read(); // Known source
+    }
+}

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
@@ -1,0 +1,11 @@
+| System#Console.ReadLine() | 2 |
+| System#DateTime.AddYears(System.Int32) | 2 |
+| System.Collections.Generic#List<>.Add(T) | 2 |
+| System.Web#HttpResponse.Write(System.Object) | 2 |
+| System#Console.Read() | 1 |
+| System#Console.SetError(System.IO.TextWriter) | 1 |
+| System#Console.get_Out() | 1 |
+| System#DateTime.AddDays(System.Double) | 1 |
+| System#DateTime.DateTime(System.Int32,System.Int32,System.Int32) | 1 |
+| System#Guid.Parse(System.String) | 1 |
+| System.Web#HttpResponse.WriteFile(System.String) | 1 |

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.qlref
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.qlref
@@ -1,0 +1,1 @@
+Telemetry/SupportedExternalApis.ql

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalApis/options
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalApis/options
@@ -1,0 +1,2 @@
+semmle-extractor-options: /r:System.Collections.Specialized.dll
+semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs

--- a/java/ql/src/Telemetry/SupportedExternalApis.ql
+++ b/java/ql/src/Telemetry/SupportedExternalApis.ql
@@ -8,7 +8,6 @@
 
 import java
 import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
-import semmle.code.java.dataflow.internal.NegativeSummary
 import ExternalApi
 
 private predicate relevant(ExternalApi api) {

--- a/java/ql/src/Telemetry/SupportedExternalApis.ql
+++ b/java/ql/src/Telemetry/SupportedExternalApis.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Usage of supported APIs coming from external libraries
+ * @description A list of supported 3rd party APIs used in the codebase. Excludes test and generated code.
+ * @kind metric
+ * @tags summary telemetry
+ * @id java/telemetry/supported-external-api
+ */
+
+import java
+import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
+import semmle.code.java.dataflow.internal.NegativeSummary
+import ExternalApi
+
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  (
+    api.isSupported() or
+    api = any(FlowSummaryImpl::Public::NegativeSummarizedCallable nsc).asCallable()
+  )
+}
+
+from string apiName, int usages
+where Results<relevant/1>::restrict(apiName, usages)
+select apiName, usages order by usages desc

--- a/java/ql/src/change-notes/2022-12-01-supported-external-apis-query.md
+++ b/java/ql/src/change-notes/2022-12-01-supported-external-apis-query.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* Added a new query, `java/telemetry/supported-external-api`, to detect supported 3rd party APIs used in a codebase.

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
@@ -1,5 +1,5 @@
+| java.io.File#File(String) | 2 |
 | java.net.URL#URL(String) | 2 |
-| java.io.File#File(String) | 1 |
 | java.io.FileWriter#FileWriter(File) | 1 |
 | java.lang.StringBuilder#append(String) | 1 |
 | java.lang.StringBuilder#toString() | 1 |
@@ -7,3 +7,4 @@
 | java.net.URL#openStream() | 1 |
 | java.net.URLConnection#getInputStream() | 1 |
 | java.util.Map#put(Object,Object) | 1 |
+| org.apache.commons.io.FileUtils#deleteDirectory(File) | 1 |

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
@@ -1,0 +1,3 @@
+| java.lang.StringBuilder#append(String) | 1 |
+| java.lang.StringBuilder#toString() | 1 |
+| java.util.Map#put(Object,Object) | 1 |

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
@@ -1,3 +1,9 @@
+| java.net.URL#URL(String) | 2 |
+| java.io.File#File(String) | 1 |
+| java.io.FileWriter#FileWriter(File) | 1 |
 | java.lang.StringBuilder#append(String) | 1 |
 | java.lang.StringBuilder#toString() | 1 |
+| java.net.URL#openConnection() | 1 |
+| java.net.URL#openStream() | 1 |
+| java.net.URLConnection#getInputStream() | 1 |
 | java.util.Map#put(Object,Object) | 1 |

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.java
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.java
@@ -1,0 +1,16 @@
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+class SupportedExternalApis {
+	public static void main(String[] args) throws Exception {
+		StringBuilder builder = new StringBuilder();
+		builder.append("foo");  // supported
+		builder.toString();  // supported
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("foo", new Object()); // supported
+
+		Duration d = java.time.Duration.ofMillis(1000); // not supported
+	}
+}

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.java
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.io.File;
 import java.io.FileWriter;
+import org.apache.commons.io.FileUtils;
 
 class SupportedExternalApis {
 	public static void main(String[] args) throws Exception {
@@ -22,5 +23,7 @@ class SupportedExternalApis {
 
 		new FileWriter(new File("foo")); // supported sink (FileWriter), supported summary (File)
 		new URL("http://foo").openStream(); // supported sink (openStream), supported summary (URL)
+
+		FileUtils.deleteDirectory(new File("foo")); // supported negative summary (deleteDirectory), supported summary (File)
 	}
 }

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.java
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.java
@@ -1,16 +1,26 @@
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.io.InputStream;
+import java.net.URL;
+import java.io.File;
+import java.io.FileWriter;
 
 class SupportedExternalApis {
 	public static void main(String[] args) throws Exception {
-		StringBuilder builder = new StringBuilder();
-		builder.append("foo");  // supported
-		builder.toString();  // supported
+		StringBuilder builder = new StringBuilder(); // uninteresting (parameterless constructor)
+		builder.append("foo");  // supported summary
+		builder.toString();  // supported summary
 
-		Map<String, Object> map = new HashMap<>();
-		map.put("foo", new Object()); // supported
+		Map<String, Object> map = new HashMap<>(); // uninteresting (parameterless constructor)
+		map.put("foo", new Object()); // supported summary
 
 		Duration d = java.time.Duration.ofMillis(1000); // not supported
+
+		URL github = new URL("https://www.github.com/"); // supported summary
+		InputStream stream = github.openConnection().getInputStream(); // supported source (getInputStream), supported sink (openConnection)
+
+		new FileWriter(new File("foo")); // supported sink (FileWriter), supported summary (File)
+		new URL("http://foo").openStream(); // supported sink (openStream), supported summary (URL)
 	}
 }

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.qlref
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.qlref
@@ -1,0 +1,1 @@
+Telemetry/SupportedExternalApis.ql


### PR DESCRIPTION
### Description
This PR adds a `SupportedExternalApis.ql` telemetry query, which complements the existing [UnsupportedExternalAPIs.ql](https://github.com/github/codeql/blob/6ae10c5171aaac2903d9bdf6fef9600a471067fd/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql) query.  The addition of this query is based on discussion with @michaelnebel. 

### Consideration
- This PR currently only adds the query for Java, should it be added for C# as well?
- I've never added a telemetry query before, so let me know if there's anything else that needs to be included beyond the query and tests. (e.g. change note?)