### PR TITLE
Java: Cleanup imports of `ExternalFlow`

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -81,53 +81,6 @@ private import internal.AccessPathSyntax
 private import FlowSummary
 
 /**
- * A module importing the frameworks that provide external flow data,
- * ensuring that they are visible to the taint tracking / data flow library.
- */
-private module Frameworks {
-  private import internal.ContainerFlow
-  private import semmle.code.java.frameworks.android.Android
-  private import semmle.code.java.frameworks.android.ContentProviders
-  private import semmle.code.java.frameworks.android.ExternalStorage
-  private import semmle.code.java.frameworks.android.Intent
-  private import semmle.code.java.frameworks.android.SharedPreferences
-  private import semmle.code.java.frameworks.android.Slice
-  private import semmle.code.java.frameworks.android.SQLite
-  private import semmle.code.java.frameworks.android.Widget
-  private import semmle.code.java.frameworks.ApacheHttp
-  private import semmle.code.java.frameworks.apache.Collections
-  private import semmle.code.java.frameworks.apache.Lang
-  private import semmle.code.java.frameworks.Flexjson
-  private import semmle.code.java.frameworks.guava.Guava
-  private import semmle.code.java.frameworks.jackson.JacksonSerializability
-  private import semmle.code.java.frameworks.javaee.jsf.JSFRenderer
-  private import semmle.code.java.frameworks.JaxWS
-  private import semmle.code.java.frameworks.JoddJson
-  private import semmle.code.java.frameworks.Stream
-  private import semmle.code.java.frameworks.ratpack.RatpackExec
-  private import semmle.code.java.frameworks.spring.SpringHttp
-  private import semmle.code.java.frameworks.spring.SpringWebClient
-  private import semmle.code.java.security.AndroidIntentRedirection
-  private import semmle.code.java.security.ResponseSplitting
-  private import semmle.code.java.security.InformationLeak
-  private import semmle.code.java.security.FragmentInjection
-  private import semmle.code.java.security.GroovyInjection
-  private import semmle.code.java.security.ImplicitPendingIntents
-  private import semmle.code.java.security.JndiInjection
-  private import semmle.code.java.security.LdapInjection
-  private import semmle.code.java.security.MvelInjection
-  private import semmle.code.java.security.OgnlInjection
-  private import semmle.code.java.security.TemplateInjection
-  private import semmle.code.java.security.XPath
-  private import semmle.code.java.security.XsltInjection
-  private import semmle.code.java.frameworks.Jdbc
-  private import semmle.code.java.frameworks.SpringJdbc
-  private import semmle.code.java.frameworks.MyBatis
-  private import semmle.code.java.frameworks.Hibernate
-  private import semmle.code.java.frameworks.jOOQ
-}
-
-/**
  * DEPRECATED: Define source models as data extensions instead.
  *
  * A unit class for adding additional source model rows.

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -36,6 +36,14 @@ abstract class RemoteFlowSource extends DataFlow::Node {
   abstract string getSourceType();
 }
 
+/**
+ * A module for importing frameworks that define remote flow sources.
+ */
+private module RemoteFlowSources {
+  private import semmle.code.java.frameworks.android.Widget
+  private import semmle.code.java.security.TemplateInjection
+}
+
 private class ExternalRemoteFlowSource extends RemoteFlowSource {
   ExternalRemoteFlowSource() { sourceNode(this, "remote") }
 

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -41,7 +41,6 @@ abstract class RemoteFlowSource extends DataFlow::Node {
  */
 private module RemoteFlowSources {
   private import semmle.code.java.frameworks.android.Widget
-  private import semmle.code.java.security.TemplateInjection
 }
 
 private class ExternalRemoteFlowSource extends RemoteFlowSource {

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSteps.qll
@@ -10,19 +10,19 @@ private import semmle.code.java.dataflow.DataFlow
  * ensuring that they are visible to the taint tracking library.
  */
 private module Frameworks {
-  private import semmle.code.java.JDK
-  private import semmle.code.java.frameworks.jackson.JacksonSerializability
   private import semmle.code.java.frameworks.android.AsyncTask
   private import semmle.code.java.frameworks.android.Intent
+  private import semmle.code.java.frameworks.android.Slice
   private import semmle.code.java.frameworks.android.SQLite
-  private import semmle.code.java.frameworks.Guice
-  private import semmle.code.java.frameworks.Properties
-  private import semmle.code.java.frameworks.Protobuf
-  private import semmle.code.java.frameworks.guava.Guava
   private import semmle.code.java.frameworks.apache.Lang
   private import semmle.code.java.frameworks.ApacheHttp
+  private import semmle.code.java.frameworks.guava.Guava
+  private import semmle.code.java.frameworks.Guice
+  private import semmle.code.java.frameworks.jackson.JacksonSerializability
+  private import semmle.code.java.frameworks.Properties
+  private import semmle.code.java.frameworks.Protobuf
   private import semmle.code.java.frameworks.ratpack.RatpackExec
-  private import semmle.code.java.frameworks.android.Slice
+  private import semmle.code.java.JDK
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSteps.qll
@@ -21,6 +21,8 @@ private module Frameworks {
   private import semmle.code.java.frameworks.guava.Guava
   private import semmle.code.java.frameworks.apache.Lang
   private import semmle.code.java.frameworks.ApacheHttp
+  private import semmle.code.java.frameworks.ratpack.RatpackExec
+  private import semmle.code.java.frameworks.android.Slice
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSummary.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSummary.qll
@@ -97,6 +97,14 @@ abstract class SyntheticCallable extends string {
   Type getReturnType() { none() }
 }
 
+/**
+ * A module for importing frameworks that define synthetic callables.
+ */
+private module SyntheticCallables {
+  private import semmle.code.java.frameworks.android.Intent
+  private import semmle.code.java.frameworks.Stream
+}
+
 private newtype TSummarizedCallableBase =
   TSimpleCallable(Callable c) { c.isSourceDeclaration() } or
   TSyntheticCallable(SyntheticCallable c)

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSummary.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSummary.qll
@@ -6,11 +6,6 @@ import java
 private import internal.FlowSummaryImpl as Impl
 private import internal.DataFlowUtil
 
-// import all instances of SummarizedCallable below
-private module Summaries {
-  private import semmle.code.java.dataflow.ExternalFlow
-}
-
 class SummaryComponent = Impl::Public::SummaryComponent;
 
 /** Provides predicates for constructing summary components. */

--- a/java/ql/lib/semmle/code/java/dataflow/internal/ContainerFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/ContainerFlow.qll
@@ -3,7 +3,6 @@ import semmle.code.java.Collections
 import semmle.code.java.Maps
 private import semmle.code.java.dataflow.SSA
 private import DataFlowUtil
-private import semmle.code.java.dataflow.ExternalFlow
 
 private class EntryType extends RefType {
   EntryType() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -14,6 +14,13 @@ private import semmle.code.java.dataflow.internal.AccessPathSyntax as AccessPath
 
 class SummarizedCallableBase = FlowSummary::SummarizedCallableBase;
 
+/**
+ * A module for importing frameworks that define synthetic globals.
+ */
+private module SyntheticGlobals {
+  private import semmle.code.java.frameworks.android.Intent
+}
+
 DataFlowCallable inject(SummarizedCallable c) { result.asSummarizedCallable() = c }
 
 /** Gets the parameter position of the instance parameter. */

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -10,7 +10,6 @@ private import semmle.code.java.dataflow.internal.ContainerFlow
 private import semmle.code.java.frameworks.spring.SpringController
 private import semmle.code.java.frameworks.spring.SpringHttp
 private import semmle.code.java.frameworks.Networking
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSources
 private import semmle.code.java.dataflow.internal.DataFlowPrivate
 import semmle.code.java.dataflow.FlowSteps

--- a/java/ql/lib/semmle/code/java/frameworks/ApacheHttp.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/ApacheHttp.qll
@@ -4,7 +4,6 @@
 
 import java
 private import semmle.code.java.dataflow.FlowSteps
-private import semmle.code.java.dataflow.ExternalFlow
 
 class ApacheHttpGetParams extends Method {
   ApacheHttpGetParams() {

--- a/java/ql/lib/semmle/code/java/frameworks/Flexjson.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Flexjson.qll
@@ -3,7 +3,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The class `flexjson.JSONDeserializer`. */
 class FlexjsonDeserializer extends RefType {

--- a/java/ql/lib/semmle/code/java/frameworks/Hibernate.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Hibernate.qll
@@ -3,7 +3,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The interface `org.hibernate.query.QueryProducer`. */
 class HibernateQueryProducer extends RefType {

--- a/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
@@ -4,7 +4,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.security.XSS
 
 /**

--- a/java/ql/lib/semmle/code/java/frameworks/Jdbc.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Jdbc.qll
@@ -2,7 +2,7 @@
  * Provides classes and predicates for working with the Java JDBC API.
  */
 
-private import semmle.code.java.dataflow.ExternalFlow
+private import java
 
 /*--- Types ---*/
 /** The interface `java.sql.Connection`. */

--- a/java/ql/lib/semmle/code/java/frameworks/Jdbc.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Jdbc.qll
@@ -2,7 +2,7 @@
  * Provides classes and predicates for working with the Java JDBC API.
  */
 
-private import java
+import java
 
 /*--- Types ---*/
 /** The interface `java.sql.Connection`. */

--- a/java/ql/lib/semmle/code/java/frameworks/JoddJson.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JoddJson.qll
@@ -3,7 +3,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The class `jodd.json.Parser`. */
 class JoddJsonParser extends RefType {

--- a/java/ql/lib/semmle/code/java/frameworks/MyBatis.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/MyBatis.qll
@@ -5,7 +5,6 @@
 import java
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.TaintTracking
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The class `org.apache.ibatis.jdbc.SqlRunner`. */
 class MyBatisSqlRunner extends RefType {

--- a/java/ql/lib/semmle/code/java/frameworks/Regex.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Regex.qll
@@ -1,6 +1,6 @@
 /** Definitions related to `java.util.regex`. */
 
-private import java
+import java
 
 /** The class `java.util.regex.Pattern`. */
 class TypeRegexPattern extends Class {

--- a/java/ql/lib/semmle/code/java/frameworks/Regex.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Regex.qll
@@ -1,6 +1,6 @@
 /** Definitions related to `java.util.regex`. */
 
-private import semmle.code.java.dataflow.ExternalFlow
+private import java
 
 /** The class `java.util.regex.Pattern`. */
 class TypeRegexPattern extends Class {

--- a/java/ql/lib/semmle/code/java/frameworks/SpringJdbc.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/SpringJdbc.qll
@@ -3,7 +3,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The class `org.springframework.jdbc.core.JdbcTemplate`. */
 class JdbcTemplate extends RefType {

--- a/java/ql/lib/semmle/code/java/frameworks/Stream.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Stream.qll
@@ -1,6 +1,5 @@
 /** Definitions related to `java.util.stream`. */
 
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSummary
 
 private class CollectCall extends MethodAccess {

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -3,7 +3,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.xml.AndroidManifest
 
 /**

--- a/java/ql/lib/semmle/code/java/frameworks/android/ContentProviders.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/ContentProviders.qll
@@ -3,7 +3,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The class `android.content.ContentValues`. */
 class ContentValues extends Class {

--- a/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll
@@ -1,7 +1,6 @@
 /** Provides classes and predicates for working with SQLite databases. */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSteps
 private import semmle.code.java.frameworks.android.Android
 

--- a/java/ql/lib/semmle/code/java/frameworks/android/SharedPreferences.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/SharedPreferences.qll
@@ -1,7 +1,6 @@
 /** Provides classes related to `android.content.SharedPreferences`. */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The interface `android.content.SharedPreferences`. */
 class SharedPreferences extends Interface {

--- a/java/ql/lib/semmle/code/java/frameworks/android/Slice.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Slice.qll
@@ -3,7 +3,6 @@
 import java
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.FlowSteps
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The class `androidx.slice.SliceProvider`. */
 class SliceProvider extends Class {

--- a/java/ql/lib/semmle/code/java/frameworks/apache/Collections.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/apache/Collections.qll
@@ -2,7 +2,6 @@
 
 import java
 private import semmle.code.java.dataflow.FlowSteps
-private import semmle.code.java.dataflow.ExternalFlow
 
 /**
  * The method `isEmpty` in either `org.apache.commons.collections.CollectionUtils`

--- a/java/ql/lib/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/apache/Lang.qll
@@ -2,7 +2,6 @@
 
 import java
 private import semmle.code.java.dataflow.FlowSteps
-private import semmle.code.java.dataflow.ExternalFlow
 
 /**
  * The class `org.apache.commons.lang.RandomStringUtils` or `org.apache.commons.lang3.RandomStringUtils`.

--- a/java/ql/lib/semmle/code/java/frameworks/guava/Collections.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/guava/Collections.qll
@@ -3,7 +3,6 @@
 import java
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.FlowSteps
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.Collections
 
 private string guavaCollectPackage() { result = "com.google.common.collect" }

--- a/java/ql/lib/semmle/code/java/frameworks/jOOQ.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/jOOQ.qll
@@ -3,7 +3,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 
 /**
  * Methods annotated with this allow for generation of "plain SQL"

--- a/java/ql/lib/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
@@ -9,7 +9,6 @@ import semmle.code.java.Reflection
 import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.internal.DataFlowForSerializability
 import semmle.code.java.dataflow.FlowSteps
-private import semmle.code.java.dataflow.ExternalFlow
 
 /**
  * A `@com.fasterxml.jackson.annotation.JsonIgnore` annoation.

--- a/java/ql/lib/semmle/code/java/frameworks/javaee/jsf/JSFRenderer.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/javaee/jsf/JSFRenderer.qll
@@ -1,7 +1,6 @@
 /** Provides classes and predicates for working with JavaServer Faces renderer. */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 
 /**
  * The JSF class `FacesContext` for processing HTTP requests.

--- a/java/ql/lib/semmle/code/java/frameworks/ratpack/RatpackExec.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/ratpack/RatpackExec.qll
@@ -5,7 +5,6 @@
 import java
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.FlowSteps
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** A reference type that extends a parameterization the Promise type. */
 private class RatpackPromise extends RefType {

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
@@ -4,7 +4,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.frameworks.spring.SpringController
 private import semmle.code.java.security.XSS as XSS

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringWebClient.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringWebClient.qll
@@ -4,7 +4,6 @@
 
 import java
 import SpringHttp
-private import semmle.code.java.dataflow.ExternalFlow
 
 /** The class `org.springframework.web.client.RestTemplate`. */
 class SpringRestTemplate extends Class {

--- a/java/ql/lib/semmle/code/java/security/PartialPathTraversalQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/PartialPathTraversalQuery.qll
@@ -3,7 +3,6 @@
 import java
 import semmle.code.java.security.PartialPathTraversal
 import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.ExternalFlow
 import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.FlowSources
 

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -2,7 +2,6 @@
 
 import java
 private import semmle.code.java.controlflow.Guards
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSources
 private import semmle.code.java.dataflow.SSA
 

--- a/java/ql/lib/semmle/code/java/security/SpelInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/SpelInjection.qll
@@ -2,7 +2,6 @@
 
 import java
 private import semmle.code.java.dataflow.DataFlow
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.frameworks.spring.SpringExpression
 
 /** A data flow sink for unvalidated user input that is used to construct SpEL expressions. */

--- a/java/ql/lib/semmle/code/java/security/UnsafeContentUriResolutionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeContentUriResolutionQuery.qll
@@ -1,7 +1,6 @@
 /** Provides taint tracking configurations to be used in unsafe content URI resolution queries. */
 
 import java
-import semmle.code.java.dataflow.ExternalFlow
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.security.UnsafeContentUriResolution

--- a/java/ql/src/experimental/Security/CWE/CWE-073/JFinalController.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-073/JFinalController.qll
@@ -1,5 +1,4 @@
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSources
 
 /** The class `com.jfinal.core.Controller`. */

--- a/java/ql/src/experimental/semmle/code/java/frameworks/SpringResource.qll
+++ b/java/ql/src/experimental/semmle/code/java/frameworks/SpringResource.qll
@@ -3,7 +3,6 @@
  */
 
 import java
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSources
 
 /** A utility class for resolving resource locations to files in the file system in the Spring framework. */

--- a/java/ql/src/utils/flowtestcasegenerator/FlowTestCaseSupportMethods.qll
+++ b/java/ql/src/utils/flowtestcasegenerator/FlowTestCaseSupportMethods.qll
@@ -4,7 +4,6 @@
 
 import java
 private import semmle.code.java.dataflow.internal.DataFlowUtil
-private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSummary
 private import semmle.code.java.dataflow.internal.FlowSummaryImpl
 private import FlowTestCaseUtils

--- a/java/ql/test/kotlin/library-tests/dataflow/extensionMethod/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/extensionMethod/test.ql
@@ -1,6 +1,5 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.ExternalFlow
 
 class Conf extends TaintTracking::Configuration {
   Conf() { this = "qltest:extension-method" }

--- a/java/ql/test/kotlin/library-tests/dataflow/foreach/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/foreach/test.ql
@@ -1,6 +1,5 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.ExternalFlow
 
 class Conf extends TaintTracking::Configuration {
   Conf() { this = "qltest:foreach-array-iterator" }

--- a/java/ql/test/kotlin/library-tests/dataflow/func/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/func/test.ql
@@ -1,6 +1,5 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.ExternalFlow
 
 class Conf extends TaintTracking::Configuration {
   Conf() { this = "qltest:lambdaFlow" }

--- a/java/ql/test/kotlin/library-tests/dataflow/notnullexpr/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/notnullexpr/test.ql
@@ -1,6 +1,5 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.ExternalFlow
 
 class Conf extends TaintTracking::Configuration {
   Conf() { this = "qltest:notNullExprFlow" }

--- a/java/ql/test/kotlin/library-tests/dataflow/whenexpr/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/whenexpr/test.ql
@@ -1,6 +1,5 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.ExternalFlow
 
 class Conf extends TaintTracking::Configuration {
   Conf() { this = "qltest:notNullExprFlow" }

--- a/java/ql/test/library-tests/dataflow/callback-dispatch/test.ql
+++ b/java/ql/test/library-tests/dataflow/callback-dispatch/test.ql
@@ -1,6 +1,5 @@
 import java
 import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.ExternalFlow
 import TestUtilities.InlineExpectationsTest
 
 class Conf extends DataFlow::Configuration {

--- a/java/ql/test/library-tests/dataflow/collections/containerflow.ql
+++ b/java/ql/test/library-tests/dataflow/collections/containerflow.ql
@@ -1,6 +1,5 @@
 import java
 import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.ExternalFlow
 import TestUtilities.InlineFlowTest
 
 class HasFlowTest extends InlineFlowTest {


### PR DESCRIPTION
In this PR we cleanup the bi-directional *framework* imports that were introduced for Models as Data.
The bi-directional imports created a huge SCC of dependencies and removing the importa revealed some missing imports in other parts of the code that were relying on the framework SCC in `ExternalFlow.qll`.
The code has been modified accordingly and bi-directional imports because of other abstract classes have been introduced where needed.
