### PR TITLE
Docs: Add missing `language[monotonicAggregates]` annotation

### DIFF
--- a/docs/codeql/ql-language-reference/expressions.rst
+++ b/docs/codeql/ql-language-reference/expressions.rst
@@ -602,6 +602,7 @@ the distance of a node in a graph from the leaves as follows:
 
 .. code-block:: ql
 
+   language[monotonicAggregates]
    int depth(Node n) {
      if not exists(n.getAChild())
      then result = 0


### PR DESCRIPTION
This adds the `language[monotonicAggregates]` annotation so that the example compiles.

Related: https://github.com/github/codeql/issues/11361 https://github.com/github/codeql/discussions/7263