### PR TITLE
Python: Fix `py/meta/points-to-call-graph`

### DIFF
--- a/python/ql/src/meta/analysis-quality/CallGraph.ql
+++ b/python/ql/src/meta/analysis-quality/CallGraph.ql
@@ -16,5 +16,5 @@ from DataFlowCall c, DataFlowCallableValue f
 where
   c.getCallable() = f and
   not c.getLocation().getFile() instanceof IgnoredFile and
-  not f.getLocation().getFile() instanceof IgnoredFile
+  not f.getScope().getLocation().getFile() instanceof IgnoredFile
 select c, "Call to $@", f.getScope(), f.toString()


### PR DESCRIPTION
I simply had forgotten that the callable didn't have a valid location, since that's not how it work with the new call graph :face_exhaling: 