### PR TITLE
Fix `mayHaveSideEffects` for `ReturnStmt`

### DIFF
--- a/go/ql/lib/change-notes/2022-12-6-may-have-side-effects-return-stmt.md
+++ b/go/ql/lib/change-notes/2022-12-6-may-have-side-effects-return-stmt.md
@@ -1,0 +1,8 @@
+---
+category: minorAnalysis
+---
+The definition of `mayHaveSideEffects` for `ReturnStmt` was incorrect when more
+than one expression was being returned. Such return statements were
+effectively considered to never have side effects. This has now been fixed.
+In rare circumstances `globalValueNumber` may have incorrectly treated two
+values as the same when they were in fact distinct.

--- a/go/ql/lib/semmle/go/Stmt.qll
+++ b/go/ql/lib/semmle/go/Stmt.qll
@@ -569,7 +569,7 @@ class ReturnStmt extends @returnstmt, Stmt {
   /** Gets the unique returned expression, if there is only one. */
   Expr getExpr() { getNumChild() = 1 and result = getExpr(0) }
 
-  override predicate mayHaveSideEffects() { getExpr().mayHaveSideEffects() }
+  override predicate mayHaveSideEffects() { getAnExpr().mayHaveSideEffects() }
 
   override string toString() { result = "return statement" }
 


### PR DESCRIPTION
The previous code only worked when the return statement only has one returned expression.