### PR TITLE
fix: use WHATWG URL for JS examples

### DIFF
--- a/javascript/ql/src/Security/CWE-918/examples/RequestForgeryBad.js
+++ b/javascript/ql/src/Security/CWE-918/examples/RequestForgeryBad.js
@@ -1,8 +1,7 @@
 import http from 'http';
-import url from 'url';
 
-var server = http.createServer(function(req, res) {
-    var target = url.parse(req.url, true).query.target;
+const server = http.createServer(function(req, res) {
+    const target = new URL(req.url).searchParams.get("target");
 
     // BAD: `target` is controlled by the attacker
     http.get('https://' + target + ".example.com/data/", res => {

--- a/javascript/ql/src/Security/CWE-918/examples/RequestForgeryBad.js
+++ b/javascript/ql/src/Security/CWE-918/examples/RequestForgeryBad.js
@@ -1,7 +1,7 @@
 import http from 'http';
 
 const server = http.createServer(function(req, res) {
-    const target = new URL(req.url).searchParams.get("target");
+    const target = new URL(req.url, "http://example.com").searchParams.get("target");
 
     // BAD: `target` is controlled by the attacker
     http.get('https://' + target + ".example.com/data/", res => {

--- a/javascript/ql/src/Security/CWE-918/examples/RequestForgeryGood.js
+++ b/javascript/ql/src/Security/CWE-918/examples/RequestForgeryGood.js
@@ -3,7 +3,7 @@ import http from 'http';
 const server = http.createServer(function(req, res) {
     const target = new URL(req.url).searchParams.get("target");
 
-    const subdomain;
+    let subdomain;
     if (target === 'EU') {
         subdomain = "europe"
     } else {

--- a/javascript/ql/src/Security/CWE-918/examples/RequestForgeryGood.js
+++ b/javascript/ql/src/Security/CWE-918/examples/RequestForgeryGood.js
@@ -1,7 +1,7 @@
 import http from 'http';
 
 const server = http.createServer(function(req, res) {
-    const target = new URL(req.url).searchParams.get("target");
+    const target = new URL(req.url, "http://example.com").searchParams.get("target");
 
     let subdomain;
     if (target === 'EU') {

--- a/javascript/ql/src/Security/CWE-918/examples/RequestForgeryGood.js
+++ b/javascript/ql/src/Security/CWE-918/examples/RequestForgeryGood.js
@@ -1,10 +1,9 @@
 import http from 'http';
-import url from 'url';
 
-var server = http.createServer(function(req, res) {
-    var target = url.parse(req.url, true).query.target;
+const server = http.createServer(function(req, res) {
+    const target = new URL(req.url).searchParams.get("target");
 
-    var subdomain;
+    const subdomain;
     if (target === 'EU') {
         subdomain = "europe"
     } else {


### PR DESCRIPTION
Updates the Javascript `RequestForgery` examples to use the WHATWG `URL` API, given the `URL` Node library is discouraged and soon to be deprecated.

While in here, I've changed the `var` assignments to `const` and `let` (which I have no strong opinions on... just feels more idiomatic JS in 2022).