### PR TITLE
Ruby: model `rails/globalid` component

### DIFF
--- a/ruby/ql/lib/change-notes/2022-11-30-rails-globalid.md
+++ b/ruby/ql/lib/change-notes/2022-11-30-rails-globalid.md
@@ -1,0 +1,4 @@
+---
+ category: minorAnalysis
+---
+ * Calls to `GlobalID::Locator.locate` and its variants are now recognized as instances of `OrmInstantiation`.

--- a/ruby/ql/lib/codeql/ruby/frameworks/GlobalId.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/GlobalId.qll
@@ -70,26 +70,40 @@ module GlobalId {
     }
   }
 
-  // TODO: methods in this module are available to any class that includes it, not just ActiveRecord models
   /** `GlobalID::Identification` */
   module Identification {
+    /** A `DataFlow::CallNode` against an instance of a class that includes the `GlobalID::Identification` module */
+    private class IdentificationInstanceCall extends DataFlow::CallNode {
+      IdentificationInstanceCall() {
+        this =
+          DataFlow::getConstant("GlobalID")
+              .getConstant("Identification")
+              .getADescendentModule()
+              .getAnImmediateReference()
+              .getAMethodCall(["new", "find"])
+              .getAMethodCall()
+        or
+        this instanceof ActiveRecordInstanceMethodCall
+      }
+    }
+
     /** A call to `GlobalID::Identification.to_global_id` */
-    class ToGlobalIdCall extends ActiveRecordInstanceMethodCall {
+    class ToGlobalIdCall extends IdentificationInstanceCall {
       ToGlobalIdCall() { this.getMethodName() = ["to_global_id", "to_gid"] }
     }
 
     /** A call to `GlobalID::Identification.to_gid_param` */
-    class ToGidParamCall extends ActiveRecordInstanceMethodCall {
+    class ToGidParamCall extends DataFlow::CallNode {
       ToGidParamCall() { this.getMethodName() = "to_gid_param" }
     }
 
     /** A call to `GlobalID::Identification.to_signed_global_id` */
-    class ToSignedGlobalIdCall extends ActiveRecordInstanceMethodCall {
+    class ToSignedGlobalIdCall extends DataFlow::CallNode {
       ToSignedGlobalIdCall() { this.getMethodName() = ["to_signed_global_id", "to_sgid"] }
     }
 
     /** A call to `GlobalID::Identification.to_sgid_param` */
-    class ToSgidParamCall extends ActiveRecordInstanceMethodCall {
+    class ToSgidParamCall extends DataFlow::CallNode {
       ToSgidParamCall() { this.getMethodName() = "to_sgid_param" }
     }
   }

--- a/ruby/ql/lib/codeql/ruby/frameworks/GlobalId.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/GlobalId.qll
@@ -1,0 +1,111 @@
+/**
+ * Provides modeling for `GlobalID`, a library for identifying model instances by URI.
+ * Version: 1.0.0
+ * https://github.com/rails/globalid
+ */
+
+private import codeql.ruby.ApiGraphs
+private import codeql.ruby.Concepts
+private import codeql.ruby.DataFlow
+private import codeql.ruby.frameworks.ActiveRecord
+
+/**
+ * Provides modeling for `GlobalID`, a library for identifying model instances by URI.
+ * Version: 1.0.0
+ * https://github.com/rails/globalid
+ */
+module GlobalId {
+  /** A call to `GlobalID::parse` */
+  class ParseCall extends DataFlow::CallNode {
+    ParseCall() { this = API::getTopLevelMember("GlobalID").getAMethodCall("parse") }
+  }
+
+  /** A call to `GlobalID::find` */
+  class FindCall extends DataFlow::CallNode, OrmInstantiation::Range {
+    FindCall() { this = API::getTopLevelMember("GlobalID").getAMethodCall("find") }
+
+    override predicate methodCallMayAccessField(string methodName) { none() }
+  }
+
+  /** `GlobalID::Locator` */
+  module Locator {
+    /** A call to `GlobalID::Locator.locate` */
+    class LocateCall extends DataFlow::CallNode, OrmInstantiation::Range {
+      LocateCall() {
+        this = API::getTopLevelMember("GlobalID").getMember("Locator").getAMethodCall("locate")
+      }
+
+      override predicate methodCallMayAccessField(string methodName) { none() }
+    }
+
+    /** A call to `GlobalID::Locator.locate_signed` */
+    class LocateSignedCall extends DataFlow::CallNode, OrmInstantiation::Range {
+      LocateSignedCall() {
+        this =
+          API::getTopLevelMember("GlobalID").getMember("Locator").getAMethodCall("locate_signed")
+      }
+
+      override predicate methodCallMayAccessField(string methodName) { none() }
+    }
+
+    /** A call to `GlobalID::Locator.locate_many` */
+    class LocateManyCall extends DataFlow::CallNode, OrmInstantiation::Range {
+      LocateManyCall() {
+        this = API::getTopLevelMember("GlobalID").getMember("Locator").getAMethodCall("locate_many")
+      }
+
+      override predicate methodCallMayAccessField(string methodName) { none() }
+    }
+
+    /** A call to `GlobalID::Locator.locate_many_signed` */
+    class LocateManySignedCall extends DataFlow::CallNode, OrmInstantiation::Range {
+      LocateManySignedCall() {
+        this =
+          API::getTopLevelMember("GlobalID")
+              .getMember("Locator")
+              .getAMethodCall("locate_many_signed")
+      }
+
+      override predicate methodCallMayAccessField(string methodName) { none() }
+    }
+  }
+
+  // TODO: methods in this module are available to any class that includes it, not just ActiveRecord models
+  /** `GlobalID::Identification` */
+  module Identification {
+    /** A call to `GlobalID::Identification.to_global_id` */
+    class ToGlobalIdCall extends ActiveRecordInstanceMethodCall {
+      ToGlobalIdCall() { this.getMethodName() = ["to_global_id", "to_gid"] }
+    }
+
+    /** A call to `GlobalID::Identification.to_gid_param` */
+    class ToGidParamCall extends ActiveRecordInstanceMethodCall {
+      ToGidParamCall() { this.getMethodName() = "to_gid_param" }
+    }
+
+    /** A call to `GlobalID::Identification.to_signed_global_id` */
+    class ToSignedGlobalIdCall extends ActiveRecordInstanceMethodCall {
+      ToSignedGlobalIdCall() { this.getMethodName() = ["to_signed_global_id", "to_sgid"] }
+    }
+
+    /** A call to `GlobalID::Identification.to_sgid_param` */
+    class ToSgidParamCall extends ActiveRecordInstanceMethodCall {
+      ToSgidParamCall() { this.getMethodName() = "to_sgid_param" }
+    }
+  }
+}
+
+/** Provides modeling for `SignedGlobalID`, a module of the `rails/globalid` library. */
+module SignedGlobalId {
+  /** A call to `SignedGlobalID::parse` */
+  class ParseCall extends DataFlow::CallNode {
+    ParseCall() { this = API::getTopLevelMember("SignedGlobalID").getAMethodCall("parse") }
+  }
+
+  /** A call to `SignedGlobalID::find` */
+  class FindCall extends DataFlow::CallNode, OrmInstantiation::Range {
+    FindCall() { this = API::getTopLevelMember("SignedGlobalID").getAMethodCall("find") }
+
+    override predicate methodCallMayAccessField(string methodName) { none() }
+  }
+}

--- a/ruby/ql/test/library-tests/frameworks/globalid/GlobalId.expected
+++ b/ruby/ql/test/library-tests/frameworks/globalid/GlobalId.expected
@@ -1,24 +1,38 @@
 locateCalls
 | globalid.rb:6:3:6:30 | call to locate |
 | globalid.rb:11:3:11:30 | call to locate |
+| globalid.rb:70:3:70:30 | call to locate |
 locateSignedCalls
 | globalid.rb:16:3:16:38 | call to locate_signed |
 | globalid.rb:21:3:21:38 | call to locate_signed |
+| globalid.rb:89:3:89:38 | call to locate_signed |
 toGlobalIdCalls
 | globalid.rb:5:9:5:33 | call to to_global_id |
 | globalid.rb:10:9:10:27 | call to to_gid |
+| globalid.rb:56:9:56:16 | call to to_gid |
+| globalid.rb:62:9:62:22 | call to to_global_id |
 toGidParamCalls
 | globalid.rb:35:10:35:34 | call to to_gid_param |
+| globalid.rb:68:10:68:23 | call to to_gid_param |
 toSignedGlobalIdCalls
 | globalid.rb:15:10:15:41 | call to to_signed_global_id |
 | globalid.rb:20:10:20:29 | call to to_sgid |
+| globalid.rb:75:10:75:18 | call to to_sgid |
+| globalid.rb:81:10:81:30 | call to to_signed_global_id |
 toSgidParamCalls
 | globalid.rb:41:11:41:36 | call to to_sgid_param |
+| globalid.rb:87:11:87:25 | call to to_sgid_param |
 globalIdParseCalls
 | globalid.rb:36:9:36:27 | call to parse |
+| globalid.rb:69:9:69:27 | call to parse |
 globalIdFindCalls
 | globalid.rb:37:3:37:19 | call to find |
+| globalid.rb:57:3:57:19 | call to find |
+| globalid.rb:63:3:63:19 | call to find |
 signedGlobalIdParseCalls
 | globalid.rb:42:10:42:35 | call to parse |
+| globalid.rb:88:10:88:35 | call to parse |
 signedGlobalIdFindCalls
 | globalid.rb:43:3:43:26 | call to find |
+| globalid.rb:76:3:76:26 | call to find |
+| globalid.rb:82:3:82:26 | call to find |

--- a/ruby/ql/test/library-tests/frameworks/globalid/GlobalId.expected
+++ b/ruby/ql/test/library-tests/frameworks/globalid/GlobalId.expected
@@ -1,0 +1,24 @@
+locateCalls
+| globalid.rb:6:3:6:30 | call to locate |
+| globalid.rb:11:3:11:30 | call to locate |
+locateSignedCalls
+| globalid.rb:16:3:16:38 | call to locate_signed |
+| globalid.rb:21:3:21:38 | call to locate_signed |
+toGlobalIdCalls
+| globalid.rb:5:9:5:33 | call to to_global_id |
+| globalid.rb:10:9:10:27 | call to to_gid |
+toGidParamCalls
+| globalid.rb:35:10:35:34 | call to to_gid_param |
+toSignedGlobalIdCalls
+| globalid.rb:15:10:15:41 | call to to_signed_global_id |
+| globalid.rb:20:10:20:29 | call to to_sgid |
+toSgidParamCalls
+| globalid.rb:41:11:41:36 | call to to_sgid_param |
+globalIdParseCalls
+| globalid.rb:36:9:36:27 | call to parse |
+globalIdFindCalls
+| globalid.rb:37:3:37:19 | call to find |
+signedGlobalIdParseCalls
+| globalid.rb:42:10:42:35 | call to parse |
+signedGlobalIdFindCalls
+| globalid.rb:43:3:43:26 | call to find |

--- a/ruby/ql/test/library-tests/frameworks/globalid/GlobalId.ql
+++ b/ruby/ql/test/library-tests/frameworks/globalid/GlobalId.ql
@@ -1,0 +1,21 @@
+import codeql.ruby.frameworks.GlobalId
+
+query predicate locateCalls(GlobalId::Locator::LocateCall c) { any() }
+
+query predicate locateSignedCalls(GlobalId::Locator::LocateSignedCall c) { any() }
+
+query predicate toGlobalIdCalls(GlobalId::Identification::ToGlobalIdCall c) { any() }
+
+query predicate toGidParamCalls(GlobalId::Identification::ToGidParamCall c) { any() }
+
+query predicate toSignedGlobalIdCalls(GlobalId::Identification::ToSignedGlobalIdCall c) { any() }
+
+query predicate toSgidParamCalls(GlobalId::Identification::ToSgidParamCall c) { any() }
+
+query predicate globalIdParseCalls(GlobalId::ParseCall c) { any() }
+
+query predicate globalIdFindCalls(GlobalId::FindCall c) { any() }
+
+query predicate signedGlobalIdParseCalls(SignedGlobalId::ParseCall c) { any() }
+
+query predicate signedGlobalIdFindCalls(SignedGlobalId::FindCall c) { any() }

--- a/ruby/ql/test/library-tests/frameworks/globalid/globalid.rb
+++ b/ruby/ql/test/library-tests/frameworks/globalid/globalid.rb
@@ -1,0 +1,44 @@
+class User < ActiveRecord::Base
+end
+
+def m1
+  gid = User.find(1).to_global_id
+  GlobalID::Locator.locate gid
+end
+
+def m2
+  gid = User.find(1).to_gid
+  GlobalID::Locator.locate gid
+end
+
+def m3
+  sgid = User.find(1).to_signed_global_id
+  GlobalID::Locator.locate_signed sgid
+end
+
+def m4
+  sgid = User.find(1).to_sgid
+  GlobalID::Locator.locate_signed sgid
+end
+
+def m5
+  gids = User.all.map(&:to_gid)
+  GlobalID::Locator.locate_many gids
+end
+
+def m6
+  sgids = User.all.map(&:to_sgid)
+  GlobalID::Locator.locate_many_signed sgids
+end
+
+def m7
+  gidp = User.find(1).to_gid_param
+  gid = GlobalID.parse gidp
+  GlobalID.find gid
+end
+
+def m8
+  sgidp = User.find(1).to_sgid_param
+  sgid = SignedGlobalID.parse sgidp
+  SignedGlobalID.find sgid
+end

--- a/ruby/ql/test/library-tests/frameworks/globalid/globalid.rb
+++ b/ruby/ql/test/library-tests/frameworks/globalid/globalid.rb
@@ -42,3 +42,49 @@ def m8
   sgid = SignedGlobalID.parse sgidp
   SignedGlobalID.find sgid
 end
+
+class Person
+  include GlobalID::Identification
+
+  def self.find(id)
+    # implementation goes here
+  end
+end
+
+def m9
+  p = Person.find(1)
+  gid = p.to_gid
+  GlobalID.find gid
+end
+
+def m10
+  p = Person.find(1)
+  gid = p.to_global_id
+  GlobalID.find gid
+end
+
+def m11
+  p = Person.find(1)
+  gidp = p.to_gid_param
+  gid = GlobalID.parse gidp
+  GlobalID::Locator.locate gid
+end
+
+def m12
+  p = Person.find(1)
+  sgid = p.to_sgid
+  SignedGlobalID.find sgid
+end
+
+def m10
+  p = Person.find(1)
+  sgid = p.to_signed_global_id
+  SignedGlobalID.find sgid
+end
+
+def m11
+  p = Person.find(1)
+  sgidp = p.to_sgid_param
+  sgid = SignedGlobalID.parse sgidp
+  GlobalID::Locator.locate_signed sgid
+end


### PR DESCRIPTION
https://github.com/rails/globalid

I don't think we get a huge amount of value from this, but it may let us resolve a few more `OrmInstantiation`s.

Use of unsigned global IDs may be a signal that the application is vulnerable to IDOR. `GlobalID::Locator.locate` can handle both signed and unsigned IDs, so use of this method is not necessarily a signal that unsigned IDs are used. Use of `GlobalID::Identification#to_global_id` is a stronger signal, though I haven't tested how noisy or useful this would be as a query yet.

`GlobalID::Identification` uses are restricted to `ActiveRecord` models so far, but we could in theory extend this to any class including the module.