### PR TITLE
C++: Introduce a pre-SSA `DataFlow::Node` class

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -327,7 +327,10 @@ private string toExprString(Node n) {
   result = n.asIndirectExpr().toString() + " indirection"
 }
 
-class Node0 extends Node, TNode0 {
+/**
+ * A class that lifts pre-SSA dataflow nodes to regular dataflow nodes.
+ */
+private class Node0 extends Node, TNode0 {
   Node0Impl node;
 
   Node0() { this = TNode0(node) }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -222,16 +222,16 @@ class DefImpl extends DefOrUseImpl, TDefImpl {
 
   override int getIndirectionIndex() { result = ind }
 
-  Instruction getDefiningInstruction() { isDef(_, result, address, _, _, _) }
+  Node0Impl getValue() { isDef(_, result, address, _, _, _) }
 
   override string toString() { result = "DefImpl" }
 
-  override IRBlock getBlock() { result = this.getDefiningInstruction().getBlock() }
+  override IRBlock getBlock() { result = this.getAddressOperand().getUse().getBlock() }
 
-  override Cpp::Location getLocation() { result = this.getDefiningInstruction().getLocation() }
+  override Cpp::Location getLocation() { result = this.getAddressOperand().getUse().getLocation() }
 
   final override predicate hasIndexInBlock(IRBlock block, int index) {
-    this.getDefiningInstruction() = block.getInstruction(index)
+    this.getAddressOperand().getUse() = block.getInstruction(index)
   }
 
   predicate isCertain() { isDef(true, _, address, _, _, ind) }
@@ -308,7 +308,10 @@ predicate outNodeHasAddressAndIndex(
 }
 
 private predicate defToNode(Node nodeFrom, Def def) {
-  nodeHasInstruction(nodeFrom, def.getDefiningInstruction(), def.getIndirectionIndex())
+  // TODO: This is not yet needed (and in fact, the compiler rejects it because `exists(def.getValue().asOperand())` never holds).
+  // nodeHasOperand(nodeFrom, def.getValue().asOperand(), def.getIndirectionIndex())
+  // or
+  nodeHasInstruction(nodeFrom, def.getValue().asInstruction(), def.getIndirectionIndex())
 }
 
 /**
@@ -562,7 +565,7 @@ class Def extends DefOrUse {
     pragma[only_bind_into](result) = pragma[only_bind_out](defOrUse).getIndirectionIndex()
   }
 
-  Instruction getDefiningInstruction() { result = defOrUse.getDefiningInstruction() }
+  Node0Impl getValue() { result = defOrUse.getValue() }
 }
 
 private module SsaImpl = SsaImplCommon::Make<SsaInput>;

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll
@@ -168,16 +168,16 @@ class DefImpl extends DefOrUseImpl, TDefImpl {
 
   Operand getAddressOperand() { result = address }
 
-  Instruction getDefiningInstruction() { isDef(_, result, address, _, _, _) }
+  Node0Impl getValue() { isDef(_, result, address, _, _, _) }
 
   override string toString() { result = address.toString() }
 
-  override IRBlock getBlock() { result = this.getDefiningInstruction().getBlock() }
+  override IRBlock getBlock() { result = this.getAddressOperand().getDef().getBlock() }
 
-  override Cpp::Location getLocation() { result = this.getDefiningInstruction().getLocation() }
+  override Cpp::Location getLocation() { result = this.getAddressOperand().getLocation() }
 
   final override predicate hasIndexInBlock(IRBlock block, int index) {
-    this.getDefiningInstruction() = block.getInstruction(index)
+    this.getAddressOperand().getUse() = block.getInstruction(index)
   }
 
   predicate isCertain() { isDef(true, _, address, _, _, _) }
@@ -302,9 +302,9 @@ class Def extends DefOrUse {
 
   Instruction getAddress() { result = this.getAddressOperand().getDef() }
 
-  Instruction getDefiningInstruction() { result = defOrUse.getDefiningInstruction() }
+  Node0Impl getValue() { result = defOrUse.getValue() }
 
-  override string toString() { result = this.asDefOrUse().toString() + " (def)" }
+  override string toString() { result = this.asDefOrUse().toString() }
 }
 
 private module SsaImpl = SsaImplCommon::Make<SsaInput>;


### PR DESCRIPTION
This is a simple refactoring that introduces a `Node` class that exists before computing any SSA. This is a necessary step for my ongoing work on IR dataflow through iterators.