### PR TITLE
Kotlin: Adapt PathSanitizer

### DIFF
--- a/java/ql/lib/change-notes/2022-12-05-kotlin-path-sanitizer.md
+++ b/java/ql/lib/change-notes/2022-12-05-kotlin-path-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The library `PathSanitizer.qll` has been improved to detect more path validation patterns in Kotlin.

--- a/java/ql/lib/semmle/code/java/frameworks/kotlin/IO.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/kotlin/IO.qll
@@ -1,0 +1,8 @@
+/** Provides classes and predicates related to `kotlin.io`. */
+
+import java
+
+/** The type `kotlin.io.FilesKt`, where `File` extension methods are declared. */
+class FilesKt extends RefType {
+  FilesKt() { this.hasQualifiedName("kotlin.io", "FilesKt") }
+}

--- a/java/ql/lib/semmle/code/java/frameworks/kotlin/Text.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/kotlin/Text.qll
@@ -14,6 +14,7 @@ class KtToRegex extends MethodAccess {
     this.getMethod().hasName("toRegex")
   }
 
+  /** Gets the constant string value being converted to a regex by this call. */
   string getExpressionString() {
     result = this.getArgument(0).(CompileTimeConstantExpr).getStringValue()
   }

--- a/java/ql/lib/semmle/code/java/frameworks/kotlin/Text.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/kotlin/Text.qll
@@ -1,0 +1,20 @@
+/** Provides classes and predicates related to `kotlin.text`. */
+
+import java
+
+/** The type `kotlin.text.StringsKt`, where `String` extension methods are declared. */
+class StringsKt extends RefType {
+  StringsKt() { this.hasQualifiedName("kotlin.text", "StringsKt") }
+}
+
+/** A call to the extension method `String.toRegex` from `kotlin.text`. */
+class KtToRegex extends MethodAccess {
+  KtToRegex() {
+    this.getMethod().getDeclaringType() instanceof StringsKt and
+    this.getMethod().hasName("toRegex")
+  }
+
+  string getExpressionString() {
+    result = this.getArgument(0).(CompileTimeConstantExpr).getStringValue()
+  }
+}

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -332,7 +332,7 @@ private Argument getVisualArgument(MethodAccess ma, int argPos) {
 }
 
 /**
- * Gets the proxied method if `m` is a Kotlin proxy that supplies default parameter values,
+ * Gets the proxied method if `m` is a Kotlin proxy that supplies default parameter values.
  * Otherwise, just gets `m`.
  */
 private Method getSourceMethod(Method m) {

--- a/java/ql/test/library-tests/pathsanitizer/Test.java
+++ b/java/ql/test/library-tests/pathsanitizer/Test.java
@@ -279,7 +279,7 @@ public class Test {
     }
 
     private void blockListGuardValidation(String path) throws Exception {
-        if (path.contains("..") || !path.startsWith("/data"))
+        if (path.contains("..") || path.startsWith("/data"))
             throw new Exception();
     }
 

--- a/java/ql/test/library-tests/pathsanitizer/TestKt.kt
+++ b/java/ql/test/library-tests/pathsanitizer/TestKt.kt
@@ -95,7 +95,7 @@ class TestKt {
         // PathTraversalSanitizer + allowListGuard
         run {
             val source: File? = source() as File?
-            val normalized: String = source!!.getCanonicalPath()
+            val normalized: String = source!!.canonicalPath
             if (normalized.startsWith("/safe")) {
                 sink(source) // Safe
                 sink(normalized) // Safe
@@ -106,7 +106,7 @@ class TestKt {
         }
         run {
             val source: File? = source() as File?
-            val normalized: String = source!!.getCanonicalFile().toString()
+            val normalized: File = source!!.canonicalFile.toString()
             if (normalized.startsWith("/safe")) {
                 sink(source) // Safe
                 sink(normalized) // Safe
@@ -328,7 +328,7 @@ class TestKt {
         // PathTraversalSanitizer + blockListGuard
         run {
             val source: File? = source() as File?
-            val normalized: String = source!!.getCanonicalPath()
+            val normalized: String = source!!.canonicalPath
             if (!normalized.startsWith("/data")) {
                 sink(source) // Safe
                 sink(normalized) // Safe
@@ -339,7 +339,7 @@ class TestKt {
         }
         run {
             val source: File? = source() as File?
-            val normalized: String = source!!.getCanonicalFile().toString()
+            val normalized: String = source!!.canonicalFile.toString()
             if (!normalized.startsWith("/data")) {
                 sink(source) // Safe
                 sink(normalized) // Safe

--- a/java/ql/test/library-tests/pathsanitizer/TestKt.kt
+++ b/java/ql/test/library-tests/pathsanitizer/TestKt.kt
@@ -106,7 +106,18 @@ class TestKt {
         }
         run {
             val source: File? = source() as File?
-            val normalized: File = source!!.canonicalFile.toString()
+            val normalized: File = source!!.canonicalFile
+            if (normalized.startsWith("/safe")) {
+                sink(source) // Safe
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ hasTaintFlow
+            }
+        }
+        run {
+            val source: File? = source() as File?
+            val normalized: String = source!!.canonicalFile.toString()
             if (normalized.startsWith("/safe")) {
                 sink(source) // Safe
                 sink(normalized) // Safe
@@ -329,6 +340,17 @@ class TestKt {
         run {
             val source: File? = source() as File?
             val normalized: String = source!!.canonicalPath
+            if (!normalized.startsWith("/data")) {
+                sink(source) // Safe
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ hasTaintFlow
+            }
+        }
+        run {
+            val source: File? = source() as File?
+            val normalized: File = source!!.canonicalFile
             if (!normalized.startsWith("/data")) {
                 sink(source) // Safe
                 sink(normalized) // Safe

--- a/java/ql/test/library-tests/pathsanitizer/TestKt.kt
+++ b/java/ql/test/library-tests/pathsanitizer/TestKt.kt
@@ -1,0 +1,479 @@
+import java.io.File
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+import android.net.Uri
+
+class TestKt {
+    fun source(): Any? {
+        return null
+    }
+
+    fun sink(o: Any?) {}
+
+    @Throws(Exception::class)
+    private fun exactPathMatchGuardValidation(path: String?) {
+        if (!path.equals("/safe/path")) throw Exception()
+    }
+
+    @Throws(Exception::class)
+    fun exactPathMatchGuard() {
+        run {
+            val source = source() as String?
+            // This gets extracted as Object.equals, which makes the definitions in exactPathMatchGuard not catch it.
+            // Note that it gets correctly extracted in Java.
+            if (source!!.equals("/safe/path"))
+                sink(source) // $SPURIOUS: $ hasTaintFlow
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as URI?
+            if (source!!.equals(URI("http://safe/uri")))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as File?
+            if (source!!.equals(File("/safe/file")))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as Uri?
+            if (source!!.equals(Uri.parse("http://safe/uri")))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            exactPathMatchGuardValidation(source)
+            sink(source) // Safe
+        }
+    }
+
+    @Throws(Exception::class)
+    private fun allowListGuardValidation(path: String?) {
+        if (path!!.contains("..") || !path.startsWith("/safe")) throw Exception()
+    }
+
+    @Throws(Exception::class)
+    fun allowListGuard() {
+        // Prefix check by itself is not enough
+        run {
+            val source = source() as String?
+            if (source!!.startsWith("/safe")) {
+                sink(source) // $ hasTaintFlow
+            } else
+                sink(source) // $ hasTaintFlow
+        }
+        // PathTraversalGuard + allowListGuard
+        run {
+            val source = source() as String?
+            if (!source!!.contains("..") && source.startsWith("/safe"))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            if (source!!.indexOf("..") == -1 && source.startsWith("/safe"))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            if (source!!.lastIndexOf("..") == -1 && source.startsWith("/safe"))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        // PathTraversalSanitizer + allowListGuard
+        run {
+            val source: File? = source() as File?
+            val normalized: String = source!!.getCanonicalPath()
+            if (normalized.startsWith("/safe")) {
+                sink(source) // Safe
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ hasTaintFlow
+            }
+        }
+        run {
+            val source: File? = source() as File?
+            val normalized: String = source!!.getCanonicalFile().toString()
+            if (normalized.startsWith("/safe")) {
+                sink(source) // Safe
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            val normalized: Path = Paths.get(source).normalize()
+            if (normalized.startsWith("/safe")) {
+                sink(source) // Safe
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (normalized.startsWith("/safe")) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (normalized.regionMatches(0, "/safe", 0, 5)) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (normalized.matches("/safe/.*".toRegex())) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        // validation method
+        run {
+            val source = source() as String?
+            allowListGuardValidation(source)
+            sink(source) // Safe
+        }
+        // PathInjectionSanitizer + partial string match is considered unsafe
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (normalized.contains("/safe")) {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (normalized.regionMatches(1, "/safe", 0, 5)) {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (normalized.matches(".*/safe/.*".toRegex())) {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+    }
+
+    @Throws(Exception::class)
+    private fun dotDotCheckGuardValidation(path: String?) {
+        if (!path!!.startsWith("/safe") || path.contains("..")) throw Exception()
+    }
+
+    @Throws(Exception::class)
+    fun dotDotCheckGuard() {
+        // dot dot check by itself is not enough
+        run {
+            val source = source() as String?
+            if (!source!!.contains("..")) {
+                sink(source) // $ hasTaintFlow
+            } else
+                sink(source) // $ hasTaintFlow
+        }
+        // allowListGuard + dotDotCheckGuard
+        run {
+            val source = source() as String?
+            if (source!!.startsWith("/safe") && !source.contains(".."))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            if (source!!.startsWith("/safe") && source.indexOf("..") == -1)
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            if (!source!!.startsWith("/safe") || source.indexOf("..") != -1)
+                sink(source) // $ hasTaintFlow
+            else
+                sink(source) // Safe
+        }
+        run {
+            val source = source() as String?
+            if (source!!.startsWith("/safe") && source.lastIndexOf("..") == -1)
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        // blockListGuard + dotDotCheckGuard
+        run {
+            val source = source() as String?
+            if (!source!!.startsWith("/data") && !source.contains(".."))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            if (!source!!.startsWith("/data") && source.indexOf("..") == -1)
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            if (source!!.startsWith("/data") || source.indexOf("..") != -1)
+                sink(source) // $ hasTaintFlow
+            else
+                sink(source) // Safe
+        }
+        run {
+            val source = source() as String?
+            if (!source!!.startsWith("/data") && source.lastIndexOf("..") == -1)
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        // validation method
+        run {
+            val source = source() as String?
+            dotDotCheckGuardValidation(source)
+            sink(source) // Safe
+        }
+    }
+
+    @Throws(Exception::class)
+    private fun blockListGuardValidation(path: String?) {
+        if (path!!.contains("..") || path.startsWith("/data")) throw Exception()
+    }
+
+    @Throws(Exception::class)
+    fun blockListGuard() {
+        // Prefix check by itself is not enough
+        run {
+            val source = source() as String?
+            if (!source!!.startsWith("/data")) {
+                sink(source) // $ hasTaintFlow
+            } else
+                sink(source) // $ hasTaintFlow
+        }
+        // PathTraversalGuard + blockListGuard
+        run {
+            val source = source() as String?
+            if (!source!!.contains("..") && !source.startsWith("/data"))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            if (source!!.indexOf("..") == -1 && !source.startsWith("/data"))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        run {
+            val source = source() as String?
+            if (source!!.lastIndexOf("..") == -1 && !source.startsWith("/data"))
+                sink(source) // Safe
+            else
+                sink(source) // $ hasTaintFlow
+        }
+        // PathTraversalSanitizer + blockListGuard
+        run {
+            val source: File? = source() as File?
+            val normalized: String = source!!.getCanonicalPath()
+            if (!normalized.startsWith("/data")) {
+                sink(source) // Safe
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ hasTaintFlow
+            }
+        }
+        run {
+            val source: File? = source() as File?
+            val normalized: String = source!!.getCanonicalFile().toString()
+            if (!normalized.startsWith("/data")) {
+                sink(source) // Safe
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            val normalized: Path = Paths.get(source).normalize()
+            if (!normalized.startsWith("/data")) {
+                sink(source) // Safe
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.startsWith("/data")) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+           // normalize().toString() gets extracted as Object.toString, stopping taint here
+             val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.regionMatches(0, "/data", 0, 5)) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.matches("/data/.*".toRegex())) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        // validation method
+        run {
+            val source = source() as String?
+            blockListGuardValidation(source)
+            sink(source) // Safe
+        }
+        // PathInjectionSanitizer + partial string match with disallowed words
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.contains("/")) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.regionMatches(1, "/", 0, 5)) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.matches("/".toRegex())) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        // PathInjectionSanitizer + partial string match with disallowed prefixes
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.contains("/data")) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.regionMatches(1, "/data", 0, 5)) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+        run {
+            val source = source() as String?
+            // normalize().toString() gets extracted as Object.toString, stopping taint here
+            val normalized: String = Paths.get(source).normalize().toString()
+            if (!normalized.matches(".*/data/.*".toRegex())) {
+                sink(source) // $ SPURIOUS: hasTaintFlow
+                sink(normalized) // Safe
+            } else {
+                sink(source) // $ hasTaintFlow
+                sink(normalized) // $ MISSING: hasTaintFlow
+            }
+        }
+    }
+}

--- a/java/ql/test/library-tests/pathsanitizer/TestKt.kt
+++ b/java/ql/test/library-tests/pathsanitizer/TestKt.kt
@@ -20,10 +20,8 @@ class TestKt {
     fun exactPathMatchGuard() {
         run {
             val source = source() as String?
-            // This gets extracted as Object.equals, which makes the definitions in exactPathMatchGuard not catch it.
-            // Note that it gets correctly extracted in Java.
             if (source!!.equals("/safe/path"))
-                sink(source) // $SPURIOUS: $ hasTaintFlow
+                sink(source) // Safe
             else
                 sink(source) // $ hasTaintFlow
         }

--- a/java/ql/test/library-tests/pathsanitizer/options
+++ b/java/ql/test/library-tests/pathsanitizer/options
@@ -1,1 +1,2 @@
 //semmle-extractor-options: --javac-args -cp ${testdir}/../../stubs/google-android-9.0.0
+//codeql-extractor-kotlin-options: ${testdir}/../../stubs/google-android-9.0.0


### PR DESCRIPTION
Adapts `PathSanitizer.qll` so that it works properly on Kotlin codebases too. Mainly handles `$default` methods (which have a different name) and extension methods (which have a different declaring type and receiver position).

Note the considerable amount of `MISSING/SPURIOUS` alerts in the Kotlin test: all are due to an extraction error where `String.equals` and `Path.toString` are extracted as `Object.equals` and `Object.toString` respectively, causing the local taint flow calculations (which are needed for many sanitizers/guards) to fail.