### PR TITLE
Kotlin: Don't add name mangling to top-level internal functions

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -821,7 +821,7 @@ open class KotlinUsesExtractor(
                 OperatorNameConventions.INVOKE.asString())
 
         fun getSuffixIfInternal() =
-            if (f.visibility == DescriptorVisibilities.INTERNAL && f !is IrConstructor) {
+            if (f.visibility == DescriptorVisibilities.INTERNAL && f !is IrConstructor && !(f.parent is IrFile || isExternalFileClassMember(f))) {
                 "\$" + getJvmModuleName(f)
             } else {
                 ""

--- a/java/ql/test/kotlin/library-tests/java_and_kotlin_internal/Java.java
+++ b/java/ql/test/kotlin/library-tests/java_and_kotlin_internal/Java.java
@@ -1,5 +1,6 @@
 public class Java {
 	void javaFun() {
 		new Kotlin().kotlinFun$main();
+		KotlinKt.topLevelKotlinFun();
 	}
 }

--- a/java/ql/test/kotlin/library-tests/java_and_kotlin_internal/Kotlin.kt
+++ b/java/ql/test/kotlin/library-tests/java_and_kotlin_internal/Kotlin.kt
@@ -3,3 +3,4 @@ public class Kotlin {
 	}
 }
 
+internal fun topLevelKotlinFun() { }

--- a/java/ql/test/kotlin/library-tests/java_and_kotlin_internal/visibility.expected
+++ b/java/ql/test/kotlin/library-tests/java_and_kotlin_internal/visibility.expected
@@ -1,9 +1,16 @@
 isPublic
 isInternal
 | Kotlin.kt:2:11:3:2 | kotlinFun$main |
+| Kotlin.kt:6:10:6:36 | topLevelKotlinFun |
 modifiers_methods
 | file://:0:0:0:0 | final | Kotlin.kt:2:11:3:2 | kotlinFun$main |
+| file://:0:0:0:0 | final | Kotlin.kt:6:10:6:36 | topLevelKotlinFun |
 | file://:0:0:0:0 | internal | Kotlin.kt:2:11:3:2 | kotlinFun$main |
+| file://:0:0:0:0 | internal | Kotlin.kt:6:10:6:36 | topLevelKotlinFun |
+| file://:0:0:0:0 | static | Kotlin.kt:6:10:6:36 | topLevelKotlinFun |
 #select
 | Kotlin.kt:2:11:3:2 | kotlinFun$main | final |
 | Kotlin.kt:2:11:3:2 | kotlinFun$main | internal |
+| Kotlin.kt:6:10:6:36 | topLevelKotlinFun | final |
+| Kotlin.kt:6:10:6:36 | topLevelKotlinFun | internal |
+| Kotlin.kt:6:10:6:36 | topLevelKotlinFun | static |


### PR DESCRIPTION
Turns out kotlinc only adds this sort of name mangling to class member functions