### PR TITLE
CI: Change `--ram` value from 52G to 50G in `codeql` tests

### DIFF
--- a/.github/workflows/csharp-qltest.yml
+++ b/.github/workflows/csharp-qltest.yml
@@ -67,7 +67,7 @@ jobs:
           mv "$CODEQL_PATH/csharp/tools/extractor-asp.jar" "${{ github.workspace }}/csharp/extractor-pack/tools"
           # Safe guard against using the bundled extractor
           rm -rf "$CODEQL_PATH/csharp"
-          codeql test run --threads=0 --ram 52000 --slice ${{ matrix.slice }} --search-path "${{ github.workspace }}/csharp/extractor-pack" --check-databases --check-undefined-labels --check-repeated-labels --check-redefined-labels --consistency-queries ql/consistency-queries ql/test --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}"
+          codeql test run --threads=0 --ram 50000 --slice ${{ matrix.slice }} --search-path "${{ github.workspace }}/csharp/extractor-pack" --check-databases --check-undefined-labels --check-repeated-labels --check-redefined-labels --consistency-queries ql/consistency-queries ql/test --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}
   unit-tests:

--- a/.github/workflows/js-ml-tests.yml
+++ b/.github/workflows/js-ml-tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           codeql query compile \
             --check-only \
-            --ram 52000 \
+            --ram 50000 \
             --additional-packs "${{ github.workspace }}" \
             --threads=0 \
             --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}" \
@@ -58,7 +58,7 @@ jobs:
         run: |
           codeql test run \
             --threads=0 \
-            --ram 52000 \
+            --ram 50000 \
             --additional-packs "${{ github.workspace }}" \
             --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}" \
             -- \

--- a/.github/workflows/ruby-qltest.yml
+++ b/.github/workflows/ruby-qltest.yml
@@ -62,6 +62,6 @@ jobs:
           key: ruby-qltest
       - name: Run QL tests
         run: |
-          codeql test run --threads=0 --ram 52000 --search-path "${{ github.workspace }}/ruby/extractor-pack" --check-databases --check-undefined-labels --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --consistency-queries ql/consistency-queries ql/test --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}"
+          codeql test run --threads=0 --ram 50000 --search-path "${{ github.workspace }}/ruby/extractor-pack" --check-databases --check-undefined-labels --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --consistency-queries ql/consistency-queries ql/test --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/swift/actions/run-ql-tests/action.yml
+++ b/swift/actions/run-ql-tests/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         codeql test run \
           --threads=0 \
-          --ram 52000 \
+          --ram 50000 \
           --search-path "${{ github.workspace }}/swift/extractor-pack" \
           --check-databases \
           --check-unused-labels \


### PR DESCRIPTION
We sometimes have failing C# CI jobs because of OOM (e.g. https://github.com/github/codeql/actions/runs/3595112804/jobs/6054199494). This PR tries to avoid that, by leaving more memory for the OS.