### PR TITLE
Swift: always upload integration test logs

### DIFF
--- a/swift/actions/run-integration-tests/action.yml
+++ b/swift/actions/run-integration-tests/action.yml
@@ -28,7 +28,7 @@ runs:
       env:
         SEMMLE_DEBUG_TRACER: 10000
     - name: Upload test logs
-      if: ${{ !cancelled() }}
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: swift-integration-tests-logs-${{ runner.os }}


### PR DESCRIPTION
This way we can get logs also in case we cancelled the job due to a test hanging indefinitely (which is happening from time to time to the Xcode test).