### PR TITLE
Taintflow: Additional steps at sink

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
@@ -120,6 +120,12 @@ predicate defaultAdditionalTaintStep(DataFlow::Node src, DataFlow::Node sink) {
 }
 
 /**
+ * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+ * of such steps can reach a sink.
+ */
+predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+/**
  * Holds if default `TaintTracking::Configuration`s should allow implicit reads
  * of `c` at sinks and inputs to additional taint steps.
  */

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -35,6 +35,12 @@ predicate defaultAdditionalTaintStep(DataFlow::Node src, DataFlow::Node sink) {
 }
 
 /**
+ * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+ * of such steps can reach a sink.
+ */
+predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+/**
  * Holds if default `TaintTracking::Configuration`s should allow implicit reads
  * of `c` at sinks and inputs to additional taint steps.
  */

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
@@ -151,6 +151,12 @@ predicate defaultAdditionalTaintStep(DataFlow::Node src, DataFlow::Node sink) {
 }
 
 /**
+ * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+ * of such steps can reach a sink.
+ */
+predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+/**
  * Holds if default `TaintTracking::Configuration`s should allow implicit reads
  * of `c` at sinks and inputs to additional taint steps.
  */

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
@@ -160,6 +160,13 @@ private module Cached {
     or
     nodeTo = nodeFrom.(DataFlow::NonLocalJumpNode).getAJumpSuccessor(false)
   }
+
+  /**
+   * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+   * of such steps can reach a sink.
+   */
+  cached
+  predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
 }
 
 import Cached

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking4/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking4/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking5/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking5/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/go/ql/lib/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -217,6 +217,12 @@ predicate defaultAdditionalTaintStep(DataFlow::Node src, DataFlow::Node sink) {
 }
 
 /**
+ * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+ * of such steps can reach a sink.
+ */
+predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+/**
  * A sanitizer in all global taint flow configurations but not in local taint.
  */
 abstract class DefaultTaintSanitizer extends DataFlow::Node { }

--- a/go/ql/lib/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/go/ql/lib/semmle/go/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -152,6 +152,13 @@ private module Cached {
   }
 
   /**
+   * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+   * of such steps can reach a sink.
+   */
+  cached
+  predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+  /**
    * Holds if `node` should be a sanitizer in all global taint flow configurations
    * but not in local taint.
    */

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/TaintTrackingPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TaintTrackingPrivate.qll
@@ -30,6 +30,13 @@ private module Cached {
   }
 
   /**
+   * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+   * of such steps can reach a sink.
+   */
+  cached
+  predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+  /**
    * Holds if taint can flow in one local step from `nodeFrom` to `nodeTo` excluding
    * local data flow steps. That is, `nodeFrom` and `nodeTo` are likely to represent
    * different objects.

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking2/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking3/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking4/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking4/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -112,6 +112,13 @@ private module Cached {
   }
 
   /**
+   * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+   * of such steps can reach a sink.
+   */
+  cached
+  predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+  /**
    * Holds if taint propagates from `nodeFrom` to `nodeTo` in exactly one local
    * (intra-procedural) step.
    */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**

--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
@@ -69,6 +69,13 @@ private module Cached {
   }
 
   /**
+   * Like `defaultAdditionalTaintStep`, but these steps are only applied when a transitive closure
+   * of such steps can reach a sink.
+   */
+  cached
+  predicate defaultAdditionalTaintStepAtSink(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+  /**
    * Holds if taint propagates from `nodeFrom` to `nodeTo` in exactly one local
    * (intra-procedural) step.
    */

--- a/swift/ql/lib/codeql/swift/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -149,8 +149,12 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    this.isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2)
+    or
     defaultAdditionalTaintStep(node1, node2)
+    or
+    this.isSink(node2) and
+    defaultAdditionalTaintStepAtSink+(node1, node2)
   }
 
   /**


### PR DESCRIPTION
**Some background:**
For C/C++ we really want to track pointer indirections (i.e., whatever `p` points to when `p` is a pointer) precisely. Intuitively, we can do this perfectly well by using `ArrayContent` to model flow to a pointer's indirection.

However, as we learned (the hard way) a year ago, this doesn't perform well. So instead, we're tracking `*p` precisely by allocating an SSA variable for each indirection. We then have taint flow from `p` to `*p`. However, we don't want taint flow from `*p` to `p` in general.

**This PR:**
This PR adds a predicate for specifying taint flow that is only applied at the very end when a TC of such steps can reach a sink.

The plan is to specify taint flow from `*p` to `p` using this predicate (which I'll do in a separate PR as it depends on [another large C/C++ PR](https://github.com/github/codeql/pull/10817/)).

@aschackmull I'm curious to hear what your opinion on this is.